### PR TITLE
feat: add common data structures (BinarySection, BinaryString, InternalRow)

### DIFF
--- a/src/paimon/common/data/binary_section.cpp
+++ b/src/paimon/common/data/binary_section.cpp
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/data/binary_section.h"
+
+#include "paimon/common/memory/memory_segment_utils.h"
+#include "paimon/io/byte_order.h"
+
+namespace paimon {
+bool BinarySection::operator==(const BinarySection& that) const {
+    if (this == &that) {
+        return true;
+    }
+    return size_in_bytes_ == that.size_in_bytes_ &&
+           MemorySegmentUtils::Equals({segment_}, offset_, {that.segment_}, that.offset_,
+                                      size_in_bytes_);
+}
+
+std::shared_ptr<Bytes> BinarySection::ToBytes(MemoryPool* pool) const {
+    return MemorySegmentUtils::GetBytes({segment_}, offset_, size_in_bytes_, pool);
+}
+
+int32_t BinarySection::HashCode() const {
+    return MemorySegmentUtils::Hash({segment_}, offset_, size_in_bytes_, GetDefaultPool().get());
+}
+
+PAIMON_UNIQUE_PTR<Bytes> BinarySection::ReadBinary(const MemorySegment& segment,
+                                                   int32_t base_offset, int32_t field_offset,
+                                                   int64_t variable_part_offset_and_len,
+                                                   MemoryPool* pool) {
+    int64_t mark = variable_part_offset_and_len & BinarySection::HIGHEST_FIRST_BIT;
+    if (mark == 0) {
+        const auto sub_offset = static_cast<int32_t>(variable_part_offset_and_len >> 32);
+        const auto len = static_cast<int32_t>(variable_part_offset_and_len);
+        return MemorySegmentUtils::CopyToBytes({segment}, base_offset + sub_offset, len, pool);
+    } else {
+        auto len = static_cast<int32_t>(
+            (variable_part_offset_and_len & BinarySection::HIGHEST_SECOND_TO_EIGHTH_BIT) >> 56);
+        if ((SystemByteOrder() == ByteOrder::PAIMON_LITTLE_ENDIAN)) {
+            return MemorySegmentUtils::CopyToBytes({segment}, field_offset, len, pool);
+        } else {
+            // field_offset + 1 to skip header.
+            return MemorySegmentUtils::CopyToBytes({segment}, field_offset + 1, len, pool);
+        }
+    }
+}
+
+}  // namespace paimon

--- a/src/paimon/common/data/binary_section.h
+++ b/src/paimon/common/data/binary_section.h
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "paimon/common/memory/memory_segment.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+/// Describe a section of a single MemorySegment.
+///
+/// @note: Unlike the Java implementation where data may span multiple MemorySegments,
+/// in this C++ implementation all data resides within a single MemorySegment.
+class PAIMON_EXPORT BinarySection {
+ public:
+    BinarySection() = default;
+    BinarySection(const MemorySegment& segment, int32_t offset, int32_t size_in_bytes)
+        : segment_(segment), offset_(offset), size_in_bytes_(size_in_bytes) {}
+    virtual ~BinarySection() = default;
+    /// It decides whether to put data in FixLenPart or VarLenPart. See more in `/// BinaryRow`.
+    /// If len is less than 8, its binary format is: 1-bit mark(1) = 1, 7-bits len, and
+    /// 7-bytes data. Data is stored in fix-length part.
+    /// If len is greater or equal to 8, its binary format is: 1-bit mark(1) = 0,
+    /// 31-bits offset to the data, and 4-bytes length of data. Data is stored in
+    /// variable-length part.
+
+    static constexpr int32_t MAX_FIX_PART_DATA_SIZE = 7;
+    /// To get the mark in highest bit of int64_t. Form: 10000000 00000000 ... (8 bytes)
+    /// This is used to decide whether the data is stored in fixed-length part or
+    /// variable-length part. see `MAX_FIX_PART_DATA_SIZE` for more information.
+
+    static constexpr int64_t HIGHEST_FIRST_BIT = 0x80L << 56;
+    /// To get the 7 bits length in second bit to eighth bit out of a int64_t. Form:
+    /// 01111111 00000000... (8 bytes)
+    /// This is used to get the length of the data which is stored in this int64_t. see
+    /// `MAX_FIX_PART_DATA_SIZE` for more information.
+
+    static constexpr int64_t HIGHEST_SECOND_TO_EIGHTH_BIT = 0x7FL << 56;
+
+    /// Get binary, if len less than 8, will be include in variable_part_offset_and_len.
+    /// @note Need to consider the ByteOrder.
+    /// @param base_offset base offset of composite binary format.
+    /// @param field_offset absolute start offset of variable_part_offset_and_len.
+    /// @param variable_part_offset_and_len a long value, real data or offset and len.
+    static PAIMON_UNIQUE_PTR<Bytes> ReadBinary(const MemorySegment& segment, int32_t base_offset,
+                                               int32_t field_offset,
+                                               int64_t variable_part_offset_and_len,
+                                               MemoryPool* pool);
+
+    bool operator==(const BinarySection& that) const;
+
+    virtual void PointTo(const MemorySegment& segment, int32_t offset, int32_t size_in_bytes) {
+        segment_ = segment;
+        offset_ = offset;
+        size_in_bytes_ = size_in_bytes;
+    }
+
+    const MemorySegment& GetSegment() const {
+        return segment_;
+    }
+
+    int32_t GetOffset() const {
+        return offset_;
+    }
+
+    int32_t GetSizeInBytes() const {
+        return size_in_bytes_;
+    }
+
+    std::shared_ptr<Bytes> ToBytes(MemoryPool* pool) const;
+
+    virtual int32_t HashCode() const;
+
+ protected:
+    MemorySegment segment_;
+    int32_t offset_ = 0;
+    int32_t size_in_bytes_ = 0;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/data/binary_section.h
+++ b/src/paimon/common/data/binary_section.h
@@ -51,13 +51,13 @@ class PAIMON_EXPORT BinarySection {
     /// This is used to decide whether the data is stored in fixed-length part or
     /// variable-length part. see `MAX_FIX_PART_DATA_SIZE` for more information.
 
-    static constexpr int64_t HIGHEST_FIRST_BIT = 0x80L << 56;
+    static constexpr int64_t HIGHEST_FIRST_BIT = static_cast<int64_t>(0x80ULL << 56);
     /// To get the 7 bits length in second bit to eighth bit out of a int64_t. Form:
     /// 01111111 00000000... (8 bytes)
     /// This is used to get the length of the data which is stored in this int64_t. see
     /// `MAX_FIX_PART_DATA_SIZE` for more information.
 
-    static constexpr int64_t HIGHEST_SECOND_TO_EIGHTH_BIT = 0x7FL << 56;
+    static constexpr int64_t HIGHEST_SECOND_TO_EIGHTH_BIT = static_cast<int64_t>(0x7FULL << 56);
 
     /// Get binary, if len less than 8, will be include in variable_part_offset_and_len.
     /// @note Need to consider the ByteOrder.

--- a/src/paimon/common/data/binary_section_test.cpp
+++ b/src/paimon/common/data/binary_section_test.cpp
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/data/binary_section.h"
+
+#include "gtest/gtest.h"
+#include "paimon/memory/memory_pool.h"
+
+namespace paimon::test {
+
+class BinarySectionTest : public ::testing::Test {
+ protected:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+
+        segment_ = MemorySegment::AllocateHeapMemory(2048, pool_.get());
+        for (int32_t i = 0; i < 2048; ++i) {
+            segment_.Put(i, static_cast<uint8_t>(i % 128));
+        }
+        offset_ = 0;
+        size_in_bytes_ = 2048;
+        binary_section_ = BinarySection(segment_, offset_, size_in_bytes_);
+    }
+
+    MemorySegment segment_;
+    int32_t offset_;
+    int32_t size_in_bytes_;
+    BinarySection binary_section_;
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+TEST_F(BinarySectionTest, EqualityOperator) {
+    BinarySection other(segment_, offset_, size_in_bytes_);
+    EXPECT_TRUE(binary_section_ == other);
+
+    BinarySection different(segment_, offset_, size_in_bytes_ - 1);
+    EXPECT_FALSE(binary_section_ == different);
+}
+
+TEST_F(BinarySectionTest, ToBytes) {
+    auto bytes = binary_section_.ToBytes(pool_.get());
+    ASSERT_EQ(bytes->size(), size_in_bytes_);
+    for (int32_t i = 0; i < size_in_bytes_; ++i) {
+        EXPECT_EQ(static_cast<uint8_t>(bytes->data()[i]), static_cast<uint8_t>(i % 128));
+    }
+}
+
+TEST_F(BinarySectionTest, HashCode) {
+    int32_t hash_code = binary_section_.HashCode();
+    EXPECT_NE(hash_code, 0);
+}
+
+TEST_F(BinarySectionTest, ReadBinary) {
+    int64_t variable_part_offset_and_len = (static_cast<int64_t>(offset_) << 32) | size_in_bytes_;
+    auto bytes =
+        BinarySection::ReadBinary(segment_, 0, offset_, variable_part_offset_and_len, pool_.get());
+    ASSERT_EQ(bytes->size(), size_in_bytes_);
+    for (int32_t i = 0; i < size_in_bytes_; ++i) {
+        EXPECT_EQ(static_cast<uint8_t>(bytes->data()[i]), static_cast<uint8_t>(i % 128));
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/data/binary_string.cpp
+++ b/src/paimon/common/data/binary_string.cpp
@@ -1,0 +1,287 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/data/binary_string.h"
+
+#include <algorithm>
+#include <cctype>
+
+#include "paimon/common/memory/memory_segment_utils.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+
+namespace paimon {
+
+const BinaryString& BinaryString::EmptyUtf8() {
+    static const BinaryString empty_utf8 = BinaryString();
+    return empty_utf8;
+}
+
+BinaryString::BinaryString(const MemorySegment& segment, int32_t offset, int32_t size_in_bytes)
+    : BinarySection(segment, offset, size_in_bytes) {}
+
+BinaryString::BinaryString() {
+    std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(0, GetDefaultPool().get());
+    segment_ = MemorySegment::Wrap(bytes);
+    offset_ = 0;
+    size_in_bytes_ = bytes->size();
+}
+
+BinaryString BinaryString::FromAddress(const MemorySegment& segment, int32_t offset,
+                                       int32_t num_bytes) {
+    return BinaryString(segment, offset, num_bytes);
+}
+
+BinaryString BinaryString::FromString(const std::string& str, MemoryPool* pool) {
+    std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(str, pool);
+    return FromBytes(bytes);
+}
+
+BinaryString BinaryString::FromBytes(const std::shared_ptr<Bytes>& bytes) {
+    return FromBytes(bytes, 0, bytes->size());
+}
+
+BinaryString BinaryString::FromBytes(const std::shared_ptr<Bytes>& bytes, int32_t offset,
+                                     int32_t num_bytes) {
+    return BinaryString(MemorySegment::Wrap(bytes), offset, num_bytes);
+}
+
+BinaryString BinaryString::BlankString(int32_t length, MemoryPool* pool) {
+    std::shared_ptr<Bytes> spaces = Bytes::AllocateBytes(length, pool);
+    std::fill(spaces->data(), spaces->data() + length, ' ');
+    return FromBytes(spaces);
+}
+
+std::string BinaryString::ToString() const {
+    std::string ret(size_in_bytes_, '\0');
+    MemorySegmentUtils::CopyToBytes({segment_}, offset_, &ret, 0, size_in_bytes_);
+    return ret;
+}
+
+int32_t BinaryString::NumBytesForFirstByte(char b) {
+    if (b >= 0) {
+        // 1 byte, 7 bits: 0xxxxxxx
+        return 1;
+    } else if ((b >> 5) == -2 && (b & 0x1e) != 0) {
+        // 2 bytes, 11 bits: 110xxxxx 10xxxxxx
+        return 2;
+    } else if ((b >> 4) == -2) {
+        // 3 bytes, 16 bits: 1110xxxx 10xxxxxx 10xxxxxx
+        return 3;
+    } else if ((b >> 3) == -2) {
+        // 4 bytes, 21 bits: 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx
+        return 4;
+    } else {
+        // Skip the first byte disallowed in UTF-8
+        // Handling errors quietly, same semantics to java String.
+        return 1;
+    }
+}
+
+int32_t BinaryString::CompareTo(const BinaryString& other) const {
+    int32_t len = std::min(size_in_bytes_, other.size_in_bytes_);
+    for (int32_t i = 0; i < len; i++) {
+        int32_t res =
+            (segment_.Get(offset_ + i) & 0xFF) - (other.segment_.Get(other.offset_ + i) & 0xFF);
+        if (res != 0) {
+            return res;
+        }
+    }
+    return size_in_bytes_ - other.size_in_bytes_;
+}
+
+int32_t BinaryString::NumChars() const {
+    int32_t len = 0;
+    for (int32_t i = 0; i < size_in_bytes_; i += NumBytesForFirstByte(GetByteOneSegment(i))) {
+        len++;
+    }
+    return len;
+}
+
+char BinaryString::ByteAt(int32_t index) const {
+    return segment_.Get(offset_ + index);
+}
+
+BinaryString BinaryString::Copy(MemoryPool* pool) const {
+    std::shared_ptr<Bytes> copy =
+        MemorySegmentUtils::CopyToBytes({segment_}, offset_, size_in_bytes_, pool);
+    return FromBytes(copy);
+}
+
+BinaryString BinaryString::Substring(int32_t begin_index, int32_t end_index,
+                                     MemoryPool* pool) const {
+    if (end_index <= begin_index || begin_index >= size_in_bytes_) {
+        return EmptyUtf8();
+    }
+    int32_t i = 0;
+    int32_t c = 0;
+    while (i < size_in_bytes_ && c < begin_index) {
+        i += NumBytesForFirstByte(segment_.Get(i + offset_));
+        c += 1;
+    }
+
+    int32_t j = i;
+    while (i < size_in_bytes_ && c < end_index) {
+        i += NumBytesForFirstByte(segment_.Get(i + offset_));
+        c += 1;
+    }
+
+    if (i > j) {
+        std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(i - j, pool);
+        segment_.Get(offset_ + j, bytes.get(), 0, i - j);
+        return FromBytes(bytes);
+    } else {
+        return EmptyUtf8();
+    }
+}
+
+bool BinaryString::Contains(const BinaryString& s) const {
+    if (s.size_in_bytes_ == 0) {
+        return true;
+    }
+    int32_t find = MemorySegmentUtils::Find({segment_}, offset_, size_in_bytes_, {s.segment_},
+                                            s.offset_, s.size_in_bytes_);
+    return find != -1;
+}
+
+bool BinaryString::StartsWith(const BinaryString& prefix) const {
+    return MatchAt(prefix, 0);
+}
+
+bool BinaryString::EndsWith(const BinaryString& suffix) const {
+    return MatchAt(suffix, size_in_bytes_ - suffix.size_in_bytes_);
+}
+
+int32_t BinaryString::IndexOf(const BinaryString& str, int32_t from_index) const {
+    if (str.size_in_bytes_ == 0) {
+        return 0;
+    }
+    // position in byte
+    int32_t byte_idx = 0;
+    // position is char
+    int32_t char_idx = 0;
+    while (byte_idx < size_in_bytes_ && char_idx < from_index) {
+        byte_idx += NumBytesForFirstByte(GetByteOneSegment(byte_idx));
+        char_idx++;
+    }
+    do {
+        if (byte_idx + str.size_in_bytes_ > size_in_bytes_) {
+            return -1;
+        }
+        if (MemorySegmentUtils::Equals({segment_}, offset_ + byte_idx, {str.segment_}, str.offset_,
+                                       str.size_in_bytes_)) {
+            return char_idx;
+        }
+        byte_idx += NumBytesForFirstByte(GetByteOneSegment(byte_idx));
+        char_idx++;
+    } while (byte_idx < size_in_bytes_);
+
+    return -1;
+}
+
+BinaryString BinaryString::ToUpperCase(MemoryPool* pool) const {
+    if (size_in_bytes_ == 0) {
+        return EmptyUtf8();
+    }
+    int32_t size = segment_.Size();
+    SegmentAndOffset segment_and_offset = StartSegmentAndOffset(size);
+    std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(size_in_bytes_, pool);
+    (*bytes)[0] = tolower(segment_and_offset.Value());
+    for (int32_t i = 0; i < size_in_bytes_; i++) {
+        char b = segment_and_offset.Value();
+        if (NumBytesForFirstByte(b) != 1) {
+            // fallback
+            return CppToUpperCase(pool);
+        }
+        int32_t upper = toupper(static_cast<int32_t>(b));
+        if (upper > 127) {
+            // fallback
+            return CppToUpperCase(pool);
+        }
+        (*bytes)[i] = static_cast<char>(upper);
+        segment_and_offset.NextByte(size);
+    }
+    return FromBytes(bytes);
+}
+
+BinaryString BinaryString::CppToUpperCase(MemoryPool* pool) const {
+    std::string str = ToString();
+    std::transform(str.begin(), str.end(), str.begin(), ::toupper);
+    return FromString(str, pool);
+}
+
+BinaryString BinaryString::ToLowerCase(MemoryPool* pool) const {
+    if (size_in_bytes_ == 0) {
+        return EmptyUtf8();
+    }
+    int32_t size = segment_.Size();
+    SegmentAndOffset segment_and_offset = StartSegmentAndOffset(size);
+    std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(size_in_bytes_, pool);
+    (*bytes)[0] = tolower(segment_and_offset.Value());
+    for (int32_t i = 0; i < size_in_bytes_; i++) {
+        char b = segment_and_offset.Value();
+        if (NumBytesForFirstByte(b) != 1) {
+            // fallback
+            return CppToLowerCase(pool);
+        }
+        int32_t lower = tolower(static_cast<int32_t>(b));
+        if (lower > 127) {
+            // fallback
+            return CppToLowerCase(pool);
+        }
+        (*bytes)[i] = static_cast<char>(lower);
+        segment_and_offset.NextByte(size);
+    }
+    return FromBytes(bytes);
+}
+
+BinaryString BinaryString::CppToLowerCase(MemoryPool* pool) const {
+    std::string str = ToString();
+    std::transform(str.begin(), str.end(), str.begin(), ::tolower);
+    return FromString(str, pool);
+}
+
+char BinaryString::GetByteOneSegment(int32_t i) const {
+    return segment_.Get(offset_ + i);
+}
+
+BinaryString::SegmentAndOffset BinaryString::StartSegmentAndOffset(int32_t seg_size) const {
+    return BinaryString::SegmentAndOffset(segment_, offset_);
+}
+
+BinaryString BinaryString::CopyBinaryString(int32_t start, int32_t end, MemoryPool* pool) const {
+    int32_t len = end - start + 1;
+    std::shared_ptr<Bytes> new_bytes = Bytes::AllocateBytes(len, pool);
+    MemorySegmentUtils::CopyToBytes({segment_}, offset_ + start, new_bytes.get(), 0, len);
+    return FromBytes(new_bytes);
+}
+
+bool BinaryString::MatchAt(const BinaryString& s, int32_t pos) const {
+    return MatchAtOneSeg(s, pos);
+}
+
+bool BinaryString::MatchAtOneSeg(const BinaryString& s, int32_t pos) const {
+    return s.size_in_bytes_ + pos <= size_in_bytes_ && pos >= 0 &&
+           segment_.EqualTo(s.segment_, offset_ + pos, s.offset_, s.size_in_bytes_);
+}
+
+std::string_view BinaryString::GetStringView() const {
+    return std::string_view(segment_.Data() + offset_, size_in_bytes_);
+}
+}  // namespace paimon

--- a/src/paimon/common/data/binary_string.h
+++ b/src/paimon/common/data/binary_string.h
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "paimon/common/data/binary_section.h"
+#include "paimon/common/memory/memory_segment.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+class Bytes;
+class MemoryPool;
+
+/// A string which is backed by a single `MemorySegment`.
+///
+/// @note: Unlike the Java implementation where a BinaryString may span multiple
+/// MemorySegments, in this C++ implementation all data resides within a single MemorySegment.
+class PAIMON_EXPORT BinaryString : public BinarySection {
+ public:
+    static const BinaryString& EmptyUtf8();
+
+    BinaryString(const MemorySegment& segment, int32_t offset, int32_t size_in_bytes);
+
+    static BinaryString FromAddress(const MemorySegment& segment, int32_t offset,
+                                    int32_t num_bytes);
+    static BinaryString FromString(const std::string& str, MemoryPool* pool);
+
+    /// Creates a `BinaryString` instance from the given UTF-8 bytes.
+    static BinaryString FromBytes(const std::shared_ptr<Bytes>& bytes);
+    /// Creates a `BinaryString` instance from the given UTF-8 bytes with offset and number of
+    /// bytes.
+    static BinaryString FromBytes(const std::shared_ptr<Bytes>& bytes, int32_t offset,
+                                  int32_t num_bytes);
+    /// Creates a `BinaryString` instance that contains length spaces.
+    static BinaryString BlankString(int32_t length, MemoryPool* pool);
+
+    std::string ToString() const;
+
+    bool operator==(const BinaryString& other) const {
+        if (this == &other) {
+            return true;
+        }
+        return CompareTo(other) == 0;
+    }
+    bool operator<(const BinaryString& other) const {
+        return CompareTo(other) < 0;
+    }
+
+    int32_t CompareTo(const BinaryString& other) const;
+
+    /// @return the number of UTF-8 code points in the string.
+    int32_t NumChars() const;
+
+    /// Returns the byte value at the specified index. An index ranges from `0` to
+    /// `size_in_bytes_ - 1`.
+    /// @param index the index of the byte value.
+    /// @return the byte value at the specified index of this UTF-8 bytes.
+    char ByteAt(int32_t index) const;
+
+    /// Copy a new BinaryString.
+    BinaryString Copy(MemoryPool* pool) const;
+
+    /// Returns a binary string that is a substring of this binary string. The substring
+    /// begins at the specified `begin_index` and extends to the character at index
+    /// `end_index - 1`.
+    /// Examples:
+    /// FromString("hamburger").Substring(4, 8) returns binary string "urge"
+    /// FromString("smiles").Substring(1, 5) returns binary string "mile"
+    ///
+    /// @param begin_index the beginning index, inclusive.
+    /// @param end_index the ending index, exclusive.
+    /// @return the specified substring, return `EmptyUtf8()` when index out of bounds
+    BinaryString Substring(int32_t begin_index, int32_t end_index, MemoryPool* pool) const;
+
+    bool Contains(const BinaryString& s) const;
+
+    /// Tests if this BinaryString starts with the specified prefix.
+    /// @param prefix the prefix.
+    /// @return `true` if the bytes represented by the argument is a prefix of the
+    /// bytes represented by this string; `false` otherwise. Note also that `true` will be returned
+    /// if the argument is an empty BinaryString or is equal to this BinaryString object as
+    /// determined by the `operator==` method.
+    bool StartsWith(const BinaryString& prefix) const;
+
+    /// Tests if this BinaryString ends with the specified suffix.
+    /// @param suffix the suffix.
+    /// @return `true` if the bytes represented by the argument is a suffix of the
+    /// bytes represented by this object; `false` otherwise. Note that the result
+    /// will be `true` if the argument is the empty string or is equal to this BinaryString object
+    /// as determined by the `operator==` method.
+    bool EndsWith(const BinaryString& suffix) const;
+
+    /// Returns the index within this string of the first occurrence of the specified
+    /// substring, starting at the specified index.
+    /// @param str the substring to search for.
+    /// @param from_index the index from which to start the search.
+    /// @return the utf8 index of the first occurrence of the specified substring, starting
+    /// at the specified index, or `-1` if there is no such occurrence.
+    int32_t IndexOf(const BinaryString& str, int32_t from_index) const;
+
+    /// Converts all of the characters in this BinaryString to upper case.
+    /// @return the BinaryString, converted to uppercase.
+    BinaryString ToUpperCase(MemoryPool* pool) const;
+
+    /// Converts all of the characters in this BinaryString to lower case.
+    /// @return the BinaryString, converted to lowercase.
+    BinaryString ToLowerCase(MemoryPool* pool) const;
+
+    std::string_view GetStringView() const;
+
+    // @return copied sub string from [start, end].
+    BinaryString CopyBinaryString(int32_t start, int32_t end, MemoryPool* pool) const;
+
+    /// @return the number of bytes for a code point with the first byte as b.
+    /// @param b The first byte of a code point
+    static int32_t NumBytesForFirstByte(char b);
+
+ private:
+    char GetByteOneSegment(int32_t i) const;
+    bool MatchAt(const BinaryString& s, int32_t pos) const;
+    bool MatchAtOneSeg(const BinaryString& s, int32_t pos) const;
+
+    /// CurrentSegment and positionInSegment.
+    class SegmentAndOffset {
+        friend class BinaryString;
+
+     public:
+        SegmentAndOffset(const MemorySegment& segment, int32_t offset)
+            : offset_(offset), segment_(segment) {}
+
+        void NextByte(int32_t seg_size) {
+            offset_++;
+        }
+
+        void SkipBytes(int32_t n, int32_t seg_size) {
+            offset_ += n;
+        }
+
+        char Value() const {
+            return segment_.Get(offset_);
+        }
+
+     private:
+        int32_t offset_;
+        MemorySegment segment_;
+    };
+    SegmentAndOffset StartSegmentAndOffset(int32_t seg_size) const;
+
+    BinaryString();
+
+    BinaryString CppToLowerCase(MemoryPool* pool) const;
+    BinaryString CppToUpperCase(MemoryPool* pool) const;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/data/binary_string_test.cpp
+++ b/src/paimon/common/data/binary_string_test.cpp
@@ -1,0 +1,379 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/data/binary_string.h"
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+
+namespace paimon::test {
+class BinaryStringTest : public testing::Test {
+ private:
+    BinaryString FromString(const std::string& str) {
+        auto pool = GetDefaultPool();
+        return BinaryString::FromString(str, pool.get());
+    }
+
+    template <typename T, typename U>
+    void InnerCheckEqual(T&& expected, U&& actual) {
+        ASSERT_EQ(std::forward<T>(expected), std::forward<U>(actual));
+    }
+
+    template <typename T>
+    void InnerCheck(T&& expected) {
+        ASSERT_TRUE(std::forward<T>(expected));
+    }
+
+    template <typename T>
+    void InnerCheckFalse(T&& expected) {
+        ASSERT_FALSE(std::forward<T>(expected));
+    }
+
+    void CheckBasic(const std::string& str, int32_t len) {
+        BinaryString s1 = FromString(str);
+        auto pool = GetDefaultPool();
+        std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(str, pool.get());
+        BinaryString s2 = BinaryString::FromBytes(bytes);
+        InnerCheckEqual(len, s1.NumChars());
+        InnerCheckEqual(len, s2.NumChars());
+
+        InnerCheckEqual(str, s1.ToString());
+        InnerCheckEqual(str, s2.ToString());
+        InnerCheck(s1 == s2);
+
+        InnerCheckEqual(s2.HashCode(), s1.HashCode());
+
+        InnerCheck(s1.Contains(s2));
+        InnerCheck(s2.Contains(s1));
+        InnerCheck(s1.StartsWith(s1));
+        InnerCheck(s1.EndsWith(s1));
+        InnerCheck(s2.StartsWith(s2));
+        InnerCheck(s2.EndsWith(s2));
+    }
+};
+
+TEST_F(BinaryStringTest, TestBasic) {
+    CheckBasic("", 0);
+    CheckBasic(",", 1);
+    CheckBasic("hello", 5);
+    CheckBasic("hello world", 11);
+    CheckBasic("Paimon中文社区", 10);
+    CheckBasic("中 文 社 区", 7);
+
+    CheckBasic("¡", 1);       // 2 bytes char
+    CheckBasic("ку", 2);      // 2 * 2 bytes chars
+    CheckBasic("︽﹋％", 3);  // 3 * 3 bytes chars
+    // CheckBasic("\uD83E\uDD19", 1);  // 4 bytes char
+}
+
+TEST_F(BinaryStringTest, EmptyStringTest) {
+    InnerCheckEqual(FromString(""), BinaryString::EmptyUtf8());
+    std::string empty_str;
+    auto pool = GetDefaultPool();
+    std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(empty_str, pool.get());
+    InnerCheckEqual(BinaryString::FromBytes(bytes), BinaryString::EmptyUtf8());
+    InnerCheckEqual(BinaryString::EmptyUtf8().NumChars(), 0);
+    InnerCheckEqual(BinaryString::EmptyUtf8().GetSizeInBytes(), 0);
+}
+
+TEST_F(BinaryStringTest, TestCompareTo) {
+    auto pool = GetDefaultPool();
+    InnerCheckEqual(FromString("   ").CompareTo(BinaryString::BlankString(3, pool.get())), 0);
+    InnerCheck(FromString("").CompareTo(FromString("a")) < 0);
+    InnerCheck(FromString("abc").CompareTo(FromString("ABC")) > 0);
+    InnerCheck(FromString("abc0").CompareTo(FromString("abc")) > 0);
+    InnerCheckEqual(FromString("abcabcabc").CompareTo(FromString("abcabcabc")), 0);
+    InnerCheck(FromString("aBcabcabc").CompareTo(FromString("Abcabcabc")) > 0);
+    InnerCheck(FromString("Abcabcabc").CompareTo(FromString("abcabcabC")) < 0);
+    InnerCheck(FromString("abcabcabc").CompareTo(FromString("abcabcabC")) > 0);
+
+    InnerCheck(FromString("abc").CompareTo(FromString("世界")) < 0);
+    InnerCheck(FromString("你好").CompareTo(FromString("世界")) > 0);
+    InnerCheck(FromString("你好123").CompareTo(FromString("你好122")) > 0);
+}
+
+TEST_F(BinaryStringTest, TestSingleSegment) {
+    // prepare
+    auto pool = GetDefaultPool();
+    std::shared_ptr<Bytes> data1 = Bytes::AllocateBytes("aaaaaabcde", pool.get());
+    MemorySegment seg1 = MemorySegment::Wrap(data1);
+
+    std::shared_ptr<Bytes> data2 = Bytes::AllocateBytes("abcdeb", pool.get());
+    MemorySegment seg2 = MemorySegment::Wrap(data2);
+
+    // test compare
+    BinaryString binary_string1 = BinaryString::FromAddress(seg1, 0, 10);
+    BinaryString binary_string2 = BinaryString::FromAddress(seg2, 0, 6);
+    InnerCheckEqual(binary_string1.ToString(), "aaaaaabcde");
+    InnerCheckEqual(binary_string2.ToString(), "abcdeb");
+    InnerCheckEqual(binary_string1.CompareTo(binary_string2), -1);
+    InnerCheckEqual(binary_string1, binary_string1);
+    InnerCheck(binary_string1 < binary_string2);
+
+    // test equal length compare
+    binary_string1 = BinaryString::FromAddress(seg1, 5, 5);
+    binary_string2 = BinaryString::FromAddress(seg2, 0, 5);
+    InnerCheckEqual(binary_string1.ToString(), "abcde");
+    InnerCheckEqual(binary_string2.ToString(), "abcde");
+    InnerCheckEqual(binary_string1, binary_string2);
+
+    // test not equal
+    binary_string1 = BinaryString::FromAddress(seg1, 0, 5);
+    binary_string2 = BinaryString::FromAddress(seg2, 0, 5);
+    InnerCheckEqual(binary_string1.ToString(), "aaaaa");
+    InnerCheckEqual(binary_string2.ToString(), "abcde");
+    InnerCheckEqual(binary_string1.CompareTo(binary_string2), -1);
+    InnerCheckEqual(binary_string2.CompareTo(binary_string1), 1);
+
+    // test with offset in single segment
+    std::shared_ptr<Bytes> data3 = Bytes::AllocateBytes(10, pool.get());
+    MemorySegment seg3 = MemorySegment::Wrap(data3);
+    seg3.Put(4, Bytes("abcdeb", pool.get()), 0, 6);
+    binary_string2 = BinaryString::FromAddress(seg3, 4, 6);
+    InnerCheckEqual(binary_string2.ToString(), "abcdeb");
+    InnerCheckEqual(binary_string1.CompareTo(binary_string2), -1);
+    InnerCheckEqual(binary_string2.CompareTo(binary_string1), 1);
+}
+
+TEST_F(BinaryStringTest, TestContains) {
+    InnerCheck(BinaryString::EmptyUtf8().Contains(BinaryString::EmptyUtf8()));
+    InnerCheck(FromString("hello").Contains(FromString("ello")));
+    InnerCheckFalse(FromString("hello").Contains(FromString("vello")));
+    InnerCheckFalse(FromString("hello").Contains(FromString("hellooo")));
+    InnerCheck(FromString("大千世界").Contains(FromString("千世界")));
+    InnerCheckFalse(FromString("大千世界").Contains(FromString("世千")));
+    InnerCheckFalse(FromString("大千世界").Contains(FromString("大千世界好")));
+}
+
+TEST_F(BinaryStringTest, TestStartsWith) {
+    InnerCheck(BinaryString::EmptyUtf8().StartsWith(BinaryString::EmptyUtf8()));
+    InnerCheck(FromString("hello").StartsWith(FromString("hell")));
+    InnerCheckFalse(FromString("hello").StartsWith(FromString("ell")));
+    InnerCheckFalse(FromString("hello").StartsWith(FromString("hellooo")));
+    InnerCheck(FromString("数据砖头").StartsWith(FromString("数据")));
+    InnerCheckFalse(FromString("大千世界").StartsWith(FromString("千")));
+    InnerCheckFalse(FromString("大千世界").StartsWith(FromString("大千世界好")));
+}
+
+TEST_F(BinaryStringTest, TestEndsWith) {
+    InnerCheck(BinaryString::EmptyUtf8().EndsWith(BinaryString::EmptyUtf8()));
+    InnerCheck(FromString("hello").EndsWith(FromString("ello")));
+    InnerCheckFalse(FromString("hello").EndsWith(FromString("ellov")));
+    InnerCheckFalse(FromString("hello").EndsWith(FromString("hhhello")));
+    InnerCheck(FromString("大千世界").EndsWith(FromString("世界")));
+    InnerCheckFalse(FromString("大千世界").EndsWith(FromString("世")));
+    InnerCheckFalse(FromString("数据砖头").EndsWith(FromString("我的数据砖头")));
+}
+
+TEST_F(BinaryStringTest, TestSubstring) {
+    auto pool = GetDefaultPool();
+    InnerCheckEqual(FromString("hello").Substring(0, 0, pool.get()), BinaryString::EmptyUtf8());
+    InnerCheckEqual(FromString("hello").Substring(1, 3, pool.get()), FromString("el"));
+    InnerCheckEqual(FromString("数据砖头").Substring(0, 1, pool.get()), FromString("数"));
+    InnerCheckEqual(FromString("数据砖头").Substring(1, 3, pool.get()), FromString("据砖"));
+    InnerCheckEqual(FromString("数据砖头").Substring(3, 5, pool.get()), FromString("头"));
+    InnerCheckEqual(FromString("ߵ梷").Substring(0, 2, pool.get()), FromString("ߵ梷"));
+}
+
+TEST_F(BinaryStringTest, TestSubStringAndCopyBinaryString) {
+    auto pool = GetDefaultPool();
+    std::string combined = "hello world!nice to meet you!";
+    std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(combined, pool.get());
+    MemorySegment seg = MemorySegment::Wrap(bytes);
+    BinaryString binary_string = BinaryString(seg, 0, combined.size());
+    int32_t left = 6, right = 20;
+
+    // Substring [left, right), The right is not included
+    InnerCheckEqual(binary_string.Substring(left, right, pool.get()),
+                    FromString(combined.substr(left, right - left)));
+    // CopyBinaryString [left, right], The right is included
+    InnerCheckEqual(binary_string.CopyBinaryString(left, right, pool.get()),
+                    FromString(combined.substr(left, right - left + 1)));
+    InnerCheckEqual(binary_string.CopyBinaryString(0, 11, pool.get()), FromString("hello world!"));
+}
+
+TEST_F(BinaryStringTest, TestIndexOf) {
+    {
+        InnerCheckEqual(BinaryString::EmptyUtf8().IndexOf(BinaryString::EmptyUtf8(), 0), 0);
+        InnerCheckEqual(BinaryString::EmptyUtf8().IndexOf(FromString("l"), 0), -1);
+        InnerCheckEqual(FromString("hello").IndexOf(BinaryString::EmptyUtf8(), 0), 0);
+        InnerCheckEqual(FromString("hello").IndexOf(FromString("l"), 0), 2);
+        InnerCheckEqual(FromString("hello").IndexOf(FromString("l"), 3), 3);
+        InnerCheckEqual(FromString("hello").IndexOf(FromString("a"), 0), -1);
+        InnerCheckEqual(FromString("hello").IndexOf(FromString("ll"), 0), 2);
+        InnerCheckEqual(FromString("hello").IndexOf(FromString("ll"), 4), -1);
+        InnerCheckEqual(FromString("数据砖头").IndexOf(FromString("据砖"), 0), 1);
+        InnerCheckEqual(FromString("数据砖头").IndexOf(FromString("数"), 3), -1);
+        InnerCheckEqual(FromString("数据砖头").IndexOf(FromString("数"), 0), 0);
+        InnerCheckEqual(FromString("数据砖头").IndexOf(FromString("头"), 0), 3);
+    }
+    {
+        auto pool = GetDefaultPool();
+        std::string combined = "Strive not to be a success, but rather to be of value.";
+        auto bytes = std::make_shared<Bytes>(combined, pool.get());
+        MemorySegment seg = MemorySegment::Wrap(bytes);
+        auto binary_string = BinaryString::FromAddress(seg, /*offset=*/0,
+                                                       /*num_bytes=*/combined.length());
+        InnerCheckEqual(combined, binary_string.ToString());
+        InnerCheckEqual(binary_string.IndexOf(FromString("value"), 0), 48);
+        InnerCheckEqual(binary_string.IndexOf(FromString("value"), 5), 48);
+        InnerCheckEqual(binary_string.IndexOf(FromString("vvalue"), 0), -1);
+        InnerCheckEqual(binary_string.IndexOf(FromString("!"), 0), -1);
+    }
+}
+
+TEST_F(BinaryStringTest, TestToUpperLowerCase) {
+    auto pool = GetDefaultPool();
+    InnerCheckEqual(FromString("我是中国人").ToLowerCase(pool.get()), FromString("我是中国人"));
+    InnerCheckEqual(FromString("我是中国人").ToUpperCase(pool.get()), FromString("我是中国人"));
+    InnerCheckEqual(BinaryString::EmptyUtf8().ToUpperCase(pool.get()), BinaryString::EmptyUtf8());
+
+    InnerCheckEqual(FromString("aBcDeFg").ToLowerCase(pool.get()), FromString("abcdefg"));
+    InnerCheckEqual(FromString("aBcDeFg").ToUpperCase(pool.get()), FromString("ABCDEFG"));
+
+    InnerCheckEqual(FromString("!@#$%^*").ToLowerCase(pool.get()), FromString("!@#$%^*"));
+    InnerCheckEqual(FromString("!@#$%^*").ToLowerCase(pool.get()), FromString("!@#$%^*"));
+    InnerCheckEqual(BinaryString::EmptyUtf8().ToLowerCase(pool.get()), BinaryString::EmptyUtf8());
+}
+
+TEST_F(BinaryStringTest, TestEmptyString) {
+    BinaryString str2 = FromString("hahahahah");
+    BinaryString str3;
+    auto pool = GetDefaultPool();
+    {
+        std::shared_ptr<Bytes> bytes0 = Bytes::AllocateBytes(10, pool.get());
+        MemorySegment seg0 = MemorySegment::Wrap(bytes0);
+        str3 = BinaryString::FromAddress(seg0, /*offset=*/5, /*num_bytes=*/0);
+    }
+
+    InnerCheck(BinaryString::EmptyUtf8().CompareTo(str2) < 0);
+    InnerCheck(str2.CompareTo(BinaryString::EmptyUtf8()) > 0);
+
+    InnerCheckEqual(BinaryString::EmptyUtf8().CompareTo(str3), 0);
+    InnerCheckEqual(str3.CompareTo(BinaryString::EmptyUtf8()), 0);
+
+    InnerCheckFalse(str2 == BinaryString::EmptyUtf8());
+    InnerCheckFalse(BinaryString::EmptyUtf8() == str2);
+
+    InnerCheckEqual(str3, BinaryString::EmptyUtf8());
+    InnerCheckEqual(BinaryString::EmptyUtf8(), str3);
+}
+
+TEST_F(BinaryStringTest, TestSkipWrongFirstByte) {
+    auto pool = GetDefaultPool();
+    std::vector<int32_t> wrong_first_bytes = {0x80, 0x9F,
+                                              0xBF,  // Skip Continuation bytes
+                                              0xC0,
+                                              0xC2,  // 0xC0..0xC1 - disallowed in UTF-8
+                                              // 0xF5..0xFF - disallowed in UTF-8
+                                              0xF5, 0xF6, 0xF7, 0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD,
+                                              0xFE, 0xFF};
+    std::shared_ptr<Bytes> c = Bytes::AllocateBytes(1, pool.get());
+    for (int32_t wrong_first_byte : wrong_first_bytes) {
+        (*c)[0] = static_cast<char>(wrong_first_byte);
+        InnerCheckEqual(1, BinaryString::FromBytes(c).NumChars());
+    }
+}
+
+TEST_F(BinaryStringTest, TestFromBytes) {
+    auto pool = GetDefaultPool();
+    std::string s = "hahahe";
+    std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(s, pool.get());
+    InnerCheck(BinaryString::FromBytes(bytes, 0, 6) == BinaryString::FromString(s, pool.get()));
+}
+
+TEST_F(BinaryStringTest, TestCopy) {
+    auto pool = GetDefaultPool();
+    std::string s = "hahahe";
+    std::shared_ptr<Bytes> bytes = Bytes::AllocateBytes(s, pool.get());
+    BinaryString binary_string = BinaryString::FromBytes(bytes, 0, 6);
+    BinaryString copy_binary_string = binary_string.Copy(pool.get());
+    InnerCheckEqual(binary_string, copy_binary_string);
+    InnerCheckEqual(copy_binary_string.ByteAt(2), 'h');
+}
+
+TEST_F(BinaryStringTest, TestByteAt) {
+    auto pool = GetDefaultPool();
+    std::string combined = "helloworld!";
+    auto bytes = std::make_shared<Bytes>(combined, pool.get());
+    MemorySegment seg = MemorySegment::Wrap(bytes);
+    auto binary_string = BinaryString::FromAddress(seg, /*offset=*/2,
+                                                   /*num_bytes=*/combined.length() - 2);
+    InnerCheckEqual(binary_string.ByteAt(0), 'l');
+    InnerCheckEqual(binary_string.ByteAt(5), 'r');
+}
+
+TEST_F(BinaryStringTest, TestNumChars) {
+    auto pool = GetDefaultPool();
+    {
+        auto bytes = std::make_shared<Bytes>("hello", pool.get());
+        MemorySegment seg = MemorySegment::Wrap(bytes);
+        auto binary_string = BinaryString::FromAddress(seg, /*offset=*/0,
+                                                       /*num_bytes=*/5);
+        InnerCheckEqual(5, binary_string.NumChars());
+    }
+    {
+        auto bytes = std::make_shared<Bytes>("helloworld", pool.get());
+        MemorySegment seg = MemorySegment::Wrap(bytes);
+        auto binary_string = BinaryString::FromAddress(seg, /*offset=*/0,
+                                                       /*num_bytes=*/10);
+        InnerCheckEqual(10, binary_string.NumChars());
+    }
+}
+
+TEST_F(BinaryStringTest, TestMatchAt) {
+    auto pool = GetDefaultPool();
+    {
+        // abc
+        std::shared_ptr<Bytes> bytes1 = Bytes::AllocateBytes("abc", pool.get());
+        MemorySegment seg1 = MemorySegment::Wrap(bytes1);
+        auto binary_string1 = BinaryString::FromAddress(seg1, /*offset=*/0,
+                                                        /*num_bytes=*/3);
+        // bc
+        std::shared_ptr<Bytes> bytes2 = Bytes::AllocateBytes("bc", pool.get());
+        MemorySegment seg2 = MemorySegment::Wrap(bytes2);
+        auto binary_string2 = BinaryString::FromAddress(seg2, /*offset=*/0,
+                                                        /*num_bytes=*/2);
+        InnerCheck(binary_string1.MatchAt(binary_string2, /*pos=*/1));
+        InnerCheckFalse(binary_string1.MatchAt(binary_string2, /*pos=*/0));
+    }
+    {
+        // abcdef
+        std::shared_ptr<Bytes> bytes1 = Bytes::AllocateBytes("abcdef", pool.get());
+        MemorySegment seg1 = MemorySegment::Wrap(bytes1);
+        auto binary_string1 = BinaryString::FromAddress(seg1, /*offset=*/0,
+                                                        /*num_bytes=*/6);
+        // bc
+        std::shared_ptr<Bytes> bytes2 = Bytes::AllocateBytes("bc", pool.get());
+        MemorySegment seg2 = MemorySegment::Wrap(bytes2);
+        auto binary_string2 = BinaryString::FromAddress(seg2, /*offset=*/0,
+                                                        /*num_bytes=*/2);
+        InnerCheck(binary_string1.MatchAt(binary_string2, /*pos=*/1));
+        InnerCheckFalse(binary_string1.MatchAt(binary_string2, /*pos=*/0));
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/data/data_define.h
+++ b/src/paimon/common/data/data_define.h
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include "arrow/api.h"
+#include "fmt/format.h"
+#include "paimon/common/data/binary_string.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class InternalArray;
+class InternalRow;
+class InternalMap;
+
+/// std::monostate indicates null
+using NullType = std::monostate;
+using VariantType =
+    std::variant<NullType, bool, char, int16_t, int32_t, int64_t, float, double, BinaryString,
+                 std::shared_ptr<Bytes>, Timestamp, Decimal, std::shared_ptr<InternalRow>,
+                 std::shared_ptr<InternalArray>, std::shared_ptr<InternalMap>, std::string_view>;
+class DataDefine {
+ public:
+    DataDefine() = delete;
+    ~DataDefine() = delete;
+    inline static bool IsVariantNull(const VariantType& value) {
+        return std::holds_alternative<NullType>(value);
+    }
+
+    // @warning Always make sure value is T type
+    template <typename T>
+    inline static T GetVariantValue(const VariantType& value) {
+        const T* ptr = std::get_if<T>(&value);
+        assert(ptr);
+        return *ptr;
+    }
+
+    /// if value type mismatch T, return nullptr
+    template <typename T>
+    inline static const T* GetVariantPtr(const VariantType& value) {
+        return std::get_if<T>(&value);
+    }
+
+    // @warning Always make sure value is string_view or std::shared_ptr<Bytes> or BinaryString
+    inline static std::string_view GetStringView(const VariantType& value) {
+        if (auto* view_ptr = GetVariantPtr<std::string_view>(value)) {
+            return *view_ptr;
+        } else if (auto* bytes_ptr = GetVariantPtr<std::shared_ptr<Bytes>>(value)) {
+            const auto& bytes = *bytes_ptr;
+            return std::string_view(bytes->data(), bytes->size());
+        } else if (auto* binary_string_ptr = GetVariantPtr<BinaryString>(value)) {
+            return binary_string_ptr->GetStringView();
+        }
+        assert(false);
+        return {};
+    }
+
+    static std::string VariantValueToString(const VariantType& value) {
+        return std::visit(
+            [](const auto& arg) -> std::string {
+                using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, NullType>) {
+                    return "null";
+                } else if constexpr (std::is_same_v<T, bool>) {
+                    return arg ? "true" : "false";
+                } else if constexpr (std::is_same_v<T, std::shared_ptr<Bytes>>) {
+                    return std::string(arg->data(), arg->size());
+                } else if constexpr (std::is_same_v<T,  // NOLINT(readability/braces)
+                                                    BinaryString> ||
+                                     std::is_same_v<T, Timestamp> || std::is_same_v<T, Decimal>) {
+                    return arg.ToString();
+                } else if constexpr (std::is_same_v<T, std::shared_ptr<InternalRow>>) {
+                    return "row";
+                } else if constexpr (std::is_same_v<T, std::shared_ptr<InternalArray>>) {
+                    return "array";
+                } else if constexpr (std::is_same_v<T, std::shared_ptr<InternalMap>>) {
+                    return "map";
+                } else if constexpr (std::is_same_v<T, std::string_view>) {
+                    return std::string(arg);
+                } else {
+                    return std::to_string(arg);
+                }
+            },
+            value);
+    }
+
+    static Result<Literal> VariantValueToLiteral(const VariantType& value,
+                                                 const arrow::Type::type& arrow_type) {
+        switch (arrow_type) {
+            case arrow::Type::type::BOOL:
+                return Literal(GetVariantValue<bool>(value));
+            case arrow::Type::type::INT8:
+                return Literal(static_cast<int8_t>(GetVariantValue<char>(value)));
+            case arrow::Type::type::INT16:
+                return Literal(GetVariantValue<int16_t>(value));
+            case arrow::Type::type::INT32:
+                return Literal(GetVariantValue<int32_t>(value));
+            case arrow::Type::type::INT64:
+                return Literal(GetVariantValue<int64_t>(value));
+            case arrow::Type::type::FLOAT:
+                return Literal(GetVariantValue<float>(value));
+            case arrow::Type::type::DOUBLE:
+                return Literal(GetVariantValue<double>(value));
+            case arrow::Type::type::STRING: {
+                auto view = GetStringView(value);
+                return Literal(FieldType::STRING, view.data(), view.size());
+            }
+            case arrow::Type::type::BINARY: {
+                auto view = GetStringView(value);
+                return Literal(FieldType::BINARY, view.data(), view.size());
+            }
+            case arrow::Type::type::TIMESTAMP:
+                return Literal(GetVariantValue<Timestamp>(value));
+            case arrow::Type::type::DECIMAL128:
+                return Literal(GetVariantValue<Decimal>(value));
+            case arrow::Type::type::DATE32:
+                return Literal(FieldType::DATE, GetVariantValue<int32_t>(value));
+            default:
+                return Status::Invalid(
+                    fmt::format("Not support arrow type {} in VariantValueToLiteral",
+                                static_cast<int32_t>(arrow_type)));
+        }
+    }
+};
+}  // namespace paimon

--- a/src/paimon/common/data/data_getters.h
+++ b/src/paimon/common/data/data_getters.h
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "paimon/common/data/binary_string.h"
+#include "paimon/common/data/data_define.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+
+namespace paimon {
+class Bytes;
+class Decimal;
+class InternalRow;
+class InternalMap;
+class InternalArray;
+class Timestamp;
+/// Getters to get data.
+class DataGetters {
+ public:
+    virtual ~DataGetters() = default;
+
+    /// @return true if the element is null at the given position.
+    virtual bool IsNullAt(int32_t pos) const = 0;
+
+    /// @return the boolean value at the given position.
+    virtual bool GetBoolean(int32_t pos) const = 0;
+
+    /// @return the byte value at the given position.
+    virtual char GetByte(int32_t pos) const = 0;
+
+    /// @return the short value at the given position.
+    virtual int16_t GetShort(int32_t pos) const = 0;
+
+    /// @return the integer value at the given position.
+    virtual int32_t GetInt(int32_t pos) const = 0;
+
+    /// @return the date integer value at the given position.
+    virtual int32_t GetDate(int32_t pos) const = 0;
+
+    /// @return the long value at the given position.
+    virtual int64_t GetLong(int32_t pos) const = 0;
+
+    /// @return the float value at the given position.
+    virtual float GetFloat(int32_t pos) const = 0;
+
+    /// @return the double value at the given position.
+    virtual double GetDouble(int32_t pos) const = 0;
+
+    /// @return the string value at the given position.
+    virtual BinaryString GetString(int32_t pos) const = 0;
+
+    /// @return the string view value at the given position. Original string data must be valid.
+    virtual std::string_view GetStringView(int32_t pos) const = 0;
+
+    /// @return the decimal value at the given position.
+    /// The precision and scale are required to determine whether the decimal value
+    /// was stored in a compact representation (see `Decimal`).
+    virtual Decimal GetDecimal(int32_t pos, int32_t precision, int32_t scale) const = 0;
+
+    /// @return the timestamp value at the given position.
+    /// The precision is required to determine whether the timestamp value was stored
+    /// in a compact representation (see `Timestamp`).
+    virtual Timestamp GetTimestamp(int32_t pos, int32_t precision) const = 0;
+
+    /// @return the binary value at the given position.
+    virtual std::shared_ptr<Bytes> GetBinary(int32_t pos) const = 0;
+
+    /// @return the array value at the given position.
+    virtual std::shared_ptr<InternalArray> GetArray(int32_t pos) const = 0;
+
+    /// @return the map value at the given position.
+    virtual std::shared_ptr<InternalMap> GetMap(int32_t pos) const = 0;
+
+    /// @return the row value at the given position.
+    /// The number of fields is required to correctly extract the row.
+    virtual std::shared_ptr<InternalRow> GetRow(int32_t pos, int32_t num_fields) const = 0;
+};
+}  // namespace paimon

--- a/src/paimon/common/data/data_setters.h
+++ b/src/paimon/common/data/data_setters.h
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace paimon {
+/// Provide type specialized setters to reduce if/else and eliminate box and unbox. This is
+/// mainly used on the binary format such as `BinaryRow`.
+class DataSetters {
+ public:
+    virtual void SetNullAt(int32_t pos) = 0;
+
+    virtual void SetBoolean(int32_t pos, bool value) = 0;
+
+    virtual void SetByte(int32_t pos, char value) = 0;
+
+    virtual void SetShort(int32_t pos, int16_t value) = 0;
+
+    virtual void SetInt(int32_t pos, int32_t value) = 0;
+
+    virtual void SetLong(int32_t pos, int64_t value) = 0;
+
+    virtual void SetFloat(int32_t pos, float value) = 0;
+
+    virtual void SetDouble(int32_t pos, double value) = 0;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/data/internal_array.h
+++ b/src/paimon/common/data/internal_array.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "paimon/common/data/data_getters.h"
+#include "paimon/result.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+/// Base interface of an internal data structure representing data of ArrayType.
+/// @note All elements of this data structure must be internal data structures and must be of the
+/// same type. See `InternalRow` for more information about internal data structures.
+class PAIMON_EXPORT InternalArray : public DataGetters {
+ public:
+    /// @return the number of elements in this array.
+    virtual int32_t Size() const = 0;
+
+    /// ToBooleanArray return std::vector<char> rather than vector<bool>, as vector<bool> is not
+    /// safe
+    virtual Result<std::vector<char>> ToBooleanArray() const = 0;
+    virtual Result<std::vector<char>> ToByteArray() const = 0;
+    virtual Result<std::vector<int16_t>> ToShortArray() const = 0;
+    virtual Result<std::vector<int32_t>> ToIntArray() const = 0;
+    virtual Result<std::vector<int64_t>> ToLongArray() const = 0;
+    virtual Result<std::vector<float>> ToFloatArray() const = 0;
+    virtual Result<std::vector<double>> ToDoubleArray() const = 0;
+
+    std::string ToString() const {
+        assert(false);
+        return "";
+    }
+};
+
+}  // namespace paimon

--- a/src/paimon/common/data/internal_map.h
+++ b/src/paimon/common/data/internal_map.h
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "paimon/common/data/internal_array.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+
+class PAIMON_EXPORT InternalMap {
+ public:
+    virtual ~InternalMap() = default;
+    virtual int32_t Size() const = 0;
+    virtual std::shared_ptr<InternalArray> KeyArray() const = 0;
+    virtual std::shared_ptr<InternalArray> ValueArray() const = 0;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/data/internal_row.cpp
+++ b/src/paimon/common/data/internal_row.cpp
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/data/internal_row.h"
+
+#include <cassert>
+#include <utility>
+#include <variant>
+
+#include "arrow/api.h"
+#include "arrow/util/checked_cast.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/status.h"
+
+namespace paimon {
+Result<InternalRow::FieldGetterFunc> InternalRow::CreateFieldGetter(
+    int32_t field_idx, const std::shared_ptr<arrow::DataType>& field_type, bool use_view) {
+    arrow::Type::type type = field_type->id();
+    InternalRow::FieldGetterFunc field_getter;
+    switch (type) {
+        case arrow::Type::type::BOOL: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetBoolean(field_idx);
+            };
+            break;
+        }
+        case arrow::Type::type::INT8: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetByte(field_idx);
+            };
+            break;
+        }
+        case arrow::Type::type::INT16: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetShort(field_idx);
+            };
+            break;
+        }
+        case arrow::Type::type::INT32: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetInt(field_idx);
+            };
+            break;
+        }
+        case arrow::Type::type::INT64: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetLong(field_idx);
+            };
+            break;
+        }
+        case arrow::Type::type::FLOAT: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetFloat(field_idx);
+            };
+            break;
+        }
+        case arrow::Type::type::DOUBLE: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetDouble(field_idx);
+            };
+            break;
+        }
+        case arrow::Type::type::DATE32: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetDate(field_idx);
+            };
+            break;
+        }
+        case arrow::Type::type::STRING: {
+            field_getter = [field_idx, use_view](const InternalRow& row) -> VariantType {
+                if (use_view) {
+                    return row.GetStringView(field_idx);
+                } else {
+                    return row.GetString(field_idx);
+                }
+            };
+            break;
+        }
+        case arrow::Type::type::BINARY: {
+            field_getter = [field_idx, use_view](const InternalRow& row) -> VariantType {
+                if (use_view) {
+                    return row.GetStringView(field_idx);
+                } else {
+                    return row.GetBinary(field_idx);
+                }
+            };
+            break;
+        }
+        case arrow::Type::type::TIMESTAMP: {
+            auto timestamp_type =
+                arrow::internal::checked_pointer_cast<arrow::TimestampType>(field_type);
+            assert(timestamp_type);
+            int32_t precision = DateTimeUtils::GetPrecisionFromType(timestamp_type);
+            field_getter = [field_idx, precision](const InternalRow& row) -> VariantType {
+                return row.GetTimestamp(field_idx, precision);
+            };
+            break;
+        }
+        case arrow::Type::type::DECIMAL: {
+            auto* decimal_type =
+                arrow::internal::checked_cast<arrow::Decimal128Type*>(field_type.get());
+            assert(decimal_type);
+            auto precision = decimal_type->precision();
+            auto scale = decimal_type->scale();
+            field_getter = [field_idx, precision, scale](const InternalRow& row) -> VariantType {
+                return row.GetDecimal(field_idx, precision, scale);
+            };
+            break;
+        }
+        case arrow::Type::type::STRUCT: {
+            auto* struct_type = arrow::internal::checked_cast<arrow::StructType*>(field_type.get());
+            assert(struct_type);
+            auto num_fields = struct_type->num_fields();
+            field_getter = [field_idx, num_fields](const InternalRow& row) -> VariantType {
+                return row.GetRow(field_idx, num_fields);
+            };
+            break;
+        }
+        case arrow::Type::type::LIST: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetArray(field_idx);
+            };
+            break;
+        }
+        case arrow::Type::type::MAP: {
+            field_getter = [field_idx](const InternalRow& row) -> VariantType {
+                return row.GetMap(field_idx);
+            };
+            break;
+        }
+        default:
+            return Status::Invalid(
+                fmt::format("type {} not support in data getter", field_type->ToString()));
+    }
+    InternalRow::FieldGetterFunc ret = [field_idx,
+                                        field_getter](const InternalRow& row) -> VariantType {
+        if (row.IsNullAt(field_idx)) {
+            return NullType();
+        }
+        return field_getter(row);
+    };
+    return ret;
+}
+
+}  // namespace paimon

--- a/src/paimon/common/data/internal_row.h
+++ b/src/paimon/common/data/internal_row.h
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "paimon/common/data/data_define.h"
+#include "paimon/common/data/data_getters.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/result.h"
+#include "paimon/visibility.h"
+
+namespace arrow {
+class DataType;
+}  // namespace arrow
+
+namespace paimon {
+/// Base interface for an internal data structure representing data of `RowType`.
+/// The mappings from SQL data types to the internal data structures are listed in the
+/// following table:
+/// +--------------------------------+-----------------------------------------+
+/// | SQL Data Types                 | Internal Data Structures                |
+/// +--------------------------------+-----------------------------------------+
+/// | BOOLEAN                        | boolean                                 |
+/// +--------------------------------+-----------------------------------------+
+/// | CHAR / VARCHAR / STRING        | `BinaryString`                    |
+/// +--------------------------------+-----------------------------------------+
+/// | BINARY / VARBINARY / BYTES     | byte[]                                  |
+/// +--------------------------------+-----------------------------------------+
+/// | DECIMAL                        | `Decimal`                         |
+/// +--------------------------------+-----------------------------------------+
+/// | TINYINT                        | byte                                    |
+/// +--------------------------------+-----------------------------------------+
+/// | SMALLINT                       | short                                   |
+/// +--------------------------------+-----------------------------------------+
+/// | INT                            | int                                     |
+/// +--------------------------------+-----------------------------------------+
+/// | BIGINT                         | long                                    |
+/// +--------------------------------+-----------------------------------------+
+/// | FLOAT                          | float                                   |
+/// +--------------------------------+-----------------------------------------+
+/// | DOUBLE                         | double                                  |
+/// +--------------------------------+-----------------------------------------+
+/// | DATE                           | int (number of days since epoch)        |
+/// +--------------------------------+-----------------------------------------+
+/// | TIME                           | int (number of milliseconds of the day) |
+/// +--------------------------------+-----------------------------------------+
+/// | TIMESTAMP                      | `Timestamp`                       |
+/// +--------------------------------+-----------------------------------------+
+/// | TIMESTAMP WITH LOCAL TIME ZONE | `Timestamp`                       |
+/// +--------------------------------+-----------------------------------------+
+/// | ROW                            | `InternalRow`                     |
+/// +--------------------------------+-----------------------------------------+
+/// | ARRAY                          | `InternalArray`                   |
+/// +--------------------------------+-----------------------------------------+
+/// | MAP / MULTISET                 | `InternalMap`                     |
+/// +--------------------------------+-----------------------------------------+
+/// Nullability is always handled by the container data structure.
+
+class PAIMON_EXPORT InternalRow : public DataGetters {
+ public:
+    ~InternalRow() override = default;
+
+    /// @return the number of fields in this row.
+    /// The number does not include `RowKind`. It is kept separately.
+    virtual int32_t GetFieldCount() const = 0;
+
+    /// @return the kind of change that this row describes in a changelog.
+    virtual Result<const RowKind*> GetRowKind() const = 0;
+
+    /// Sets the kind of change that this row describes in a changelog.
+    virtual void SetRowKind(const RowKind* kind) = 0;
+
+    virtual std::string ToString() const = 0;
+
+    using FieldGetterFunc = std::function<VariantType(const InternalRow&)>;
+
+    static Result<FieldGetterFunc> CreateFieldGetter(
+        int32_t field_idx, const std::shared_ptr<arrow::DataType>& field_type, bool use_view);
+};
+
+}  // namespace paimon

--- a/src/paimon/common/data/internal_row_test.cpp
+++ b/src/paimon/common/data/internal_row_test.cpp
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/data/internal_row.h"
+
+#include <cstddef>
+#include <string_view>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/columnar/columnar_row.h"
+#include "paimon/common/data/internal_array.h"
+#include "paimon/common/data/internal_map.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/decimal_utils.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+TEST(InternalRowTest, TestCreateFieldGetter) {
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::boolean()),
+        arrow::field("f1", arrow::int8()),
+        arrow::field("f2", arrow::int16()),
+        arrow::field("f3", arrow::int32()),
+        arrow::field("f4", arrow::int64()),
+        arrow::field("f5", arrow::float32()),
+        arrow::field("f6", arrow::float64()),
+        arrow::field("f7", arrow::utf8()),
+        arrow::field("f8", arrow::binary()),
+        arrow::field("f9", arrow::timestamp(arrow::TimeUnit::SECOND)),
+        arrow::field("f10", arrow::timestamp(arrow::TimeUnit::MILLI)),
+        arrow::field("f11", arrow::timestamp(arrow::TimeUnit::MICRO)),
+        arrow::field("f12", arrow::timestamp(arrow::TimeUnit::NANO)),
+        arrow::field("f13", arrow::timestamp(arrow::TimeUnit::SECOND, timezone)),
+        arrow::field("f14", arrow::timestamp(arrow::TimeUnit::MILLI, timezone)),
+        arrow::field("f15", arrow::timestamp(arrow::TimeUnit::MICRO, timezone)),
+        arrow::field("f16", arrow::timestamp(arrow::TimeUnit::NANO, timezone)),
+        arrow::field("f17", arrow::decimal128(30, 5)),
+        arrow::field("f18", arrow::date32()),
+        arrow::field("f19", arrow::list(arrow::int32())),
+        arrow::field("f20", arrow::map(arrow::boolean(), arrow::int64())),
+        arrow::field("f21",
+                     arrow::struct_({field("sub1", arrow::int64()), field("sub2", arrow::float64()),
+                                     field("sub3", arrow::boolean())})),
+    };
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        [true, 1, 2, 3, 4, 5.1, 6.12, "abc", "def", "1970-01-02 00:00:01", "1970-01-02 00:00:00.001",
+        "1970-01-02 00:00:00.000001", "1970-01-02 00:00:00.000000001", "1970-01-02 00:00:02", "1970-01-02 00:00:00.002",
+        "1970-01-02 00:00:00.000002", "1970-01-02 00:00:00.000000002", "-123456789987654321.45678", 12345,
+        [1, 2, 3], [[true, 3], [false, 4]], [10, 10.1, false]]
+    ])")
+            .ValueOrDie());
+    auto pool = GetDefaultPool();
+    ColumnarRow row(src_array->fields(), pool, /*row_id=*/0);
+
+    std::vector<InternalRow::FieldGetterFunc> getters;
+    for (size_t i = 0; i < fields.size(); i++) {
+        ASSERT_OK_AND_ASSIGN(
+            InternalRow::FieldGetterFunc getter,
+            InternalRow::CreateFieldGetter(i, fields[i]->type(), /*use_view=*/true));
+        getters.push_back(getter);
+    }
+
+    ASSERT_EQ(getters[0](row), VariantType(true));
+    ASSERT_EQ(getters[1](row), VariantType(static_cast<char>(1)));
+    ASSERT_EQ(getters[2](row), VariantType(static_cast<int16_t>(2)));
+    ASSERT_EQ(getters[3](row), VariantType(static_cast<int32_t>(3)));
+    ASSERT_EQ(getters[4](row), VariantType(static_cast<int64_t>(4)));
+    ASSERT_EQ(getters[5](row), VariantType(static_cast<float>(5.1)));
+    ASSERT_EQ(getters[6](row), VariantType(static_cast<double>(6.12)));
+    auto string_view7 = DataDefine::GetVariantValue<std::string_view>(getters[7](row));
+    ASSERT_EQ(std::string(string_view7), "abc");
+    auto string_view8 = DataDefine::GetVariantValue<std::string_view>(getters[8](row));
+    ASSERT_EQ(std::string(string_view8), "def");
+    ASSERT_EQ(getters[9](row), VariantType(Timestamp(1 * DateTimeUtils::MILLIS_PER_DAY + 1000, 0)));
+    ASSERT_EQ(getters[10](row), VariantType(Timestamp(1 * DateTimeUtils::MILLIS_PER_DAY + 1, 0)));
+    ASSERT_EQ(getters[11](row), VariantType(Timestamp(1 * DateTimeUtils::MILLIS_PER_DAY, 1000)));
+    ASSERT_EQ(getters[12](row), VariantType(Timestamp(1 * DateTimeUtils::MILLIS_PER_DAY, 1)));
+    ASSERT_EQ(getters[13](row),
+              VariantType(Timestamp(1 * DateTimeUtils::MILLIS_PER_DAY + 2000, 0)));
+    ASSERT_EQ(getters[14](row), VariantType(Timestamp(1 * DateTimeUtils::MILLIS_PER_DAY + 2, 0)));
+    ASSERT_EQ(getters[15](row), VariantType(Timestamp(1 * DateTimeUtils::MILLIS_PER_DAY, 2000)));
+    ASSERT_EQ(getters[16](row), VariantType(Timestamp(1 * DateTimeUtils::MILLIS_PER_DAY, 2)));
+
+    ASSERT_EQ(
+        getters[17](row),
+        VariantType(Decimal(30, 5, DecimalUtils::StrToInt128("-12345678998765432145678").value())));
+    ASSERT_EQ(getters[18](row), VariantType(12345));
+    ASSERT_EQ(DataDefine::GetVariantValue<std::shared_ptr<InternalArray>>(getters[19](row))
+                  ->ToIntArray()
+                  .value(),
+              std::vector<int32_t>({1, 2, 3}));
+    ASSERT_EQ(DataDefine::GetVariantValue<std::shared_ptr<InternalMap>>(getters[20](row))
+                  ->KeyArray()
+                  ->ToBooleanArray()
+                  .value(),
+              std::vector<char>({true, false}));
+    ASSERT_EQ(DataDefine::GetVariantValue<std::shared_ptr<InternalMap>>(getters[20](row))
+                  ->ValueArray()
+                  ->ToLongArray()
+                  .value(),
+              std::vector<int64_t>({3l, 4l}));
+    auto inner_row = DataDefine::GetVariantValue<std::shared_ptr<InternalRow>>(getters[21](row));
+    ASSERT_EQ(inner_row->GetLong(0), 10l);
+    ASSERT_EQ(inner_row->GetDouble(1), 10.1);
+    ASSERT_EQ(inner_row->GetBoolean(2), false);
+}
+
+TEST(InternalRowTest, TestCreateFieldGetterWithNull) {
+    arrow::FieldVector fields = {arrow::field("f0", arrow::boolean()),
+                                 arrow::field("f1", arrow::int8())};
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        [true, null]
+    ])")
+            .ValueOrDie());
+    auto pool = GetDefaultPool();
+    ColumnarRow row(src_array->fields(), pool, /*row_id=*/0);
+
+    std::vector<InternalRow::FieldGetterFunc> getters;
+    for (size_t i = 0; i < fields.size(); i++) {
+        ASSERT_OK_AND_ASSIGN(
+            InternalRow::FieldGetterFunc getter,
+            InternalRow::CreateFieldGetter(i, fields[i]->type(), /*use_view=*/true));
+        getters.push_back(getter);
+    }
+
+    ASSERT_EQ(getters[0](row), VariantType(true));
+    ASSERT_TRUE(DataDefine::IsVariantNull(getters[1](row)));
+}
+
+TEST(InternalRowTest, TestCreateFieldGetterWithInvalidType) {
+    arrow::FieldVector fields = {arrow::field("f0", arrow::large_utf8())};
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        ["hello"]
+    ])")
+            .ValueOrDie());
+    auto pool = GetDefaultPool();
+    ColumnarRow row(src_array->fields(), pool, /*row_id=*/0);
+
+    ASSERT_NOK_WITH_MSG(InternalRow::CreateFieldGetter(0, fields[0]->type(), /*use_view=*/true),
+                        "not support in data getter");
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

### Introduce

- `BinarySection` — base class for binary data backed by a MemorySegment, providing offset/size-based access (`binary_section.h/cpp`)
- `BinaryString` — variable-length binary string with comparison, copy, hash, and substring operations (`binary_string.h/cpp`)
- `DataDefine` — variant type definitions (`NullableDataField`, `DataField`) for Paimon columnar data (`data_define.h`)
- `DataGetters` / `DataSetters` — abstract interfaces for typed columnar read/write access (`data_getters.h`, `data_setters.h`)
- `InternalRow` — abstract row interface with typed field accessors and field count (`internal_row.h/cpp`)
- `InternalArray` — abstract array interface for columnar array data (`internal_array.h`)
- `InternalMap` — abstract map interface wrapping key/value InternalArrays (`internal_map.h`)

<!-- What is the purpose of the change -->

### Tests
- `binary_section_test.cpp` — BinarySection construction and memory access
- `binary_string_test.cpp` — BinaryString comparison, copy, hash, substring operations
- `internal_row_test.cpp` — InternalRow field access and JoinedRow correctness
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling

<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
