### PR TITLE
fix(cmake): parse add_paimon_lib link arguments.

### DIFF
--- a/cmake_modules/BuildUtils.cmake
+++ b/cmake_modules/BuildUtils.cmake
@@ -24,7 +24,10 @@ function(add_paimon_lib LIB_NAME)
     set(multi_value_args
         SOURCES
         STATIC_LINK_LIBS
+        STATIC_INSTALL_INTERFACE_LIBS
         SHARED_LINK_LIBS
+        SHARED_INSTALL_INTERFACE_LIBS
+        SHARED_PRIVATE_LINK_LIBS
         EXTRA_INCLUDES
         PRIVATE_INCLUDES
         DEPENDENCIES)


### PR DESCRIPTION

### Purpose

Linked issue: close #8.

`add_paimon_lib()` uses several link-related `ARG_*` variables internally, but the corresponding keywords were not declared in `cmake_parse_arguments()`.

This change adds the missing argument names:

- `STATIC_INSTALL_INTERFACE_LIBS`
- `SHARED_INSTALL_INTERFACE_LIBS`
- `SHARED_PRIVATE_LINK_LIBS`

so these options are parsed correctly instead of leaking into preceding link argument lists.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

No.

### Documentation

No.

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
