### PR TITLE
Configure squash-only merge button

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -30,7 +30,7 @@ github:
   enabled_merge_buttons:
     merge: false
     squash: true
-    rebase: true
+    rebase: false
   protected_branches:
     main:
       required_pull_request_reviews:


### PR DESCRIPTION
This updates `.asf.yaml` so Apache GitHub settings expose only the squash merge button for pull requests. Merge commits and rebase merges are both disabled; squash remains enabled.