### PR TITLE
feat(cmake): add find package modules

### DIFF
--- a/cmake_modules/FindArrowAlt.cmake
+++ b/cmake_modules/FindArrowAlt.cmake
@@ -1,0 +1,100 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_ARROW_ROOTS ${Arrow_ROOT} ${ARROW_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_ARROW_ROOTS "")
+if(_PAIMON_ARROW_ROOTS)
+    set(_PAIMON_ARROW_FIND_ARGS HINTS ${_PAIMON_ARROW_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+find_package(Arrow CONFIG QUIET ${_PAIMON_ARROW_FIND_ARGS})
+find_package(Parquet CONFIG QUIET ${_PAIMON_ARROW_FIND_ARGS})
+find_package(ArrowDataset CONFIG QUIET ${_PAIMON_ARROW_FIND_ARGS})
+find_package(ArrowAcero CONFIG QUIET ${_PAIMON_ARROW_FIND_ARGS})
+
+function(_paimon_select_first_target OUT_VAR)
+    foreach(_target IN LISTS ARGN)
+        if(TARGET ${_target})
+            set(${OUT_VAR}
+                ${_target}
+                PARENT_SCOPE)
+            return()
+        endif()
+    endforeach()
+endfunction()
+
+if(PAIMON_DEPENDENCY_USE_SHARED)
+    _paimon_select_first_target(_PAIMON_ARROW_TARGET Arrow::arrow_shared Arrow::arrow)
+    _paimon_select_first_target(_PAIMON_PARQUET_TARGET Parquet::parquet_shared
+                                Parquet::parquet)
+    _paimon_select_first_target(_PAIMON_ARROW_DATASET_TARGET
+                                ArrowDataset::arrow_dataset_shared
+                                Arrow::arrow_dataset_shared ArrowDataset::arrow_dataset)
+    _paimon_select_first_target(_PAIMON_ARROW_ACERO_TARGET ArrowAcero::arrow_acero_shared
+                                Arrow::arrow_acero_shared ArrowAcero::arrow_acero)
+else()
+    _paimon_select_first_target(_PAIMON_ARROW_TARGET Arrow::arrow_static Arrow::arrow)
+    _paimon_select_first_target(_PAIMON_PARQUET_TARGET Parquet::parquet_static
+                                Parquet::parquet)
+    _paimon_select_first_target(_PAIMON_ARROW_DATASET_TARGET
+                                ArrowDataset::arrow_dataset_static
+                                Arrow::arrow_dataset_static ArrowDataset::arrow_dataset)
+    _paimon_select_first_target(_PAIMON_ARROW_ACERO_TARGET ArrowAcero::arrow_acero_static
+                                Arrow::arrow_acero_static ArrowAcero::arrow_acero)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+    ArrowAlt REQUIRED_VARS _PAIMON_ARROW_TARGET _PAIMON_PARQUET_TARGET
+                           _PAIMON_ARROW_DATASET_TARGET _PAIMON_ARROW_ACERO_TARGET)
+
+if(ArrowAlt_FOUND)
+    get_target_property(ARROW_INCLUDE_DIR ${_PAIMON_ARROW_TARGET}
+                        INTERFACE_INCLUDE_DIRECTORIES)
+
+    if(NOT TARGET arrow)
+        add_library(arrow INTERFACE IMPORTED)
+        if(ARROW_INCLUDE_DIR)
+            set_target_properties(arrow PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                   "${ARROW_INCLUDE_DIR}")
+        endif()
+        target_link_libraries(arrow INTERFACE ${_PAIMON_ARROW_TARGET})
+    endif()
+
+    if(NOT TARGET arrow_acero)
+        add_library(arrow_acero INTERFACE IMPORTED)
+        target_link_libraries(arrow_acero INTERFACE ${_PAIMON_ARROW_ACERO_TARGET} arrow)
+    endif()
+
+    if(NOT TARGET arrow_dataset)
+        add_library(arrow_dataset INTERFACE IMPORTED)
+        target_link_libraries(arrow_dataset INTERFACE ${_PAIMON_ARROW_DATASET_TARGET}
+                                                      arrow_acero)
+    endif()
+
+    if(NOT TARGET parquet)
+        add_library(parquet INTERFACE IMPORTED)
+        target_link_libraries(parquet INTERFACE ${_PAIMON_PARQUET_TARGET} arrow_dataset)
+    endif()
+endif()
+
+unset(_PAIMON_ARROW_ACERO_TARGET)
+unset(_PAIMON_ARROW_DATASET_TARGET)
+unset(_PAIMON_ARROW_FIND_ARGS)
+unset(_PAIMON_ARROW_ROOTS)
+unset(_PAIMON_ARROW_TARGET)
+unset(_PAIMON_PARQUET_TARGET)

--- a/cmake_modules/FindAvroAlt.cmake
+++ b/cmake_modules/FindAvroAlt.cmake
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_AVRO_ROOTS ${Avro_ROOT} ${AVRO_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_AVRO_ROOTS "")
+if(_PAIMON_AVRO_ROOTS)
+    set(_PAIMON_AVRO_FIND_ARGS HINTS ${_PAIMON_AVRO_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+find_package(PkgConfig QUIET)
+if(PkgConfig_FOUND)
+    pkg_check_modules(PC_Avro QUIET avro-cpp)
+endif()
+
+find_path(AVRO_INCLUDE_DIR
+          NAMES avro/Decoder.hh ${_PAIMON_AVRO_FIND_ARGS}
+          HINTS ${PC_Avro_INCLUDE_DIRS}
+          PATH_SUFFIXES include)
+
+if(PAIMON_DEPENDENCY_USE_SHARED)
+    set(_PAIMON_AVRO_LIBRARY_NAMES avrocpp avrocpp_s)
+else()
+    set(_PAIMON_AVRO_LIBRARY_NAMES avrocpp_s avrocpp)
+endif()
+
+find_library(AVRO_LIBRARY
+             NAMES ${_PAIMON_AVRO_LIBRARY_NAMES} ${_PAIMON_AVRO_FIND_ARGS}
+             HINTS ${PC_Avro_LIBRARY_DIRS}
+             PATH_SUFFIXES lib lib64)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(AvroAlt REQUIRED_VARS AVRO_LIBRARY AVRO_INCLUDE_DIR)
+
+if(AvroAlt_FOUND AND NOT TARGET avro)
+    add_library(avro UNKNOWN IMPORTED)
+    set_target_properties(avro
+                          PROPERTIES IMPORTED_LOCATION "${AVRO_LIBRARY}"
+                                     INTERFACE_INCLUDE_DIRECTORIES "${AVRO_INCLUDE_DIR}")
+    foreach(_dependency zlib zstd snappy)
+        if(TARGET ${_dependency})
+            target_link_libraries(avro INTERFACE ${_dependency})
+        endif()
+    endforeach()
+    set(AVRO_LIBRARIES "${AVRO_LIBRARY}")
+endif()
+
+unset(_PAIMON_AVRO_FIND_ARGS)
+unset(_PAIMON_AVRO_LIBRARY_NAMES)
+unset(_PAIMON_AVRO_ROOTS)

--- a/cmake_modules/FindGTestAlt.cmake
+++ b/cmake_modules/FindGTestAlt.cmake
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_GTEST_ROOTS ${GTest_ROOT} ${GTEST_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_GTEST_ROOTS "")
+if(_PAIMON_GTEST_ROOTS)
+    set(_PAIMON_GTEST_FIND_ARGS HINTS ${_PAIMON_GTEST_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(GTest CONFIG QUIET ${_PAIMON_GTEST_FIND_ARGS})
+
+if(NOT TARGET GTest::gtest
+   OR NOT TARGET GTest::gtest_main
+   OR NOT TARGET GTest::gmock)
+    find_path(GTEST_INCLUDE_DIR
+              NAMES gtest/gtest.h ${_PAIMON_GTEST_FIND_ARGS}
+              PATH_SUFFIXES include)
+    find_library(GTEST_LIBRARY
+                 NAMES gtest ${_PAIMON_GTEST_FIND_ARGS}
+                 PATH_SUFFIXES lib lib64)
+    find_library(GTEST_MAIN_LIBRARY
+                 NAMES gtest_main ${_PAIMON_GTEST_FIND_ARGS}
+                 PATH_SUFFIXES lib lib64)
+    find_library(GMOCK_LIBRARY
+                 NAMES gmock ${_PAIMON_GTEST_FIND_ARGS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(
+        GTestAlt REQUIRED_VARS GTEST_INCLUDE_DIR GTEST_LIBRARY GTEST_MAIN_LIBRARY
+                               GMOCK_LIBRARY)
+
+    if(GTestAlt_FOUND)
+        if(NOT TARGET GTest::gtest)
+            add_library(GTest::gtest UNKNOWN IMPORTED)
+            set_target_properties(GTest::gtest
+                                  PROPERTIES IMPORTED_LOCATION "${GTEST_LIBRARY}"
+                                             INTERFACE_INCLUDE_DIRECTORIES
+                                             "${GTEST_INCLUDE_DIR}")
+        endif()
+        if(NOT TARGET GTest::gtest_main)
+            add_library(GTest::gtest_main UNKNOWN IMPORTED)
+            set_target_properties(GTest::gtest_main
+                                  PROPERTIES IMPORTED_LOCATION "${GTEST_MAIN_LIBRARY}"
+                                             INTERFACE_INCLUDE_DIRECTORIES
+                                             "${GTEST_INCLUDE_DIR}")
+        endif()
+        if(NOT TARGET GTest::gmock)
+            add_library(GTest::gmock UNKNOWN IMPORTED)
+            set_target_properties(GTest::gmock
+                                  PROPERTIES IMPORTED_LOCATION "${GMOCK_LIBRARY}"
+                                             INTERFACE_INCLUDE_DIRECTORIES
+                                             "${GTEST_INCLUDE_DIR}")
+        endif()
+    endif()
+else()
+    paimon_find_target_headers(GTEST_INCLUDE_DIR
+                               GTest::gtest
+                               NAMES
+                               gtest/gtest.h
+                               ${_PAIMON_GTEST_FIND_ARGS})
+    paimon_find_target_headers(GMOCK_INCLUDE_DIR
+                               GTest::gmock
+                               NAMES
+                               gmock/gmock.h
+                               ${_PAIMON_GTEST_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(GTestAlt REQUIRED_VARS GTEST_INCLUDE_DIR
+                                                             GMOCK_INCLUDE_DIR)
+endif()
+
+if(GTestAlt_FOUND)
+    find_package(Threads REQUIRED)
+    set(GTEST_LINK_TOOLCHAIN GTest::gtest_main GTest::gtest GTest::gmock Threads::Threads)
+endif()
+
+unset(_PAIMON_GTEST_FIND_ARGS)
+unset(_PAIMON_GTEST_ROOTS)

--- a/cmake_modules/FindLZ4Alt.cmake
+++ b/cmake_modules/FindLZ4Alt.cmake
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_LZ4_ROOTS ${LZ4_ROOT} ${lz4_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_LZ4_ROOTS "")
+if(_PAIMON_LZ4_ROOTS)
+    set(_PAIMON_LZ4_FIND_ARGS HINTS ${_PAIMON_LZ4_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(lz4 CONFIG QUIET ${_PAIMON_LZ4_FIND_ARGS})
+find_package(LZ4 CONFIG QUIET ${_PAIMON_LZ4_FIND_ARGS})
+
+set(_PAIMON_LZ4_TARGETS lz4::lz4 lz4::lz4_static LZ4::lz4 LZ4::LZ4)
+foreach(_target IN LISTS _PAIMON_LZ4_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_LZ4_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+if(_PAIMON_LZ4_TARGET)
+    paimon_find_target_headers(LZ4_INCLUDE_DIR
+                               ${_PAIMON_LZ4_TARGET}
+                               NAMES
+                               lz4.h
+                               ${_PAIMON_LZ4_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(LZ4Alt REQUIRED_VARS LZ4_INCLUDE_DIR)
+
+    if(LZ4Alt_FOUND AND NOT TARGET lz4)
+        add_library(lz4 INTERFACE IMPORTED)
+        set_target_properties(lz4 PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                             "${LZ4_INCLUDE_DIR}")
+        target_link_libraries(lz4 INTERFACE ${_PAIMON_LZ4_TARGET})
+    endif()
+    if(LZ4Alt_FOUND)
+        set(LZ4_LIBRARIES ${_PAIMON_LZ4_TARGET})
+    endif()
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PC_LZ4 QUIET liblz4)
+    endif()
+
+    find_path(LZ4_INCLUDE_DIR
+              NAMES lz4.h ${_PAIMON_LZ4_FIND_ARGS}
+              HINTS ${PC_LZ4_INCLUDE_DIRS}
+              PATH_SUFFIXES include)
+    find_library(LZ4_LIBRARY
+                 NAMES lz4 liblz4 ${_PAIMON_LZ4_FIND_ARGS}
+                 HINTS ${PC_LZ4_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(LZ4Alt REQUIRED_VARS LZ4_LIBRARY LZ4_INCLUDE_DIR)
+
+    if(LZ4Alt_FOUND AND NOT TARGET lz4)
+        add_library(lz4 UNKNOWN IMPORTED)
+        set_target_properties(lz4
+                              PROPERTIES IMPORTED_LOCATION "${LZ4_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES
+                                         "${LZ4_INCLUDE_DIR}")
+        set(LZ4_LIBRARIES "${LZ4_LIBRARY}")
+    endif()
+endif()
+
+unset(_PAIMON_LZ4_FIND_ARGS)
+unset(_PAIMON_LZ4_ROOTS)
+unset(_PAIMON_LZ4_TARGET)
+unset(_PAIMON_LZ4_TARGETS)

--- a/cmake_modules/FindORCAlt.cmake
+++ b/cmake_modules/FindORCAlt.cmake
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_ORC_ROOTS ${ORC_ROOT} ${orc_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_ORC_ROOTS "")
+if(_PAIMON_ORC_ROOTS)
+    set(_PAIMON_ORC_FIND_ARGS HINTS ${_PAIMON_ORC_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+find_package(orc CONFIG QUIET ${_PAIMON_ORC_FIND_ARGS})
+find_package(ORC CONFIG QUIET ${_PAIMON_ORC_FIND_ARGS})
+
+set(_PAIMON_ORC_TARGETS orc::orc ORC::orc ORC::ORC orc)
+foreach(_target IN LISTS _PAIMON_ORC_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_ORC_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+if(_PAIMON_ORC_TARGET)
+    if(NOT TARGET orc::orc)
+        add_library(orc::orc INTERFACE IMPORTED)
+        target_link_libraries(orc::orc INTERFACE ${_PAIMON_ORC_TARGET})
+    endif()
+
+    foreach(_dependency
+            zstd
+            snappy
+            lz4
+            zlib
+            libprotobuf)
+        if(TARGET ${_dependency})
+            target_link_libraries(orc::orc INTERFACE ${_dependency})
+        endif()
+    endforeach()
+
+    get_target_property(ORC_INCLUDE_DIR orc::orc INTERFACE_INCLUDE_DIRECTORIES)
+    set(ORCAlt_FOUND TRUE)
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PC_ORC QUIET orc)
+    endif()
+
+    find_path(ORC_INCLUDE_DIR
+              NAMES orc/OrcFile.hh ${_PAIMON_ORC_FIND_ARGS}
+              HINTS ${PC_ORC_INCLUDE_DIRS}
+              PATH_SUFFIXES include)
+    find_library(ORC_LIBRARY
+                 NAMES orc ${_PAIMON_ORC_FIND_ARGS}
+                 HINTS ${PC_ORC_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(ORCAlt REQUIRED_VARS ORC_LIBRARY ORC_INCLUDE_DIR)
+
+    if(ORCAlt_FOUND AND NOT TARGET orc::orc)
+        add_library(orc::orc UNKNOWN IMPORTED)
+        set_target_properties(orc::orc
+                              PROPERTIES IMPORTED_LOCATION "${ORC_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES
+                                         "${ORC_INCLUDE_DIR}")
+        foreach(_dependency
+                zstd
+                snappy
+                lz4
+                zlib
+                libprotobuf)
+            if(TARGET ${_dependency})
+                target_link_libraries(orc::orc INTERFACE ${_dependency})
+            endif()
+        endforeach()
+    endif()
+endif()
+
+unset(_PAIMON_ORC_FIND_ARGS)
+unset(_PAIMON_ORC_ROOTS)
+unset(_PAIMON_ORC_TARGET)
+unset(_PAIMON_ORC_TARGETS)

--- a/cmake_modules/FindPackageUtils.cmake
+++ b/cmake_modules/FindPackageUtils.cmake
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+function(paimon_find_target_headers OUT_VAR TARGET_NAME)
+    set(options NO_DEFAULT_PATH)
+    set(one_value_args)
+    set(multi_value_args NAMES HINTS PATH_SUFFIXES)
+    cmake_parse_arguments(ARG
+                          "${options}"
+                          "${one_value_args}"
+                          "${multi_value_args}"
+                          ${ARGN})
+
+    if(NOT TARGET ${TARGET_NAME} OR NOT ARG_NAMES)
+        set(${OUT_VAR}
+            "${OUT_VAR}-NOTFOUND"
+            PARENT_SCOPE)
+        return()
+    endif()
+
+    set(_target_include_dirs)
+    foreach(_property INTERFACE_INCLUDE_DIRECTORIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES
+                      INCLUDE_DIRECTORIES)
+        get_target_property(_property_value ${TARGET_NAME} ${_property})
+        if(_property_value AND NOT _property_value MATCHES "-NOTFOUND$")
+            list(APPEND _target_include_dirs ${_property_value})
+        endif()
+    endforeach()
+
+    set(_search_dirs)
+    foreach(_dir IN LISTS _target_include_dirs)
+        if(_dir MATCHES "^\\$<BUILD_INTERFACE:(.*)>$")
+            list(APPEND _search_dirs "${CMAKE_MATCH_1}")
+        elseif(_dir MATCHES "^\\$<INSTALL_INTERFACE:(.*)>$")
+            if(IS_ABSOLUTE "${CMAKE_MATCH_1}")
+                list(APPEND _search_dirs "${CMAKE_MATCH_1}")
+            endif()
+        elseif(NOT _dir MATCHES "^\\$<")
+            list(APPEND _search_dirs "${_dir}")
+        endif()
+    endforeach()
+
+    list(APPEND _search_dirs ${ARG_HINTS})
+    if(_search_dirs)
+        list(REMOVE_DUPLICATES _search_dirs)
+    endif()
+
+    string(MAKE_C_IDENTIFIER "${TARGET_NAME}_${ARG_NAMES}" _header_var_suffix)
+    set(_header_dir_var "PAIMON_${_header_var_suffix}_HEADER_DIR")
+    set(_find_args NAMES ${ARG_NAMES})
+    if(_search_dirs)
+        list(APPEND _find_args HINTS ${_search_dirs})
+    endif()
+    if(ARG_PATH_SUFFIXES)
+        list(APPEND _find_args PATH_SUFFIXES ${ARG_PATH_SUFFIXES})
+    endif()
+    list(APPEND _find_args NO_DEFAULT_PATH)
+
+    unset(${_header_dir_var} CACHE)
+    find_path(${_header_dir_var} ${_find_args})
+
+    if(NOT ${_header_dir_var})
+        get_property(_partial_targets GLOBAL PROPERTY PAIMON_PARTIAL_SYSTEM_TARGETS)
+        list(APPEND _partial_targets "${TARGET_NAME}: ${ARG_NAMES}")
+        set_property(GLOBAL PROPERTY PAIMON_PARTIAL_SYSTEM_TARGETS "${_partial_targets}")
+    endif()
+
+    set(${OUT_VAR}
+        "${${_header_dir_var}}"
+        PARENT_SCOPE)
+
+    unset(${_header_dir_var} CACHE)
+    unset(_find_args)
+    unset(_header_dir_var)
+    unset(_header_var_suffix)
+    unset(_partial_targets)
+    unset(_property_value)
+    unset(_search_dirs)
+    unset(_target_include_dirs)
+endfunction()

--- a/cmake_modules/FindProtobufAlt.cmake
+++ b/cmake_modules/FindProtobufAlt.cmake
@@ -1,0 +1,157 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_PROTOBUF_ROOTS ${Protobuf_ROOT} ${PROTOBUF_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_PROTOBUF_ROOTS "")
+if(_PAIMON_PROTOBUF_ROOTS)
+    set(_PAIMON_PROTOBUF_FIND_ARGS HINTS ${_PAIMON_PROTOBUF_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(Protobuf CONFIG QUIET ${_PAIMON_PROTOBUF_FIND_ARGS})
+
+set(_PAIMON_PROTOBUF_LIBRARY_TARGETS protobuf::libprotobuf Protobuf::libprotobuf)
+foreach(_target IN LISTS _PAIMON_PROTOBUF_LIBRARY_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_PROTOBUF_LIBRARY_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+set(_PAIMON_PROTOC_LIBRARY_TARGETS protobuf::libprotoc Protobuf::libprotoc)
+foreach(_target IN LISTS _PAIMON_PROTOC_LIBRARY_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_PROTOC_LIBRARY_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+set(_PAIMON_PROTOC_TARGETS protobuf::protoc Protobuf::protoc)
+foreach(_target IN LISTS _PAIMON_PROTOC_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_PROTOC_TARGET ${_target})
+        get_target_property(PROTOBUF_COMPILER ${_PAIMON_PROTOC_TARGET} IMPORTED_LOCATION)
+        break()
+    endif()
+endforeach()
+
+if(_PAIMON_PROTOBUF_LIBRARY_TARGET AND NOT PROTOBUF_COMPILER)
+    find_program(PROTOBUF_COMPILER
+                 NAMES protoc ${_PAIMON_PROTOBUF_FIND_ARGS}
+                 PATH_SUFFIXES bin)
+endif()
+
+if(_PAIMON_PROTOBUF_LIBRARY_TARGET)
+    paimon_find_target_headers(PROTOBUF_INCLUDE_DIR
+                               ${_PAIMON_PROTOBUF_LIBRARY_TARGET}
+                               NAMES
+                               google/protobuf/message.h
+                               ${_PAIMON_PROTOBUF_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(
+        ProtobufAlt REQUIRED_VARS _PAIMON_PROTOBUF_LIBRARY_TARGET PROTOBUF_INCLUDE_DIR
+                                  PROTOBUF_COMPILER)
+    if(ProtobufAlt_FOUND)
+        if(NOT TARGET libprotobuf)
+            add_library(libprotobuf INTERFACE IMPORTED)
+            set_target_properties(libprotobuf PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                         "${PROTOBUF_INCLUDE_DIR}")
+            target_link_libraries(libprotobuf
+                                  INTERFACE ${_PAIMON_PROTOBUF_LIBRARY_TARGET})
+        endif()
+
+        if(_PAIMON_PROTOC_LIBRARY_TARGET AND NOT TARGET libprotoc)
+            add_library(libprotoc INTERFACE IMPORTED)
+            set_target_properties(libprotoc PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                       "${PROTOBUF_INCLUDE_DIR}")
+            target_link_libraries(libprotoc INTERFACE ${_PAIMON_PROTOC_LIBRARY_TARGET})
+        endif()
+
+        if(NOT TARGET protoc)
+            add_executable(protoc IMPORTED)
+            set_target_properties(protoc PROPERTIES IMPORTED_LOCATION
+                                                    "${PROTOBUF_COMPILER}")
+        endif()
+
+        set(PROTOBUF_LIBRARIES ${_PAIMON_PROTOBUF_LIBRARY_TARGET})
+    endif()
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PC_Protobuf QUIET protobuf)
+    endif()
+
+    find_path(PROTOBUF_INCLUDE_DIR
+              NAMES google/protobuf/message.h ${_PAIMON_PROTOBUF_FIND_ARGS}
+              HINTS ${PC_Protobuf_INCLUDE_DIRS}
+              PATH_SUFFIXES include)
+    find_library(PROTOBUF_LIBRARY
+                 NAMES protobuf ${_PAIMON_PROTOBUF_FIND_ARGS}
+                 HINTS ${PC_Protobuf_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+    find_library(PROTOC_LIBRARY
+                 NAMES protoc ${_PAIMON_PROTOBUF_FIND_ARGS}
+                 HINTS ${PC_Protobuf_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+    find_program(PROTOBUF_COMPILER
+                 NAMES protoc ${_PAIMON_PROTOBUF_FIND_ARGS}
+                 PATH_SUFFIXES bin)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(
+        ProtobufAlt REQUIRED_VARS PROTOBUF_LIBRARY PROTOBUF_INCLUDE_DIR PROTOBUF_COMPILER)
+
+    if(ProtobufAlt_FOUND)
+        if(NOT TARGET libprotobuf)
+            add_library(libprotobuf UNKNOWN IMPORTED)
+            set_target_properties(libprotobuf
+                                  PROPERTIES IMPORTED_LOCATION "${PROTOBUF_LIBRARY}"
+                                             INTERFACE_INCLUDE_DIRECTORIES
+                                             "${PROTOBUF_INCLUDE_DIR}")
+            if(TARGET zlib)
+                target_link_libraries(libprotobuf INTERFACE zlib)
+            endif()
+        endif()
+
+        if(PROTOC_LIBRARY AND NOT TARGET libprotoc)
+            add_library(libprotoc UNKNOWN IMPORTED)
+            set_target_properties(libprotoc
+                                  PROPERTIES IMPORTED_LOCATION "${PROTOC_LIBRARY}"
+                                             INTERFACE_INCLUDE_DIRECTORIES
+                                             "${PROTOBUF_INCLUDE_DIR}")
+            target_link_libraries(libprotoc INTERFACE libprotobuf)
+        endif()
+
+        if(NOT TARGET protoc)
+            add_executable(protoc IMPORTED)
+            set_target_properties(protoc PROPERTIES IMPORTED_LOCATION
+                                                    "${PROTOBUF_COMPILER}")
+        endif()
+
+        set(PROTOBUF_LIBRARIES "${PROTOBUF_LIBRARY}")
+    endif()
+endif()
+
+unset(_PAIMON_PROTOBUF_FIND_ARGS)
+unset(_PAIMON_PROTOBUF_LIBRARY_TARGET)
+unset(_PAIMON_PROTOBUF_LIBRARY_TARGETS)
+unset(_PAIMON_PROTOBUF_ROOTS)
+unset(_PAIMON_PROTOC_LIBRARY_TARGET)
+unset(_PAIMON_PROTOC_LIBRARY_TARGETS)
+unset(_PAIMON_PROTOC_TARGET)
+unset(_PAIMON_PROTOC_TARGETS)

--- a/cmake_modules/FindRE2Alt.cmake
+++ b/cmake_modules/FindRE2Alt.cmake
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_RE2_ROOTS ${RE2_ROOT} ${re2_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_RE2_ROOTS "")
+if(_PAIMON_RE2_ROOTS)
+    set(_PAIMON_RE2_FIND_ARGS HINTS ${_PAIMON_RE2_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(re2 CONFIG QUIET ${_PAIMON_RE2_FIND_ARGS})
+
+if(TARGET re2::re2)
+    paimon_find_target_headers(RE2_INCLUDE_DIR
+                               re2::re2
+                               NAMES
+                               re2/re2.h
+                               ${_PAIMON_RE2_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(RE2Alt REQUIRED_VARS RE2_INCLUDE_DIR)
+
+    if(RE2Alt_FOUND)
+        set(RE2_LIBRARIES re2::re2)
+    endif()
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PC_RE2 QUIET re2)
+    endif()
+
+    find_path(RE2_INCLUDE_DIR
+              NAMES re2/re2.h ${_PAIMON_RE2_FIND_ARGS}
+              HINTS ${PC_RE2_INCLUDE_DIRS}
+              PATH_SUFFIXES include)
+    find_library(RE2_LIBRARY
+                 NAMES re2 ${_PAIMON_RE2_FIND_ARGS}
+                 HINTS ${PC_RE2_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(RE2Alt REQUIRED_VARS RE2_LIBRARY RE2_INCLUDE_DIR)
+
+    if(RE2Alt_FOUND)
+        add_library(re2::re2 UNKNOWN IMPORTED)
+        set_target_properties(re2::re2
+                              PROPERTIES IMPORTED_LOCATION "${RE2_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES
+                                         "${RE2_INCLUDE_DIR}")
+        set(RE2_LIBRARIES "${RE2_LIBRARY}")
+    endif()
+endif()
+
+unset(_PAIMON_RE2_FIND_ARGS)
+unset(_PAIMON_RE2_ROOTS)

--- a/cmake_modules/FindRapidJSONAlt.cmake
+++ b/cmake_modules/FindRapidJSONAlt.cmake
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_RAPIDJSON_ROOTS ${RapidJSON_ROOT} ${RAPIDJSON_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_RAPIDJSON_ROOTS "")
+if(_PAIMON_RAPIDJSON_ROOTS)
+    set(_PAIMON_RAPIDJSON_FIND_ARGS HINTS ${_PAIMON_RAPIDJSON_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(RapidJSON CONFIG QUIET ${_PAIMON_RAPIDJSON_FIND_ARGS})
+
+set(_PAIMON_RAPIDJSON_TARGETS RapidJSON RapidJSON::RapidJSON)
+foreach(_target IN LISTS _PAIMON_RAPIDJSON_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_RAPIDJSON_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+if(_PAIMON_RAPIDJSON_TARGET)
+    paimon_find_target_headers(RAPIDJSON_INCLUDE_DIR
+                               ${_PAIMON_RAPIDJSON_TARGET}
+                               NAMES
+                               rapidjson/rapidjson.h
+                               ${_PAIMON_RAPIDJSON_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(RapidJSONAlt REQUIRED_VARS RAPIDJSON_INCLUDE_DIR)
+
+    if(RapidJSONAlt_FOUND AND NOT TARGET RapidJSON)
+        add_library(RapidJSON INTERFACE IMPORTED)
+        target_include_directories(RapidJSON INTERFACE "${RAPIDJSON_INCLUDE_DIR}")
+        target_link_libraries(RapidJSON INTERFACE ${_PAIMON_RAPIDJSON_TARGET})
+    endif()
+else()
+    find_path(RAPIDJSON_INCLUDE_DIR
+              NAMES rapidjson/rapidjson.h ${_PAIMON_RAPIDJSON_FIND_ARGS}
+              PATH_SUFFIXES include)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(RapidJSONAlt REQUIRED_VARS RAPIDJSON_INCLUDE_DIR)
+
+    if(RapidJSONAlt_FOUND AND NOT TARGET RapidJSON)
+        add_library(RapidJSON INTERFACE IMPORTED)
+        target_include_directories(RapidJSON INTERFACE "${RAPIDJSON_INCLUDE_DIR}")
+    endif()
+endif()
+
+unset(_PAIMON_RAPIDJSON_FIND_ARGS)
+unset(_PAIMON_RAPIDJSON_ROOTS)
+unset(_PAIMON_RAPIDJSON_TARGET)
+unset(_PAIMON_RAPIDJSON_TARGETS)

--- a/cmake_modules/FindSnappyAlt.cmake
+++ b/cmake_modules/FindSnappyAlt.cmake
@@ -1,0 +1,86 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_SNAPPY_ROOTS ${Snappy_ROOT} ${SNAPPY_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_SNAPPY_ROOTS "")
+if(_PAIMON_SNAPPY_ROOTS)
+    set(_PAIMON_SNAPPY_FIND_ARGS HINTS ${_PAIMON_SNAPPY_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(Snappy CONFIG QUIET ${_PAIMON_SNAPPY_FIND_ARGS})
+
+set(_PAIMON_SNAPPY_TARGETS Snappy::snappy snappy::snappy)
+foreach(_target IN LISTS _PAIMON_SNAPPY_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_SNAPPY_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+if(_PAIMON_SNAPPY_TARGET)
+    paimon_find_target_headers(SNAPPY_INCLUDE_DIR
+                               ${_PAIMON_SNAPPY_TARGET}
+                               NAMES
+                               snappy.h
+                               ${_PAIMON_SNAPPY_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(SnappyAlt REQUIRED_VARS SNAPPY_INCLUDE_DIR)
+
+    if(SnappyAlt_FOUND AND NOT TARGET snappy)
+        add_library(snappy INTERFACE IMPORTED)
+        set_target_properties(snappy PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                                "${SNAPPY_INCLUDE_DIR}")
+        target_link_libraries(snappy INTERFACE ${_PAIMON_SNAPPY_TARGET})
+    endif()
+    if(SnappyAlt_FOUND)
+        set(SNAPPY_LIBRARIES ${_PAIMON_SNAPPY_TARGET})
+    endif()
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PC_Snappy QUIET snappy)
+    endif()
+
+    find_path(SNAPPY_INCLUDE_DIR
+              NAMES snappy.h ${_PAIMON_SNAPPY_FIND_ARGS}
+              HINTS ${PC_Snappy_INCLUDE_DIRS}
+              PATH_SUFFIXES include)
+    find_library(SNAPPY_LIBRARY
+                 NAMES snappy ${_PAIMON_SNAPPY_FIND_ARGS}
+                 HINTS ${PC_Snappy_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(SnappyAlt REQUIRED_VARS SNAPPY_LIBRARY
+                                                              SNAPPY_INCLUDE_DIR)
+
+    if(SnappyAlt_FOUND AND NOT TARGET snappy)
+        add_library(snappy UNKNOWN IMPORTED)
+        set_target_properties(snappy
+                              PROPERTIES IMPORTED_LOCATION "${SNAPPY_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES
+                                         "${SNAPPY_INCLUDE_DIR}")
+        set(SNAPPY_LIBRARIES "${SNAPPY_LIBRARY}")
+    endif()
+endif()
+
+unset(_PAIMON_SNAPPY_FIND_ARGS)
+unset(_PAIMON_SNAPPY_ROOTS)
+unset(_PAIMON_SNAPPY_TARGET)
+unset(_PAIMON_SNAPPY_TARGETS)

--- a/cmake_modules/FindTBBAlt.cmake
+++ b/cmake_modules/FindTBBAlt.cmake
@@ -1,0 +1,82 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_TBB_ROOTS ${TBB_ROOT} ${tbb_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_TBB_ROOTS "")
+if(_PAIMON_TBB_ROOTS)
+    set(_PAIMON_TBB_FIND_ARGS HINTS ${_PAIMON_TBB_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(TBB CONFIG QUIET ${_PAIMON_TBB_FIND_ARGS})
+
+set(_PAIMON_TBB_TARGETS TBB::tbb tbb)
+foreach(_target IN LISTS _PAIMON_TBB_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_TBB_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+if(_PAIMON_TBB_TARGET)
+    paimon_find_target_headers(TBB_INCLUDE_DIR
+                               ${_PAIMON_TBB_TARGET}
+                               NAMES
+                               tbb/tbb.h
+                               oneapi/tbb/tbb.h
+                               ${_PAIMON_TBB_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(TBBAlt REQUIRED_VARS TBB_INCLUDE_DIR)
+
+    if(TBBAlt_FOUND AND NOT TARGET tbb)
+        add_library(tbb INTERFACE IMPORTED)
+        set_target_properties(tbb PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                             "${TBB_INCLUDE_DIR}")
+        target_link_libraries(tbb INTERFACE ${_PAIMON_TBB_TARGET})
+    endif()
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PC_TBB QUIET tbb)
+    endif()
+
+    find_path(TBB_INCLUDE_DIR
+              NAMES tbb/tbb.h oneapi/tbb/tbb.h ${_PAIMON_TBB_FIND_ARGS}
+              HINTS ${PC_TBB_INCLUDE_DIRS}
+              PATH_SUFFIXES include)
+    find_library(TBB_LIBRARY
+                 NAMES tbb ${_PAIMON_TBB_FIND_ARGS}
+                 HINTS ${PC_TBB_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(TBBAlt REQUIRED_VARS TBB_LIBRARY TBB_INCLUDE_DIR)
+
+    if(TBBAlt_FOUND AND NOT TARGET tbb)
+        add_library(tbb UNKNOWN IMPORTED)
+        set_target_properties(tbb
+                              PROPERTIES IMPORTED_LOCATION "${TBB_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES
+                                         "${TBB_INCLUDE_DIR}")
+    endif()
+endif()
+
+unset(_PAIMON_TBB_FIND_ARGS)
+unset(_PAIMON_TBB_ROOTS)
+unset(_PAIMON_TBB_TARGET)
+unset(_PAIMON_TBB_TARGETS)

--- a/cmake_modules/FindZLIBAlt.cmake
+++ b/cmake_modules/FindZLIBAlt.cmake
@@ -1,0 +1,74 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_ZLIB_ROOTS ${ZLIB_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_ZLIB_ROOTS "")
+if(_PAIMON_ZLIB_ROOTS)
+    set(_PAIMON_ZLIB_FIND_ARGS HINTS ${_PAIMON_ZLIB_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+if(_PAIMON_ZLIB_ROOTS)
+    find_package(ZLIB CONFIG QUIET ${_PAIMON_ZLIB_FIND_ARGS})
+else()
+    find_package(ZLIB QUIET)
+endif()
+
+if(TARGET ZLIB::ZLIB)
+    paimon_find_target_headers(ZLIB_INCLUDE_DIR
+                               ZLIB::ZLIB
+                               NAMES
+                               zlib.h
+                               HINTS
+                               ${ZLIB_INCLUDE_DIRS}
+                               ${_PAIMON_ZLIB_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(ZLIBAlt REQUIRED_VARS ZLIB_INCLUDE_DIR)
+
+    if(ZLIBAlt_FOUND AND NOT TARGET zlib)
+        add_library(zlib INTERFACE IMPORTED)
+        set_target_properties(zlib PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                              "${ZLIB_INCLUDE_DIR}")
+        target_link_libraries(zlib INTERFACE ZLIB::ZLIB)
+    endif()
+    if(ZLIBAlt_FOUND)
+        set(ZLIB_LIBRARIES ZLIB::ZLIB)
+    endif()
+else()
+    find_path(ZLIB_INCLUDE_DIR
+              NAMES zlib.h ${_PAIMON_ZLIB_FIND_ARGS}
+              PATH_SUFFIXES include)
+    find_library(ZLIB_LIBRARY
+                 NAMES z zlib ${_PAIMON_ZLIB_FIND_ARGS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(ZLIBAlt REQUIRED_VARS ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
+
+    if(ZLIBAlt_FOUND AND NOT TARGET zlib)
+        add_library(zlib UNKNOWN IMPORTED)
+        set_target_properties(zlib
+                              PROPERTIES IMPORTED_LOCATION "${ZLIB_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES
+                                         "${ZLIB_INCLUDE_DIR}")
+        set(ZLIB_LIBRARIES "${ZLIB_LIBRARY}")
+    endif()
+endif()
+
+unset(_PAIMON_ZLIB_FIND_ARGS)
+unset(_PAIMON_ZLIB_ROOTS)

--- a/cmake_modules/FindfmtAlt.cmake
+++ b/cmake_modules/FindfmtAlt.cmake
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_FMT_ROOTS ${fmt_ROOT} ${FMT_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_FMT_ROOTS "")
+if(_PAIMON_FMT_ROOTS)
+    set(_PAIMON_FMT_FIND_ARGS HINTS ${_PAIMON_FMT_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(fmt CONFIG QUIET ${_PAIMON_FMT_FIND_ARGS})
+
+set(_PAIMON_FMT_TARGETS fmt::fmt fmt::fmt-header-only)
+foreach(_target IN LISTS _PAIMON_FMT_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_FMT_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+if(_PAIMON_FMT_TARGET)
+    paimon_find_target_headers(FMT_INCLUDE_DIR
+                               ${_PAIMON_FMT_TARGET}
+                               NAMES
+                               fmt/core.h
+                               ${_PAIMON_FMT_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(fmtAlt REQUIRED_VARS FMT_INCLUDE_DIR)
+
+    if(fmtAlt_FOUND AND NOT TARGET fmt)
+        add_library(fmt INTERFACE IMPORTED)
+        set_target_properties(fmt PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                             "${FMT_INCLUDE_DIR}")
+        target_link_libraries(fmt INTERFACE ${_PAIMON_FMT_TARGET})
+    endif()
+    if(fmtAlt_FOUND)
+        set(FMT_LIBRARIES ${_PAIMON_FMT_TARGET})
+    endif()
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PC_fmt QUIET fmt)
+    endif()
+
+    find_path(FMT_INCLUDE_DIR
+              NAMES fmt/core.h ${_PAIMON_FMT_FIND_ARGS}
+              HINTS ${PC_fmt_INCLUDE_DIRS}
+              PATH_SUFFIXES include)
+    find_library(FMT_LIBRARY
+                 NAMES fmt ${_PAIMON_FMT_FIND_ARGS}
+                 HINTS ${PC_fmt_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(fmtAlt REQUIRED_VARS FMT_INCLUDE_DIR FMT_LIBRARY)
+
+    if(fmtAlt_FOUND AND NOT TARGET fmt)
+        add_library(fmt UNKNOWN IMPORTED)
+        set_target_properties(fmt
+                              PROPERTIES IMPORTED_LOCATION "${FMT_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES
+                                         "${FMT_INCLUDE_DIR}")
+        set(FMT_LIBRARIES "${FMT_LIBRARY}")
+    endif()
+endif()
+
+unset(_PAIMON_FMT_FIND_ARGS)
+unset(_PAIMON_FMT_ROOTS)
+unset(_PAIMON_FMT_TARGET)
+unset(_PAIMON_FMT_TARGETS)

--- a/cmake_modules/FindglogAlt.cmake
+++ b/cmake_modules/FindglogAlt.cmake
@@ -1,0 +1,87 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_GLOG_ROOTS ${glog_ROOT} ${GLOG_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_GLOG_ROOTS "")
+if(_PAIMON_GLOG_ROOTS)
+    set(_PAIMON_GLOG_FIND_ARGS HINTS ${_PAIMON_GLOG_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(glog CONFIG QUIET ${_PAIMON_GLOG_FIND_ARGS})
+
+set(_PAIMON_GLOG_TARGETS glog::glog glog)
+foreach(_target IN LISTS _PAIMON_GLOG_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_GLOG_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+if(_PAIMON_GLOG_TARGET)
+    paimon_find_target_headers(GLOG_INCLUDE_DIR
+                               ${_PAIMON_GLOG_TARGET}
+                               NAMES
+                               glog/logging.h
+                               ${_PAIMON_GLOG_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(glogAlt REQUIRED_VARS GLOG_INCLUDE_DIR)
+
+    if(glogAlt_FOUND AND NOT TARGET glog)
+        add_library(glog INTERFACE IMPORTED)
+        set_target_properties(glog PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                              "${GLOG_INCLUDE_DIR}")
+        target_link_libraries(glog INTERFACE ${_PAIMON_GLOG_TARGET})
+    endif()
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PC_glog QUIET libglog)
+    endif()
+
+    find_path(GLOG_INCLUDE_DIR
+              NAMES glog/logging.h ${_PAIMON_GLOG_FIND_ARGS}
+              HINTS ${PC_glog_INCLUDE_DIRS}
+              PATH_SUFFIXES include)
+    find_library(GLOG_LIBRARY
+                 NAMES glog ${_PAIMON_GLOG_FIND_ARGS}
+                 HINTS ${PC_glog_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(glogAlt REQUIRED_VARS GLOG_LIBRARY GLOG_INCLUDE_DIR)
+
+    if(glogAlt_FOUND AND NOT TARGET glog)
+        add_library(glog UNKNOWN IMPORTED)
+        set_target_properties(glog
+                              PROPERTIES IMPORTED_LOCATION "${GLOG_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES
+                                         "${GLOG_INCLUDE_DIR}"
+                                         INTERFACE_COMPILE_DEFINITIONS
+                                         "GLOG_USE_GLOG_EXPORT")
+        find_library(LIBUNWIND_LIBRARY NAMES unwind)
+        if(LIBUNWIND_LIBRARY)
+            target_link_libraries(glog INTERFACE ${LIBUNWIND_LIBRARY})
+        endif()
+    endif()
+endif()
+
+unset(_PAIMON_GLOG_FIND_ARGS)
+unset(_PAIMON_GLOG_ROOTS)
+unset(_PAIMON_GLOG_TARGET)
+unset(_PAIMON_GLOG_TARGETS)

--- a/cmake_modules/FindzstdAlt.cmake
+++ b/cmake_modules/FindzstdAlt.cmake
@@ -1,0 +1,94 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(_PAIMON_ZSTD_ROOTS ${zstd_ROOT} ${ZSTD_ROOT} ${PAIMON_PACKAGE_PREFIX})
+list(REMOVE_ITEM _PAIMON_ZSTD_ROOTS "")
+if(_PAIMON_ZSTD_ROOTS)
+    set(_PAIMON_ZSTD_FIND_ARGS HINTS ${_PAIMON_ZSTD_ROOTS} NO_DEFAULT_PATH)
+endif()
+
+include(FindPackageUtils)
+find_package(zstd CONFIG QUIET ${_PAIMON_ZSTD_FIND_ARGS})
+
+set(_PAIMON_ZSTD_TARGETS)
+if(PAIMON_DEPENDENCY_USE_SHARED)
+    list(APPEND _PAIMON_ZSTD_TARGETS zstd::libzstd_shared zstd::libzstd)
+endif()
+list(APPEND
+     _PAIMON_ZSTD_TARGETS
+     zstd::libzstd_static
+     zstd::libzstd
+     zstd::zstd)
+
+foreach(_target IN LISTS _PAIMON_ZSTD_TARGETS)
+    if(TARGET ${_target})
+        set(_PAIMON_ZSTD_TARGET ${_target})
+        break()
+    endif()
+endforeach()
+
+if(_PAIMON_ZSTD_TARGET)
+    paimon_find_target_headers(ZSTD_INCLUDE_DIR
+                               ${_PAIMON_ZSTD_TARGET}
+                               NAMES
+                               zstd.h
+                               ${_PAIMON_ZSTD_FIND_ARGS})
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(zstdAlt REQUIRED_VARS ZSTD_INCLUDE_DIR)
+
+    if(zstdAlt_FOUND AND NOT TARGET zstd)
+        add_library(zstd INTERFACE IMPORTED)
+        set_target_properties(zstd PROPERTIES INTERFACE_INCLUDE_DIRECTORIES
+                                              "${ZSTD_INCLUDE_DIR}")
+        target_link_libraries(zstd INTERFACE ${_PAIMON_ZSTD_TARGET})
+    endif()
+    if(zstdAlt_FOUND)
+        set(ZSTD_LIBRARIES ${_PAIMON_ZSTD_TARGET})
+    endif()
+else()
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(PC_zstd QUIET libzstd)
+    endif()
+
+    find_path(ZSTD_INCLUDE_DIR
+              NAMES zstd.h ${_PAIMON_ZSTD_FIND_ARGS}
+              HINTS ${PC_zstd_INCLUDE_DIRS}
+              PATH_SUFFIXES include)
+    find_library(ZSTD_LIBRARY
+                 NAMES zstd libzstd ${_PAIMON_ZSTD_FIND_ARGS}
+                 HINTS ${PC_zstd_LIBRARY_DIRS}
+                 PATH_SUFFIXES lib lib64)
+
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(zstdAlt REQUIRED_VARS ZSTD_LIBRARY ZSTD_INCLUDE_DIR)
+
+    if(zstdAlt_FOUND AND NOT TARGET zstd)
+        add_library(zstd UNKNOWN IMPORTED)
+        set_target_properties(zstd
+                              PROPERTIES IMPORTED_LOCATION "${ZSTD_LIBRARY}"
+                                         INTERFACE_INCLUDE_DIRECTORIES
+                                         "${ZSTD_INCLUDE_DIR}")
+        set(ZSTD_LIBRARIES "${ZSTD_LIBRARY}")
+    endif()
+endif()
+
+unset(_PAIMON_ZSTD_FIND_ARGS)
+unset(_PAIMON_ZSTD_ROOTS)
+unset(_PAIMON_ZSTD_TARGET)
+unset(_PAIMON_ZSTD_TARGETS)


### PR DESCRIPTION
### Purpose

Linked issue: N/A

Migrate CMake find-package modules from the Alibaba-origin C++ repository into the Apache repository. These modules provide alternate package discovery for Arrow, Avro, GTest, LZ4, ORC, Protobuf, RE2, RapidJSON, Snappy, TBB, ZLIB, fmt, glog, zstd, plus shared `FindPackageUtils.cmake` helpers.

The migrated files keep their source paths under `cmake_modules/`. Alibaba-owned headers were converted to the ASF CMake-style license header used in this repository. No files needed original third-party license preservation, and no requested files were skipped.

### Tests

- `python3 /home/jinli.zjw/.codex/skills/paimon-cpp-migrate/scripts/check_migration_batch.py --files ...`
- `git diff --cached --check`
- Compared migrated file bodies against source files after license-header removal
- `cmake -P cmake_modules/FindPackageUtils.cmake`

### API and Format

No public C++ API, storage format, or protocol changes.

### Documentation

No user-facing documentation changes.

### Generative AI tooling

Migrate-by: OpenAI Codex