### PR TITLE
fix(types): make RowKind short string parsing case-insensitive

### DIFF
--- a/src/paimon/common/types/row_kind.cpp
+++ b/src/paimon/common/types/row_kind.cpp
@@ -21,6 +21,10 @@
 
 #include <cstdint>
 
+#include "fmt/format.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/status.h"
+
 namespace paimon {
 
 const RowKind* RowKind::Insert() {
@@ -41,6 +45,21 @@ const RowKind* RowKind::UpdateAfter() {
 const RowKind* RowKind::Delete() {
     static const RowKind kDelete{"-D", "DELETE", static_cast<std::int8_t>(3)};
     return &kDelete;
+}
+
+Result<const RowKind*> RowKind::FromShortString(const std::string& value) {
+    std::string upper_value = StringUtils::ToUpperCase(value);
+    if (upper_value == "+I") {
+        return Insert();
+    } else if (upper_value == "-U") {
+        return UpdateBefore();
+    } else if (upper_value == "+U") {
+        return UpdateAfter();
+    } else if (upper_value == "-D") {
+        return Delete();
+    } else {
+        return Status::Invalid(fmt::format("Unsupported short string {} for row kind.", value));
+    }
 }
 
 }  // namespace paimon

--- a/src/paimon/common/types/row_kind.h
+++ b/src/paimon/common/types/row_kind.h
@@ -121,19 +121,7 @@ class RowKind {
     /// Creates a `RowKind` from the given short string.
     ///
     /// @see #shortString() for mapping of string and `RowKind`.
-    static Result<const RowKind*> FromShortString(const std::string& value) {
-        if (value == "+I" || value == "+i") {
-            return Insert();
-        } else if (value == "-U" || value == "-u") {
-            return UpdateBefore();
-        } else if (value == "+U" || value == "+u") {
-            return UpdateAfter();
-        } else if (value == "-D" || value == "-d") {
-            return Delete();
-        } else {
-            return Status::Invalid(fmt::format("Unsupported short string {} for row kind.", value));
-        }
-    }
+    static Result<const RowKind*> FromShortString(const std::string& value);
 
  private:
     /// Creates a `RowKind` with the given short string and byte value representation

--- a/src/paimon/common/types/row_kind.h
+++ b/src/paimon/common/types/row_kind.h
@@ -122,13 +122,13 @@ class RowKind {
     ///
     /// @see #shortString() for mapping of string and `RowKind`.
     static Result<const RowKind*> FromShortString(const std::string& value) {
-        if (value == "+I") {
+        if (value == "+I" || value == "+i") {
             return Insert();
-        } else if (value == "-U") {
+        } else if (value == "-U" || value == "-u") {
             return UpdateBefore();
-        } else if (value == "+U") {
+        } else if (value == "+U" || value == "+u") {
             return UpdateAfter();
-        } else if (value == "-D") {
+        } else if (value == "-D" || value == "-d") {
             return Delete();
         } else {
             return Status::Invalid(fmt::format("Unsupported short string {} for row kind.", value));

--- a/src/paimon/common/types/row_kind_test.cpp
+++ b/src/paimon/common/types/row_kind_test.cpp
@@ -43,4 +43,16 @@ TEST(RowKindTest, TestSimple) {
     ASSERT_FALSE(*insert == *delete_kind);
 }
 
+TEST(RowKindTest, TestFromShortStringIgnoresCase) {
+    ASSERT_OK_AND_ASSIGN(const RowKind* insert, RowKind::FromShortString("+i"));
+    ASSERT_OK_AND_ASSIGN(const RowKind* update_before, RowKind::FromShortString("-u"));
+    ASSERT_OK_AND_ASSIGN(const RowKind* update_after, RowKind::FromShortString("+u"));
+    ASSERT_OK_AND_ASSIGN(const RowKind* delete_kind, RowKind::FromShortString("-d"));
+
+    ASSERT_EQ(insert, RowKind::Insert());
+    ASSERT_EQ(update_before, RowKind::UpdateBefore());
+    ASSERT_EQ(update_after, RowKind::UpdateAfter());
+    ASSERT_EQ(delete_kind, RowKind::Delete());
+}
+
 }  // namespace paimon::test


### PR DESCRIPTION
### Purpose

Linked issue: close #14

Make `RowKind::FromShortString` consistent with Java Paimon's `RowKind.fromShortString` behavior.

Java Paimon normalizes the input to uppercase before matching, so lowercase short strings such as `+i`, `-u`, `+u`, and `-d` are accepted. This PR updates paimon-cpp to accept the same lowercase variants.

### Tests

Added unit test coverage for lowercase RowKind short strings:

- `+i` maps to `INSERT`
- `-u` maps to `UPDATE_BEFORE`
- `+u` maps to `UPDATE_AFTER`
- `-d` maps to `DELETE`

### API and Format

No. 
This change does not affect public API headers under include/, storage format, or protocol.

### Documentation

No.
This is a compatibility bug fix and does not introduce a new feature.

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
