### PR TITLE
feat: introduce base utilities including Status, Defs, Executor, and MemoryPool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -206,6 +206,7 @@ This product includes code from RocksDB.
 
 * endian utility in src/paimon/common/utils/math.h
 * uuid utility in src/paimon/common/utils/uuid.h
+* Assert utilities in src/paimon/testing/utils/testharness.cpp and src/paimon/testing/utils/testharness.h
 
 Copyright: 2011-present, Facebook, Inc.  All rights reserved.
 Copyright: 2011 The LevelDB Authors. All rights reserved.

--- a/LICENSE
+++ b/LICENSE
@@ -243,3 +243,25 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
+
+This product includes code from Apache Arrow.
+
+* Core utilities:
+  * docs utilities in docs/ directory
+  * basic utilities in
+    - include/paimon/compare.h
+    - include/paimon/macros.h
+    - include/paimon/status.h
+    - include/paimon/string_builder.h
+    - src/paimon/common/utils/status.cpp
+* Build system modules:
+  * cmake_modules/BuildUtils.cmake
+  * cmake_modules/DefineOptions.cmake
+  * cmake_modules/san-config.cmake
+  * cmake_modules/SetupCxxFlags.cmake
+  * third_party/download_dependencies.sh
+
+Copyright: 2016-2024 The Apache Software Foundation.
+Home page: https://arrow.apache.org/
+License: https://www.apache.org/licenses/LICENSE-2.0
+--------------------------------------------------------------------------------

--- a/LICENSE
+++ b/LICENSE
@@ -259,7 +259,6 @@ This product includes code from Apache Arrow.
   * cmake_modules/DefineOptions.cmake
   * cmake_modules/san-config.cmake
   * cmake_modules/SetupCxxFlags.cmake
-  * third_party/download_dependencies.sh
 
 Copyright: 2016-2024 The Apache Software Foundation.
 Home page: https://arrow.apache.org/

--- a/NOTICE
+++ b/NOTICE
@@ -4,6 +4,9 @@ Copyright 2024-2026 The Apache Software Foundation
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+Apache Arrow
+Copyright 2016-2024 The Apache Software Foundation
+
 This product includes software from RocksDB project (Apache 2.0 and BSD 3-clause)
 Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
 Copyright (c) 2011 The LevelDB Authors. All rights reserved.

--- a/include/paimon/compare.h
+++ b/include/paimon/compare.h
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Adapted from Apache Arrow
+// https://github.com/apache/arrow/blob/main/cpp/src/arrow/util/compare.h
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include "paimon/macros.h"
+#include "paimon/type_fwd.h"
+
+namespace paimon::util {
+
+/// CRTP helper for declaring equality comparison. Defines operator== and operator!=
+template <typename T>
+class PAIMON_EXPORT EqualityComparable {
+ public:
+    ~EqualityComparable() {
+        static_assert(
+            std::is_same_v<decltype(std::declval<const T>().Equals(std::declval<const T>())), bool>,
+            "EqualityComparable depends on the method T::Equals(const T&) const");
+    }
+
+    template <typename... Extra>
+    bool Equals(const std::shared_ptr<T>& other, Extra&&... extra) const {
+        if (other == nullptr) {
+            return false;
+        }
+        return cast().Equals(*other, std::forward<Extra>(extra)...);
+    }
+
+    struct PtrsEqual {
+        bool operator()(const std::shared_ptr<T>& l, const std::shared_ptr<T>& r) const {
+            return l->Equals(r);
+        }
+    };
+
+    bool operator==(const T& other) const {
+        return cast().Equals(other);
+    }
+    bool operator!=(const T& other) const {
+        return !(cast() == other);
+    }
+
+ private:
+    const T& cast() const {
+        return static_cast<const T&>(*this);
+    }
+};
+
+}  // namespace paimon::util

--- a/include/paimon/defs.h
+++ b/include/paimon/defs.h
@@ -1,0 +1,512 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+#include "paimon/visibility.h"
+
+namespace paimon {
+
+/// Enumeration of supported data types in Paimon tables.
+enum class FieldType {
+    BOOLEAN = 1,
+    TINYINT = 2,
+    SMALLINT = 3,
+    INT = 4,
+    BIGINT = 5,
+    FLOAT = 6,
+    DOUBLE = 7,
+    STRING = 8,
+    BINARY = 9,
+    /// timestamp type only supports precision values of 0, 3, 6, 9:
+    /// - 0: second precision
+    /// - 3: millisecond precision
+    /// - 6: microsecond precision
+    /// - 9: nanosecond precision
+    TIMESTAMP = 10,
+    DECIMAL = 11,
+    DATE = 12,
+    ARRAY = 13,
+    MAP = 14,
+    STRUCT = 15,
+    BLOB = 16,
+    UNKNOWN = 128,
+};
+
+/// Configuration options and constants for Paimon table operations.
+///
+/// The Options struct contains static string constants that define configuration keys
+/// used throughout the Paimon system.
+struct PAIMON_EXPORT Options {
+    /// @name merge-on-read configurations
+    /// The 5 constants are the prefixes or suffixes for merge on read configuration.
+    /// The complete configuration keys can be:
+    /// - fields.$field_name.aggregate-function
+    /// - fields.$field_name.ignore-retract
+    /// - fields.$field_names.sequence-group ($field_names support one or more field_name, split
+    /// with FIELDS_SEPARATOR)
+    ///
+    /// examples:
+    /// - fields.f1.aggregate-function
+    /// - fields.f2.sequence-group
+    /// - fields.f3,f4.sequence-group
+    ///
+    /// @{
+
+    /// FIELDS_SEPARATOR is ","
+    static const char FIELDS_SEPARATOR[];
+    /// FIELDS_PREFIX is "fields"
+    static const char FIELDS_PREFIX[];
+    /// AGG_FUNCTION is "aggregate-function"
+    static const char AGG_FUNCTION[];
+    /// DEFAULT_AGG_FUNCTION is "default-aggregate-function"
+    static const char DEFAULT_AGG_FUNCTION[];
+    /// IGNORE_RETRACT is "ignore-retract"
+    static const char IGNORE_RETRACT[];
+    /// "distinct" - Distinct option for aggregate functions like listagg. Default value is false.
+    /// Example: fields.f.distinct=true to deduplicate values during aggregation.
+    static const char DISTINCT[];
+    /// "list-agg-delimiter" - Delimiter for listagg aggregate function. Default value is ",".
+    /// Example: fields.f.list-agg-delimiter="-" to concatenate values with "-".
+    static const char LIST_AGG_DELIMITER[];
+    /// SEQUENCE_GROUP is "sequence-group"
+    static const char SEQUENCE_GROUP[];
+    /// @}
+
+    /// "bucket" - Bucket number for file store. It should either be equal to -1 (dynamic bucket
+    /// mode), or it must be greater than 0 (fixed bucket mode).
+    static const char BUCKET[];
+
+    /// "bucket-key" - Specify the paimon distribution policy. Data is assigned to each bucket
+    /// according to the hash value of bucket-key. If you specify multiple fields, delimiter is ','.
+    /// If not specified, the primary key will be used, if there is no primary key, the full row
+    /// will be used.
+    static const char BUCKET_KEY[];
+
+    // TODO(yonghao.fyh): This option has not been used yet
+    /// "page-size" - Memory page size, default value 64 kb.
+    static const char PAGE_SIZE[];
+
+    /// "file.format" - Specify the message format of data files.
+    /// Default value is parquet.
+    static const char FILE_FORMAT[];
+
+    /// "file-system" - Specify the file system.
+    /// Default value is local.
+    static const char FILE_SYSTEM[];
+
+    /// "target-file-size" - Target size of a file. primary key table: the default value is 128 MB.
+    /// append table: the default value is 256 MB.
+    static const char TARGET_FILE_SIZE[];
+
+    /// "blob.target-file-size" - Target size of a blob file. Default is TARGET_FILE_SIZE.
+    static const char BLOB_TARGET_FILE_SIZE[];
+
+    /// "partition.default-name" - The default partition name in case the dynamic partition column
+    /// value is null/empty string. Default is "__DEFAULT_PARTITION__".
+    static const char PARTITION_DEFAULT_NAME[];
+
+    /// "file.compression" - The default file compression is zstd. For faster read and write, it is
+    /// recommended to use zstd.
+    static const char FILE_COMPRESSION[];
+
+    /// "file.compression.zstd-level"
+    /// Default file compression zstd level. For higher compression rates, it can be configured to
+    /// 9, but the read and write speed will significantly decrease. Default value is 1.
+    static const char FILE_COMPRESSION_ZSTD_LEVEL[];
+
+    /// "manifest.target-file-size" - Suggested file size of a manifest file.
+    /// Default value is 8MB.
+    static const char MANIFEST_TARGET_FILE_SIZE[];
+
+    /// "manifest.format" - Specify the message format of manifest files.
+    /// Default value is avro.
+    static const char MANIFEST_FORMAT[];
+
+    /// "manifest.compression" - File compression for manifest, default value is zstd.
+    static const char MANIFEST_COMPRESSION[];
+
+    /// "manifest.merge-min-count" - To avoid frequent manifest merges, this parameter specifies the
+    /// minimum number of ManifestFileMeta to merge, default value is 30.
+    static const char MANIFEST_MERGE_MIN_COUNT[];
+
+    /// "manifest.full-compaction-threshold-size" - The size threshold for triggering full
+    /// compaction of manifest, default value is 16MB.
+    static const char MANIFEST_FULL_COMPACTION_FILE_SIZE[];
+
+    /// "source.split.target-size" - Target size of a source split when scanning a bucket. Default
+    /// value is 128MB.
+    static const char SOURCE_SPLIT_TARGET_SIZE[];
+
+    /// "source.split.open-file-cost" - Open file cost of a source file. It is used to avoid reading
+    /// too many files with a source split, which can be very slow. Default value is 4MB.
+    static const char SOURCE_SPLIT_OPEN_FILE_COST[];
+
+    /// "scan.snapshot-id" - Optional snapshot id used in case of "from-snapshot" or
+    /// "from-snapshot-full" scan mode
+    static const char SCAN_SNAPSHOT_ID[];
+
+    /// "scan.mode" - Specify the scanning behavior of the source. Values can be: "default",
+    /// "latest-full", "latest", "from-snapshot", "from-snapshot-full". Default value is "default".
+    static const char SCAN_MODE[];
+
+    /// "read.batch-size" - Read batch size for any file format if it supports.
+    /// The default value is 1024.
+    static const char READ_BATCH_SIZE[];
+
+    /// "write.batch-size" - Write batch size for any file format if it supports.
+    /// The default value is 1024.
+    static const char WRITE_BATCH_SIZE[];
+
+    /// "write-buffer-size" - Amount of data to build up in memory before converting to a sorted
+    /// on-disk file. The default value is 256 mb
+    static const char WRITE_BUFFER_SIZE[];
+
+    /// "write-buffer-spillable" - Whether the write buffer can be spillable. Default value is true.
+    static const char WRITE_BUFFER_SPILLABLE[];
+
+    /// "write-buffer-spill.max-disk-size" - The max disk to use for write buffer spill. This only
+    /// works when the write buffer spill is enabled. Default value is unlimited.
+    static const char WRITE_BUFFER_SPILL_MAX_DISK_SIZE[];
+
+    /// "local-sort.max-num-file-handles" - The maximal fan-in for external merge sort. It limits
+    /// the number of file handles. If it is too small, may cause intermediate merging. But if it is
+    /// too large, it will cause too many files opened at the same time, consume memory and lead to
+    /// random reading. Default value is 128.
+    static const char LOCAL_SORT_MAX_NUM_FILE_HANDLES[];
+
+    /// "spill-compression" - Compression for spill. Default value is zstd.
+    static const char SPILL_COMPRESSION[];
+
+    /// "spill-compression.zstd-level" - Default spill compression zstd level. For higher
+    /// compression rates, it can be configured to 9, but the read and write speed will
+    /// significantly decrease. Default value is 1.
+    static const char SPILL_COMPRESSION_ZSTD_LEVEL[];
+
+    /// "snapshot.num-retained.min" - The minimum number of completed snapshots to retain. Should be
+    /// greater than or equal to 1. Default value is 10
+    static const char SNAPSHOT_NUM_RETAINED_MIN[];
+
+    /// "snapshot.num-retained.max" - The maximum number of completed snapshots to retain. Should be
+    /// greater than or equal to the minimum number. Default value is int32 max value.
+    static const char SNAPSHOT_NUM_RETAINED_MAX[];
+
+    /// "snapshot.time-retained" - The maximum time of completed snapshots to retain. Default value
+    /// is 1 hour.
+    static const char SNAPSHOT_TIME_RETAINED[];
+
+    /// "snapshot.expire.limit" - The maximum number of snapshots allowed to expire at a time.
+    /// Default value is 50.
+    static const char SNAPSHOT_EXPIRE_LIMIT[];
+
+    /// "snapshot.clean-empty-directories" - Whether to try to clean empty directories when expiring
+    /// snapshots, if enabled, please note: hdfs: may print exceptions in NameNode. oss/s3: may
+    /// cause performance issue. Default value is false.
+    static const char SNAPSHOT_CLEAN_EMPTY_DIRECTORIES[];
+
+    /// "commit.force-compact" - Whether to force a compaction before commit. Default value is
+    /// "false".
+    static const char COMMIT_FORCE_COMPACT[];
+
+    /// "commit.timeout" - Timeout duration of retry when commit failed. No default value.
+    static const char COMMIT_TIMEOUT[];
+
+    /// "commit.max-retries" - Maximum number of retries when commit failed. Default value is 10.
+    static const char COMMIT_MAX_RETRIES[];
+
+    /// "compaction.max-size-amplification-percent" - The size amplification is defined as the
+    /// amount (in percentage) of additional storage needed to store a single byte of data in the
+    /// merge tree for changelog mode table. Default value is 200.
+    static const char COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT[];
+
+    /// "compaction.size-ratio" - Percentage flexibility while comparing sorted run size for
+    /// changelog mode table. If the candidate sorted run(s) size is 1% smaller than the next
+    /// sorted run's size, then include next sorted run into this candidate set. Default value is 1.
+    static const char COMPACTION_SIZE_RATIO[];
+
+    /// "num-sorted-run.compaction-trigger" - The sorted run number to trigger compaction. Includes
+    /// level0 files (one file one sorted run) and high-level runs (one level one sorted run).
+    /// Default value is 5.
+    static const char NUM_SORTED_RUNS_COMPACTION_TRIGGER[];
+
+    /// "num-sorted-run.stop-trigger" - The number of sorted runs that trigger the stopping of
+    /// writes, the default value is 'num-sorted-run.compaction-trigger' + 3.
+    static const char NUM_SORTED_RUNS_STOP_TRIGGER[];
+
+    /// "num-levels" - Total level number, for example, there are 3 levels, including 0,1,2 levels.
+    /// No default value.
+    static const char NUM_LEVELS[];
+
+    /// "lookup-wait" - When need to lookup, commit will wait for compaction by lookup. Default
+    /// value is "true".
+    static const char LOOKUP_WAIT[];
+
+    /// "lookup-compact" - Lookup compact mode used for lookup compaction. Default value is
+    /// LookupCompactMode::RADICAL.
+    static const char LOOKUP_COMPACT[];
+
+    /// "compaction.force-up-level-0" - If set to true, compaction strategy will always include all
+    /// level 0 files in candidates. Default value is false.
+    static const char COMPACTION_FORCE_UP_LEVEL_0[];
+
+    /// "lookup-compact.max-interval" - The max interval for a gentle mode lookup compaction to be
+    /// triggered. For every interval, a forced lookup compaction will be performed to flush L0
+    /// files to higher level. This option is only valid when lookup-compact mode is gentle. No
+    /// default value.
+    static const char LOOKUP_COMPACT_MAX_INTERVAL[];
+
+    /// "sequence.field" - The field that generates the sequence number for primary key table, the
+    /// sequence number determines which data is the most recent. Value use "," as delimiter.
+    static const char SEQUENCE_FIELD[];
+
+    /// "sequence.field.sort-order" - Specify the order of sequence.field. Values can be:
+    /// "ascending", "descending". Default value is "ascending".
+    static const char SEQUENCE_FIELD_SORT_ORDER[];
+
+    /// "merge-engine" - Specify the merge engine for table with primary key. Values can be:
+    /// "deduplicate", "partial-update", "aggregation", "first-row". Default value is "deduplicate".
+    static const char MERGE_ENGINE[];
+
+    /// "sort-engine" - Specify the sort engine for table with primary key. Values can be:
+    /// "min-heap", "loser-tree". Default value is "loser-tree".
+    static const char SORT_ENGINE[];
+
+    /// "ignore-delete" - Whether to ignore delete records. Default value is "false".
+    static const char IGNORE_DELETE[];
+
+    /// "fields.default-aggregate-function" - Default aggregate function of all fields for
+    /// partial-update and aggregate merge function.
+    static const char FIELDS_DEFAULT_AGG_FUNC[];
+
+    /// "deletion-vectors.enabled" - Whether to enable deletion vectors mode. In this mode, index
+    /// files containing deletion vectors are generated when data is written, which marks the data
+    /// for deletion. During read operations, by applying these index files, merging can be avoided.
+    /// Default value is false.
+    static const char DELETION_VECTORS_ENABLED[];
+
+    /// "deletion-vector.index-file.target-size" - The target size of deletion vector index file.
+    /// Default value is 2MB.
+    static const char DELETION_VECTOR_INDEX_FILE_TARGET_SIZE[];
+
+    /// "deletion-vectors.bitmap64" - Enable 64 bit bitmap implementation. Note that only 64 bit
+    /// bitmap implementation is compatible with Iceberg. Default value is "false".
+    /// @note: bitmap64 dv is not supported.
+    static const char DELETION_VECTOR_BITMAP64[];
+
+    ///  @note `CHANGELOG_PRODUCER` currently only support `none`
+    ///
+    /// "changelog-producer" - Whether to double write to a changelog file. This changelog file
+    /// keeps the details of data changes, it can be read directly during stream reads. This can be
+    /// applied to tables with primary keys. Values can be "none", "input", "lookup",
+    /// "full-compaction". Default value is "none".
+    static const char CHANGELOG_PRODUCER[];
+
+    /// "force-lookup" - Whether to force the use of lookup for compaction. Default value is
+    /// "false".
+    static const char FORCE_LOOKUP[];
+
+    /// "partial-update.remove-record-on-delete" - Whether to remove the whole row in partial-update
+    /// engine when records are received. Default value is "false".
+    static const char PARTIAL_UPDATE_REMOVE_RECORD_ON_DELETE[];
+
+    /// "partial-update.remove-record-on-sequence-group" - When records of the given sequence groups
+    /// are received, remove the whole row.
+    static const char PARTIAL_UPDATE_REMOVE_RECORD_ON_SEQUENCE_GROUP[];
+
+    /// "scan.fallback-branch" - When a batch job queries from a table, if a partition does not
+    /// exist in the current branch, the reader will try to get this partition from this fallback
+    /// branch.
+    static const char SCAN_FALLBACK_BRANCH[];
+
+    /// "branch" - Specify branch name. Default value is "main".
+    static const char BRANCH[];
+
+    /// "file-index.read.enabled" - Whether enabled read file index. Default value is "true".
+    static const char FILE_INDEX_READ_ENABLED[];
+
+    /// "data-file.external-paths" - The external paths where the data of this table will be
+    /// written, multiple elements separated by commas.
+    static const char DATA_FILE_EXTERNAL_PATHS[];
+    /// "data-file.external-paths.strategy" - The strategy of selecting an external path when
+    /// writing data. Values can be: "none", "specific-fs", "round-robin". Default value is "none".
+    static const char DATA_FILE_EXTERNAL_PATHS_STRATEGY[];
+    /// "data-file.prefix" - Specify the file name prefix of data files. Default value is "data-".
+    static const char DATA_FILE_PREFIX[];
+    /// "index-file-in-data-file-dir" - Whether index file in data file directory. Default value is
+    /// "false".
+    static const char INDEX_FILE_IN_DATA_FILE_DIR[];
+    /// "row-tracking.enabled" - Whether enable unique row id for append table. Default value is
+    /// "false".
+    static const char ROW_TRACKING_ENABLED[];
+    /// "row-tracking.partition-group-on-commit" - When row-tracking is enabled, whether to group
+    /// new file metas by partition before commit, so that assigned row IDs are contiguous within
+    /// each partition. This is useful if you want to build global indices on this table. Default
+    /// value is "true".
+    static const char ROW_TRACKING_PARTITION_GROUP_ON_COMMIT[];
+    /// "data-evolution.enabled" - Whether enable data evolution for row tracking table. Default
+    /// value is "false".
+    static const char DATA_EVOLUTION_ENABLED[];
+    /// "partition.legacy-name" - The legacy partition name is using `ToString` for all types. If
+    /// false, using casting to string for all types. Default value is "true".
+    static const char PARTITION_GENERATE_LEGACY_NAME[];
+    /// "blob-as-descriptor" - Read and write blob field using blob descriptor rather than blob
+    /// bytes. Default value is "false".
+    static const char BLOB_AS_DESCRIPTOR[];
+    /// "blob-field" - Specifies column names that should be stored as blob type. This is used
+    /// when you want to treat a BYTES column as a BLOB. Fields listed in blob-descriptor-field or
+    /// blob-view-field are also treated as BLOB fields. Comma-separated field names. Multiple blob
+    /// fields are supported. No default value.
+    static const char BLOB_FIELD[];
+    /// "blob-descriptor-field" - Comma-separated field names to treat as BLOB fields and store as
+    /// serialized BlobDescriptor bytes inline in data files. No default value.
+    static const char BLOB_DESCRIPTOR_FIELD[];
+    /// "blob.stored-descriptor-fields" deprecated as a fallback for `BLOB_DESCRIPTOR_FIELD`.
+    static const char FALLBACK_BLOB_DESCRIPTOR_FIELD[];
+    /// "blob-view-field" - Comma-separated field names to treat as BLOB fields and store as
+    /// serialized BlobViewStruct bytes inline in data files and resolve from upstream tables at
+    /// read time. No default value.
+    static const char BLOB_VIEW_FIELD[];
+    /// "blob-external-storage-field" - Comma-separated BLOB field names (must be a subset of
+    /// blob-descriptor-field ) whose raw data will be written to external storage at write time.
+    /// The external storage path is configured via blob-external-storage-path. Orphan file cleanup
+    /// is not applied to that path. No default value.
+    static const char BLOB_EXTERNAL_STORAGE_FIELD[];
+    /// "blob-external-storage-path" - The external storage path where raw BLOB data from fields
+    /// configured by 'blob-external-storage-field' is written at write time. Orphan file cleanup is
+    /// not applied to this path. No default value.
+    static const char BLOB_EXTERNAL_STORAGE_PATH[];
+    /// "global-index.enabled" - Whether to enable global index for scan. Default value is "true".
+    static const char GLOBAL_INDEX_ENABLED[];
+    /// "global-index.thread-num" - The maximum number of concurrent scanner for global index. No
+    /// default value. By default is the number of processors available to the machine.
+    static const char GLOBAL_INDEX_THREAD_NUM[];
+    /// "global-index.external-path" - Global index root directory, if not set, the global index
+    /// files will be stored under the index directory.
+    static const char GLOBAL_INDEX_EXTERNAL_PATH[];
+    /// "aggregation.remove-record-on-delete" - Whether to remove the whole row in aggregation
+    /// engine when delete records are received. Default value is "false".
+    static const char AGGREGATION_REMOVE_RECORD_ON_DELETE[];
+    /// "table-read.sequence-number.enabled" - Whether to include the _SEQUENCE_NUMBER field when
+    /// reading the audit_log or binlog system tables. This is only valid for primary key tables.
+    /// Default value is "false".
+    static const char TABLE_READ_SEQUENCE_NUMBER_ENABLED[];
+    /// "key-value.sequence_number.enabled" - Whether to include the _SEQUENCE_NUMBER field when
+    /// reading key-value data. This is an internal option used by AuditLogTable and BinlogTable
+    /// when table-read.sequence-number.enabled is set to true. Default value is "false".
+    static const char KEY_VALUE_SEQUENCE_NUMBER_ENABLED[];
+
+    /// "scan.timestamp-millis" - Optional timestamp used in case of "from-timestamp" scan mode.
+    /// For batch sources, produces the latest snapshot earlier than or equal to the timestamp.
+    /// For streaming sources, starts from the first snapshot at or after the timestamp.
+    /// "scan.timestamp" can be used as an alternative string input for the same mode.
+    static const char SCAN_TIMESTAMP_MILLIS[];
+
+    /// "scan.timestamp" - Optional timestamp string used in case of "from-timestamp" scan mode,
+    /// as an alternative to "scan.timestamp-millis".
+    /// It will be automatically converted to timestamp in unix milliseconds, using local time zone.
+    /// Supported formats: yyyy-MM-dd, yyyy-MM-dd HH:mm:ss, yyyy-MM-dd HH:mm:ss.SSS.
+    static const char SCAN_TIMESTAMP[];
+
+    /// "scan.tag-name" - Optional tag name used in case of "from-snapshot" scan mode.
+    static const char SCAN_TAG_NAME[];
+    /// "write-only" - If set to "true", compactions and snapshot expiration will be skipped. This
+    /// option is used along with dedicated compact jobs. Default value is "false".
+    static const char WRITE_ONLY[];
+    /// "compaction.min.file-num" - For file set [f_0,...,f_N], the minimum file number to trigger a
+    /// compaction for append-only table. Default value is 5.
+    static const char COMPACTION_MIN_FILE_NUM[];
+    /// "compaction.force-rewrite-all-files" - Whether to force pick all files for a full
+    /// compaction. Usually seen in a compaction task to external paths. Default value is "false".
+    static const char COMPACTION_FORCE_REWRITE_ALL_FILES[];
+    /// "compaction.optimization-interval" - Implying how often to perform an optimization
+    /// compaction, this configuration is used to ensure the query timeliness of the read-optimized
+    /// system table. No default value.
+    static const char COMPACTION_OPTIMIZATION_INTERVAL[];
+    /// "compaction.total-size-threshold" - When total size is smaller than this threshold, force a
+    /// full compaction. No default value.
+    static const char COMPACTION_TOTAL_SIZE_THRESHOLD[];
+    /// "compaction.incremental-size-threshold" - When incremental size is bigger than this
+    /// threshold, force a full compaction. No default value.
+    static const char COMPACTION_INCREMENTAL_SIZE_THRESHOLD[];
+    /// "compaction.offpeak.start.hour" - The start of off-peak hours, expressed as an integer
+    /// between 0 and 23, inclusive. Set to -1 to disable off-peak. Default is -1.
+    static const char COMPACT_OFFPEAK_START_HOUR[];
+    /// "compaction.offpeak.end.hour" - The end of off-peak hours, expressed as an integer between 0
+    /// and 23, exclusive. Set to -1 to disable off-peak. Default is -1.
+    static const char COMPACT_OFFPEAK_END_HOUR[];
+    /// "compaction.offpeak-ratio" - Allows you to set a different (by default, more aggressive)
+    /// percentage ratio for determining whether larger sorted run's size are included in
+    /// compactions during off-peak hours. Works in the same way as compaction.size-ratio. Only
+    /// applies if offpeak.start.hour and offpeak.end.hour are also enabled.
+    /// For instance, if your cluster experiences low pressure between 2 AM  and 6 PM , you can
+    /// configure `compaction.offpeak.start.hour=2` and `compaction.offpeak.end.hour=18` to define
+    /// this period as off-peak hours.  During these hours, you can increase the off-peak compaction
+    /// ratio (e.g. `compaction.offpeak-ratio=20`) to enable more aggressive data compaction.
+    /// Default is 0.
+    static const char COMPACTION_OFFPEAK_RATIO[];
+    /// "lookup.cache.bloom.filter.enabled" - Whether to enable the bloom filter for lookup cache.
+    /// Default value is true.
+    static const char LOOKUP_CACHE_BLOOM_FILTER_ENABLED[];
+    /// "lookup.cache.bloom.filter.fpp" - Define the default false positive probability for lookup
+    /// cache bloom filters. Default value is 0.05.
+    static const char LOOKUP_CACHE_BLOOM_FILTER_FPP[];
+    /// "lookup.remote-file.enabled" - Whether to enable the remote file for lookup.
+    /// Default value is false.
+    static const char LOOKUP_REMOTE_FILE_ENABLED[];
+    /// "lookup.remote-file.level-threshold" - Level threshold of lookup to generate remote lookup
+    /// files. Level files below this threshold will not generate remote lookup files.
+    /// Default value is INT32_MIN.
+    static const char LOOKUP_REMOTE_LEVEL_THRESHOLD[];
+    /// "lookup.cache-spill-compression" - Spill compression for lookup cache, currently zstd, none,
+    /// lz4 are supported. Default value is zstd.
+    /// Noted that java paimon also supports lzo which paimon-cpp does not support for now.
+    static const char LOOKUP_CACHE_SPILL_COMPRESSION[];
+    /// "cache-page-size" - Memory page size for caching. Default value is 64 kb.
+    static const char CACHE_PAGE_SIZE[];
+    /// "file.format.per.level" - Define different file format for different level, you can add the
+    /// conf like this:  'file.format.per.level' = '0:avro,3:parquet', if the file format for level
+    /// is not provided, the default format which set by FILE_FORMAT will be used.
+    static const char FILE_FORMAT_PER_LEVEL[];
+    /// "file.compression.per.level" - Define different compression policies for different level,
+    /// you can add the conf like this: 'file.compression.per.level' = '0:lz4,1:zstd'.
+    /// If a level is not configured, the default compression set by FILE_COMPRESSION will be used.
+    static const char FILE_COMPRESSION_PER_LEVEL[];
+    /// "lookup.cache-max-memory-size" - Max memory size for lookup cache. Default value is 256 mb.
+    static const char LOOKUP_CACHE_MAX_MEMORY_SIZE[];
+    /// "lookup.cache.high-priority-pool-ratio" - The fraction of cache memory that is reserved for
+    /// high-priority data like index, filter. Default value is 0.25.
+    static const char LOOKUP_CACHE_HIGH_PRIO_POOL_RATIO[];
+    /// "bucket-function.type" - The bucket function type for paimon bucket.
+    /// Values can be: "default", "mod", "hive". Default value is "default".
+    static const char BUCKET_FUNCTION_TYPE[];
+    /// "lookup.cache-file-retention" - The cached files retention time for lookup.
+    /// After the file expires, if there is a need for access, it will be re-read from the DFS
+    /// to build an index on the local disk. Default value is 1 hour.
+    static const char LOOKUP_CACHE_FILE_RETENTION[];
+    /// "lookup.cache-max-disk-size" - Max disk size for lookup cache, you can use this option
+    /// to limit the use of local disks. Default value is unlimited (INT64_MAX).
+    static const char LOOKUP_CACHE_MAX_DISK_SIZE[];
+};
+
+static constexpr int64_t BATCH_WRITE_COMMIT_IDENTIFIER = std::numeric_limits<int64_t>::max();
+
+}  // namespace paimon

--- a/include/paimon/executor.h
+++ b/include/paimon/executor.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+
+#include "paimon/visibility.h"
+
+namespace paimon {
+class Executor;
+
+static constexpr uint32_t DEFAULT_EXECUTOR_THREAD_COUNT = 4;
+
+/// Get a system wide singleton executor.
+PAIMON_EXPORT std::shared_ptr<Executor> GetGlobalDefaultExecutor();
+
+/// Create a default implementation of executor with `DEFAULT_EXECUTOR_THREAD_COUNT`.
+PAIMON_EXPORT std::unique_ptr<Executor> CreateDefaultExecutor();
+
+/// Create a default implementation of executor with specified thread_count.
+PAIMON_EXPORT std::unique_ptr<Executor> CreateDefaultExecutor(uint32_t thread_count);
+
+/// Interface class for defining basic operations of a task executor.
+///
+/// The Executor class provides interfaces for adding tasks and waiting for all tasks to complete.
+class PAIMON_EXPORT Executor {
+ public:
+    virtual ~Executor() = default;
+
+    /// Add a task to the executor.
+    ///
+    /// @param func The task to be executed, represented as a function object with no parameters and
+    /// no return value.
+    ///
+    /// @note This method should be thread-safe and can be called from multiple threads
+    /// simultaneously.
+    virtual void Add(std::function<void()> func) = 0;
+
+    /// Shutdown the executor immediately, discarding all pending tasks.
+    virtual void ShutdownNow() = 0;
+};
+
+}  // namespace paimon

--- a/include/paimon/macros.h
+++ b/include/paimon/macros.h
@@ -1,0 +1,184 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Adapted from Apache Arrow
+// https://github.com/apache/arrow/blob/main/cpp/src/arrow/util/macros.h
+
+#pragma once
+
+#include <cstdint>
+
+#if defined(__GNUC__) && __GNUC__ >= 4
+#define PAIMON_LIKELY(x) (__builtin_expect((x), 1))
+#define PAIMON_UNLIKELY(x) (__builtin_expect((x), 0))
+#else
+#define PAIMON_LIKELY(x) (x)
+#define PAIMON_UNLIKELY(x) (x)
+#endif
+
+#define MEMORY_BARRIER() __asm__ __volatile__("" ::: "memory")
+
+#define PAIMON_EXPAND(x) x
+#define PAIMON_STRINGIFY(x) #x
+#define PAIMON_CONCAT(x, y) x##y
+
+// From Google gutil
+#ifndef PAIMON_DISALLOW_COPY_AND_ASSIGN
+#define PAIMON_DISALLOW_COPY_AND_ASSIGN(TypeName) \
+    TypeName(const TypeName&) = delete;           \
+    void operator=(const TypeName&) = delete
+#endif
+
+#ifndef PAIMON_DEFAULT_MOVE_AND_ASSIGN
+#define PAIMON_DEFAULT_MOVE_AND_ASSIGN(TypeName) \
+    TypeName(TypeName&&) = default;              \
+    TypeName& operator=(TypeName&&) = default
+#endif
+
+#define PAIMON_UNUSED(x) (void)(x)
+#define PAIMON_ARG_UNUSED(x)
+//
+// GCC can be told that a certain branch is not likely to be taken (for
+// instance, a CHECK failure), and use that information in static analysis.
+// Giving it this information can help it optimize for the common case in
+// the absence of better information (ie. -fprofile-arcs).
+//
+#if defined(__GNUC__)
+#define PAIMON_PREDICT_FALSE(x) (__builtin_expect(!!(x), 0))
+#define PAIMON_PREDICT_TRUE(x) (__builtin_expect(!!(x), 1))
+#define PAIMON_NORETURN __attribute__((noreturn))
+#define PAIMON_NOINLINE __attribute__((noinline))
+#define PAIMON_PREFETCH(addr) __builtin_prefetch(addr)
+#elif defined(_MSC_VER)
+#define PAIMON_NORETURN __declspec(noreturn)
+#define PAIMON_NOINLINE __declspec(noinline)
+#define PAIMON_PREDICT_FALSE(x) (x)
+#define PAIMON_PREDICT_TRUE(x) (x)
+#define PAIMON_PREFETCH(addr)
+#else
+#define PAIMON_NORETURN
+#define PAIMON_PREDICT_FALSE(x) (x)
+#define PAIMON_PREDICT_TRUE(x) (x)
+#define PAIMON_PREFETCH(addr)
+#endif
+
+#if (defined(__GNUC__) || defined(__APPLE__))
+#define PAIMON_MUST_USE_RESULT __attribute__((warn_unused_result))
+#elif defined(_MSC_VER)
+#define PAIMON_MUST_USE_RESULT
+#else
+#define PAIMON_MUST_USE_RESULT
+#endif
+
+#if defined(__clang__)
+// Only clang supports warn_unused_result as a type annotation.
+#define PAIMON_MUST_USE_TYPE PAIMON_MUST_USE_RESULT
+#else
+#define PAIMON_MUST_USE_TYPE
+#endif
+
+// ----------------------------------------------------------------------
+
+// clang-format off
+// [[deprecated]] is only available in C++14, use this for the time being
+// This macro takes an optional deprecation message
+#ifdef __COVERITY__
+#  define PAIMON_DEPRECATED(...)
+#  define PAIMON_DEPRECATED_USING(...)
+#elif __cplusplus > 201103L
+#  define PAIMON_DEPRECATED(...) [[deprecated(__VA_ARGS__)]]
+#  define PAIMON_DEPRECATED_USING(...) PAIMON_DEPRECATED(__VA_ARGS__)
+#else
+# ifdef __GNUC__
+#  define PAIMON_DEPRECATED(...) __attribute__((deprecated(__VA_ARGS__)))
+#  define PAIMON_DEPRECATED_USING(...) PAIMON_DEPRECATED(__VA_ARGS__)
+# elif defined(_MSC_VER)
+#  define PAIMON_DEPRECATED(...) __declspec(deprecated(__VA_ARGS__))
+#  define PAIMON_DEPRECATED_USING(...)
+# else
+#  define PAIMON_DEPRECATED(...)
+#  define PAIMON_DEPRECATED_USING(...)
+# endif
+#endif
+// clang-format on
+
+// ----------------------------------------------------------------------
+
+// macros to disable padding
+// these macros are portable across different compilers and platforms
+// [https://github.com/google/flatbuffers/blob/master/include/flatbuffers/flatbuffers.h#L1355]
+#if !defined(MANUALLY_ALIGNED_STRUCT)
+#if defined(_MSC_VER)
+#define MANUALLY_ALIGNED_STRUCT(alignment) \
+    __pragma(pack(1));                     \
+    struct __declspec(align(alignment))
+#define STRUCT_END(name, size) \
+    __pragma(pack());          \
+    static_assert(sizeof(name) == size, "compiler breaks packing rules")
+#elif defined(__GNUC__) || defined(__clang__)
+#define MANUALLY_ALIGNED_STRUCT(alignment) \
+    _Pragma("pack(1)") struct __attribute__((aligned(alignment)))
+#define STRUCT_END(name, size) \
+    _Pragma("pack()") static_assert(sizeof(name) == size, "compiler breaks packing rules")
+#else
+#error Unknown compiler, please define structure alignment macros
+#endif
+#endif  // !defined(MANUALLY_ALIGNED_STRUCT)
+
+// ----------------------------------------------------------------------
+// Convenience macro disabling a particular UBSan check in a function
+
+#if defined(__clang__)
+#define PAIMON_DISABLE_UBSAN(feature) __attribute__((no_sanitize(feature)))
+#else
+#define PAIMON_DISABLE_UBSAN(feature)
+#endif
+
+// ----------------------------------------------------------------------
+// Machine information
+
+#if INTPTR_MAX == INT64_MAX
+#define PAIMON_BITNESS 64
+#elif INTPTR_MAX == INT32_MAX
+#define PAIMON_BITNESS 32
+#else
+#error Unexpected INTPTR_MAX
+#endif
+
+// ----------------------------------------------------------------------
+// From googletest
+// (also in parquet-cpp)
+
+// When you need to test the private or protected members of a class,
+// use the FRIEND_TEST macro to declare your tests as friends of the
+// class.  For example:
+//
+// class MyClass {
+//  private:
+//   void MyMethod();
+//   FRIEND_TEST(MyClassTest, MyMethod);
+// };
+//
+// class MyClassTest : public testing::Test {
+//   // ...
+// };
+//
+// TEST_F(MyClassTest, MyMethod) {
+//   // Can call MyClass::MyMethod() here.
+// }
+
+#define FRIEND_TEST(test_case_name, test_name) friend class test_case_name##_##test_name##_Test

--- a/include/paimon/memory/bytes.h
+++ b/include/paimon/memory/bytes.h
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include "paimon/memory/memory_pool.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+
+/// A memory-managed byte array class that provides efficient storage and manipulation of binary
+/// data.
+///
+/// Bytes is a RAII wrapper around raw memory that integrates with Paimon's memory pool system
+/// for efficient memory allocation and deallocation. It provides safe access to byte arrays
+/// with automatic memory management and supports move semantics for efficient transfers.
+class PAIMON_EXPORT Bytes {
+ public:
+    static const std::shared_ptr<Bytes>& EmptyBytes();
+    /// Default constructor creating an empty Bytes object.
+    ///
+    /// Creates a Bytes object with no allocated memory. The object will have
+    /// null data pointer and zero size.
+    Bytes() = default;
+
+    /// Constructor that allocates memory of specified size.
+    ///
+    /// Allocates a new byte array of the given size using the provided memory pool.
+    /// The allocated memory is uninitialized.
+    ///
+    /// @param size Number of bytes to allocate.
+    /// @param pool Memory pool to use for allocation.
+    Bytes(size_t size, MemoryPool* pool);
+
+    /// Constructor that creates a copy of a string.
+    ///
+    /// Allocates memory and copies the contents of the provided string into
+    /// the new Bytes object.
+    ///
+    /// @param str String to copy data from.
+    /// @param pool Memory pool to use for allocation.
+    Bytes(const std::string& str, MemoryPool* pool);
+
+    /// Create a copy of existing Bytes with specified size.
+    ///
+    /// Creates a new Bytes object by copying data from an existing Bytes object.
+    /// The copy will have the specified size, which may be different from the
+    /// source object's size (truncation or padding may occur).
+    ///
+    /// @param bytes Source Bytes object to copy from.
+    /// @param size Size of the new Bytes object.
+    /// @param pool Memory pool to use for allocation.
+    /// @return Unique pointer to the newly created Bytes object.
+    static PAIMON_UNIQUE_PTR<Bytes> CopyOf(const Bytes& bytes, size_t size, MemoryPool* pool);
+
+    /// Allocate a new Bytes object with specified length.
+    ///
+    /// %Factory method that creates a new Bytes object with uninitialized memory
+    /// of the specified length.
+    ///
+    /// @param length Number of bytes to allocate.
+    /// @param pool Memory pool to use for allocation.
+    /// @return Unique pointer to the newly allocated Bytes object.
+    static PAIMON_UNIQUE_PTR<Bytes> AllocateBytes(int32_t length, MemoryPool* pool);
+
+    /// Allocate a new Bytes object from string data.
+    ///
+    /// %Factory method that creates a new Bytes object and copies the contents
+    /// of the provided string into it.
+    ///
+    /// @param str String to copy data from.
+    /// @param pool Memory pool to use for allocation.
+    /// @return Unique pointer to the newly allocated Bytes object.
+    static PAIMON_UNIQUE_PTR<Bytes> AllocateBytes(const std::string& str, MemoryPool* pool);
+
+    // No copying allowed.
+    Bytes(const Bytes&) = delete;
+    void operator=(const Bytes&) = delete;
+    // move constructor
+    Bytes(Bytes&&) noexcept;
+    Bytes& operator=(Bytes&&) noexcept;
+
+    ~Bytes();
+
+    bool operator==(const Bytes& other) const;
+    bool operator<(const Bytes& other) const;
+    char& operator[](size_t idx) const;
+
+    /// Compare this Bytes object with another.
+    /// @return Negative value if this < other; 0 if equal; positive value if this > other.
+    int32_t compare(const Bytes& other) const;
+
+    /// Get pointer to the raw data.
+    /// @return A pointer to the underlying byte array. The pointer remains valid
+    /// as long as the Bytes object exists and is not moved from.
+    inline char* data() const {
+        return data_;
+    }
+
+    /// Get the size of the byte array.
+    inline size_t size() const {
+        return size_;
+    }
+
+ private:
+    MemoryPool* pool_ = nullptr;
+    char* data_ = nullptr;
+    size_t size_ = 0;
+};
+
+}  // namespace paimon

--- a/include/paimon/memory/memory_pool.h
+++ b/include/paimon/memory/memory_pool.h
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <new>
+#include <utility>
+
+#include "paimon/macros.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+
+class MemoryPool;
+
+/// Create a default implementation of memory pool.
+/// @return Unique pointer to a newly created `MemoryPool` instance.
+PAIMON_EXPORT std::unique_ptr<MemoryPool> GetMemoryPool();
+
+/// Get a system-wide singleton memory pool.
+/// @return Shared pointer to the singleton `MemoryPool` instance.
+PAIMON_EXPORT std::shared_ptr<MemoryPool> GetDefaultPool();
+
+/// Abstract base class for memory pool implementations that provides controlled memory management.
+class PAIMON_EXPORT MemoryPool {
+ public:
+    virtual ~MemoryPool() = default;
+    MemoryPool& operator=(const MemoryPool& other) = delete;
+    MemoryPool& operator=(MemoryPool& other) = delete;
+    MemoryPool& operator=(MemoryPool&& other) = delete;
+
+    /// Allocate memory from the pool.
+    ///
+    /// Allocates a block of memory with the specified size and alignment.
+    /// The returned memory is uninitialized and must be properly constructed
+    /// before use.
+    ///
+    /// @param size Number of bytes to allocate.
+    /// @param alignment Memory alignment requirement (0 for default alignment).
+    /// @return Pointer to allocated memory, or nullptr on failure.
+    virtual void* Malloc(uint64_t size, uint64_t alignment = 0) = 0;
+
+    /// Reallocate memory to a new size.
+    ///
+    /// Changes the size of a previously allocated memory block. The contents
+    /// of the memory block are preserved up to the minimum of the old and new sizes.
+    ///
+    /// @param p Pointer to the memory block to reallocate.
+    /// @param old_size Current size of the memory block.
+    /// @param new_size New desired size of the memory block.
+    /// @param alignment Memory alignment requirement (0 for default alignment).
+    /// @return Pointer to the reallocated memory block.
+    virtual void* Realloc(void* p, size_t old_size, size_t new_size, uint64_t alignment = 0) = 0;
+
+    /// Deallocate memory back to the pool.
+    ///
+    /// Releases a previously allocated memory block back to the pool.
+    /// The size must match the size used during allocation.
+    /// The alignment used during allocation is not provided, subclass should store it
+    /// by themselves if needed.
+    ///
+    /// @param p Pointer to the memory block to deallocate.
+    /// @param size Size of the memory block (must match allocation size).
+    virtual void Free(void* p, uint64_t size) = 0;
+
+    /// Deallocate memory back to the pool with specified alignment.
+    ///
+    /// Releases a previously allocated memory block back to the pool.
+    /// The size and alignment must match the values used during allocation.
+    /// Subclass can override this method to optimize deallocation based on alignment.
+    ///
+    /// @param p Pointer to the memory block to deallocate.
+    /// @param size Size of the memory block (must match allocation size).
+    /// @param alignment Alignment of the memory block (must match allocation alignment).
+    virtual void Free(void* p, uint64_t size, uint64_t alignment) {
+        Free(p, size);
+    }
+
+    /// Get current memory usage.
+    ///
+    /// Returns the amount of memory currently allocated from this pool.
+    /// This includes all outstanding allocations that have not been freed.
+    ///
+    /// @return Current memory usage in bytes.
+    virtual uint64_t CurrentUsage() const = 0;
+
+    /// Get peak memory usage.
+    ///
+    /// Returns the maximum amount of memory that has been allocated from
+    /// this pool at any point in time since its creation.
+    ///
+    /// @return Peak memory usage in bytes.
+    virtual uint64_t MaxMemoryUsage() const = 0;
+
+    /// Custom deleter for use with std::unique_ptr that integrates with memory pools.
+    ///
+    /// AllocatorDelete provides automatic memory deallocation through the memory pool
+    /// when used with std::unique_ptr. It stores both the pool reference and the
+    /// allocation size to ensure proper cleanup.
+    ///
+    /// @tparam T Type of object being managed.
+    template <typename T>
+    class AllocatorDelete {
+     private:
+        std::reference_wrapper<MemoryPool> pool;
+        size_t size{0};
+
+     public:
+        AllocatorDelete() : pool(*GetMemoryPool()) {}
+        AllocatorDelete(MemoryPool& _pool, size_t _size) : pool(_pool), size(_size) {}
+        AllocatorDelete(AllocatorDelete const&) = default;
+
+        template <typename U>
+        AllocatorDelete& operator=(const AllocatorDelete<U>& other) {
+            pool = other.GetPool();
+            size = other.GetSize();
+            return *this;
+        }
+
+        AllocatorDelete& operator=(AllocatorDelete const& other) {
+            pool = other.GetPool();
+            size = other.GetSize();
+            return *this;
+        }
+
+        AllocatorDelete& operator=(AllocatorDelete&& other) {
+            pool = other.GetPool();
+            size = other.GetSize();
+            return *this;
+        }
+
+        template <typename U>
+        AllocatorDelete(const AllocatorDelete<U>& other)  // NOLINT(google-explicit-constructor)
+            : pool(other.GetPool()), size(other.GetSize()) {}
+
+        MemoryPool& GetPool() const {
+            return pool;
+        }
+
+        size_t GetSize() const {
+            return size;
+        }
+
+        void operator()(T* p) const {
+            if (p) {
+                if (PAIMON_UNLIKELY(size == 0)) {
+                    // This indicates a programming error where the deleter was not properly
+                    // initialized with the correct allocation size. In debug builds, this
+                    // will trigger an assertion. In release builds, we cannot safely
+                    // deallocate without knowing the size, which may lead to undefined behavior.
+                    assert(false &&
+                           "Mismatched pointer allocation detected - deleter size is zero");
+                    return;  // Cannot safely deallocate without size information
+                }
+                p->~T();
+                pool.get().Free(reinterpret_cast<void*>(p), size);
+            }
+        }
+    };
+
+    /// Allocate an object on the pool and return a unique_ptr with custom deleter.
+    ///
+    /// This method provides a convenient way to allocate objects that are automatically
+    /// managed by the memory pool. The returned unique_ptr will automatically deallocate
+    /// the memory through the pool when it goes out of scope.
+    ///
+    /// @tparam T Type of object to allocate.
+    /// @tparam Args Types of constructor arguments.
+    /// @param args Constructor arguments to forward to T's constructor.
+    /// @return unique_ptr managing the allocated object with pool-aware deleter.
+    template <typename T, typename... Args>
+    std::unique_ptr<T, AllocatorDelete<T>> AllocateUnique(Args&&... args) {
+        struct DeferCondDeallocate {
+            bool& cond;
+            MemoryPool& pool;
+            void* p;
+            ~DeferCondDeallocate() {
+                if (PAIMON_UNLIKELY(!cond)) {
+                    pool.Free(p, sizeof(T));
+                }
+            }
+        };
+        auto p = Malloc(sizeof(T));
+        {
+            bool constructed = false;
+            DeferCondDeallocate handler{constructed, *this, p};
+            new (p) T(std::forward<Args>(args)...);
+            constructed = true;
+        }
+        return std::unique_ptr<T, AllocatorDelete<T>>(reinterpret_cast<T*>(p),
+                                                      AllocatorDelete<T>(*this, sizeof(T)));
+    }
+};
+
+template <class T>
+using pooled_unique_ptr = std::unique_ptr<T, MemoryPool::AllocatorDelete<T>>;
+
+#define PAIMON_UNIQUE_PTR pooled_unique_ptr
+
+}  // namespace paimon

--- a/include/paimon/result.h
+++ b/include/paimon/result.h
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <type_traits>
+#include <utility>
+
+#include "paimon/status.h"
+#include "paimon/traits.h"
+
+namespace paimon {
+/// A `Result<T>` object holds either a value of type T or a `Status` object explaining
+/// why such a value is not present.
+template <typename T>
+class PAIMON_MUST_USE_TYPE PAIMON_EXPORT Result {
+ public:
+    /// Destructor that properly cleans up the stored value or status.
+    ~Result() {
+        if (ok()) {
+            data_.~T();
+        }
+        status_.~Status();
+    }
+
+    // NOLINTBEGIN(google-explicit-constructor, runtime/explicit)
+    /// Construct a successful result with a copy of the given value.
+    /// @param data The value to store in result.
+    Result(const T& data) : status_(), data_(data) {}
+
+    /// Construct a successful result by moving the given value.
+    /// @param data The value to move into result.
+    Result(T&& data) : status_(), data_(std::move(data)) {}
+
+    /// Template constructor for converting compatible pointer types.
+    /// Support T = std::unique_ptr<B> and U = std::unique_ptr<D> convert, where D is derived class
+    /// of B also supports T = std::unique_ptr<B, AllocatorDelete>
+    /// @param data The value to move into result.
+    template <typename U,
+              std::enable_if_t<
+                  is_pointer<U>::value && is_pointer<T>::value &&
+                  std::is_convertible_v<value_type_traits_t<U>, value_type_traits_t<T>>>* = nullptr>
+    Result(U&& data) : status_(), data_(std::move(data)) {}
+
+    /// Construct a failed result with the given status.
+    /// @param status The status object describing the error.
+    Result(const Status& status) : status_(status) {}
+    // NOLINTEND(google-explicit-constructor, runtime/explicit)
+
+    /// Copy constructor.
+    /// @param other The result to copy from.
+    Result(const Result& other) {
+        if (other.ok()) {
+            MakeValue(other.data_);
+        }
+        MakeStatus(other.status_);
+    }
+
+    /// Move constructor.
+    /// @param other The result to move from.
+    Result(Result&& other) noexcept {
+        if (other.ok()) {
+            MakeValue(std::move(other.data_));
+        }
+        // If we moved the status, the other status may become ok but the other
+        // value hasn't been constructed => crash on other destructor.
+        MakeStatus(other.status_);
+    }
+
+    // NOLINTBEGIN(google-explicit-constructor, runtime/explicit)
+    /// Template move constructor for converting compatible `Result` types.
+    /// @param other The result to move from.
+    template <typename U,
+              std::enable_if_t<
+                  is_pointer<U>::value && is_pointer<T>::value &&
+                  std::is_convertible_v<value_type_traits_t<U>, value_type_traits_t<T>>>* = nullptr>
+    Result(Result<U>&& other) noexcept {
+        if (other.ok()) {
+            MakeValue(std::move(other).value());
+        }
+        // If we moved the status, the other status may become ok but the other
+        // value hasn't been constructed => crash on other destructor.
+        MakeStatus(other.status());
+    }
+    // NOLINTEND(google-explicit-constructor, runtime/explicit)
+
+    /// Copy assignment operator.
+    /// @param other The result to copy from.
+    /// @return Reference to this result.
+    Result& operator=(const Result& other) {
+        if (this == &other) {
+            return *this;
+        }
+        if (other.ok()) {
+            if (ok()) {
+                data_ = other.data_;
+            } else {
+                MakeValue(other.value());
+            }
+        } else {
+            if (ok()) {
+                data_.~T();
+            }
+        }
+        status_ = other.status_;
+        return *this;
+    }
+
+    /// Move assignment operator.
+    /// @param other The result to move from.
+    /// @return Reference to this result.
+    Result& operator=(Result&& other) {
+        if (this == &other) {
+            return *this;
+        }
+        if (other.ok()) {
+            if (ok()) {
+                data_ = std::move(other.data_);
+            } else {
+                MakeValue(std::move(other).value());
+            }
+        } else {
+            if (ok()) {
+                data_.~T();
+            }
+        }
+        status_ = other.status_;
+        return *this;
+    }
+
+    /// Template move assignment operator for converting compatible `Result` types.
+    /// @param other The result to move from.
+    /// @return Reference to this result.
+    template <typename U,
+              std::enable_if_t<
+                  is_pointer<U>::value && is_pointer<T>::value &&
+                  std::is_convertible_v<value_type_traits_t<U>, value_type_traits_t<T>>>* = nullptr>
+    Result& operator=(Result<U>&& other) {
+        if (other.ok()) {
+            if (ok()) {
+                data_ = std::move(other.data_);
+            } else {
+                MakeValue(std::move(other).value());
+            }
+        } else {
+            if (ok()) {
+                data_.~T();
+            }
+        }
+        status_ = other.status();
+        return *this;
+    }
+
+    /// Check if this result contains a valid value (i.e., the operation succeeded).
+    /// @return `true` if the result contains a valid value, `false` if it contains an error status.
+    inline bool ok() const {
+        return status_.ok();
+    }
+
+    /// Return the value stored in result.
+    /// @return Const reference to the stored value.
+    /// @note Calling this method when `ok()` is false results in undefined behavior.
+    inline const T& value() const& {
+        return data_;
+    }
+
+    /// Return the value stored in result.
+    /// @return Rvalue reference to the stored value.
+    /// @note Calling this method when `ok()` is false results in undefined behavior.
+    inline T&& value() && {
+        return std::move(data_);
+    }
+
+    /// Get the status of the result.
+    /// @return Const reference to the status object.
+    /// @note `status()` is always active, regardless of whether `ok()` is `true` or `false`.
+    inline const Status& status() const {
+        return status_;
+    }
+
+    /// Return the stored value if `ok()`, otherwise return the default value.
+    /// @param default_value The value to return if this result contains an error.
+    /// @return The stored value if `ok()`, otherwise the default_value.
+    inline T value_or(T&& default_value) const& {
+        if (ok()) {
+            return data_;
+        } else {
+            return std::forward<T>(default_value);
+        }
+    }
+
+    /// Return the stored value if `ok()`, otherwise return the default value (rvalue version).
+    /// @param default_value The value to return if this result contains an error.
+    /// @return The stored value if `ok()`, otherwise the default_value.
+    inline T value_or(T&& default_value) && {
+        if (ok()) {
+            return std::move(data_);
+        } else {
+            return std::forward<T>(default_value);
+        }
+    }
+
+ private:
+    /// Construct the value(data_) through placement new with the passed arguments.
+    /// @param args Arguments to forward to T's constructor.
+    template <typename... Arg>
+    void MakeValue(Arg&&... args) {
+        new (&dummy_) T(std::forward<Arg>(args)...);
+    }
+
+    /// Construct the status (status_) through placement new with the passed arguments.
+    /// @param args Arguments to forward to status constructor.
+    template <typename... Arg>
+    void MakeStatus(Arg&&... args) {
+        new (&status_) Status(std::forward<Arg>(args)...);
+    }
+
+ private:
+    // status_ will always be active after the constructor.
+    // We make it a union to be able to initialize exactly how we need without
+    // waste.
+    // Eg. in the copy constructor we use the default constructor of `Status` in
+    // the ok() path to avoid an extra Ref call.
+    union {
+        Status status_;
+    };
+
+    union {
+        // When T is const, we need some non-const object we can cast to void* for
+        // the placement new. dummy_ is that object.
+        std::aligned_storage_t<sizeof(T), alignof(T)> dummy_;
+        T data_;
+    };
+};
+
+namespace internal {
+
+/// Extract `Status` from `Result` (const lvalue reference version).
+/// @param res The result to extract the status from.
+/// @return Const reference to the status.
+template <typename T>
+inline const Status& GenericToStatus(const Result<T>& res) {
+    return res.status();
+}
+
+/// Extract `Status` from `Result` (rvalue reference version).
+/// @param res The result to extract the status from.
+/// @return status object (moved)
+template <typename T>
+inline Status GenericToStatus(Result<T>&& res) {
+    return std::move(res).status();
+}
+
+}  // namespace internal
+
+#define PAIMON_ASSIGN_OR_RAISE_IMPL(result_name, lhs, rexpr)                                 \
+    auto&& result_name = (rexpr);                                                            \
+    PAIMON_RETURN_IF_(!(result_name).ok(), (result_name).status(), PAIMON_STRINGIFY(rexpr)); \
+    lhs = std::move(result_name).value();
+
+#define PAIMON_ASSIGN_OR_RAISE_NAME(x, y) PAIMON_CONCAT(x, y)
+
+#define PAIMON_ASSIGN_OR_RAISE(lhs, rexpr)                                                      \
+    PAIMON_ASSIGN_OR_RAISE_IMPL(PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, \
+                                (rexpr));
+}  // namespace paimon

--- a/include/paimon/status.h
+++ b/include/paimon/status.h
@@ -1,0 +1,475 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+// Adapted from Apache Arrow
+// https://github.com/apache/arrow/blob/main/cpp/src/arrow/status.h
+
+// A Status encapsulates the result of an operation.  It may indicate success,
+// or it may indicate an error with an associated error message.
+//
+// Multiple threads can invoke const methods on a Status without
+// external synchronization, but if any of the threads may call a
+// non-const method, all threads accessing the same Status must use
+// external synchronization.
+
+#pragma once
+
+#include <cstring>
+#include <iosfwd>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "paimon/compare.h"
+#include "paimon/macros.h"
+#include "paimon/string_builder.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+
+enum class StatusCode : char {
+    OK = 0,
+    OutOfMemory = 1,
+    KeyError = 2,
+    TypeError = 3,
+    Invalid = 4,
+    IOError = 5,
+    CapacityError = 6,
+    IndexError = 7,
+    Cancelled = 8,
+    UnknownError = 9,
+    NotImplemented = 10,
+    SerializationError = 11,
+    NotExist = 12,
+    Exist = 13,
+};
+
+/// \brief An opaque class that allows subsystems to retain
+/// additional information inside the Status.
+class PAIMON_EXPORT StatusDetail {
+ public:
+    virtual ~StatusDetail() = default;
+    /// \brief Return a unique id for the type of the StatusDetail
+    /// (effectively a poor man's substitute for RTTI).
+    virtual const char* type_id() const = 0;
+    /// \brief Produce a human-readable description of this status.
+    virtual std::string ToString() const = 0;
+
+    bool operator==(const StatusDetail& other) const noexcept {
+        return std::string(type_id()) == other.type_id() && ToString() == other.ToString();
+    }
+};
+
+/// \brief Status outcome object (success or error)
+///
+/// The Status object is an object holding the outcome of an operation.
+/// The outcome is represented as a StatusCode, either success
+/// (StatusCode::OK) or an error (any other of the StatusCode enumeration values).
+///
+/// Additionally, if an error occurred, a specific error message is generally
+/// attached.
+class PAIMON_MUST_USE_TYPE PAIMON_EXPORT Status : public util::EqualityComparable<Status>,
+                                                  public util::ToStringOstreamable<Status> {
+ public:
+    // Create a success status.
+    Status() noexcept = default;
+    ~Status() noexcept {
+        // PAIMON-2400: On certain compilers, splitting off the slow path improves
+        // performance significantly.
+        if (PAIMON_PREDICT_FALSE(state_ != nullptr)) {
+            DeleteState();
+        }
+    }
+
+    Status(StatusCode code, const std::string& msg);
+    /// \brief Pluggable constructor for use by sub-systems.  detail cannot be null.
+    Status(StatusCode code, std::string msg, std::shared_ptr<StatusDetail> detail);
+
+    // Copy the specified status.
+    inline Status(const Status& s);
+    inline Status& operator=(const Status& s);
+
+    // Move the specified status.
+    inline Status(Status&& s) noexcept;
+    inline Status& operator=(Status&& s) noexcept;
+
+    inline bool Equals(const Status& s) const;
+
+    // AND the statuses.
+    inline Status operator&(const Status& s) const noexcept;
+    inline Status operator&(Status&& s) const noexcept;
+    inline Status& operator&=(const Status& s) noexcept;
+    inline Status& operator&=(Status&& s) noexcept;
+
+    /// Return a success status
+    static Status OK() {
+        return {};
+    }
+
+    template <typename... Args>
+    static Status FromArgs(StatusCode code, Args&&... args) {
+        return Status(code, util::StringBuilder(std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    static Status FromDetailAndArgs(StatusCode code, std::shared_ptr<StatusDetail> detail,
+                                    Args&&... args) {
+        return Status(code, util::StringBuilder(std::forward<Args>(args)...), std::move(detail));
+    }
+
+    /// Return an error status for out-of-memory conditions
+    template <typename... Args>
+    static Status OutOfMemory(Args&&... args) {
+        return Status::FromArgs(StatusCode::OutOfMemory, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status for failed key lookups (e.g. column name in a table)
+    template <typename... Args>
+    static Status KeyError(Args&&... args) {
+        return Status::FromArgs(StatusCode::KeyError, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status for type errors (such as mismatching data types)
+    template <typename... Args>
+    static Status TypeError(Args&&... args) {
+        return Status::FromArgs(StatusCode::TypeError, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status for unknown errors
+    template <typename... Args>
+    static Status UnknownError(Args&&... args) {
+        return Status::FromArgs(StatusCode::UnknownError, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status when an operation or a combination of operation and
+    /// data types is unimplemented
+    template <typename... Args>
+    static Status NotImplemented(Args&&... args) {
+        return Status::FromArgs(StatusCode::NotImplemented, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status for invalid data (for example a string that fails parsing)
+    template <typename... Args>
+    static Status Invalid(Args&&... args) {
+        return Status::FromArgs(StatusCode::Invalid, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status when an index is out of bounds
+    template <typename... Args>
+    static Status IndexError(Args&&... args) {
+        return Status::FromArgs(StatusCode::IndexError, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status for cancelled operation
+    template <typename... Args>
+    static Status Cancelled(Args&&... args) {
+        return Status::FromArgs(StatusCode::Cancelled, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status when a container's capacity would exceed its limits
+    template <typename... Args>
+    static Status CapacityError(Args&&... args) {
+        return Status::FromArgs(StatusCode::CapacityError, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status when some IO-related operation failed
+    template <typename... Args>
+    static Status IOError(Args&&... args) {
+        return Status::FromArgs(StatusCode::IOError, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status when some (de)serialization operation failed
+    template <typename... Args>
+    static Status SerializationError(Args&&... args) {
+        return Status::FromArgs(StatusCode::SerializationError, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status when something is not existed.
+    template <typename... Args>
+    static Status NotExist(Args&&... args) {
+        return Status::FromArgs(StatusCode::NotExist, std::forward<Args>(args)...);
+    }
+
+    /// Return an error status when something is already existed.
+    template <typename... Args>
+    static Status Exist(Args&&... args) {
+        return Status::FromArgs(StatusCode::Exist, std::forward<Args>(args)...);
+    }
+
+    /// Return true iff the status indicates success.
+    bool ok() const {
+        return (state_ == nullptr);
+    }
+
+    /// Return true iff the status indicates an out-of-memory error.
+    bool IsOutOfMemory() const {
+        return code() == StatusCode::OutOfMemory;
+    }
+    /// Return true iff the status indicates a key lookup error.
+    bool IsKeyError() const {
+        return code() == StatusCode::KeyError;
+    }
+    /// Return true iff the status indicates invalid data.
+    bool IsInvalid() const {
+        return code() == StatusCode::Invalid;
+    }
+    /// Return true iff the status indicates a cancelled operation.
+    bool IsCancelled() const {
+        return code() == StatusCode::Cancelled;
+    }
+    /// Return true iff the status indicates an IO-related failure.
+    bool IsIOError() const {
+        return code() == StatusCode::IOError;
+    }
+    /// Return true iff the status indicates a container reaching capacity limits.
+    bool IsCapacityError() const {
+        return code() == StatusCode::CapacityError;
+    }
+    /// Return true iff the status indicates an out of bounds index.
+    bool IsIndexError() const {
+        return code() == StatusCode::IndexError;
+    }
+    /// Return true iff the status indicates a type error.
+    bool IsTypeError() const {
+        return code() == StatusCode::TypeError;
+    }
+    /// Return true iff the status indicates an unknown error.
+    bool IsUnknownError() const {
+        return code() == StatusCode::UnknownError;
+    }
+    /// Return true iff the status indicates an unimplemented operation.
+    bool IsNotImplemented() const {
+        return code() == StatusCode::NotImplemented;
+    }
+    /// Return true iff the status indicates a (de)serialization failure
+    bool IsSerializationError() const {
+        return code() == StatusCode::SerializationError;
+    }
+    /// Return true iff the status indicates a not exist error.
+    bool IsNotExist() const {
+        return code() == StatusCode::NotExist;
+    }
+    /// Return true iff the status indicates an exist error.
+    bool IsExist() const {
+        return code() == StatusCode::Exist;
+    }
+
+    /// \brief Return a string representation of this status suitable for printing.
+    ///
+    /// The string "OK" is returned for success.
+    std::string ToString() const;
+
+    /// \brief Return a string representation of the status code, without the message
+    /// text or POSIX code information.
+    std::string CodeAsString() const;
+    static std::string CodeAsString(StatusCode);
+
+    /// \brief Return the StatusCode value attached to this status.
+    StatusCode code() const {
+        return ok() ? StatusCode::OK : state_->code;
+    }
+
+    /// \brief Return the specific error message attached to this status.
+    std::string message() const {
+        return ok() ? "" : state_->msg;
+    }
+
+    /// \brief Return the status detail attached to this message.
+    const std::shared_ptr<StatusDetail>& detail() const {
+        static std::shared_ptr<StatusDetail> no_detail = nullptr;
+        return state_ ? state_->detail : no_detail;
+    }
+
+    /// \brief Return a new Status copying the existing status, but
+    /// updating with the existing detail.
+    Status WithDetail(std::shared_ptr<StatusDetail> new_detail) const {
+        return {code(), message(), std::move(new_detail)};
+    }
+
+    /// \brief Return a new Status with changed message, copying the
+    /// existing status code and detail.
+    template <typename... Args>
+    Status WithMessage(Args&&... args) const {
+        return FromArgs(code(), std::forward<Args>(args)...).WithDetail(detail());
+    }
+
+    [[noreturn]] void Abort() const;
+    [[noreturn]] void Abort(const std::string& message) const;
+
+#ifdef PAIMON_EXTRA_ERROR_CONTEXT
+    void AddContextLine(const char* filename, int line, const char* function_name,
+                        const char* expr);
+#endif
+
+ private:
+    struct State {
+        StatusCode code;
+        std::string msg;
+        std::shared_ptr<StatusDetail> detail;
+    };
+    // OK status has a `NULL` state_.  Otherwise, `state_` points to
+    // a `State` structure containing the error code and message(s)
+    State* state_{nullptr};
+
+    void DeleteState() {
+        delete state_;
+        state_ = nullptr;
+    }
+    void CopyFrom(const Status& s);
+    inline void MoveFrom(Status& s);
+};
+
+void Status::MoveFrom(Status& s) {
+    delete state_;
+    state_ = s.state_;
+    s.state_ = nullptr;
+}
+
+Status::Status(const Status& s) : state_((s.state_ == nullptr) ? nullptr : new State(*s.state_)) {}
+
+Status& Status::operator=(const Status& s) {
+    // The following condition catches both aliasing (when this == &s),
+    // and the common case where both s and *this are ok.
+    if (state_ != s.state_) {
+        CopyFrom(s);
+    }
+    return *this;
+}
+
+Status::Status(Status&& s) noexcept : state_(s.state_) {
+    s.state_ = nullptr;
+}
+
+Status& Status::operator=(Status&& s) noexcept {
+    MoveFrom(s);
+    return *this;
+}
+
+bool Status::Equals(const Status& s) const {
+    if (state_ == s.state_) {
+        return true;
+    }
+
+    if (ok() || s.ok()) {
+        return false;
+    }
+
+    if (detail() != s.detail()) {
+        if ((detail() && !s.detail()) || (!detail() && s.detail())) {
+            return false;
+        }
+        return *detail() == *s.detail();
+    }
+
+    return code() == s.code() && message() == s.message();
+}
+
+/// \cond FALSE
+// (note: emits warnings on Doxygen < 1.8.15,
+//  see https://github.com/doxygen/doxygen/issues/6295)
+Status Status::operator&(const Status& s) const noexcept {
+    if (ok()) {
+        return s;
+    } else {
+        return *this;
+    }
+}
+
+Status Status::operator&(Status&& s) const noexcept {
+    if (ok()) {
+        return std::move(s);
+    } else {
+        return *this;
+    }
+}
+
+Status& Status::operator&=(const Status& s) noexcept {
+    if (ok() && !s.ok()) {
+        CopyFrom(s);
+    }
+    return *this;
+}
+
+Status& Status::operator&=(Status&& s) noexcept {
+    if (ok() && !s.ok()) {
+        MoveFrom(s);
+    }
+    return *this;
+}
+/// \endcond
+
+namespace internal {
+
+// Extract Status from Status or Result<T>
+// Useful for the status check macros such as RETURN_NOT_OK.
+inline Status GenericToStatus(const Status& st) {
+    return st;
+}
+inline Status GenericToStatus(Status&& st) {
+    return std::move(st);
+}
+
+}  // namespace internal
+
+#ifdef PAIMON_EXTRA_ERROR_CONTEXT
+
+/// \brief Return with given status if condition is met.
+#define PAIMON_RETURN_IF_(condition, status, expr)                      \
+    do {                                                                \
+        if (PAIMON_PREDICT_FALSE(condition)) {                          \
+            ::paimon::Status _st = (status);                            \
+            _st.AddContextLine(__FILE__, __LINE__, __FUNCTION__, expr); \
+            return _st;                                                 \
+        }                                                               \
+    } while (0)
+#else
+
+#define PAIMON_RETURN_IF_(condition, status, _) \
+    do {                                        \
+        if (PAIMON_PREDICT_FALSE(condition)) {  \
+            return (status);                    \
+        }                                       \
+    } while (0)
+
+#endif  // PAIMON_EXTRA_ERROR_CONTEXT
+
+#define PAIMON_RETURN_IF(condition, status) \
+    PAIMON_RETURN_IF_(condition, status, PAIMON_STRINGIFY(status))
+
+/// \brief Propagate any non-successful Status to the caller
+#define PAIMON_RETURN_NOT_OK(status)                                        \
+    do {                                                                    \
+        ::paimon::Status __s = ::paimon::internal::GenericToStatus(status); \
+        PAIMON_RETURN_IF_(!__s.ok(), __s, PAIMON_STRINGIFY(status));        \
+    } while (false)
+
+#define PAIMON_RETURN_NOT_OK_ELSE(s, else_)                           \
+    do {                                                              \
+        ::paimon::Status _s = ::paimon::internal::GenericToStatus(s); \
+        if (!_s.ok()) {                                               \
+            else_;                                                    \
+            return _s;                                                \
+        }                                                             \
+    } while (false)
+
+}  // namespace paimon

--- a/include/paimon/string_builder.h
+++ b/include/paimon/string_builder.h
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License. template <typename T>
+
+// Adapted from Apache Arrow
+// https://github.com/apache/arrow/blob/apache-arrow-17.0.0/cpp/src/arrow/util/string_builder.h
+
+#pragma once
+
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "paimon/visibility.h"
+
+namespace paimon::util {
+
+namespace detail {
+
+class PAIMON_EXPORT StringStreamWrapper {
+ public:
+    StringStreamWrapper() : sstream_(std::make_unique<std::ostringstream>()), ostream_(*sstream_) {}
+    ~StringStreamWrapper() = default;
+
+    std::ostream& stream() {
+        return ostream_;
+    }
+    std::string str() {
+        return sstream_->str();
+    }
+
+ protected:
+    std::unique_ptr<std::ostringstream> sstream_;
+    std::ostream& ostream_;
+};
+
+}  // namespace detail
+
+template <typename Head>
+void StringBuilderRecursive(std::ostream& stream, Head&& head) {
+    stream << head;
+}
+
+template <typename Head, typename... Tail>
+void StringBuilderRecursive(std::ostream& stream, Head&& head, Tail&&... tail) {
+    StringBuilderRecursive(stream, std::forward<Head>(head));
+    StringBuilderRecursive(stream, std::forward<Tail>(tail)...);
+}
+
+template <typename... Args>
+std::string StringBuilder(Args&&... args) {
+    detail::StringStreamWrapper ss;
+    StringBuilderRecursive(ss.stream(), std::forward<Args>(args)...);
+    return ss.str();
+}
+
+/// CRTP helper for declaring string representation. Defines operator<<
+template <typename T>
+class PAIMON_EXPORT ToStringOstreamable {
+ public:
+    ~ToStringOstreamable() {
+        static_assert(std::is_same_v<decltype(std::declval<const T>().ToString()), std::string>,
+                      "ToStringOstreamable depends on the method T::ToString() const");
+    }
+
+ private:
+    const T& cast() const {
+        return static_cast<const T&>(*this);
+    }
+
+    friend inline std::ostream& operator<<(std::ostream& os, const ToStringOstreamable& t) {
+        return os << t.cast().ToString();
+    }
+};
+
+}  // namespace paimon::util

--- a/include/paimon/traits.h
+++ b/include/paimon/traits.h
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <type_traits>
+#include <vector>
+
+namespace paimon {
+template <typename T>
+struct is_vector : std::false_type {};
+
+template <typename T>
+struct is_vector<std::vector<T>> : std::true_type {};
+
+template <typename T>
+struct is_map : std::false_type {};
+
+template <typename K, typename V>
+struct is_map<std::map<K, V>> : std::true_type {};
+
+template <typename T>
+struct is_optional : std::false_type {};
+
+template <typename T>
+struct is_optional<std::optional<T>> : std::true_type {};
+
+template <typename T>
+struct is_raw_pointer : std::is_pointer<T> {};
+
+template <typename T>
+struct is_shared_ptr : std::false_type {};
+
+template <typename T>
+struct is_shared_ptr<std::shared_ptr<T>> : std::true_type {};
+
+template <typename T>
+struct is_unique_ptr : std::false_type {};
+
+template <typename T>
+struct is_unique_ptr<std::unique_ptr<T>> : std::true_type {};
+
+template <typename T, typename Deleter>
+struct is_unique_ptr<std::unique_ptr<T, Deleter>> : std::true_type {};
+
+template <typename T>
+struct is_weak_ptr : std::false_type {};
+
+template <typename T>
+struct is_weak_ptr<std::weak_ptr<T>> : std::true_type {};
+
+// Combined checker for raw pointer or smart pointers
+template <bool... B>
+struct disjunction_impl;
+
+template <bool... B>
+struct disjunction_impl<true, B...> : std::true_type {};
+
+template <bool... B>
+struct disjunction_impl<false, B...> : disjunction_impl<B...> {};
+
+template <>
+struct disjunction_impl<> : std::false_type {};
+
+template <typename... Traits>
+using disjunction = disjunction_impl<Traits::value...>;
+
+template <typename T>
+struct is_pointer
+    : disjunction<is_raw_pointer<T>, is_shared_ptr<T>, is_unique_ptr<T>, is_weak_ptr<T>> {};
+
+template <typename T>
+struct value_type_traits {
+    using type = T;
+};
+template <typename T, typename Deleter>
+struct value_type_traits<std::unique_ptr<T, Deleter>> {
+    using type = T*;
+};
+template <typename T>
+using value_type_traits_t = typename value_type_traits<T>::type;
+
+static_assert(is_vector<std::vector<int32_t>>::value);
+static_assert(is_map<std::map<int64_t, int32_t>>::value);
+static_assert(is_optional<std::optional<int32_t>>::value);
+static_assert(!is_optional<std::vector<int32_t>>::value);
+static_assert(is_pointer<std::shared_ptr<int32_t>>::value);
+static_assert(is_pointer<std::unique_ptr<int32_t>>::value);
+static_assert(is_pointer<std::weak_ptr<int32_t>>::value);
+static_assert(is_pointer<int32_t*>::value);
+static_assert(!is_pointer<int32_t>::value);
+}  // namespace paimon

--- a/include/paimon/type_fwd.h
+++ b/include/paimon/type_fwd.h
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <limits>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/defs.h"
+#include "paimon/macros.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+
+// TODO(yonghao.fyh): type fwd is not complete, refine this in the future
+
+template <typename T>
+class Result;
+
+class Status;
+
+class MemoryPool;
+
+class FileFormat;
+
+class ColumnStats;
+class IntegerColumnStats;
+class StringColumnStats;
+class DoubleColumnStats;
+
+using ColumnStatsVector = std::vector<std::shared_ptr<ColumnStats>>;
+
+class FileSystem;
+class OutputStream;
+class InputStream;
+class FileStatus;
+class BasicFileStatus;
+
+class RecordBatch;
+
+class FormatWriter;
+
+class FileBatchReader;
+
+class BatchReader;
+
+class ScanContext;
+class ReadContext;
+
+class FileStoreWrite;
+class FileStoreCommit;
+
+class WriteContext;
+class CommitContext;
+
+class CommitMessage;
+
+class Metrics;
+
+class Executor;
+class OrphanFilesCleaner;
+
+}  // namespace paimon

--- a/include/paimon/visibility.h
+++ b/include/paimon/visibility.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#if defined(_MSC_VER)
+#pragma warning(disable : 4251)
+#else
+#pragma GCC diagnostic ignored "-Wattributes"
+#endif
+
+#ifdef PAIMON_STATIC
+#define PAIMON_EXPORT
+#elif defined(PAIMON_EXPORTING)
+#define PAIMON_EXPORT __declspec(dllexport)
+#else
+#define PAIMON_EXPORT __declspec(dllimport)
+#endif
+
+#define PAIMON_NO_EXPORT
+#define PAIMON_FORCE_INLINE __forceinline
+#else  // Not Windows
+#ifndef PAIMON_EXPORT
+#define PAIMON_EXPORT __attribute__((visibility("default")))
+#endif
+#ifndef PAIMON_NO_EXPORT
+#define PAIMON_NO_EXPORT __attribute__((visibility("hidden")))
+#define PAIMON_FORCE_INLINE
+#endif
+#endif  // Non-Windows

--- a/src/paimon/common/defs.cpp
+++ b/src/paimon/common/defs.cpp
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/defs.h"
+
+namespace paimon {
+
+const char Options::FIELDS_SEPARATOR[] = ",";
+const char Options::FIELDS_PREFIX[] = "fields";
+const char Options::AGG_FUNCTION[] = "aggregate-function";
+const char Options::DEFAULT_AGG_FUNCTION[] = "default-aggregate-function";
+const char Options::IGNORE_RETRACT[] = "ignore-retract";
+const char Options::DISTINCT[] = "distinct";
+const char Options::LIST_AGG_DELIMITER[] = "list-agg-delimiter";
+const char Options::SEQUENCE_GROUP[] = "sequence-group";
+
+const char Options::BUCKET[] = "bucket";
+const char Options::BUCKET_KEY[] = "bucket-key";
+const char Options::FILE_FORMAT[] = "file.format";
+const char Options::FILE_SYSTEM[] = "file-system";
+const char Options::TARGET_FILE_SIZE[] = "target-file-size";
+const char Options::BLOB_TARGET_FILE_SIZE[] = "blob.target-file-size";
+const char Options::PAGE_SIZE[] = "page-size";
+const char Options::PARTITION_DEFAULT_NAME[] = "partition.default-name";
+const char Options::FILE_COMPRESSION[] = "file.compression";
+const char Options::FILE_COMPRESSION_ZSTD_LEVEL[] = "file.compression.zstd-level";
+const char Options::MANIFEST_TARGET_FILE_SIZE[] = "manifest.target-file-size";
+const char Options::MANIFEST_FORMAT[] = "manifest.format";
+const char Options::MANIFEST_COMPRESSION[] = "manifest.compression";
+const char Options::MANIFEST_MERGE_MIN_COUNT[] = "manifest.merge-min-count";
+const char Options::MANIFEST_FULL_COMPACTION_FILE_SIZE[] =
+    "manifest.full-compaction-threshold-size";
+const char Options::SOURCE_SPLIT_TARGET_SIZE[] = "source.split.target-size";
+const char Options::SOURCE_SPLIT_OPEN_FILE_COST[] = "source.split.open-file-cost";
+const char Options::SCAN_SNAPSHOT_ID[] = "scan.snapshot-id";
+const char Options::SCAN_MODE[] = "scan.mode";
+const char Options::READ_BATCH_SIZE[] = "read.batch-size";
+const char Options::WRITE_BATCH_SIZE[] = "write.batch-size";
+const char Options::WRITE_BUFFER_SIZE[] = "write-buffer-size";
+const char Options::WRITE_BUFFER_SPILLABLE[] = "write-buffer-spillable";
+const char Options::WRITE_BUFFER_SPILL_MAX_DISK_SIZE[] = "write-buffer-spill.max-disk-size";
+const char Options::LOCAL_SORT_MAX_NUM_FILE_HANDLES[] = "local-sort.max-num-file-handles";
+const char Options::SPILL_COMPRESSION[] = "spill-compression";
+const char Options::SPILL_COMPRESSION_ZSTD_LEVEL[] = "spill-compression.zstd-level";
+const char Options::SNAPSHOT_NUM_RETAINED_MIN[] = "snapshot.num-retained.min";
+const char Options::SNAPSHOT_NUM_RETAINED_MAX[] = "snapshot.num-retained.max";
+const char Options::SNAPSHOT_TIME_RETAINED[] = "snapshot.time-retained";
+const char Options::SNAPSHOT_EXPIRE_LIMIT[] = "snapshot.expire.limit";
+const char Options::SNAPSHOT_CLEAN_EMPTY_DIRECTORIES[] = "snapshot.clean-empty-directories";
+const char Options::COMMIT_FORCE_COMPACT[] = "commit.force-compact";
+const char Options::COMMIT_TIMEOUT[] = "commit.timeout";
+const char Options::COMMIT_MAX_RETRIES[] = "commit.max-retries";
+const char Options::SEQUENCE_FIELD[] = "sequence.field";
+const char Options::SEQUENCE_FIELD_SORT_ORDER[] = "sequence.field.sort-order";
+const char Options::MERGE_ENGINE[] = "merge-engine";
+const char Options::SORT_ENGINE[] = "sort-engine";
+const char Options::IGNORE_DELETE[] = "ignore-delete";
+const char Options::FIELDS_DEFAULT_AGG_FUNC[] = "fields.default-aggregate-function";
+const char Options::DELETION_VECTORS_ENABLED[] = "deletion-vectors.enabled";
+const char Options::DELETION_VECTOR_INDEX_FILE_TARGET_SIZE[] =
+    "deletion-vector.index-file.target-size";
+const char Options::DELETION_VECTOR_BITMAP64[] = "deletion-vectors.bitmap64";
+const char Options::CHANGELOG_PRODUCER[] = "changelog-producer";
+const char Options::FORCE_LOOKUP[] = "force-lookup";
+const char Options::PARTIAL_UPDATE_REMOVE_RECORD_ON_DELETE[] =
+    "partial-update.remove-record-on-delete";
+const char Options::PARTIAL_UPDATE_REMOVE_RECORD_ON_SEQUENCE_GROUP[] =
+    "partial-update.remove-record-on-sequence-group";
+const char Options::SCAN_FALLBACK_BRANCH[] = "scan.fallback-branch";
+const char Options::BRANCH[] = "branch";
+const char Options::FILE_INDEX_READ_ENABLED[] = "file-index.read.enabled";
+const char Options::DATA_FILE_EXTERNAL_PATHS[] = "data-file.external-paths";
+const char Options::DATA_FILE_EXTERNAL_PATHS_STRATEGY[] = "data-file.external-paths.strategy";
+const char Options::DATA_FILE_PREFIX[] = "data-file.prefix";
+const char Options::INDEX_FILE_IN_DATA_FILE_DIR[] = "index-file-in-data-file-dir";
+const char Options::ROW_TRACKING_ENABLED[] = "row-tracking.enabled";
+const char Options::ROW_TRACKING_PARTITION_GROUP_ON_COMMIT[] =
+    "row-tracking.partition-group-on-commit";
+const char Options::DATA_EVOLUTION_ENABLED[] = "data-evolution.enabled";
+const char Options::PARTITION_GENERATE_LEGACY_NAME[] = "partition.legacy-name";
+const char Options::BLOB_AS_DESCRIPTOR[] = "blob-as-descriptor";
+const char Options::BLOB_FIELD[] = "blob-field";
+const char Options::BLOB_DESCRIPTOR_FIELD[] = "blob-descriptor-field";
+const char Options::FALLBACK_BLOB_DESCRIPTOR_FIELD[] = "blob.stored-descriptor-fields";
+const char Options::BLOB_VIEW_FIELD[] = "blob-view-field";
+const char Options::BLOB_EXTERNAL_STORAGE_FIELD[] = "blob-external-storage-field";
+const char Options::BLOB_EXTERNAL_STORAGE_PATH[] = "blob-external-storage-path";
+const char Options::GLOBAL_INDEX_ENABLED[] = "global-index.enabled";
+const char Options::GLOBAL_INDEX_THREAD_NUM[] = "global-index.thread-num";
+const char Options::GLOBAL_INDEX_EXTERNAL_PATH[] = "global-index.external-path";
+const char Options::AGGREGATION_REMOVE_RECORD_ON_DELETE[] = "aggregation.remove-record-on-delete";
+const char Options::TABLE_READ_SEQUENCE_NUMBER_ENABLED[] = "table-read.sequence-number.enabled";
+const char Options::KEY_VALUE_SEQUENCE_NUMBER_ENABLED[] = "key-value.sequence_number.enabled";
+const char Options::SCAN_TIMESTAMP_MILLIS[] = "scan.timestamp-millis";
+const char Options::SCAN_TIMESTAMP[] = "scan.timestamp";
+const char Options::SCAN_TAG_NAME[] = "scan.tag-name";
+const char Options::WRITE_ONLY[] = "write-only";
+const char Options::COMPACTION_MIN_FILE_NUM[] = "compaction.min.file-num";
+const char Options::COMPACTION_FORCE_REWRITE_ALL_FILES[] = "compaction.force-rewrite-all-files";
+const char Options::COMPACTION_OPTIMIZATION_INTERVAL[] = "compaction.optimization-interval";
+const char Options::COMPACTION_TOTAL_SIZE_THRESHOLD[] = "compaction.total-size-threshold";
+const char Options::COMPACTION_INCREMENTAL_SIZE_THRESHOLD[] =
+    "compaction.incremental-size-threshold";
+const char Options::COMPACT_OFFPEAK_START_HOUR[] = "compaction.offpeak.start.hour";
+const char Options::COMPACT_OFFPEAK_END_HOUR[] = "compaction.offpeak.end.hour";
+const char Options::COMPACTION_OFFPEAK_RATIO[] = "compaction.offpeak-ratio";
+const char Options::LOOKUP_CACHE_BLOOM_FILTER_ENABLED[] = "lookup.cache.bloom.filter.enabled";
+const char Options::LOOKUP_CACHE_BLOOM_FILTER_FPP[] = "lookup.cache.bloom.filter.fpp";
+const char Options::LOOKUP_REMOTE_FILE_ENABLED[] = "lookup.remote-file.enabled";
+const char Options::LOOKUP_REMOTE_LEVEL_THRESHOLD[] = "lookup.remote-file.level-threshold";
+const char Options::LOOKUP_CACHE_SPILL_COMPRESSION[] = "lookup.cache-spill-compression";
+const char Options::CACHE_PAGE_SIZE[] = "cache-page-size";
+const char Options::FILE_FORMAT_PER_LEVEL[] = "file.format.per.level";
+const char Options::FILE_COMPRESSION_PER_LEVEL[] = "file.compression.per.level";
+const char Options::COMPACTION_MAX_SIZE_AMPLIFICATION_PERCENT[] =
+    "compaction.max-size-amplification-percent";
+const char Options::COMPACTION_SIZE_RATIO[] = "compaction.size-ratio";
+const char Options::NUM_SORTED_RUNS_COMPACTION_TRIGGER[] = "num-sorted-run.compaction-trigger";
+const char Options::NUM_SORTED_RUNS_STOP_TRIGGER[] = "num-sorted-run.stop-trigger";
+const char Options::NUM_LEVELS[] = "num-levels";
+const char Options::COMPACTION_FORCE_UP_LEVEL_0[] = "compaction.force-up-level-0";
+const char Options::LOOKUP_WAIT[] = "lookup-wait";
+const char Options::LOOKUP_COMPACT[] = "lookup-compact";
+const char Options::LOOKUP_COMPACT_MAX_INTERVAL[] = "lookup-compact.max-interval";
+const char Options::LOOKUP_CACHE_MAX_MEMORY_SIZE[] = "lookup.cache-max-memory-size";
+const char Options::LOOKUP_CACHE_HIGH_PRIO_POOL_RATIO[] = "lookup.cache.high-priority-pool-ratio";
+const char Options::BUCKET_FUNCTION_TYPE[] = "bucket-function.type";
+const char Options::LOOKUP_CACHE_FILE_RETENTION[] = "lookup.cache-file-retention";
+const char Options::LOOKUP_CACHE_MAX_DISK_SIZE[] = "lookup.cache-max-disk-size";
+}  // namespace paimon

--- a/src/paimon/common/executor/executor.cpp
+++ b/src/paimon/common/executor/executor.cpp
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/executor.h"
+
+#include <condition_variable>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace paimon {
+
+class DefaultExecutor : public Executor {
+ public:
+    explicit DefaultExecutor(uint32_t thread_count);
+    ~DefaultExecutor() override;
+
+    void Add(std::function<void()> func) override;
+
+    void ShutdownNow() override;
+
+ private:
+    void WorkerThread();
+
+    void ShutdownInternal(bool wait_for_pending_tasks);
+
+    uint32_t thread_count_;
+    std::vector<std::thread> workers_;
+    std::queue<std::function<void()>> tasks_;
+    std::mutex queue_mutex_;
+    std::condition_variable condition_;
+    bool stop_ = false;
+    int32_t active_tasks_ = 0;
+};
+
+DefaultExecutor::DefaultExecutor(uint32_t thread_count) : thread_count_(thread_count) {
+    for (uint32_t i = 0; i < thread_count_; ++i) {
+        workers_.emplace_back(&DefaultExecutor::WorkerThread, this);
+    }
+}
+
+void DefaultExecutor::ShutdownInternal(bool wait_for_pending_tasks) {
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        if (stop_) {
+            return;
+        }
+        stop_ = true;
+        if (!wait_for_pending_tasks) {
+            // Discard all pending tasks immediately.
+            std::queue<std::function<void()>> empty;
+            tasks_.swap(empty);
+        }
+        condition_.notify_all();
+    }
+    for (std::thread& worker : workers_) {
+        if (worker.joinable()) {
+            worker.join();
+        }
+    }
+}
+
+DefaultExecutor::~DefaultExecutor() {
+    // Graceful shutdown: wait for all pending tasks to complete.
+    ShutdownInternal(/*wait_for_pending_tasks=*/true);
+}
+
+void DefaultExecutor::ShutdownNow() {
+    // Immediate shutdown: discard all pending tasks.
+    ShutdownInternal(/*wait_for_pending_tasks=*/false);
+}
+
+void DefaultExecutor::Add(std::function<void()> func) {
+    if (!func) {
+        return;
+    }
+    {
+        std::unique_lock<std::mutex> lock(queue_mutex_);
+        if (stop_) {
+            return;
+        }
+        tasks_.emplace(std::move(func));
+    }
+    condition_.notify_one();
+}
+
+void DefaultExecutor::WorkerThread() {
+    while (true) {
+        std::function<void()> task;
+        {
+            std::unique_lock<std::mutex> lock(queue_mutex_);
+            condition_.wait(lock, [this] { return stop_ || !tasks_.empty(); });
+            if (stop_ && tasks_.empty() && active_tasks_ == 0) {
+                condition_.notify_all();
+                return;
+            }
+            if (!tasks_.empty()) {
+                task = std::move(tasks_.front());
+                tasks_.pop();
+                ++active_tasks_;
+            }
+        }
+        if (task) {
+            task();
+            std::unique_lock<std::mutex> lock(queue_mutex_);
+            --active_tasks_;
+            if (tasks_.empty() && active_tasks_ == 0) {
+                condition_.notify_all();
+            }
+        }
+    }
+}
+
+PAIMON_EXPORT std::shared_ptr<Executor> GetGlobalDefaultExecutor() {
+    static uint32_t all_cores = std::thread::hardware_concurrency();
+    static std::shared_ptr<Executor> internal =
+        std::make_shared<DefaultExecutor>(/*thread_count=*/all_cores);
+    return internal;
+}
+
+PAIMON_EXPORT std::unique_ptr<Executor> CreateDefaultExecutor() {
+    return CreateDefaultExecutor(DEFAULT_EXECUTOR_THREAD_COUNT);
+}
+
+PAIMON_EXPORT std::unique_ptr<Executor> CreateDefaultExecutor(uint32_t thread_count) {
+    return std::make_unique<DefaultExecutor>(thread_count);
+}
+
+}  // namespace paimon

--- a/src/paimon/common/memory/bytes.cpp
+++ b/src/paimon/common/memory/bytes.cpp
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/memory/bytes.h"
+
+#include <cassert>
+#include <cstring>
+#include <memory>
+#include <new>
+#include <string_view>
+#include <utility>
+
+namespace paimon {
+const std::shared_ptr<Bytes>& Bytes::EmptyBytes() {
+    static const std::shared_ptr<Bytes> empty_bytes =
+        std::make_shared<Bytes>(0, GetDefaultPool().get());
+    return empty_bytes;
+}
+
+PAIMON_UNIQUE_PTR<Bytes> Bytes::AllocateBytes(int32_t length, MemoryPool* pool) {
+    return pool->AllocateUnique<Bytes>(length, pool);
+}
+
+PAIMON_UNIQUE_PTR<Bytes> Bytes::AllocateBytes(const std::string& str, MemoryPool* pool) {
+    return pool->AllocateUnique<Bytes>(str, pool);
+}
+
+Bytes::Bytes(size_t size, MemoryPool* pool) : pool_(pool), size_(size) {
+    if (size > 0) {
+        assert(pool_);
+        data_ = reinterpret_cast<char*>(pool_->Malloc(size_));
+        assert(data_);
+        std::memset(data_, 0, size_ * sizeof(char));
+    }
+}
+
+Bytes::Bytes(const std::string& str, MemoryPool* pool) : pool_(pool), size_(str.size()) {
+    if (str.size() > 0) {
+        assert(pool_);
+        data_ = reinterpret_cast<char*>(pool_->Malloc(size_));
+        assert(data_);
+        std::memcpy(data_, str.data(), size_ * sizeof(char));
+    }
+}
+
+Bytes::Bytes(Bytes&& other) noexcept {
+    *this = std::move(other);
+}
+
+Bytes& Bytes::operator=(Bytes&& other) noexcept {
+    if (&other == this) {
+        return *this;
+    }
+    if (data_ != nullptr) {
+        assert(pool_);
+        pool_->Free(data_, size_);
+    }
+    pool_ = other.pool_;
+    data_ = other.data_;
+    size_ = other.size_;
+    other.pool_ = nullptr;
+    other.data_ = nullptr;
+    other.size_ = 0;
+    return *this;
+}
+
+Bytes::~Bytes() {
+    if (data_ != nullptr) {
+        assert(pool_);
+        pool_->Free(data_, size_);
+        data_ = nullptr;
+    }
+}
+
+bool Bytes::operator==(const Bytes& other) const {
+    if (this == &other) {
+        return true;
+    }
+    return size_ == other.size_ &&
+           ((data_ == other.data_) || (std::memcmp(data_, other.data_, size_) == 0));
+}
+
+bool Bytes::operator<(const Bytes& other) const {
+    std::string_view v1(data_, size_);
+    std::string_view v2(other.data_, other.size_);
+    return v1 < v2;
+}
+
+int32_t Bytes::compare(const Bytes& other) const {
+    std::string_view v1(data_, size_);
+    std::string_view v2(other.data_, other.size_);
+    return v1.compare(v2);
+}
+
+char& Bytes::operator[](size_t idx) const {
+    assert(idx < size());
+    return data_[idx];
+}
+
+PAIMON_UNIQUE_PTR<Bytes> Bytes::CopyOf(const Bytes& other, size_t len, MemoryPool* pool) {
+    assert(pool);
+    auto bytes = Bytes::AllocateBytes(len, pool);
+    size_t copy_size = std::min(len, other.size());
+    if (bytes && bytes->data_ && other.data_ && copy_size > 0) {
+        std::memcpy(bytes->data_, other.data_, copy_size);
+    }
+    return bytes;
+}
+
+}  // namespace paimon

--- a/src/paimon/common/memory/bytes_test.cpp
+++ b/src/paimon/common/memory/bytes_test.cpp
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/memory/bytes.h"
+
+#include <memory>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "paimon/memory/memory_pool.h"
+
+namespace paimon::test {
+TEST(BytesTest, TestSimple) {
+    auto pool = paimon::GetMemoryPool();
+    Bytes bytes("abcde", pool.get());
+    Bytes moved_bytes("efgh", pool.get());
+    ASSERT_EQ(9, pool->CurrentUsage());
+
+    moved_bytes = std::move(bytes);
+    ASSERT_EQ(5, pool->CurrentUsage());
+    ASSERT_EQ("abcde", std::string(moved_bytes.data(), moved_bytes.size()));
+}
+
+TEST(BytesTest, TestCopyOf) {
+    auto pool = paimon::GetMemoryPool();
+    // pool allocate 5 bytes + sizeof(Bytes)
+    auto bytes = Bytes::AllocateBytes("abcde", pool.get());
+    ASSERT_EQ("abcde", std::string(bytes->data(), bytes->size()));
+
+    // test cp_bytes 100b and src bytes 5b
+    auto cp_bytes1 = Bytes::CopyOf(*bytes, /*size=*/100, pool.get());
+    ASSERT_EQ("abcde", std::string(cp_bytes1->data(), 5));
+    // pool allocate 100 bytes + sizeof(Bytes)
+    ASSERT_EQ(5 + 100 + sizeof(Bytes) * 2, pool->CurrentUsage());
+
+    // test cp_bytes 2b and src bytes 5b
+    auto cp_bytes2 = Bytes::CopyOf(*bytes, /*size=*/2, pool.get());
+    ASSERT_EQ("ab", std::string(cp_bytes2->data(), 2));
+    // pool allocate 2 bytes + sizeof(Bytes)
+    ASSERT_EQ(5 + 100 + 2 + sizeof(Bytes) * 3, pool->CurrentUsage());
+}
+
+TEST(BytesTest, TestAllocateBytesAndMove) {
+    auto pool = paimon::GetMemoryPool();
+    // pool allocate 5 + sizeof(Bytes)
+    PAIMON_UNIQUE_PTR<Bytes> bytes = Bytes::AllocateBytes("abcde", pool.get());
+    ASSERT_EQ("abcde", std::string(bytes->data(), bytes->size()));
+    ASSERT_EQ(5 + sizeof(Bytes), pool->CurrentUsage());
+
+    // pool allocate 4 + sizeof(Bytes)
+    PAIMON_UNIQUE_PTR<Bytes> moved_bytes = Bytes::AllocateBytes("efgh", pool.get());
+    ASSERT_EQ("efgh", std::string(moved_bytes->data(), moved_bytes->size()));
+    ASSERT_EQ(9 + 2 * sizeof(Bytes), pool->CurrentUsage());
+
+    // pool deallocate sizeof(Bytes) + 4
+    moved_bytes = std::move(bytes);
+    ASSERT_FALSE(bytes);
+    ASSERT_EQ("abcde", std::string(moved_bytes->data(), moved_bytes->size()));
+    ASSERT_EQ(5 + sizeof(Bytes), pool->CurrentUsage());
+
+    // pool allocate sizeof(Bytes) and deallocate sizeof(Bytes)
+    std::shared_ptr<Bytes> shared_bytes = std::move(moved_bytes);
+    ASSERT_FALSE(moved_bytes);
+    ASSERT_EQ("abcde", std::string(shared_bytes->data(), shared_bytes->size()));
+    ASSERT_EQ(5 + sizeof(Bytes), pool->CurrentUsage());
+}
+
+TEST(BytesTest, TestCompare) {
+    auto pool = paimon::GetMemoryPool();
+    PAIMON_UNIQUE_PTR<Bytes> bytes1 = Bytes::AllocateBytes("abcde", pool.get());
+    PAIMON_UNIQUE_PTR<Bytes> bytes2 = Bytes::AllocateBytes("abcdf", pool.get());
+    ASSERT_EQ(*bytes1, *bytes1);
+    ASSERT_EQ(*bytes2, *bytes2);
+    ASSERT_EQ(*bytes1, *bytes1);
+    ASSERT_EQ(*bytes2, *bytes2);
+    ASSERT_FALSE(*bytes1 == *bytes2);
+    ASSERT_LT(*bytes1, *bytes2);
+    ASSERT_FALSE(*bytes1 < *bytes1);
+    ASSERT_EQ(bytes1->compare(*bytes1), 0);
+    ASSERT_EQ(bytes1->compare(*bytes2), -1);
+    ASSERT_EQ(bytes2->compare(*bytes1), 1);
+}
+
+// Test to verify that move assignment correctly handles memory and prevents double-free.
+// Before the fix, the old implementation used memcpy + destructor which caused:
+// 1. The target's original memory was freed in destructor
+// 2. After memcpy, both source and target pointed to same memory
+// 3. When source was "reset" via placement new, it became empty
+// 4. But if move assignment was called again on the same target, the memcpy'd
+//    pointer would be freed again (double-free) or memory accounting would be wrong.
+TEST(BytesTest, TestMoveAssignmentNoDoubleFree) {
+    auto pool = paimon::GetMemoryPool();
+
+    // Create three Bytes objects on stack
+    Bytes a("aaaa", pool.get());          // 4 bytes
+    Bytes b("bb", pool.get());            // 2 bytes
+    Bytes c("cccccc", pool.get());        // 6 bytes
+    ASSERT_EQ(12, pool->CurrentUsage());  // 4 + 2 + 6 = 12
+
+    // First move: b = std::move(a)
+    // Should free b's original memory (2 bytes), transfer a's memory to b
+    b = std::move(a);
+    ASSERT_EQ(10, pool->CurrentUsage());  // 4 + 6 = 10 (b's 2 bytes freed)
+    ASSERT_EQ("aaaa", std::string(b.data(), b.size()));
+    // Moved-from object is expected to be empty by Bytes' contract.
+    ASSERT_EQ(nullptr, a.data());  // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+    ASSERT_EQ(0, a.size());        // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+
+    // Second move: b = std::move(c)
+    // Should free b's current memory (4 bytes from a), transfer c's memory to b
+    // This is where the old implementation would cause issues:
+    // - Old code would call destructor on b, freeing the 4 bytes
+    // - Then memcpy c into b, making b point to c's 6-byte buffer
+    // - Memory accounting would be wrong because Free was called on wrong data
+    b = std::move(c);
+    ASSERT_EQ(6, pool->CurrentUsage());  // Only c's 6 bytes remain (now owned by b)
+    ASSERT_EQ("cccccc", std::string(b.data(), b.size()));
+    // Moved-from object is expected to be empty by Bytes' contract.
+    ASSERT_EQ(nullptr, c.data());  // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+    ASSERT_EQ(0, c.size());        // NOLINT(bugprone-use-after-move, clang-analyzer-cplusplus.Move)
+
+    // Self-assignment should be safe. Use an alias to avoid -Wself-move.
+    Bytes* self = &b;
+    b = std::move(*self);
+    ASSERT_EQ(6, pool->CurrentUsage());
+    ASSERT_EQ("cccccc", std::string(b.data(), b.size()));
+}
+
+// Test move assignment with heap-allocated Bytes to verify no double-free
+// when combining unique_ptr semantics with move assignment
+TEST(BytesTest, TestMoveAssignmentHeapAllocated) {
+    auto pool = paimon::GetMemoryPool();
+
+    auto bytes1 = Bytes::AllocateBytes("hello", pool.get());   // 5 bytes + sizeof(Bytes)
+    auto bytes2 = Bytes::AllocateBytes("world!", pool.get());  // 6 bytes + sizeof(Bytes)
+    size_t expected = 5 + 6 + 2 * sizeof(Bytes);
+    ASSERT_EQ(expected, pool->CurrentUsage());
+
+    // Move the content of bytes1 into bytes2's Bytes object
+    // This should free "world!" (6 bytes) and transfer "hello" ownership
+    *bytes2 = std::move(*bytes1);
+    expected = 5 + 2 * sizeof(Bytes);  // "world!" freed, "hello" transferred
+    ASSERT_EQ(expected, pool->CurrentUsage());
+    ASSERT_EQ("hello", std::string(bytes2->data(), bytes2->size()));
+    ASSERT_EQ(nullptr, bytes1->data());
+
+    // Reset bytes2, which should free "hello"
+    bytes2.reset();
+    expected = sizeof(Bytes);  // Only bytes1's empty Bytes struct remains
+    ASSERT_EQ(expected, pool->CurrentUsage());
+}
+}  // namespace paimon::test

--- a/src/paimon/common/memory/memory_pool.cpp
+++ b/src/paimon/common/memory/memory_pool.cpp
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/memory/memory_pool.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cstddef>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+
+namespace paimon {
+
+class MemoryPoolImpl : public MemoryPool {
+ public:
+    MemoryPoolImpl() = default;
+    ~MemoryPoolImpl() override = default;
+
+    void* Malloc(uint64_t size, uint64_t alignment) override;
+    void* Realloc(void* p, size_t old_size, size_t new_size, uint64_t alignment) override;
+    void Free(void* p, uint64_t size) override;
+    uint64_t CurrentUsage() const override;
+    uint64_t MaxMemoryUsage() const override {
+        return max_allocated.load();
+    }
+
+ protected:
+    std::atomic<int64_t> total_allocated_size = {0};
+    std::atomic<int64_t> max_allocated = {0};
+};
+
+void* MemoryPoolImpl::Malloc(uint64_t size, uint64_t alignment) {
+    void* memptr = nullptr;
+#define DEFAULT_ALIGNMENT 64
+    if (posix_memalign(reinterpret_cast<void**>(&memptr),
+                       alignment == 0 ? DEFAULT_ALIGNMENT : alignment, size) != 0) {
+        throw std::bad_alloc();
+    }
+    total_allocated_size.fetch_add(size);
+    max_allocated.store(std::max(total_allocated_size.load(), max_allocated.load()));
+    return memptr;
+}
+
+void* MemoryPoolImpl::Realloc(void* p, size_t old_size, size_t new_size, uint64_t alignment) {
+    if (alignment == 0) {
+        void* memptr = ::realloc(p, new_size);
+        total_allocated_size.fetch_add(new_size - old_size);
+        max_allocated.store(std::max(total_allocated_size.load(), max_allocated.load()));
+        return memptr;
+    } else {
+        if (p == nullptr) {
+            return Malloc(new_size, alignment);
+        } else if (new_size == old_size) {
+            return p;
+        } else if (new_size == 0) {
+            Free(p, old_size);
+            return Malloc(0, alignment);
+        } else if (new_size < old_size && old_size / 2 < new_size) {
+            total_allocated_size.fetch_add(new_size - old_size);
+            max_allocated.store(std::max(total_allocated_size.load(), max_allocated.load()));
+            // do not shrink to fit, when new size is not very small, to avoid memory copy
+            return p;
+        } else {
+            void* memptr = Malloc(new_size, alignment);
+            memcpy(memptr, p, std::min(old_size, new_size));
+            Free(p, old_size);
+            return memptr;
+        }
+    }
+}
+
+void MemoryPoolImpl::Free(void* p, uint64_t size) {
+    std::free(p);
+    total_allocated_size.fetch_sub(size);
+}
+
+uint64_t MemoryPoolImpl::CurrentUsage() const {
+    return total_allocated_size.load();
+}
+
+PAIMON_EXPORT std::shared_ptr<MemoryPool> GetDefaultPool() {
+    static std::shared_ptr<MemoryPool> internal = std::make_shared<MemoryPoolImpl>();
+    return internal;
+}
+
+PAIMON_EXPORT std::unique_ptr<MemoryPool> GetMemoryPool() {
+    return std::make_unique<MemoryPoolImpl>();
+}
+
+}  // namespace paimon

--- a/src/paimon/common/memory/memory_pool_test.cpp
+++ b/src/paimon/common/memory/memory_pool_test.cpp
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/memory/memory_pool.h"
+
+#include "gtest/gtest.h"
+#include "paimon/memory/bytes.h"
+
+namespace paimon::test {
+TEST(MemoryPoolTest, TestSimple) {
+    auto pool = GetMemoryPool();
+    auto* p1 = pool->Malloc(10);
+    ASSERT_TRUE(p1);
+    ASSERT_EQ(10, pool->CurrentUsage());
+    ASSERT_EQ(10, pool->MaxMemoryUsage());
+
+    // test malloc and free
+    auto* p2 = pool->Malloc(20);
+    ASSERT_TRUE(p2);
+    ASSERT_EQ(30, pool->CurrentUsage());
+    ASSERT_EQ(30, pool->MaxMemoryUsage());
+    pool->Free(p1, 10);
+    ASSERT_EQ(20, pool->CurrentUsage());
+    ASSERT_EQ(30, pool->MaxMemoryUsage());
+
+    // test realloc without alignment
+    auto* p3 = pool->Realloc(p2, /*old_size=*/20, /*new_size=*/40);
+    ASSERT_TRUE(p3);
+    ASSERT_EQ(40, pool->CurrentUsage());
+    ASSERT_EQ(40, pool->MaxMemoryUsage());
+
+    // test realloc with nullptr
+    auto* p4 = pool->Realloc(nullptr, /*old_size=*/0, /*new_size=*/10, /*alignment=*/8);
+    ASSERT_TRUE(p4);
+    ASSERT_EQ(50, pool->CurrentUsage());
+    ASSERT_EQ(50, pool->MaxMemoryUsage());
+
+    // test realloc with same size
+    auto* p5 = pool->Realloc(p4, /*old_size=*/10, /*new_size=*/10, /*alignment=*/8);
+    ASSERT_EQ(p5, p4);
+    ASSERT_EQ(50, pool->CurrentUsage());
+    ASSERT_EQ(50, pool->MaxMemoryUsage());
+
+    // test new size is 0
+    auto* p6 = pool->Realloc(p4, /*old_size=*/10, /*new_size=*/0, /*alignment=*/8);
+    ASSERT_TRUE(p6);
+    ASSERT_EQ(40, pool->CurrentUsage());
+    ASSERT_EQ(50, pool->MaxMemoryUsage());
+
+    // do not shrink to fit, when new size is not very small, to avoid memory copy
+    auto* p7 = pool->Realloc(p3, /*old_size=*/40, /*new_size=*/30, /*alignment=*/8);
+    ASSERT_EQ(p7, p3);
+    ASSERT_EQ(30, pool->CurrentUsage());
+    ASSERT_EQ(50, pool->MaxMemoryUsage());
+
+    // test normal realloc, malloc new pointer and free the old
+    auto* p8 = pool->Realloc(p7, /*old_size=*/30, /*new_size=*/100, /*alignment=*/8);
+    ASSERT_TRUE(p8);
+    ASSERT_NE(p3, p8);
+    ASSERT_EQ(100, pool->CurrentUsage());
+    ASSERT_EQ(130, pool->MaxMemoryUsage());
+
+    pool->Free(p8, 100);
+    pool->Free(p6, 0);
+    ASSERT_EQ(0, pool->CurrentUsage());
+    ASSERT_EQ(130, pool->MaxMemoryUsage());
+}
+}  // namespace paimon::test

--- a/src/paimon/common/utils/arrow/status_utils.h
+++ b/src/paimon/common/utils/arrow/status_utils.h
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "arrow/status.h"
+#include "paimon/macros.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+
+inline arrow::Status ToArrowStatus(const Status& status) {
+    switch (status.code()) {
+        case StatusCode::OK:
+            return arrow::Status::OK();
+        case StatusCode::OutOfMemory:
+            return arrow::Status::OutOfMemory(status.message());
+        case StatusCode::KeyError:
+            return arrow::Status::KeyError(status.message());
+        case StatusCode::TypeError:
+            return arrow::Status::TypeError(status.message());
+        case StatusCode::Invalid:
+            return arrow::Status::Invalid(status.message());
+        case StatusCode::IOError:
+            return arrow::Status::IOError(status.message());
+        case StatusCode::CapacityError:
+            return arrow::Status::CapacityError(status.message());
+        case StatusCode::IndexError:
+            return arrow::Status::IndexError(status.message());
+        case StatusCode::UnknownError:
+            return arrow::Status::UnknownError(status.message());
+        case StatusCode::NotImplemented:
+            return arrow::Status::NotImplemented(status.message());
+        case StatusCode::SerializationError:
+            return arrow::Status::SerializationError(status.message());
+        default:
+            return arrow::Status::Invalid(status.message());
+    }
+}
+
+inline Status ToPaimonStatus(const arrow::Status& status) {
+    switch (status.code()) {
+        case arrow::StatusCode::OK:
+            return Status::OK();
+        case arrow::StatusCode::OutOfMemory:
+            return Status::OutOfMemory(status.message());
+        case arrow::StatusCode::KeyError:
+            return Status::KeyError(status.message());
+        case arrow::StatusCode::TypeError:
+            return Status::TypeError(status.message());
+        case arrow::StatusCode::Invalid:
+            return Status::Invalid(status.message());
+        case arrow::StatusCode::IOError:
+            return Status::IOError(status.message());
+        case arrow::StatusCode::CapacityError:
+            return Status::CapacityError(status.message());
+        case arrow::StatusCode::IndexError:
+            return Status::IndexError(status.message());
+        case arrow::StatusCode::UnknownError:
+            return Status::UnknownError(status.message());
+        case arrow::StatusCode::NotImplemented:
+            return Status::NotImplemented(status.message());
+        case arrow::StatusCode::SerializationError:
+            return Status::SerializationError(status.message());
+        default:
+            return Status::Invalid(status.message());
+    }
+}
+
+#define PAIMON_RETURN_NOT_OK_FROM_ARROW(ARROW_STATUS) \
+    do {                                              \
+        arrow::Status __s = (ARROW_STATUS);           \
+        if (PAIMON_UNLIKELY(!(__s).ok())) {           \
+            return ToPaimonStatus(__s);               \
+        }                                             \
+    } while (false)
+
+#define PAIMON_ASSIGN_OR_RAISE_IMPL_FROM_ARROW(result_name, lhs, rexpr)            \
+    auto&& result_name = (rexpr);                                                  \
+    PAIMON_RETURN_IF_(!(result_name).ok(), ToPaimonStatus((result_name).status()), \
+                      PAIMON_STRINGIFY(rexpr));                                    \
+    lhs = std::move(result_name).ValueUnsafe();
+
+#define PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(lhs, rexpr) \
+    PAIMON_ASSIGN_OR_RAISE_IMPL_FROM_ARROW(           \
+        PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, (rexpr));
+
+}  // namespace paimon

--- a/src/paimon/common/utils/status.cpp
+++ b/src/paimon/common/utils/status.cpp
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+//
+// A Status encapsulates the result of an operation.  It may indicate success,
+// or it may indicate an error with an associated error message.
+//
+// Multiple threads can invoke const methods on a Status without
+// external synchronization, but if any of the threads may call a
+// non-const method, all threads accessing the same Status must use
+// external synchronization.
+
+// Adapted from Apache Arrow
+// https://github.com/apache/arrow/blob/main/cpp/src/arrow/status.cc
+
+#include "paimon/status.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+
+namespace paimon {
+
+Status::Status(StatusCode code, const std::string& msg) : Status::Status(code, msg, nullptr) {}
+
+Status::Status(StatusCode code, std::string msg, std::shared_ptr<StatusDetail> detail) {
+    // should not construct ok status with message
+    assert(code != StatusCode::OK);
+    state_ = new State;
+    state_->code = code;
+    state_->msg = std::move(msg);
+    if (detail != nullptr) {
+        state_->detail = std::move(detail);
+    }
+}
+
+void Status::CopyFrom(const Status& s) {
+    delete state_;
+    if (s.state_ == nullptr) {
+        state_ = nullptr;
+    } else {
+        state_ = new State(*s.state_);
+    }
+}
+
+std::string Status::CodeAsString() const {
+    if (state_ == nullptr) {
+        return "OK";
+    }
+    return CodeAsString(code());
+}
+
+std::string Status::CodeAsString(StatusCode code) {
+    const char* type;
+    switch (code) {
+        case StatusCode::OK:
+            type = "OK";
+            break;
+        case StatusCode::OutOfMemory:
+            type = "Out of memory";
+            break;
+        case StatusCode::KeyError:
+            type = "Key error";
+            break;
+        case StatusCode::TypeError:
+            type = "Type error";
+            break;
+        case StatusCode::Invalid:
+            type = "Invalid";
+            break;
+        case StatusCode::IOError:
+            type = "IOError";
+            break;
+        case StatusCode::CapacityError:
+            type = "Capacity error";
+            break;
+        case StatusCode::IndexError:
+            type = "Index error";
+            break;
+        case StatusCode::Cancelled:
+            type = "Cancelled";
+            break;
+        case StatusCode::UnknownError:
+            type = "Unknown error";
+            break;
+        case StatusCode::NotImplemented:
+            type = "NotImplemented";
+            break;
+        case StatusCode::SerializationError:
+            type = "Serialization error";
+            break;
+        case StatusCode::NotExist:
+            type = "Not exist";
+            break;
+        case StatusCode::Exist:
+            type = "Exist";
+            break;
+        default:
+            type = "Unknown";
+            break;
+    }
+    return std::string(type);
+}
+
+std::string Status::ToString() const {
+    std::string result(CodeAsString());
+    if (state_ == nullptr) {
+        return result;
+    }
+    result += ": ";
+    result += state_->msg;
+    if (state_->detail != nullptr) {
+        result += ". Detail: ";
+        result += state_->detail->ToString();
+    }
+
+    return result;
+}
+
+void Status::Abort() const {
+    Abort(std::string());
+}
+
+void Status::Abort(const std::string& message) const {
+    std::cerr << "-- Paimon Fatal Error --\n";
+    if (!message.empty()) {
+        std::cerr << message << "\n";
+    }
+    std::cerr << ToString() << std::endl;
+    std::abort();
+}
+
+#ifdef PAIMON_EXTRA_ERROR_CONTEXT
+void Status::AddContextLine(const char* filename, int line, const char* function_name,
+                            const char* expr) {
+    assert(!ok() && "Cannot add context line to ok status");
+    std::stringstream ss;
+    ss << "\nIn " << filename << ":" << line << ", function: " << function_name
+       << ", code: " << expr;
+    state_->msg += ss.str();
+}
+#endif
+
+}  // namespace paimon

--- a/src/paimon/common/utils/status_test.cpp
+++ b/src/paimon/common/utils/status_test.cpp
@@ -1,0 +1,396 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/status.h"
+
+#include <cstdint>
+#include <iosfwd>
+#include <sstream>
+
+#include "arrow/api.h"
+#include "gtest/gtest.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+namespace {
+
+class TestStatusDetail : public StatusDetail {
+ public:
+    const char* type_id() const override {
+        return "type_id";
+    }
+    std::string ToString() const override {
+        return "a specific detail message";
+    }
+};
+
+}  // namespace
+
+TEST(StatusTest, TestCodeAndMessage) {
+    Status ok = Status::OK();
+    ASSERT_EQ(StatusCode::OK, ok.code());
+    Status file_error = Status::IOError("file error");
+    ASSERT_EQ(StatusCode::IOError, file_error.code());
+    ASSERT_EQ("file error", file_error.message());
+}
+
+TEST(StatusTest, TestToString) {
+    Status file_error = Status::IOError("file error");
+    ASSERT_EQ("IOError: file error", file_error.ToString());
+
+    std::stringstream ss;
+    ss << file_error;
+    ASSERT_EQ(file_error.ToString(), ss.str());
+}
+
+TEST(StatusTest, TestToStringWithDetail) {
+    Status status(StatusCode::IOError, "summary", std::make_shared<TestStatusDetail>());
+    ASSERT_EQ("IOError: summary. Detail: a specific detail message", status.ToString());
+
+    std::stringstream ss;
+    ss << status;
+    ASSERT_EQ(status.ToString(), ss.str());
+}
+
+TEST(StatusTest, TestWithDetail) {
+    Status status(StatusCode::IOError, "summary");
+    auto detail = std::make_shared<TestStatusDetail>();
+    Status new_status = status.WithDetail(detail);
+
+    ASSERT_EQ(new_status.code(), status.code());
+    ASSERT_EQ(new_status.message(), status.message());
+    ASSERT_EQ(new_status.detail(), detail);
+}
+
+TEST(StatusTest, AndStatus) {
+    Status a = Status::OK();
+    Status b = Status::OK();
+    Status c = Status::Invalid("invalid value");
+    Status d = Status::IOError("file error");
+
+    Status res;
+    res = a & b;
+    ASSERT_OK(res);
+    res = a & c;
+    ASSERT_TRUE(res.IsInvalid());
+    res = d & c;
+    ASSERT_TRUE(res.IsIOError());
+
+    res = Status::OK();
+    res &= c;
+    ASSERT_TRUE(res.IsInvalid());
+    res &= d;
+    ASSERT_TRUE(res.IsInvalid());
+
+    // With rvalues
+    res = Status::OK() & Status::Invalid("foo");
+    ASSERT_TRUE(res.IsInvalid());
+    res = Status::Invalid("foo") & Status::OK();
+    ASSERT_TRUE(res.IsInvalid());
+    res = Status::Invalid("foo") & Status::IOError("bar");
+    ASSERT_TRUE(res.IsInvalid());
+
+    res = Status::OK();
+    res &= Status::OK();
+    ASSERT_OK(res);
+    res &= Status::Invalid("foo");
+    ASSERT_TRUE(res.IsInvalid());
+    res &= Status::IOError("bar");
+    ASSERT_TRUE(res.IsInvalid());
+}
+
+TEST(StatusTest, TestEquality) {
+    ASSERT_EQ(Status(), Status::OK());
+    ASSERT_EQ(Status::Invalid("error"), Status::Invalid("error"));
+
+    ASSERT_NE(Status::Invalid("error"), Status::OK());
+    ASSERT_NE(Status::Invalid("error"), Status::Invalid("other error"));
+}
+
+TEST(StatusTest, TestDetailEquality) {
+    const auto status_with_detail =
+        paimon::Status(StatusCode::IOError, "", std::make_shared<TestStatusDetail>());
+    const auto status_with_detail2 =
+        paimon::Status(StatusCode::IOError, "", std::make_shared<TestStatusDetail>());
+    const auto status_without_detail = paimon::Status::IOError("");
+
+    ASSERT_EQ(*status_with_detail.detail(), *status_with_detail2.detail());
+    ASSERT_EQ(status_with_detail, status_with_detail2);
+    ASSERT_NE(status_with_detail, status_without_detail);
+    ASSERT_NE(status_without_detail, status_with_detail);
+}
+
+TEST(StatusTest, TestStatusDefine) {
+    Status s;
+    ASSERT_OK(s);
+
+    auto func1 = []() {
+        PAIMON_RETURN_NOT_OK(Status::OutOfMemory("out of memory"));
+        return Status::OK();
+    };
+    ASSERT_NOK(func1());
+
+    auto func2 = [](bool is_ok) {
+        PAIMON_RETURN_IF(!is_ok, Status::Invalid("invalid args"));
+        return Status::OK();
+    };
+    ASSERT_OK(func2(true));
+    ASSERT_NOK(func2(false));
+
+    bool set_value = false;
+    auto func3 = [&]() { set_value = true; };
+    auto func4 = [&]() {
+        PAIMON_RETURN_NOT_OK_ELSE(Status::OutOfMemory("out of memory"), func3());
+        return Status::OK();
+    };
+    ASSERT_NOK(func4());
+    ASSERT_TRUE(set_value);
+}
+
+TEST(StatusTest, TestResultDefine) {
+    std::unique_ptr<int> value;
+    auto func_ok = []() -> Result<std::unique_ptr<int>> { return std::make_unique<int>(233); };
+    auto func_not_ok = []() -> Result<std::unique_ptr<int>> {
+        return Status::OutOfMemory("out of memory");
+    };
+    auto test_func = [&](const auto& func) {
+        PAIMON_ASSIGN_OR_RAISE(value, func());
+        return Status::OK();
+    };
+    ASSERT_NOK(test_func(func_not_ok));
+    ASSERT_FALSE(value);
+
+    ASSERT_OK(test_func(func_ok));
+    ASSERT_TRUE(value);
+    ASSERT_EQ(233, *value);
+}
+
+TEST(StatusTest, TestArrowStatusDefine) {
+    auto arrow_status_func = [](bool is_ok) -> arrow::Status {
+        if (!is_ok) {
+            return arrow::Status::Invalid("invalid");
+        }
+        return arrow::Status::OK();
+    };
+    auto func = [&](bool is_ok) -> Status {
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow_status_func(is_ok));
+        return Status::OK();
+    };
+    ASSERT_OK(func(true));
+    ASSERT_NOK(func(false));
+}
+
+TEST(StatusTest, TestResultSimple) {
+    {
+        Result<int32_t> result(233);
+        ASSERT_OK(result);
+        ASSERT_EQ(233, result.value());
+        ASSERT_EQ(233, result.value_or(-1));
+    }
+    {
+        Result<std::string> result("abcd");
+        ASSERT_OK(result);
+        ASSERT_EQ("abcd", result.value());
+        ASSERT_EQ("abcd", result.value_or("aaaa"));
+    }
+    {
+        Result<std::string> result = Status::Invalid("invalid args");
+        ASSERT_NOK(result);
+        ASSERT_TRUE(result.status().IsInvalid());
+        ASSERT_NOK_WITH_MSG(result, "invalid args");
+        ASSERT_EQ("aaaa", result.value_or("aaaa"));
+    }
+    {
+        auto CreateResult = []() -> Result<std::unique_ptr<int32_t>> {
+            return std::make_unique<int32_t>(233);
+        };
+        std::unique_ptr<int32_t> value = CreateResult().value_or(nullptr);
+        ASSERT_EQ(233, *value);
+    }
+}
+
+TEST(StatusTest, TestResultWithDerivedClass) {
+    class B {
+     public:
+        B() = default;
+        virtual ~B() = default;
+        virtual int32_t GetValue() const {
+            return value_b_;
+        }
+
+     private:
+        int32_t value_b_ = -1;
+    };
+    class D : public B {
+     public:
+        explicit D(int32_t value) : B(), value_d_(value) {}
+        int32_t GetValue() const override {
+            return value_d_;
+        }
+        bool operator==(const D& other) const {
+            if (this == &other) {
+                return true;
+            }
+            return value_b_ == other.value_b_ && value_d_ == other.value_d_;
+        }
+
+     private:
+        int32_t value_d_ = 1;
+    };
+    class A {
+     public:
+        int32_t GetValue() const {
+            return value_a_;
+        }
+
+     private:
+        int32_t value_a_ = 2;
+    };
+
+    {
+        Result<std::shared_ptr<B>> r0 = std::make_shared<B>();
+        r0 = Result<std::shared_ptr<D>>(Status::Invalid("invalid D"));
+        ASSERT_TRUE(r0.status().ToString().find("invalid D") != std::string::npos);
+    }
+    {
+        Result<std::shared_ptr<B>> r0 = Status::Invalid("invalid B");
+        r0 = Result<std::shared_ptr<D>>(std::make_shared<D>(20));
+        ASSERT_EQ(r0.value()->GetValue(), 20);
+    }
+
+    Result<std::unique_ptr<B>> b0 = std::make_unique<D>(232);
+    ASSERT_EQ(232, b0.value()->GetValue());
+
+    Result<std::unique_ptr<B>> b1 = std::make_unique<D>(233);
+    ASSERT_EQ(233, b1.value()->GetValue());
+
+    Result<std::shared_ptr<B>> b2 = std::make_shared<D>(234);
+    ASSERT_EQ(234, b2.value()->GetValue());
+
+    Result<std::unique_ptr<B>> b3 = std::make_unique<B>();
+    ASSERT_EQ(-1, b3.value()->GetValue());
+
+    Result<std::unique_ptr<D>> b4 = std::make_unique<D>(245);
+    ASSERT_EQ(245, b4.value()->GetValue());
+
+    b0 = std::move(b1);
+    ASSERT_EQ(233, b0.value()->GetValue());
+
+    b3 = std::move(b4);
+    ASSERT_EQ(245, b3.value()->GetValue());
+
+    Result<std::unique_ptr<B>> b5 = std::move(b3);
+    ASSERT_EQ(245, b5.value()->GetValue());
+
+    Result<std::unique_ptr<D>> b6 = std::make_unique<D>(246);
+    Result<std::unique_ptr<B>> b7 = std::move(b6);
+    ASSERT_EQ(246, b7.value()->GetValue());
+
+    // failed, because A can not convert to B
+    // Result<std::unique_ptr<B>> b5 = std::make_unique<A>();
+
+    // support PAIMON_UNIQUE_PTR
+    auto pool = GetDefaultPool();
+    Result<PAIMON_UNIQUE_PTR<B>> b8 = pool->AllocateUnique<D>(249);
+    ASSERT_EQ(249, b8.value()->GetValue());
+    Result<PAIMON_UNIQUE_PTR<D>> b9 = pool->AllocateUnique<D>(250);
+    ASSERT_EQ(250, b9.value()->GetValue());
+
+    b8 = std::move(b9);
+    ASSERT_EQ(250, b8.value()->GetValue());
+
+    auto func = [&]() -> Result<PAIMON_UNIQUE_PTR<B>> { return pool->AllocateUnique<D>(251); };
+    Result<PAIMON_UNIQUE_PTR<B>> b10 = func();
+    ASSERT_EQ(251, b10.value()->GetValue());
+}
+
+TEST(StatusTest, TestResultConstruct) {
+    {
+        // status ok
+        Result<std::shared_ptr<int32_t>> r0 = std::make_shared<int32_t>(10);
+        Result<std::shared_ptr<int32_t>> r1(std::move(r0));
+    }
+    {
+        // status invalid
+        Result<std::shared_ptr<int32_t>> r0 = Status::Invalid("invalid");
+        Result<std::shared_ptr<int32_t>> r1(std::move(r0));
+    }
+    {
+        // status ok
+        Result<std::shared_ptr<int32_t>> r0 = std::make_shared<int32_t>(10);
+        Result<std::shared_ptr<int32_t>> r1(r0);
+    }
+    {
+        // status invalid
+        Result<std::shared_ptr<int32_t>> r0 = Status::Invalid("invalid");
+        Result<std::shared_ptr<int32_t>> r1(r0);
+    }
+}
+
+TEST(StatusTest, TestResultMoveAndAssign) {
+    {
+        Result<std::shared_ptr<int32_t>> r0 = std::make_shared<int32_t>(10);
+        Result<std::shared_ptr<int32_t>> r1 = std::make_shared<int32_t>(20);
+        r0 = r1;
+        ASSERT_EQ(*r0.value(), 20);
+    }
+    {
+        Result<std::shared_ptr<int32_t>> r0 = std::make_shared<int32_t>(10);
+        r0 = Result<std::shared_ptr<int32_t>>(std::make_shared<int32_t>(20));
+        ASSERT_EQ(*r0.value(), 20);
+    }
+    {
+        Result<std::shared_ptr<int32_t>> r0 = Status::Invalid("invalid 10");
+        Result<std::shared_ptr<int32_t>> r1 = Status::Invalid("invalid 20");
+        r0 = r1;
+        ASSERT_TRUE(r0.status().ToString().find("invalid 20") != std::string::npos);
+    }
+    {
+        Result<std::shared_ptr<int32_t>> r0 = Status::Invalid("invalid 10");
+        r0 = Result<std::shared_ptr<int32_t>>(Status::Invalid("invalid 20"));
+        ASSERT_TRUE(r0.status().ToString().find("invalid 20") != std::string::npos);
+    }
+    {
+        Result<std::shared_ptr<int32_t>> r0 = std::make_shared<int32_t>(10);
+        Result<std::shared_ptr<int32_t>> r1 = Status::Invalid("invalid 20");
+        r0 = r1;
+        ASSERT_TRUE(r0.status().ToString().find("invalid 20") != std::string::npos);
+    }
+    {
+        Result<std::shared_ptr<int32_t>> r0 = std::make_shared<int32_t>(10);
+        r0 = Result<std::shared_ptr<int32_t>>(Status::Invalid("invalid 20"));
+        ASSERT_TRUE(r0.status().ToString().find("invalid 20") != std::string::npos);
+    }
+    {
+        Result<std::shared_ptr<int32_t>> r0 = Status::Invalid("invalid 10");
+        Result<std::shared_ptr<int32_t>> r1 = std::make_shared<int32_t>(20);
+        r0 = r1;
+        ASSERT_EQ(*r0.value(), 20);
+    }
+    {
+        Result<std::shared_ptr<int32_t>> r0 = Status::Invalid("invalid 10");
+        r0 = Result<std::shared_ptr<int32_t>>(std::make_shared<int32_t>(20));
+        ASSERT_EQ(*r0.value(), 20);
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/testing/utils/testharness.cpp
+++ b/src/paimon/testing/utils/testharness.cpp
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+// Assert utilities is adapted from RocksDB
+// https://github.com/facebook/rocksdb/blob/main/test_util/testharness.cc
+
+#include "paimon/testing/utils/testharness.h"
+
+#include "paimon/status.h"
+
+namespace paimon::test {
+
+::testing::AssertionResult AssertStatus(const char* s_expr, const Status& s) {
+    if (s.ok()) {
+        return ::testing::AssertionSuccess();
+    } else {
+        return ::testing::AssertionFailure() << s_expr << std::endl << s.ToString();
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/testing/utils/testharness.h
+++ b/src/paimon/testing/utils/testharness.h
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+//  Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+//  This source code is licensed under both the GPLv2 (found in the
+//  COPYING file in the root directory) and Apache 2.0 License
+//  (found in the LICENSE.Apache file in the root directory).
+//
+// Copyright (c) 2011 The LevelDB Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file. See the AUTHORS file for names of contributors.
+
+// Assert utilities is adapted from RocksDB
+// https://github.com/facebook/rocksdb/blob/main/test_util/testharness.h
+
+#pragma once
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "paimon/macros.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon::test {
+
+::testing::AssertionResult AssertStatus(const char* s_expr, const Status& s);
+
+#define ASSERT_OK(expr)                                                                  \
+    for (::paimon::Status _st = ::paimon::internal::GenericToStatus((expr)); !_st.ok();) \
+    FAIL() << "'" PAIMON_STRINGIFY(expr) "' failed with " << _st.ToString()
+
+#define ASSERT_NOK(expr)                                                                \
+    for (::paimon::Status _st = ::paimon::internal::GenericToStatus((expr)); _st.ok();) \
+    FAIL() << "'" PAIMON_STRINGIFY(expr) "' did not failed " << _st.ToString()
+
+#define ASSERT_NOK_WITH_MSG(expr, error_msg)                                   \
+    do {                                                                       \
+        ::paimon::Status _st = ::paimon::internal::GenericToStatus((expr));    \
+        ASSERT_TRUE(!_st.ok()) << "'" PAIMON_STRINGIFY(expr) "' did not fail"; \
+        ASSERT_TRUE(_st.ToString().find(error_msg) != std::string::npos)       \
+            << "'" PAIMON_STRINGIFY(expr) "' failed with " << _st.ToString()   \
+            << " but did not contain expected message: " << error_msg;         \
+    } while (0)
+
+#define ASSIGN_OR_HANDLE_ERROR_IMPL(handle_error, status_name, lhs, rexpr) \
+    auto&& status_name = (rexpr);                                          \
+    handle_error(status_name.status());                                    \
+    lhs = std::move(status_name).value();
+
+#define ASSERT_OK_AND_ASSIGN(lhs, rexpr) \
+    ASSIGN_OR_HANDLE_ERROR_IMPL(         \
+        ASSERT_OK, PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, rexpr);
+
+#define EXPECT_OK_AND_ASSIGN(lhs, rexpr) \
+    ASSIGN_OR_HANDLE_ERROR_IMPL(         \
+        EXPECT_OK, PAIMON_ASSIGN_OR_RAISE_NAME(_error_or_value, __COUNTER__), lhs, rexpr);
+
+#define EXPECT_OK(s) EXPECT_PRED_FORMAT1(paimon::test::AssertStatus, s)
+#define EXPECT_NOK(s) EXPECT_FALSE((s).ok())
+
+}  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

Introduce the foundational utility modules from alibaba/paimon-cpp to bootstrap the apache/paimon-cpp codebase. These modules provide core infrastructure (status handling, type definitions, memory management, executor) that other components depend on.

- Introduce `Status`, `Result<T>`, and related utilities (`status.cpp`, `status_test.cpp`, `status_utils.h`)
- Introduce type definitions and constants (`defs.h`, `defs.cpp`, `type_fwd.h`)
- Introduce `Executor` interface and default implementation (`executor.h`, `executor.cpp`)
- Introduce `MemoryPool` and `Bytes` with unit tests (`memory_pool.h/cpp`, `memory_pool_test.cpp`, `bytes.h/cpp`, `bytes_test.cpp`)
- Introduce shared utilities: `compare.h`, `macros.h`, `string_builder.h`, `result.h`, `traits.h`, `visibility.h`
- Introduce test harness (trimmed to status assertion macros only)
- Preserve third-party attribution comments (Apache Arrow, RocksDB/LevelDB, Google LLC/LiteRT)

<!-- What is the purpose of the change -->

### Tests

- `status_test.cpp` — Status and Result type correctness
- `memory_pool_test.cpp` — MemoryPool allocation and lifecycle
- `bytes_test.cpp` — Bytes buffer operations

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
