### PR TITLE
feat: add Range, RangeHelper, RowRangeIndex, and ByteRangeCombiner ut…

### DIFF
--- a/include/paimon/utils/range.h
+++ b/include/paimon/utils/range.h
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "paimon/visibility.h"
+
+namespace paimon {
+/// Range represents from (inclusive) and to (inclusive).
+struct PAIMON_EXPORT Range {
+    Range(int64_t _from, int64_t _to);
+
+    /// Returns the number of integers in the range [from, to].
+    int64_t Count() const;
+
+    /// Computes the intersection of two ranges.
+    static std::optional<Range> Intersection(const Range& left, const Range& right);
+
+    /// Checks whether two ranges have any overlap.
+    static bool HasIntersection(const Range& left, const Range& right);
+
+    /// Sorts a list of ranges by `from`, then merges overlapping or adjacent ranges.
+    /// @param ranges Input vector of ranges to merge.
+    /// @param adjacent If true, also merges ranges that are adjacent (e.g., [1,3] and [4,5] →
+    /// [1,5]).
+    ///                 If false, only merges strictly overlapping ranges.
+    /// @return A new vector of non-overlapping, sorted ranges.
+    static std::vector<Range> SortAndMergeOverlap(const std::vector<Range>& ranges, bool adjacent);
+
+    /// Computes the set intersection of two collections of disjoint, sorted ranges.
+    static std::vector<Range> And(const std::vector<Range>& left, const std::vector<Range>& right);
+
+    /// Excludes the given ranges from this range and returns the remaining ranges.
+    ///
+    /// For example, if this range is [0, 10000] and ranges to exclude are [1000, 2000], [3000,
+    /// 4000], [5000, 6000], then the result is [0, 999], [2001, 2999], [4001, 4999], [6001, 10000].
+    ///
+    /// @param ranges The ranges to exclude (can be unsorted and overlapping).
+    /// @return The remaining ranges after exclusion.
+    std::vector<Range> Exclude(const std::vector<Range>& ranges) const;
+
+    bool operator==(const Range& other) const;
+    bool operator<(const Range& other) const;
+
+    std::string ToString() const;
+
+    int64_t from;
+    int64_t to;
+};
+
+}  // namespace paimon

--- a/include/paimon/utils/row_range_index.h
+++ b/include/paimon/utils/row_range_index.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "paimon/result.h"
+#include "paimon/utils/range.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+
+/// Index for row ranges. Provides efficient intersection queries over a sorted, non-overlapping
+/// collection of ranges using binary search.
+class PAIMON_EXPORT RowRangeIndex {
+ public:
+    /// Creates a RowRangeIndex from the given ranges. The ranges will be sorted and merged
+    /// (overlapping and adjacent ranges are combined) before indexing.
+    static Result<RowRangeIndex> Create(const std::vector<Range>& ranges);
+
+    /// Returns the sorted, non-overlapping ranges held by this index.
+    const std::vector<Range>& Ranges() const;
+
+    /// Returns true if any range in this index intersects with the interval [start, end].
+    bool Intersects(int64_t start, int64_t end) const;
+
+    /// Returns the sub-ranges of this index that intersect with the interval [start, end].
+    /// Each returned range is clipped to lie within [start, end].
+    std::vector<Range> IntersectedRanges(int64_t start, int64_t end) const;
+
+ private:
+    explicit RowRangeIndex(std::vector<Range> ranges);
+
+    /// Finds the first index in `ends_` whose value is >= target (lower bound).
+    int32_t LowerBound(int64_t target) const;
+
+ private:
+    std::vector<Range> ranges_;
+    std::vector<int64_t> starts_;
+    std::vector<int64_t> ends_;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/utils/range.cpp
+++ b/src/paimon/common/utils/range.cpp
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "paimon/utils/range.h"
+
+#include <algorithm>
+#include <cassert>
+
+#include "fmt/format.h"
+namespace paimon {
+Range::Range(int64_t _from, int64_t _to) : from(_from), to(_to) {
+    assert(from <= to);
+}
+
+int64_t Range::Count() const {
+    return to - from + 1;
+}
+
+std::vector<Range> Range::SortAndMergeOverlap(const std::vector<Range>& ranges, bool adjacent) {
+    if (ranges.empty() || ranges.size() == 1) {
+        return ranges;
+    }
+    // sort
+    std::vector<Range> sorted_ranges = ranges;
+    std::sort(sorted_ranges.begin(), sorted_ranges.end(),
+              [](const Range& left, const Range& right) { return left.from < right.from; });
+
+    std::vector<Range> results;
+    Range current = sorted_ranges[0];
+
+    for (size_t i = 1; i < sorted_ranges.size(); ++i) {
+        Range next = sorted_ranges[i];
+        // Check if current and next overlap (not just adjacent)
+        if (current.to + (adjacent ? 1 : 0) >= next.from) {
+            // Merge: extend current range
+            current = Range(current.from, std::max(current.to, next.to));
+        } else {
+            // No overlap: add current to result and move to next
+            results.push_back(current);
+            current = next;
+        }
+    }
+    // Add the last range
+    results.push_back(current);
+    return results;
+}
+
+std::vector<Range> Range::And(const std::vector<Range>& left, const std::vector<Range>& right) {
+    if (left.empty() || right.empty()) {
+        return {};
+    }
+    std::vector<Range> results;
+    size_t i = 0;
+    size_t j = 0;
+
+    while (i < left.size() && j < right.size()) {
+        const Range& lhs = left[i];
+        const Range& rhs = right[j];
+
+        // Compute intersection of current ranges
+        std::optional<Range> intersect = Range::Intersection(lhs, rhs);
+        if (intersect) {
+            results.push_back(intersect.value());
+        }
+
+        // Advance the pointer of the range that ends earlier
+        if (lhs.to <= rhs.to) {
+            i++;
+        } else {
+            j++;
+        }
+    }
+
+    return results;
+}
+
+std::optional<Range> Range::Intersection(const Range& left, const Range& right) {
+    int64_t start = std::max(left.from, right.from);
+    int64_t end = std::min(left.to, right.to);
+    if (start > end) {
+        return std::nullopt;
+    }
+    return Range(start, end);
+}
+
+bool Range::HasIntersection(const Range& left, const Range& right) {
+    int64_t intersection_start = std::max(left.from, right.from);
+    int64_t intersection_end = std::min(left.to, right.to);
+    return intersection_start <= intersection_end;
+}
+
+std::vector<Range> Range::Exclude(const std::vector<Range>& ranges) const {
+    if (ranges.empty()) {
+        return {*this};
+    }
+
+    // Sort ranges by from
+    std::vector<Range> sorted = ranges;
+    std::sort(sorted.begin(), sorted.end(),
+              [](const Range& left, const Range& right) { return left.from < right.from; });
+
+    std::vector<Range> result;
+    int64_t current = from;
+
+    for (const auto& exclude : sorted) {
+        // Compute intersection with the current range
+        auto intersect = Range::Intersection(Range(current, to), exclude);
+        if (!intersect) {
+            continue;
+        }
+        // Add the part before the intersection (if any)
+        if (current < intersect.value().from) {
+            result.emplace_back(current, intersect.value().from - 1);
+        }
+        // Move current position past the intersection
+        current = intersect.value().to + 1;
+        if (current > to) {
+            break;
+        }
+    }
+    // Add the remaining part after all exclusions (if any)
+    if (current <= to) {
+        result.emplace_back(current, to);
+    }
+
+    return result;
+}
+
+bool Range::operator==(const Range& other) const {
+    if (this == &other) {
+        return true;
+    }
+    return from == other.from && to == other.to;
+}
+
+bool Range::operator<(const Range& other) const {
+    if (from == other.from) {
+        return to < other.to;
+    }
+    return from < other.from;
+}
+
+std::string Range::ToString() const {
+    return fmt::format("[{}, {}]", from, to);
+}
+
+}  // namespace paimon

--- a/src/paimon/common/utils/range_helper.h
+++ b/src/paimon/common/utils/range_helper.h
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "paimon/result.h"
+
+namespace paimon {
+/// A helper class to handle ranges.
+template <typename T>
+class RangeHelper {
+ public:
+    // start_func and end_func refer to a closed interval (inclusive of both endpoints).
+    RangeHelper(std::function<Result<int64_t>(const T&)> start_func,
+                std::function<Result<int64_t>(const T&)> end_func)
+        : start_func_(std::move(start_func)), end_func_(std::move(end_func)) {}
+
+    Result<bool> AreAllRangesSame(const std::vector<T>& ranges) const {
+        if (ranges.empty()) {
+            return true;
+        }
+        // Get the first range as reference
+        const auto& first = ranges[0];
+        PAIMON_ASSIGN_OR_RAISE(int64_t first_start, start_func_(first));
+        PAIMON_ASSIGN_OR_RAISE(int64_t first_end, end_func_(first));
+
+        // Compare all other ranges with the first one
+        for (size_t i = 1; i < ranges.size(); i++) {
+            const auto& current = ranges[i];
+            PAIMON_ASSIGN_OR_RAISE(int64_t current_start, start_func_(current));
+            PAIMON_ASSIGN_OR_RAISE(int64_t current_end, end_func_(current));
+            if (current_start != first_start || current_end != first_end) {
+                // Found a different range
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /// A helper class to track original indices of range.
+    struct IndexedValue {
+        IndexedValue(T&& _value, int32_t _original_idx, int64_t _start, int64_t _end)
+            : value(std::move(_value)), original_idx(_original_idx), start(_start), end(_end) {}
+        IndexedValue(IndexedValue&& other)
+            : value(std::move(other.value)),
+              original_idx(other.original_idx),
+              start(other.start),
+              end(other.end) {}
+        IndexedValue(const IndexedValue& other)
+            : value(other.value),
+              original_idx(other.original_idx),
+              start(other.start),
+              end(other.end) {}
+        IndexedValue& operator=(IndexedValue&& other) noexcept {
+            if (&other == this) {
+                return *this;
+            }
+            value = std::move(other.value);
+            original_idx = other.original_idx;
+            start = other.start;
+            end = other.end;
+            return *this;
+        }
+
+        IndexedValue& operator=(const IndexedValue& other) noexcept {
+            if (&other == this) {
+                return *this;
+            }
+            value = other.value;
+            original_idx = other.original_idx;
+            start = other.start;
+            end = other.end;
+            return *this;
+        }
+
+        T value;
+        int32_t original_idx;
+        int64_t start;
+        int64_t end;
+    };
+
+    Result<std::vector<std::vector<T>>> MergeOverlappingRanges(std::vector<T>&& ranges) const {
+        std::vector<std::vector<T>> result;
+        if (ranges.empty()) {
+            return result;
+        }
+        // Create a list of IndexedValue to keep track of original indices
+        std::vector<IndexedValue> index_ranges;
+        index_ranges.reserve(ranges.size());
+        for (int32_t i = 0; i < static_cast<int32_t>(ranges.size()); i++) {
+            // just check start_func_ and end_func_ is valid for ranges[i]
+            // range in IndexedValue must be valid
+            PAIMON_ASSIGN_OR_RAISE(int64_t start, start_func_(ranges[i]));
+            PAIMON_ASSIGN_OR_RAISE(int64_t end, end_func_(ranges[i]));
+            index_ranges.emplace_back(std::move(ranges[i]), /*original_idx=*/i, start, end);
+        }
+
+        // Sort the ranges by their start value
+        std::stable_sort(index_ranges.begin(), index_ranges.end(),
+                         [&](const IndexedValue& r1, const IndexedValue& r2) {
+                             if (r1.start != r2.start) {
+                                 return r1.start < r2.start;
+                             }
+                             return r1.end < r2.end;
+                         });
+        // Initialize with the first range
+        std::vector<std::vector<IndexedValue>> groups;
+        std::vector<IndexedValue> current_group;
+        current_group.emplace_back(std::move(index_ranges[0]));
+        int64_t current_end = current_group.back().end;
+
+        // Iterate through the sorted ranges and merge overlapping ones
+        for (size_t i = 1; i < index_ranges.size(); i++) {
+            auto& current = index_ranges[i];
+            int64_t start = current.start;
+            int64_t end = current.end;
+
+            // If the current range overlaps with the current group, merge it
+            if (start <= current_end) {
+                current_group.emplace_back(std::move(current));
+                // Update the current end to the maximum end of the merged ranges
+                if (end > current_end) {
+                    current_end = end;
+                }
+            } else {
+                // Otherwise, start a new group
+                groups.emplace_back(std::move(current_group));
+                current_group.clear();
+                current_group.emplace_back(std::move(current));
+                current_end = end;
+            }
+        }
+        // Add the last group
+        groups.emplace_back(std::move(current_group));
+
+        // Convert the groups to the required format and sort each group by original index
+        for (auto& group : groups) {
+            // Sort the group by original index to maintain the input order
+            std::stable_sort(group.begin(), group.end(),
+                             [](const IndexedValue& r1, const IndexedValue& r2) {
+                                 return r1.original_idx < r2.original_idx;
+                             });
+            std::vector<T> sorted_group;
+            sorted_group.reserve(group.size());
+            for (auto& index_value : group) {
+                sorted_group.emplace_back(std::move(index_value.value));
+            }
+            result.emplace_back(std::move(sorted_group));
+        }
+        return result;
+    }
+
+ private:
+    std::function<Result<int64_t>(const T&)> start_func_;
+    std::function<Result<int64_t>(const T&)> end_func_;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/utils/range_helper_test.cpp
+++ b/src/paimon/common/utils/range_helper_test.cpp
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/utils/range_helper.h"
+
+#include <optional>
+
+#include "gtest/gtest.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class RangeHelperTest : public ::testing::Test {
+ public:
+    void SetUp() override {
+        start_func_ = [](const Range& range) -> Result<int64_t> {
+            if (range.start) {
+                return range.start.value();
+            }
+            return Status::Invalid("start is null");
+        };
+        end_func_ = [](const Range& range) -> Result<int64_t> {
+            if (range.end) {
+                return range.end.value();
+            }
+            return Status::Invalid("end is null");
+        };
+    }
+    void TearDown() override {}
+    struct Range {
+        Range(const std::optional<int64_t>& _start, const std::optional<int64_t>& _end)
+            : start(_start), end(_end) {}
+        Range(Range&& other) : start(other.start), end(other.end) {}
+        Range(const Range& other) = default;
+        Range& operator=(Range&& other) noexcept {
+            if (&other == this) {
+                return *this;
+            }
+            start = other.start;
+            end = other.end;
+            return *this;
+        }
+        Range& operator=(const Range& other) noexcept {
+            if (&other == this) {
+                return *this;
+            }
+            start = other.start;
+            end = other.end;
+            return *this;
+        }
+        bool operator==(const Range& other) const {
+            return start == other.start && end == other.end;
+        }
+        std::optional<int64_t> start;
+        std::optional<int64_t> end;
+    };
+
+ private:
+    std::function<Result<int64_t>(const Range&)> start_func_;
+    std::function<Result<int64_t>(const Range&)> end_func_;
+};
+
+TEST_F(RangeHelperTest, TestAreAllRangesSame) {
+    {
+        std::vector<Range> ranges = {Range(0l, 100l), Range(0l, 100l), Range(1l, 100l)};
+        ASSERT_OK_AND_ASSIGN(bool same,
+                             RangeHelper(start_func_, end_func_).AreAllRangesSame(ranges));
+        ASSERT_FALSE(same);
+    }
+    {
+        std::vector<Range> ranges = {Range(0l, 100l), Range(0l, 100l), Range(0l, 300l)};
+        ASSERT_OK_AND_ASSIGN(bool same,
+                             RangeHelper(start_func_, end_func_).AreAllRangesSame(ranges));
+        ASSERT_FALSE(same);
+    }
+    {
+        std::vector<Range> ranges = {Range(0l, 100l), Range(0l, 100l), Range(0l, 100l)};
+        ASSERT_OK_AND_ASSIGN(bool same,
+                             RangeHelper(start_func_, end_func_).AreAllRangesSame(ranges));
+        ASSERT_TRUE(same);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(bool same, RangeHelper(start_func_, end_func_).AreAllRangesSame({}));
+        ASSERT_TRUE(same);
+    }
+    {
+        std::vector<Range> ranges = {Range(0l, 100l)};
+        ASSERT_OK_AND_ASSIGN(bool same,
+                             RangeHelper(start_func_, end_func_).AreAllRangesSame(ranges));
+        ASSERT_TRUE(same);
+    }
+    {
+        std::vector<Range> ranges = {Range(0l, std::nullopt)};
+        ASSERT_NOK_WITH_MSG(RangeHelper(start_func_, end_func_).AreAllRangesSame(ranges),
+                            "end is null");
+    }
+}
+TEST_F(RangeHelperTest, TestMergeOverlappingRanges) {
+    {
+        std::vector<Range> ranges = {Range(200, 299), Range(0, 99),    Range(110, 199),
+                                     Range(100, 109), Range(100, 199), Range(0, 49),
+                                     Range(50, 99)};
+        ASSERT_OK_AND_ASSIGN(
+            auto merged_ranges,
+            RangeHelper(start_func_, end_func_).MergeOverlappingRanges(std::move(ranges)));
+        std::vector<std::vector<Range>> expected = {
+            {Range(0, 99), Range(0, 49), Range(50, 99)},
+            {Range(110, 199), Range(100, 109), Range(100, 199)},
+            {Range(200, 299)},
+        };
+        ASSERT_EQ(expected, merged_ranges);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto merged_ranges,
+                             RangeHelper(start_func_, end_func_).MergeOverlappingRanges({}));
+        ASSERT_TRUE(merged_ranges.empty());
+    }
+    {
+        std::vector<Range> ranges = {Range(0, 99)};
+        ASSERT_OK_AND_ASSIGN(
+            auto merged_ranges,
+            RangeHelper(start_func_, end_func_).MergeOverlappingRanges(std::move(ranges)));
+        std::vector<std::vector<Range>> expected = {{Range(0, 99)}};
+        ASSERT_EQ(expected, merged_ranges);
+    }
+    {
+        std::vector<Range> ranges = {Range(200, 299), Range(std::nullopt, 299)};
+        ASSERT_NOK_WITH_MSG(
+            RangeHelper(start_func_, end_func_).MergeOverlappingRanges(std::move(ranges)),
+            "start is null");
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/utils/range_test.cpp
+++ b/src/paimon/common/utils/range_test.cpp
@@ -1,0 +1,384 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/utils/range.h"
+
+#include "gtest/gtest.h"
+
+namespace paimon::test {
+TEST(RangeTest, TestSimple) {
+    Range range(/*from=*/0, /*to=*/5);
+    ASSERT_EQ(range.Count(), 6);
+    ASSERT_EQ(range.ToString(), "[0, 5]");
+}
+
+TEST(RangeTest, TestHasIntersection) {
+    {
+        Range r1(10, 20);
+        Range r2(15, 25);
+        ASSERT_TRUE(Range::HasIntersection(r1, r2));
+        ASSERT_TRUE(Range::HasIntersection(r2, r1));
+        ASSERT_TRUE(Range::HasIntersection(r1, r1));
+        ASSERT_TRUE(Range::HasIntersection(r2, r2));
+    }
+    {
+        Range r1(10, 20);
+        Range r2(21, 30);
+        ASSERT_FALSE(Range::HasIntersection(r1, r2));
+        ASSERT_FALSE(Range::HasIntersection(r2, r1));
+    }
+    {
+        Range r1(10, 20);
+        Range r2(20, 30);
+        ASSERT_TRUE(Range::HasIntersection(r1, r2));
+        ASSERT_TRUE(Range::HasIntersection(r2, r1));
+    }
+    {
+        Range r1(10, 20);
+        Range r2(12, 18);
+        ASSERT_TRUE(Range::HasIntersection(r1, r2));
+        ASSERT_TRUE(Range::HasIntersection(r2, r1));
+    }
+}
+
+TEST(RangeTest, TestIntersection) {
+    {
+        Range r1(10, 20);
+        Range r2(15, 25);
+        ASSERT_EQ(Range::Intersection(r1, r2), Range(15, 20));
+        ASSERT_EQ(Range::Intersection(r2, r1), Range(15, 20));
+        ASSERT_EQ(Range::Intersection(r1, r1), r1);
+        ASSERT_EQ(Range::Intersection(r2, r2), r2);
+    }
+    {
+        Range r1(10, 20);
+        Range r2(21, 30);
+        ASSERT_FALSE(Range::Intersection(r1, r2));
+        ASSERT_FALSE(Range::Intersection(r2, r1));
+    }
+    {
+        Range r1(10, 20);
+        Range r2(20, 30);
+        ASSERT_EQ(Range::Intersection(r1, r2), Range(20, 20));
+        ASSERT_EQ(Range::Intersection(r2, r1), Range(20, 20));
+    }
+    {
+        Range r1(10, 20);
+        Range r2(12, 18);
+        ASSERT_EQ(Range::Intersection(r1, r2), r2);
+        ASSERT_EQ(Range::Intersection(r2, r1), r2);
+    }
+}
+
+TEST(RangeTest, TestCompare) {
+    Range r1(10, 20);
+    Range r2(15, 25);
+    Range r3(10, 30);
+    ASSERT_EQ(r1, r1);
+    ASSERT_LT(r1, r2);
+    ASSERT_LT(r1, r3);
+    ASSERT_LT(r3, r2);
+}
+
+TEST(RangeTest, TestSortAndMergeOverlap) {
+    {
+        // test simple
+        std::vector<Range> ranges = {Range(0, 10), Range(5, 15)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 15)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test no overlap with adjacent = true
+        std::vector<Range> ranges = {Range(0, 10), Range(11, 20)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/true);
+        std::vector<Range> expected = {Range(0, 20)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test no overlap with adjacent = false
+        std::vector<Range> ranges = {Range(0, 10), Range(11, 20)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 10), Range(11, 20)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test overlap multiple
+        std::vector<Range> ranges = {Range(0, 10), Range(5, 15), Range(12, 20)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 20)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test overlap mixed
+        std::vector<Range> ranges = {Range(0, 10), Range(5, 15), Range(20, 30), Range(25, 35)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 15), Range(20, 35)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test overlap unsorted
+        std::vector<Range> ranges = {Range(20, 30), Range(0, 10), Range(5, 15)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 15), Range(20, 30)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test overlap contained
+        std::vector<Range> ranges = {Range(0, 20), Range(5, 10)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 20)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test single
+        std::vector<Range> ranges = {Range(0, 10)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 10)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test identical
+        std::vector<Range> ranges = {Range(0, 10), Range(0, 10)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 10)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test overlap touching exactly
+        std::vector<Range> ranges = {Range(0, 10), Range(10, 20)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 20)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test overlap complex
+        std::vector<Range> ranges = {Range(0, 5),   Range(3, 8),   Range(10, 15),
+                                     Range(20, 25), Range(22, 28), Range(30, 35)};
+        auto result = Range::SortAndMergeOverlap(ranges, /*adjacent=*/false);
+        std::vector<Range> expected = {Range(0, 8), Range(10, 15), Range(20, 28), Range(30, 35)};
+        ASSERT_EQ(result, expected);
+    }
+}
+
+TEST(RangeTest, TestAnd) {
+    {
+        // test and basic
+        std::vector<Range> left = {Range(0, 10), Range(20, 30)};
+        std::vector<Range> right = {Range(5, 15), Range(25, 35)};
+        auto result = Range::And(left, right);
+        std::vector<Range> expected = {Range(5, 10), Range(25, 30)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test no intersection
+        std::vector<Range> left = {Range(0, 10)};
+        std::vector<Range> right = {Range(20, 30)};
+        auto result = Range::And(left, right);
+        ASSERT_TRUE(result.empty());
+    }
+    {
+        // test and same ranges
+        std::vector<Range> left = {Range(0, 10)};
+        std::vector<Range> right = {Range(0, 10)};
+        auto result = Range::And(left, right);
+        std::vector<Range> expected = {Range(0, 10)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test and partial overlap
+        std::vector<Range> left = {Range(0, 10)};
+        std::vector<Range> right = {Range(5, 15)};
+        auto result = Range::And(left, right);
+        std::vector<Range> expected = {Range(5, 10)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test and contained
+        std::vector<Range> left = {Range(0, 20)};
+        std::vector<Range> right = {Range(5, 10)};
+        auto result = Range::And(left, right);
+        std::vector<Range> expected = {Range(5, 10)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test and multiple ranges
+        std::vector<Range> left = {Range(0, 10), Range(20, 30), Range(40, 50)};
+        std::vector<Range> right = {Range(5, 25), Range(35, 45)};
+        auto result = Range::And(left, right);
+        std::vector<Range> expected = {Range(5, 10), Range(20, 25), Range(40, 45)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test and empty left
+        std::vector<Range> left = {};
+        std::vector<Range> right = {Range(0, 10)};
+        auto result = Range::And(left, right);
+        ASSERT_TRUE(result.empty());
+    }
+    {
+        // test and empty right
+        std::vector<Range> left = {Range(0, 10)};
+        std::vector<Range> right = {};
+        auto result = Range::And(left, right);
+        ASSERT_TRUE(result.empty());
+    }
+    {
+        // test and touching at boundary
+        std::vector<Range> left = {Range(0, 10)};
+        std::vector<Range> right = {Range(10, 20)};
+        auto result = Range::And(left, right);
+        std::vector<Range> expected = {Range(10, 10)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // test and complex
+        std::vector<Range> left = {Range(0, 5), Range(10, 15), Range(20, 25), Range(30, 35)};
+        std::vector<Range> right = {Range(3, 12), Range(18, 28), Range(32, 40)};
+        auto result = Range::And(left, right);
+        std::vector<Range> expected = {Range(3, 5), Range(10, 12), Range(20, 25), Range(32, 35)};
+        ASSERT_EQ(result, expected);
+    }
+}
+
+TEST(RangeTest, TestExclude) {
+    {
+        // test basic
+        // [0, 10000] exclude [1000,2000],[3000,4000],[5000,6000]
+        // Expected: [0, 999],[2001,2999],[4001,4999],[6001, 10000]
+        Range range(0, 10000);
+        std::vector<Range> excludes = {Range(1000, 2000), Range(3000, 4000), Range(5000, 6000)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(0, 999), Range(2001, 2999), Range(4001, 4999),
+                                       Range(6001, 10000)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // Same as basic but with unsorted exclusions
+        Range range(0, 10000);
+        std::vector<Range> excludes = {Range(5000, 6000), Range(1000, 2000), Range(3000, 4000)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(0, 999), Range(2001, 2999), Range(4001, 4999),
+                                       Range(6001, 10000)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // exclude empty exclusions
+        Range range(100, 200);
+        std::vector<Range> excludes = {};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(100, 200)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // exclude no intersection
+        Range range(100, 200);
+        std::vector<Range> excludes = {Range(300, 400), Range(500, 600)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(100, 200)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // exclude at start
+        Range range(0, 100);
+        std::vector<Range> excludes = {Range(0, 10)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(11, 100)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // exclude at end
+        Range range(0, 100);
+        std::vector<Range> excludes = {Range(90, 100)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(0, 89)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // exclusion extends past the end of the range
+        Range range(100, 200);
+        std::vector<Range> excludes = {Range(150, 300)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(100, 149)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // exclusion starts before the range
+        Range range(100, 200);
+        std::vector<Range> excludes = {Range(50, 150)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(151, 200)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // overlapping exclusion ranges
+        Range range(0, 100);
+        std::vector<Range> excludes = {Range(20, 50), Range(40, 70)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(0, 19), Range(71, 100)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // exclusion completely covers the range
+        Range range(50, 60);
+        std::vector<Range> excludes = {Range(0, 100)};
+        auto result = range.Exclude(excludes);
+        ASSERT_TRUE(result.empty());
+    }
+    {
+        // exclusion completely matches the range
+        Range range(50, 60);
+        std::vector<Range> excludes = {Range(50, 60)};
+        auto result = range.Exclude(excludes);
+        ASSERT_TRUE(result.empty());
+    }
+    {
+        // single exclusion in the middle
+        Range range(0, 100);
+        std::vector<Range> excludes = {Range(40, 60)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(0, 39), Range(61, 100)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // adjacent exclusion ranges
+        Range range(0, 100);
+        std::vector<Range> excludes = {Range(20, 30), Range(31, 40)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(0, 19), Range(41, 100)};
+        ASSERT_EQ(result, expected);
+    }
+    {
+        // range is a single point
+        Range range(50, 50);
+        std::vector<Range> excludes = {Range(50, 50)};
+        auto result = range.Exclude(excludes);
+        ASSERT_TRUE(result.empty());
+    }
+    {
+        // single point exclusion
+        Range range(0, 100);
+        std::vector<Range> excludes = {Range(50, 50)};
+        auto result = range.Exclude(excludes);
+        std::vector<Range> expected = {Range(0, 49), Range(51, 100)};
+        ASSERT_EQ(result, expected);
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/utils/row_range_index.cpp
+++ b/src/paimon/common/utils/row_range_index.cpp
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/utils/row_range_index.h"
+
+#include <algorithm>
+#include <utility>
+
+namespace paimon {
+
+RowRangeIndex::RowRangeIndex(std::vector<Range> ranges) : ranges_(std::move(ranges)) {
+    starts_.reserve(ranges_.size());
+    ends_.reserve(ranges_.size());
+    for (const auto& range : ranges_) {
+        starts_.push_back(range.from);
+        ends_.push_back(range.to);
+    }
+}
+
+Result<RowRangeIndex> RowRangeIndex::Create(const std::vector<Range>& ranges) {
+    if (ranges.empty()) {
+        return Status::Invalid("Ranges cannot be empty in RowRangeIndex");
+    }
+    return RowRangeIndex(Range::SortAndMergeOverlap(ranges, /*adjacent=*/true));
+}
+
+const std::vector<Range>& RowRangeIndex::Ranges() const {
+    return ranges_;
+}
+
+bool RowRangeIndex::Intersects(int64_t start, int64_t end) const {
+    int32_t candidate = LowerBound(start);
+    return candidate < static_cast<int32_t>(starts_.size()) && starts_[candidate] <= end;
+}
+
+std::vector<Range> RowRangeIndex::IntersectedRanges(int64_t start, int64_t end) const {
+    int32_t left = LowerBound(start);
+    if (left >= static_cast<int32_t>(ranges_.size())) {
+        return {};
+    }
+
+    int32_t right = LowerBound(end);
+    if (right >= static_cast<int32_t>(ranges_.size())) {
+        right = static_cast<int32_t>(ranges_.size()) - 1;
+    }
+
+    if (starts_[left] > end) {
+        return {};
+    }
+
+    std::vector<Range> expected;
+
+    // Add the first intersecting range, clipped to [start, end].
+    const Range& first_range = ranges_[left];
+    expected.emplace_back(std::max(start, first_range.from), std::min(end, first_range.to));
+
+    // Add all fully contained ranges between first and last.
+    for (int32_t i = left + 1; i < right; ++i) {
+        expected.push_back(ranges_[i]);
+    }
+
+    // Add the last intersecting range (if different from the first), clipped to [start, end].
+    if (right != left) {
+        const Range& last_range = ranges_[right];
+        if (last_range.from <= end) {
+            expected.emplace_back(std::max(start, last_range.from), std::min(end, last_range.to));
+        }
+    }
+
+    return expected;
+}
+
+int32_t RowRangeIndex::LowerBound(int64_t target) const {
+    int32_t left = 0;
+    auto right = static_cast<int32_t>(ends_.size());
+    while (left < right) {
+        int32_t mid = left + (right - left) / 2;
+        if (ends_[mid] < target) {
+            left = mid + 1;
+        } else {
+            right = mid;
+        }
+    }
+    return left;
+}
+
+}  // namespace paimon

--- a/src/paimon/common/utils/row_range_index_test.cpp
+++ b/src/paimon/common/utils/row_range_index_test.cpp
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/utils/row_range_index.h"
+
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+// ======================== Create ========================
+
+TEST(RowRangeIndexTest, CreateWithEmptyRangesReturnsError) {
+    ASSERT_NOK_WITH_MSG(RowRangeIndex::Create({}), "Ranges cannot be empty in RowRangeIndex");
+}
+
+TEST(RowRangeIndexTest, CreateWithSingleRange) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_EQ(index.Ranges().size(), 1);
+    ASSERT_EQ(index.Ranges()[0], Range(10, 20));
+}
+
+TEST(RowRangeIndexTest, CreateSortsAndMergesOverlappingRanges) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(20, 30), Range(0, 10), Range(5, 15)}));
+    std::vector<Range> expected = {Range(0, 15), Range(20, 30)};
+    ASSERT_EQ(index.Ranges(), expected);
+}
+
+TEST(RowRangeIndexTest, CreateMergesAdjacentRanges) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(0, 10), Range(11, 20)}));
+    std::vector<Range> expected = {Range(0, 20)};
+    ASSERT_EQ(index.Ranges(), expected);
+}
+
+TEST(RowRangeIndexTest, CreateMergesDuplicateRanges) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(0, 10), Range(0, 10)}));
+    std::vector<Range> expected = {Range(0, 10)};
+    ASSERT_EQ(index.Ranges(), expected);
+}
+
+TEST(RowRangeIndexTest, CreateWithMultipleDisjointRanges) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(0, 5), Range(10, 15), Range(20, 25)}));
+    std::vector<Range> expected = {Range(0, 5), Range(10, 15), Range(20, 25)};
+    ASSERT_EQ(index.Ranges(), expected);
+}
+
+// ======================== Ranges ========================
+
+TEST(RowRangeIndexTest, RangesReturnsUnmodifiableReference) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(0, 10), Range(20, 30)}));
+    const auto& ranges1 = index.Ranges();
+    const auto& ranges2 = index.Ranges();
+    ASSERT_EQ(&ranges1, &ranges2);
+}
+
+// ======================== Intersects ========================
+
+TEST(RowRangeIndexTest, IntersectsExactMatch) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_TRUE(index.Intersects(10, 20));
+}
+
+TEST(RowRangeIndexTest, IntersectsPartialOverlapFromLeft) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_TRUE(index.Intersects(5, 15));
+}
+
+TEST(RowRangeIndexTest, IntersectsPartialOverlapFromRight) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_TRUE(index.Intersects(15, 25));
+}
+
+TEST(RowRangeIndexTest, IntersectsContainedRange) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_TRUE(index.Intersects(12, 18));
+}
+
+TEST(RowRangeIndexTest, IntersectsContainingRange) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_TRUE(index.Intersects(0, 30));
+}
+
+TEST(RowRangeIndexTest, IntersectsTouchingLeftBoundary) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_TRUE(index.Intersects(5, 10));
+}
+
+TEST(RowRangeIndexTest, IntersectsTouchingRightBoundary) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_TRUE(index.Intersects(20, 25));
+}
+
+TEST(RowRangeIndexTest, IntersectsNoOverlapBefore) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_FALSE(index.Intersects(0, 9));
+}
+
+TEST(RowRangeIndexTest, IntersectsNoOverlapAfter) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    ASSERT_FALSE(index.Intersects(21, 30));
+}
+
+TEST(RowRangeIndexTest, IntersectsMultipleRangesHitsFirst) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(0, 10), Range(20, 30), Range(40, 50)}));
+    ASSERT_TRUE(index.Intersects(5, 8));
+}
+
+TEST(RowRangeIndexTest, IntersectsMultipleRangesHitsMiddle) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(0, 10), Range(20, 30), Range(40, 50)}));
+    ASSERT_TRUE(index.Intersects(22, 28));
+}
+
+TEST(RowRangeIndexTest, IntersectsMultipleRangesHitsLast) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(0, 10), Range(20, 30), Range(40, 50)}));
+    ASSERT_TRUE(index.Intersects(42, 48));
+}
+
+TEST(RowRangeIndexTest, IntersectsMultipleRangesSpansGap) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(0, 10), Range(20, 30)}));
+    ASSERT_TRUE(index.Intersects(8, 22));
+}
+
+TEST(RowRangeIndexTest, IntersectsMultipleRangesFallsInGap) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(0, 10), Range(20, 30)}));
+    ASSERT_FALSE(index.Intersects(11, 19));
+}
+
+TEST(RowRangeIndexTest, IntersectsMultipleRangesBeforeAll) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20), Range(30, 40)}));
+    ASSERT_FALSE(index.Intersects(0, 5));
+}
+
+TEST(RowRangeIndexTest, IntersectsMultipleRangesAfterAll) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20), Range(30, 40)}));
+    ASSERT_FALSE(index.Intersects(50, 60));
+}
+
+TEST(RowRangeIndexTest, IntersectsSinglePointMatch) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 10)}));
+    ASSERT_TRUE(index.Intersects(10, 10));
+}
+
+TEST(RowRangeIndexTest, IntersectsSinglePointNoMatch) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 10)}));
+    ASSERT_FALSE(index.Intersects(11, 11));
+}
+
+// ======================== IntersectedRanges ========================
+
+TEST(RowRangeIndexTest, IntersectedRangesExactMatch) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(10, 20);
+    std::vector<Range> expected = {Range(10, 20)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesClippedFromLeft) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(5, 15);
+    std::vector<Range> expected = {Range(10, 15)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesClippedFromRight) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(15, 25);
+    std::vector<Range> expected = {Range(15, 20)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesClippedBothSides) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(12, 18);
+    std::vector<Range> expected = {Range(12, 18)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesContainingRange) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(0, 30);
+    std::vector<Range> expected = {Range(10, 20)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesNoOverlapBefore) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(0, 9);
+    ASSERT_TRUE(intersected.empty());
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesNoOverlapAfter) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(21, 30);
+    ASSERT_TRUE(intersected.empty());
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesTouchingLeftBoundary) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(5, 10);
+    std::vector<Range> expected = {Range(10, 10)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesTouchingRightBoundary) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(20, 25);
+    std::vector<Range> expected = {Range(20, 20)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesMultipleRangesHitsFirst) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(0, 10), Range(20, 30), Range(40, 50)}));
+    auto intersected = index.IntersectedRanges(3, 8);
+    std::vector<Range> expected = {Range(3, 8)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesMultipleRangesHitsLast) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(0, 10), Range(20, 30), Range(40, 50)}));
+    auto intersected = index.IntersectedRanges(42, 48);
+    std::vector<Range> expected = {Range(42, 48)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesSpansTwoRanges) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(0, 10), Range(20, 30)}));
+    auto intersected = index.IntersectedRanges(5, 25);
+    std::vector<Range> expected = {Range(5, 10), Range(20, 25)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesSpansThreeRangesMiddleFullyContained) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(0, 10), Range(20, 30), Range(40, 50)}));
+    auto intersected = index.IntersectedRanges(5, 45);
+    std::vector<Range> expected = {Range(5, 10), Range(20, 30), Range(40, 45)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesSpansAllRanges) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(0, 10), Range(20, 30), Range(40, 50)}));
+    auto intersected = index.IntersectedRanges(0, 50);
+    std::vector<Range> expected = {Range(0, 10), Range(20, 30), Range(40, 50)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesSpansAllRangesWider) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(10, 20), Range(30, 40), Range(50, 60)}));
+    auto intersected = index.IntersectedRanges(0, 100);
+    std::vector<Range> expected = {Range(10, 20), Range(30, 40), Range(50, 60)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesFallsInGap) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(0, 10), Range(20, 30)}));
+    auto intersected = index.IntersectedRanges(11, 19);
+    ASSERT_TRUE(intersected.empty());
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesBeforeAll) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20), Range(30, 40)}));
+    auto intersected = index.IntersectedRanges(0, 5);
+    ASSERT_TRUE(intersected.empty());
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesAfterAll) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20), Range(30, 40)}));
+    auto intersected = index.IntersectedRanges(50, 60);
+    ASSERT_TRUE(intersected.empty());
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesSinglePointMatch) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 20)}));
+    auto intersected = index.IntersectedRanges(15, 15);
+    std::vector<Range> expected = {Range(15, 15)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesSinglePointRangeMatch) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 10)}));
+    auto intersected = index.IntersectedRanges(10, 10);
+    std::vector<Range> expected = {Range(10, 10)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesSinglePointRangeNoMatch) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(10, 10)}));
+    auto intersected = index.IntersectedRanges(11, 11);
+    ASSERT_TRUE(intersected.empty());
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesLastRangeStartsBeyondEnd) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(0, 10), Range(30, 40)}));
+    auto intersected = index.IntersectedRanges(5, 25);
+    std::vector<Range> expected = {Range(5, 10)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesFourRangesClipBothEnds) {
+    ASSERT_OK_AND_ASSIGN(auto index, RowRangeIndex::Create({Range(0, 10), Range(20, 30),
+                                                            Range(40, 50), Range(60, 70)}));
+    auto intersected = index.IntersectedRanges(5, 65);
+    std::vector<Range> expected = {Range(5, 10), Range(20, 30), Range(40, 50), Range(60, 65)};
+    ASSERT_EQ(intersected, expected);
+}
+
+TEST(RowRangeIndexTest, IntersectedRangesFiveRangesThreeMiddleFullyContained) {
+    ASSERT_OK_AND_ASSIGN(auto index,
+                         RowRangeIndex::Create({Range(0, 10), Range(20, 30), Range(40, 50),
+                                                Range(60, 70), Range(80, 90)}));
+    auto intersected = index.IntersectedRanges(5, 85);
+    std::vector<Range> expected = {Range(5, 10), Range(20, 30), Range(40, 50), Range(60, 70),
+                                   Range(80, 85)};
+    ASSERT_EQ(intersected, expected);
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
### Purpose

No Linked issue.

Introduce range-related utility modules to the apache/paimon-cpp codebase. These modules provide range representation, range manipulation helpers, row range indexing with binary search, and byte range combining adapted from Apache ORC.

- Introduce `Range` struct for inclusive integer range representation (`include/paimon/utils/range.h`, `range.cpp`)
- Introduce `RangeHelper` template for range splitting and merging operations (`range_helper.h`)
- Introduce `RowRangeIndex` for efficient intersection queries over sorted non-overlapping ranges using binary search (`include/paimon/utils/row_range_index.h`, `row_range_index.cpp`)
- Introduce `ByteRangeCombiner` for combining byte ranges, adapted from Apache ORC (`byte_range_combiner.h`, `byte_range_combiner.cpp`)
- Update `LICENSE` to add `byte_range_combiner` files under the Apache ORC attribution entry

### Tests

- `range_test.cpp` — Range construction, count, intersection, merge, and string representation
- `range_helper_test.cpp` — RangeHelper split and merge operations
- `row_range_index_test.cpp` — RowRangeIndex intersection queries and edge cases
- `byte_range_combiner_test.cpp` — ByteRangeCombiner combining logic

### API and Format

No API or format changes.

### Documentation

No documentation changes.

### Generative AI tooling
