### PR TITLE
feat: add search predicates and PredicateBuilder and tests

### DIFF
--- a/include/paimon/predicate/full_text_search.h
+++ b/include/paimon/predicate/full_text_search.h
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "paimon/predicate/predicate.h"
+#include "paimon/utils/roaring_bitmap64.h"
+#include "paimon/visibility.h"
+namespace paimon {
+/// A configuration structure for full-text search operations.
+struct PAIMON_EXPORT FullTextSearch {
+    /// Enumeration of supported full-text search types.
+    enum class SearchType {
+        /// All terms in the query must be present (AND semantics).
+        MATCH_ALL = 1,
+        /// Any term in the query can match (OR semantics).
+        MATCH_ANY = 2,
+        /// Matches the exact sequence of words (with proximity).
+        PHRASE = 3,
+        /// Matches terms starting with the given string (e.g., "run*" → running, runner).
+        PREFIX = 4,
+        /// Supports wildcards * and ? (e.g., "ap*e", "app?e" -> "apple").
+        WILDCARD = 5,
+        /// Default/fallback type for unrecognized or invalid queries.
+        UNKNOWN = 128
+    };
+
+    FullTextSearch(const std::string& _field_name, std::optional<int32_t> _limit,
+                   const std::string& _query, const SearchType& _search_type,
+                   const std::optional<RoaringBitmap64>& _pre_filter)
+        : field_name(_field_name),
+          limit(_limit),
+          query(_query),
+          search_type(_search_type),
+          pre_filter(_pre_filter) {}
+
+    std::shared_ptr<FullTextSearch> ReplacePreFilter(
+        const std::optional<RoaringBitmap64>& _pre_filter) const {
+        return std::make_shared<FullTextSearch>(field_name, limit, query, search_type, _pre_filter);
+    }
+
+    /// Name of the field to search within (must be a full-text indexed field).
+    std::string field_name;
+    /// Maximum number of documents to return. If set, limit ordered by top scores. Otherwise, no
+    /// score return.
+    std::optional<int32_t> limit;
+    /// The query string to search for. The interpretation depends on search_type:
+    ///
+    /// - For MATCH_ALL/MATCH_ANY: keywords are split into terms using the **same analyzer as
+    ///   indexing**.
+    ///   Example: "Hello World" → terms ["hello", "world"] (after lowercasing and tokenization).
+    ///
+    /// - For PHRASE: matches the exact word sequence (with optional slop). Also be analyzed.
+    ///
+    /// - For PREFIX: matches terms starting with the given string (e.g., "run" → running, runner).
+    ///   Only the prefix part is considered; analysis will not be applied.
+    ///
+    /// - For WILDCARD: supports wildcards * and ? (e.g., "ap*e", "app?e").
+    ///   Not passed through analyzer — matched directly against indexed terms.
+    ///
+    /// @note Analyzer consistency between indexing and querying is critical for correctness.
+    std::string query;
+    /// Type of search to perform.
+    SearchType search_type;
+    /// A pre-filter based on **global row IDs**, implemented by leveraging another global index.
+    /// Only rows whose global row ID is present in `pre_filter` will be included during search.
+    /// If not set, all rows will be included.
+    std::optional<RoaringBitmap64> pre_filter;
+};
+}  // namespace paimon

--- a/include/paimon/predicate/predicate_builder.h
+++ b/include/paimon/predicate/predicate_builder.h
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/predicate/predicate.h"
+#include "paimon/result.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+class Literal;
+enum class FieldType;
+
+/// A utility class to create `Predicate` object for common filter conditions.
+///
+/// PredicateBuilder provides static factory methods to create various types of predicates
+/// that can be used for filtering data in Paimon tables.
+class PAIMON_EXPORT PredicateBuilder {
+ public:
+    PredicateBuilder() = delete;
+    ~PredicateBuilder() = delete;
+
+    /// Create an equality predicate (field == literal).
+    ///
+    /// @param field_index The index of the field in read schema (0-based).
+    /// @param field_name The name of the field.
+    /// @param field_type The data type of the field.
+    /// @param literal The literal value to compare against.
+    /// @return A shared pointer to the created Predicate object.
+    static std::shared_ptr<Predicate> Equal(int32_t field_index, const std::string& field_name,
+                                            const FieldType& field_type, const Literal& literal);
+
+    /// Create a not-equal predicate (field != literal).
+    static std::shared_ptr<Predicate> NotEqual(int32_t field_index, const std::string& field_name,
+                                               const FieldType& field_type, const Literal& literal);
+
+    /// Create a less-than predicate (field < literal).
+    static std::shared_ptr<Predicate> LessThan(int32_t field_index, const std::string& field_name,
+                                               const FieldType& field_type, const Literal& literal);
+
+    /// Create a less-than-or-equal predicate (field <= literal).
+    static std::shared_ptr<Predicate> LessOrEqual(int32_t field_index,
+                                                  const std::string& field_name,
+                                                  const FieldType& field_type,
+                                                  const Literal& literal);
+
+    /// Create a greater-than predicate (field > literal).
+    static std::shared_ptr<Predicate> GreaterThan(int32_t field_index,
+                                                  const std::string& field_name,
+                                                  const FieldType& field_type,
+                                                  const Literal& literal);
+
+    /// Create a greater-than-or-equal predicate (field >= literal).
+    static std::shared_ptr<Predicate> GreaterOrEqual(int32_t field_index,
+                                                     const std::string& field_name,
+                                                     const FieldType& field_type,
+                                                     const Literal& literal);
+
+    /// Create an IS NULL predicate (field IS NULL).
+    static std::shared_ptr<Predicate> IsNull(int32_t field_index, const std::string& field_name,
+                                             const FieldType& field_type);
+
+    /// Create an IS NOT NULL predicate (field IS NOT NULL).
+    static std::shared_ptr<Predicate> IsNotNull(int32_t field_index, const std::string& field_name,
+                                                const FieldType& field_type);
+
+    /// Create an IN predicate (field IN (literal1, literal2, ...)).
+    ///
+    /// Tests whether the field value matches any of the provided literal values.
+    static std::shared_ptr<Predicate> In(int32_t field_index, const std::string& field_name,
+                                         const FieldType& field_type,
+                                         const std::vector<Literal>& literals);
+
+    /// Create a NOT IN predicate (field NOT IN (literal1, literal2, ...)).
+    ///
+    /// Tests whether the field value does not match any of the provided literal values.
+    static std::shared_ptr<Predicate> NotIn(int32_t field_index, const std::string& field_name,
+                                            const FieldType& field_type,
+                                            const std::vector<Literal>& literals);
+
+    /// Create a BETWEEN predicate (field BETWEEN lower_bound AND upper_bound).
+    ///
+    /// Tests whether the field value falls within the specified range (inclusive on both ends).
+    ///
+    /// @param field_index The index of the field in read schema (0-based).
+    /// @param field_name The name of the field.
+    /// @param field_type The data type of the field.
+    /// @param included_lower_bound The lower bound of the range (inclusive).
+    /// @param included_upper_bound The upper bound of the range (inclusive).
+    static std::shared_ptr<Predicate> Between(int32_t field_index, const std::string& field_name,
+                                              const FieldType& field_type,
+                                              const Literal& included_lower_bound,
+                                              const Literal& included_upper_bound);
+
+    /// Create an AND predicate combining multiple predicates.
+    ///
+    /// Creates a logical AND operation that evaluates to true only when all input predicates
+    /// evaluate to true.
+    ///
+    /// @param predicates A vector of shared pointers to the predicates, which must not be empty.
+    static Result<std::shared_ptr<Predicate>> And(
+        const std::vector<std::shared_ptr<Predicate>>& predicates);
+
+    /// Create an OR predicate combining multiple predicates.
+    ///
+    /// Creates a logical OR operation that evaluates to true when at least one of the input
+    /// predicates evaluates to true.
+    ///
+    /// @param predicates A vector of shared pointers to the predicates, which must not be empty.
+    static Result<std::shared_ptr<Predicate>> Or(
+        const std::vector<std::shared_ptr<Predicate>>& predicates);
+
+    /// Create a NOT predicate negating the result of another predicate.
+    ///
+    /// Creates a logical NOT operation that inverts the truth value of the input predicate.
+    ///
+    /// @param predicate A shared pointer to the predicate to be negated, which must not be nullptr.
+    static Result<std::shared_ptr<Predicate>> Not(const std::shared_ptr<Predicate>& predicate);
+
+    /// Create a starts-with predicate (field like 'abc%' or field like 'abc_').
+    ///
+    /// Tests whether the field value starts with the provided literal value.
+    static Result<std::shared_ptr<Predicate>> StartsWith(int32_t field_index,
+                                                         const std::string& field_name,
+                                                         const FieldType& field_type,
+                                                         const Literal& literal);
+
+    /// Create an ends-with predicate (field like '%abc' or field like '_abc').
+    ///
+    /// Tests whether the field value ends with the provided literal value.
+    static Result<std::shared_ptr<Predicate>> EndsWith(int32_t field_index,
+                                                       const std::string& field_name,
+                                                       const FieldType& field_type,
+                                                       const Literal& literal);
+
+    /// Create a contains predicate (field like '%abc%').
+    ///
+    /// Tests whether the field value contains the provided literal value.
+    static Result<std::shared_ptr<Predicate>> Contains(int32_t field_index,
+                                                       const std::string& field_name,
+                                                       const FieldType& field_type,
+                                                       const Literal& literal);
+
+    /// Create a like predicate (field like literal).
+    ///
+    /// Tests whether the field value like the provided literal value.
+    static Result<std::shared_ptr<Predicate>> Like(int32_t field_index,
+                                                   const std::string& field_name,
+                                                   const FieldType& field_type,
+                                                   const Literal& literal);
+};
+}  // namespace paimon

--- a/include/paimon/predicate/predicate_utils.h
+++ b/include/paimon/predicate/predicate_utils.h
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "paimon/predicate/function.h"
+#include "paimon/predicate/function_visitor.h"
+#include "paimon/predicate/leaf_predicate.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+
+class PAIMON_EXPORT PredicateUtils {
+ public:
+    PredicateUtils() = delete;
+    ~PredicateUtils() = delete;
+    static Result<bool> ContainAnyField(const std::shared_ptr<Predicate>& predicate,
+                                        const std::set<std::string>& field_names);
+
+    static Result<std::shared_ptr<Predicate>> ExcludePredicateWithFields(
+        const std::shared_ptr<Predicate>& predicates, const std::set<std::string>& field_names);
+
+    static Result<std::vector<std::shared_ptr<Predicate>>> ExcludePredicateWithFields(
+        const std::vector<std::shared_ptr<Predicate>>& predicates,
+        const std::set<std::string>& field_names);
+
+    static std::vector<std::shared_ptr<Predicate>> SplitAnd(
+        const std::shared_ptr<Predicate>& predicate);
+
+    // picked_field_name_to_idx: [field_name, idx in target schema]
+    static Result<std::shared_ptr<Predicate>> CreatePickedFieldFilter(
+        const std::shared_ptr<Predicate>& predicate,
+        const std::map<std::string, int32_t>& picked_field_name_to_idx);
+
+    static Status GetAllNames(const std::shared_ptr<Predicate>& predicate,
+                              std::set<std::string>* field_names);
+
+    template <typename T>
+    static Result<T> VisitPredicate(const std::shared_ptr<LeafPredicate>& predicate,
+                                    const std::shared_ptr<FunctionVisitor<T>>& visitor) {
+        auto type = predicate->GetFunction().GetType();
+        switch (type) {
+            case Function::Type::IS_NULL:
+                return visitor->VisitIsNull();
+            case Function::Type::IS_NOT_NULL:
+                return visitor->VisitIsNotNull();
+            case Function::Type::EQUAL: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitEqual(predicate->Literals()[0]);
+            }
+            case Function::Type::NOT_EQUAL: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitNotEqual(predicate->Literals()[0]);
+            }
+            case Function::Type::GREATER_THAN: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitGreaterThan(predicate->Literals()[0]);
+            }
+            case Function::Type::GREATER_OR_EQUAL: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitGreaterOrEqual(predicate->Literals()[0]);
+            }
+            case Function::Type::LESS_THAN: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitLessThan(predicate->Literals()[0]);
+            }
+            case Function::Type::LESS_OR_EQUAL: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitLessOrEqual(predicate->Literals()[0]);
+            }
+            case Function::Type::IN:
+                return visitor->VisitIn(predicate->Literals());
+            case Function::Type::NOT_IN:
+                return visitor->VisitNotIn(predicate->Literals());
+            case Function::Type::STARTS_WITH: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitStartsWith(predicate->Literals()[0]);
+            }
+            case Function::Type::ENDS_WITH: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitEndsWith(predicate->Literals()[0]);
+            }
+            case Function::Type::CONTAINS: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitContains(predicate->Literals()[0]);
+            }
+            case Function::Type::LIKE: {
+                assert(predicate->Literals().size() == 1);
+                return visitor->VisitLike(predicate->Literals()[0]);
+            }
+            default:
+                return Status::Invalid("invalid " + predicate->GetFunction().ToString() +
+                                       " function in leaf predicate");
+        }
+    }
+
+ private:
+    static Result<std::optional<std::shared_ptr<Predicate>>> ReconstructPredicateWithPickedFields(
+        const std::shared_ptr<Predicate>& predicate,
+        const std::map<std::string, int32_t>& picked_field_name_to_idx);
+
+    static void SplitCompound(const Function::Type& type,
+                              const std::shared_ptr<Predicate>& predicate,
+                              std::vector<std::shared_ptr<Predicate>>* result);
+};
+
+}  // namespace paimon

--- a/include/paimon/predicate/vector_search.h
+++ b/include/paimon/predicate/vector_search.h
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "paimon/predicate/predicate.h"
+#include "paimon/visibility.h"
+
+namespace paimon {
+/// `VectorSearch` to perform vector similarity search.
+struct PAIMON_EXPORT VectorSearch {
+    /// `PreFilter`: A lightweight pre-filtering function applied **before** similarity
+    /// scoring. It operates solely on **global row ids** and is typically driven by other global
+    /// index, such as bitmap, or range index. This filter enables early pruning of irrelevant
+    /// candidates (e.g., "only consider rows with label X"), significantly reducing the search
+    /// space. Returns true to include the row in vector search process; false to exclude it.
+    ///
+    /// @note Must be thread-safe.
+    using PreFilter = std::function<bool(int64_t)>;
+
+    /// Enumeration of distance or similarity metrics for vector comparison.
+    enum class DistanceType { EUCLIDEAN = 1, INNER_PRODUCT = 2, COSINE = 3, UNKNOWN = 128 };
+
+    VectorSearch(const std::string& _field_name, int32_t _limit, const std::vector<float>& _query,
+                 PreFilter _pre_filter, const std::shared_ptr<Predicate>& _predicate,
+                 const std::optional<DistanceType>& _distance_type,
+                 const std::map<std::string, std::string>& _options)
+        : field_name(_field_name),
+          limit(_limit),
+          query(_query),
+          pre_filter(_pre_filter),
+          predicate(_predicate),
+          distance_type(_distance_type),
+          options(_options) {}
+
+    std::shared_ptr<VectorSearch> ReplacePreFilter(PreFilter _pre_filter) const {
+        return std::make_shared<VectorSearch>(field_name, limit, query, _pre_filter, predicate,
+                                              distance_type, options);
+    }
+
+    /// Search field name.
+    std::string field_name;
+    /// Number of top results to return.
+    int32_t limit;
+    /// The query vector (must match the dimensionality of the indexed vectors).
+    std::vector<float> query;
+    /// A pre-filter based on **global row ids**, implemented by leveraging other global index
+    std::function<bool(int64_t)> pre_filter;
+    /// A runtime filtering condition that may involve graph traversal of
+    /// structured attributes. **Using this parameter often yields better
+    /// filtering accuracy** because during index construction, the underlying
+    /// graph was built with explicit consideration of field connectivity (e.g.,
+    /// relationships between attributes). As a result, predicates can leverage
+    /// this pre-established semantic structure to perform more meaningful and
+    /// context-aware filtering at query time.
+    /// @note All fields referenced in the predicate must have been materialized
+    ///       in the index during build to ensure availability.
+    std::shared_ptr<Predicate> predicate;
+    /// The distance metric to use for this query, if explicitly specified.
+    /// If set, this value must match the distance type used by the index (e.g., EUCLIDEAN, COSINE).
+    /// A mismatch will result in an error during query execution.
+    /// If not set (std::nullopt), the query will use the distance type configured in the index.
+    std::optional<DistanceType> distance_type;
+    /// A key-value map of query-specific runtime options.
+    /// Such as the size of candidate list in approximate search or parallelism for this query.
+    std::map<std::string, std::string> options;
+};
+}  // namespace paimon

--- a/src/paimon/common/predicate/predicate_builder.cpp
+++ b/src/paimon/common/predicate/predicate_builder.cpp
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/predicate/predicate_builder.h"
+
+#include <utility>
+
+#include "paimon/common/predicate/and.h"
+#include "paimon/common/predicate/compound_predicate_impl.h"
+#include "paimon/common/predicate/contains.h"
+#include "paimon/common/predicate/ends_with.h"
+#include "paimon/common/predicate/equal.h"
+#include "paimon/common/predicate/greater_or_equal.h"
+#include "paimon/common/predicate/greater_than.h"
+#include "paimon/common/predicate/in.h"
+#include "paimon/common/predicate/is_not_null.h"
+#include "paimon/common/predicate/is_null.h"
+#include "paimon/common/predicate/leaf_predicate_impl.h"
+#include "paimon/common/predicate/less_or_equal.h"
+#include "paimon/common/predicate/less_than.h"
+#include "paimon/common/predicate/like.h"
+#include "paimon/common/predicate/not_equal.h"
+#include "paimon/common/predicate/not_in.h"
+#include "paimon/common/predicate/or.h"
+#include "paimon/common/predicate/starts_with.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/status.h"
+
+namespace paimon {
+enum class FieldType;
+
+// TODO(xinyu.lxy): predicate field_index use index in read schema now, but java paimon use index
+// in file schema
+std::shared_ptr<Predicate> PredicateBuilder::Equal(int32_t field_index,
+                                                   const std::string& field_name,
+                                                   const FieldType& field_type,
+                                                   const Literal& literal) {
+    return std::make_shared<LeafPredicateImpl>(Equal::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::NotEqual(int32_t field_index,
+                                                      const std::string& field_name,
+                                                      const FieldType& field_type,
+                                                      const Literal& literal) {
+    return std::make_shared<LeafPredicateImpl>(NotEqual::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::LessThan(int32_t field_index,
+                                                      const std::string& field_name,
+                                                      const FieldType& field_type,
+                                                      const Literal& literal) {
+    return std::make_shared<LeafPredicateImpl>(LessThan::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::LessOrEqual(int32_t field_index,
+                                                         const std::string& field_name,
+                                                         const FieldType& field_type,
+                                                         const Literal& literal) {
+    return std::make_shared<LeafPredicateImpl>(LessOrEqual::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::GreaterThan(int32_t field_index,
+                                                         const std::string& field_name,
+                                                         const FieldType& field_type,
+                                                         const Literal& literal) {
+    return std::make_shared<LeafPredicateImpl>(GreaterThan::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::GreaterOrEqual(int32_t field_index,
+                                                            const std::string& field_name,
+                                                            const FieldType& field_type,
+                                                            const Literal& literal) {
+    return std::make_shared<LeafPredicateImpl>(GreaterOrEqual::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::IsNull(int32_t field_index,
+                                                    const std::string& field_name,
+                                                    const FieldType& field_type) {
+    return std::make_shared<LeafPredicateImpl>(IsNull::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>());
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::IsNotNull(int32_t field_index,
+                                                       const std::string& field_name,
+                                                       const FieldType& field_type) {
+    return std::make_shared<LeafPredicateImpl>(IsNotNull::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>());
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::In(int32_t field_index, const std::string& field_name,
+                                                const FieldType& field_type,
+                                                const std::vector<Literal>& literals) {
+    return std::make_shared<LeafPredicateImpl>(In::Instance(), field_index, field_name, field_type,
+                                               literals);
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::NotIn(int32_t field_index,
+                                                   const std::string& field_name,
+                                                   const FieldType& field_type,
+                                                   const std::vector<Literal>& literals) {
+    return std::make_shared<LeafPredicateImpl>(NotIn::Instance(), field_index, field_name,
+                                               field_type, literals);
+}
+
+std::shared_ptr<Predicate> PredicateBuilder::Between(int32_t field_index,
+                                                     const std::string& field_name,
+                                                     const FieldType& field_type,
+                                                     const Literal& included_lower_bound,
+                                                     const Literal& included_upper_bound) {
+    std::vector<std::shared_ptr<Predicate>> predicates;
+    predicates.reserve(2);
+    predicates.push_back(GreaterOrEqual(field_index, field_name, field_type, included_lower_bound));
+    predicates.push_back(LessOrEqual(field_index, field_name, field_type, included_upper_bound));
+    return std::make_shared<CompoundPredicateImpl>(And::Instance(), predicates);
+}
+
+Result<std::shared_ptr<Predicate>> PredicateBuilder::And(
+    const std::vector<std::shared_ptr<Predicate>>& predicates) {
+    if (predicates.empty()) {
+        return Status::Invalid(
+            "There must be at least 1 inner predicate to construct an AND predicate");
+    }
+    if (predicates.size() == 1) {
+        return predicates[0];
+    }
+    return std::make_shared<CompoundPredicateImpl>(And::Instance(), predicates);
+}
+
+Result<std::shared_ptr<Predicate>> PredicateBuilder::Or(
+    const std::vector<std::shared_ptr<Predicate>>& predicates) {
+    if (predicates.empty()) {
+        return Status::Invalid(
+            "There must be at least 1 inner predicate to construct an OR predicate");
+    }
+    if (predicates.size() == 1) {
+        return predicates[0];
+    }
+    return std::make_shared<CompoundPredicateImpl>(Or::Instance(), predicates);
+}
+
+Result<std::shared_ptr<Predicate>> PredicateBuilder::Not(
+    const std::shared_ptr<Predicate>& predicate) {
+    if (!predicate) {
+        return Status::Invalid("There must not be nullptr to construct a NOT predicate");
+    }
+    auto negate_predicate = predicate->Negate();
+    if (!negate_predicate) {
+        return Status::Invalid("Could not construct A NOT predicate from " + predicate->ToString());
+    }
+    return negate_predicate;
+}
+
+Result<std::shared_ptr<Predicate>> PredicateBuilder::StartsWith(int32_t field_index,
+                                                                const std::string& field_name,
+                                                                const FieldType& field_type,
+                                                                const Literal& literal) {
+    if (field_type != FieldType::STRING || literal.GetType() != FieldType::STRING) {
+        return Status::Invalid(
+            "There must be STRING type field and literal to construct a StartsWith predicate");
+    }
+    return std::make_shared<LeafPredicateImpl>(StartsWith::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+
+Result<std::shared_ptr<Predicate>> PredicateBuilder::EndsWith(int32_t field_index,
+                                                              const std::string& field_name,
+                                                              const FieldType& field_type,
+                                                              const Literal& literal) {
+    if (field_type != FieldType::STRING || literal.GetType() != FieldType::STRING) {
+        return Status::Invalid(
+            "There must be STRING type field and literal to construct an EndsWith predicate");
+    }
+    return std::make_shared<LeafPredicateImpl>(EndsWith::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+
+Result<std::shared_ptr<Predicate>> PredicateBuilder::Contains(int32_t field_index,
+                                                              const std::string& field_name,
+                                                              const FieldType& field_type,
+                                                              const Literal& literal) {
+    if (field_type != FieldType::STRING || literal.GetType() != FieldType::STRING) {
+        return Status::Invalid(
+            "There must be STRING type field and literal to construct a Contains predicate");
+    }
+    return std::make_shared<LeafPredicateImpl>(Contains::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+
+Result<std::shared_ptr<Predicate>> PredicateBuilder::Like(int32_t field_index,
+                                                          const std::string& field_name,
+                                                          const FieldType& field_type,
+                                                          const Literal& literal) {
+    if (field_type != FieldType::STRING || literal.GetType() != FieldType::STRING) {
+        return Status::Invalid(
+            "There must be STRING type field and literal to construct a Like predicate");
+    }
+    return std::make_shared<LeafPredicateImpl>(Like::Instance(), field_index, field_name,
+                                               field_type, std::vector<Literal>({literal}));
+}
+}  // namespace paimon

--- a/src/paimon/common/predicate/predicate_test.cpp
+++ b/src/paimon/common/predicate/predicate_test.cpp
@@ -1,0 +1,1624 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/predicate/predicate.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_array.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/common/predicate/predicate_filter.h"
+#include "paimon/defs.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/predicate/function.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace arrow {
+class Array;
+}  // namespace arrow
+
+namespace paimon::test {
+class PredicateTest : public ::testing::Test {
+ public:
+    void SetUp() override {}
+    void TearDown() override {}
+    struct FieldStats {
+        FieldStats(const std::optional<int64_t>& _min_value,
+                   const std::optional<int64_t>& _max_value, int64_t _null_count)
+            : min_value(_min_value), max_value(_max_value), null_count(_null_count) {}
+        std::optional<int64_t> min_value;
+        std::optional<int64_t> max_value;
+        int64_t null_count;
+    };
+
+    bool StatsCheck(const PredicateFilter& predicate, int64_t row_count,
+                    const std::vector<FieldStats>& field_stats) const {
+        auto pool = GetDefaultPool();
+        BinaryRow min_row(/*arity=*/field_stats.size());
+        BinaryRowWriter min_row_writer(&min_row, 0, pool.get());
+        BinaryRow max_row(/*arity=*/field_stats.size());
+        BinaryRowWriter max_row_writer(&max_row, 0, pool.get());
+        std::vector<int64_t> nulls;
+        arrow::FieldVector fields;
+        for (uint32_t i = 0; i < field_stats.size(); i++) {
+            const auto& stats = field_stats[i];
+            if (stats.min_value == std::nullopt) {
+                min_row_writer.SetNullAt(i);
+            } else {
+                min_row_writer.WriteLong(i, stats.min_value.value());
+            }
+            if (stats.max_value == std::nullopt) {
+                max_row_writer.SetNullAt(i);
+            } else {
+                max_row_writer.WriteLong(i, stats.max_value.value());
+            }
+            nulls.emplace_back(stats.null_count);
+            fields.emplace_back(arrow::field("f" + std::to_string(i), arrow::int64()));
+        }
+        min_row_writer.Complete();
+        max_row_writer.Complete();
+        auto null_counts = BinaryArray::FromLongArray(nulls, pool.get());
+        auto arrow_schema = arrow::schema(fields);
+        EXPECT_OK_AND_ASSIGN(
+            auto ret, predicate.Test(arrow_schema, row_count, min_row, max_row, null_counts));
+        return ret;
+    }
+
+    struct StringFieldStats {
+        StringFieldStats(const std::optional<std::string>& _min_value,
+                         const std::optional<std::string>& _max_value, int64_t _null_count)
+            : min_value(_min_value), max_value(_max_value), null_count(_null_count) {}
+        std::optional<std::string> min_value;
+        std::optional<std::string> max_value;
+        int64_t null_count;
+    };
+
+    bool StringStatsCheck(const PredicateFilter& predicate, int64_t row_count,
+                          const std::vector<StringFieldStats>& field_stats) const {
+        auto pool = GetDefaultPool();
+        BinaryRow min_row(/*arity=*/field_stats.size());
+        BinaryRowWriter min_row_writer(&min_row, 0, pool.get());
+        BinaryRow max_row(/*arity=*/field_stats.size());
+        BinaryRowWriter max_row_writer(&max_row, 0, pool.get());
+        std::vector<int64_t> nulls;
+        arrow::FieldVector fields;
+        for (uint32_t i = 0; i < field_stats.size(); i++) {
+            const auto& stats = field_stats[i];
+            if (stats.min_value == std::nullopt) {
+                min_row_writer.SetNullAt(i);
+            } else {
+                min_row_writer.WriteString(
+                    i, BinaryString::FromString(stats.min_value.value(), pool.get()));
+            }
+            if (stats.max_value == std::nullopt) {
+                max_row_writer.SetNullAt(i);
+            } else {
+                max_row_writer.WriteString(
+                    i, BinaryString::FromString(stats.max_value.value(), pool.get()));
+            }
+            nulls.emplace_back(stats.null_count);
+            fields.emplace_back(arrow::field("f" + std::to_string(i), arrow::utf8()));
+        }
+        min_row_writer.Complete();
+        max_row_writer.Complete();
+        auto null_counts = BinaryArray::FromLongArray(nulls, pool.get());
+        auto arrow_schema = arrow::schema(fields);
+        EXPECT_OK_AND_ASSIGN(
+            auto ret, predicate.Test(arrow_schema, row_count, min_row, max_row, null_counts));
+        return ret;
+    }
+
+    BinaryRow CreateBigIntRow(const std::vector<std::optional<int64_t>>& value) const {
+        auto pool = GetDefaultPool();
+        BinaryRow row(/*arity=*/value.size());
+        BinaryRowWriter row_writer(&row, 0, pool.get());
+        for (size_t i = 0; i < value.size(); ++i) {
+            if (value[i] == std::nullopt) {
+                row_writer.SetNullAt(i);
+            } else {
+                row_writer.WriteLong(i, value[i].value());
+            }
+        }
+        row_writer.Complete();
+        return row;
+    }
+
+    BinaryRow CreateStringRow(const std::vector<std::optional<std::string>>& value) const {
+        auto pool = GetDefaultPool();
+        BinaryRow row(/*arity=*/value.size());
+        BinaryRowWriter row_writer(&row, 0, pool.get());
+        for (size_t i = 0; i < value.size(); ++i) {
+            if (value[i] == std::nullopt) {
+                row_writer.SetNullAt(i);
+            } else {
+                row_writer.WriteString(i, BinaryString::FromString(value[i].value(), pool.get()));
+            }
+        }
+        row_writer.Complete();
+        return row;
+    }
+};
+
+TEST_F(PredicateTest, TestInvalidFieldIndex) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f0",
+                                                  FieldType::BIGINT, Literal(5l));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, 5, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    // with array
+    ASSERT_NOK_WITH_MSG(predicate->Test(*struct_array),
+                        "field index 2 exceed field count 2 in struct array");
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_NOK_WITH_MSG(predicate->Test(arrow_schema, CreateBigIntRow({4})),
+                        "field index 2 exceed field count 1 in row");
+}
+
+TEST_F(PredicateTest, TestEqual) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                  FieldType::BIGINT, Literal(5l));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, 5, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 1, 0}));
+
+    ASSERT_EQ(*predicate->Negate(),
+              *PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                          Literal(5l)));
+
+    ASSERT_FALSE(*predicate->Negate() ==
+                 *PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                             FieldType::BIGINT, Literal(10l)));
+    ASSERT_FALSE(*predicate->Negate() == *PredicateBuilder::Equal(/*field_index=*/0,
+                                                                  /*field_name=*/"f0",
+                                                                  FieldType::BIGINT, Literal(10l)));
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({5})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+
+    // with stats
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 6ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestEqualNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                  FieldType::BIGINT, Literal(FieldType::BIGINT));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestNotEqual) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                     FieldType::BIGINT, Literal(5l));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, 5, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({1, 0, 0}));
+
+    auto predicate_negate = std::dynamic_pointer_cast<PredicateFilter>(predicate->Negate());
+    ASSERT_EQ(*predicate_negate, *PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                          FieldType::BIGINT, Literal(5l)));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({5})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    ASSERT_TRUE(predicate_negate->Test(arrow_schema, CreateBigIntRow({5})).value());
+
+    // with stats
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 6ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(5ll, 5ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestNotEqualNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                     FieldType::BIGINT, Literal(FieldType::BIGINT));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestGreater) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                        FieldType::BIGINT, Literal(5l));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, 5, 6, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0, 1, 0}));
+
+    ASSERT_EQ(*predicate->Negate(),
+              *PredicateBuilder::LessOrEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                             FieldType::BIGINT, Literal(5l)));
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({5})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({6})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 4ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 6ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestGreaterNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::GreaterThan(
+        /*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT, Literal(FieldType::BIGINT));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 4ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestGreaterOrEqual) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::GreaterOrEqual(
+        /*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT, Literal(5l));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    ASSERT_EQ(predicate->GetFunction().ToString(), "GreaterOrEqual");
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, 5, 6, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 1, 1, 0}));
+
+    ASSERT_EQ(*predicate->Negate(),
+              *PredicateBuilder::LessThan(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                          Literal(5l)));
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({5})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({6})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 4ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 6ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestGreaterOrEqualNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::GreaterOrEqual(
+        /*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT, Literal(FieldType::BIGINT));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 4ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestLess) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::LessThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                     FieldType::BIGINT, Literal(5l));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, 5, 6, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({1, 0, 0, 0}));
+
+    ASSERT_EQ(*predicate->Negate(),
+              *PredicateBuilder::GreaterOrEqual(
+                  /*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT, Literal(5l)));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({5})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({6})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(5ll, 7ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(4ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestLessNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::LessThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                     FieldType::BIGINT, Literal(FieldType::BIGINT));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestLessOrEqual) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::LessOrEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                        FieldType::BIGINT, Literal(5l));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, 5, 6, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({1, 1, 0, 0}));
+
+    ASSERT_EQ(*predicate->Negate(),
+              *PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"f0",
+                                             FieldType::BIGINT, Literal(5l)));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({5})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({6})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(5ll, 7ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(4ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestLessOrEqualNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::LessOrEqual(
+        /*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT, Literal(FieldType::BIGINT));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestIsNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base =
+        PredicateBuilder::IsNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT);
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 1}));
+
+    ASSERT_EQ(*predicate->Negate(), *PredicateBuilder::IsNotNull(
+                                        /*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(5ll, 7ll, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestIsNotNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base =
+        PredicateBuilder::IsNotNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT);
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({1, 0}));
+
+    ASSERT_EQ(*predicate->Negate(),
+              *PredicateBuilder::IsNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(5ll, 7ll, 1ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(std::nullopt, std::nullopt, 3ll)}));
+}
+
+TEST_F(PredicateTest, TestIn) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::In(/*field_index=*/0, /*field_name=*/"f0",
+                                               FieldType::BIGINT, {Literal(1l), Literal(3l)});
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({1, 0, 1, 0}));
+
+    ASSERT_EQ(*predicate->Negate(),
+              *PredicateBuilder::NotIn(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                       {Literal(1l), Literal(3l)}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({1})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({2})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({3})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestInNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::In(
+        /*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+        {Literal(1l), Literal(FieldType::BIGINT), Literal(3l)});
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({1, 0, 1, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({1})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({2})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({3})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestNotIn) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::NotIn(/*field_index=*/0, /*field_name=*/"f0",
+                                                  FieldType::BIGINT, {Literal(1l), Literal(3l)});
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 1, 0, 0}));
+
+    ASSERT_EQ(*predicate->Negate(),
+              *PredicateBuilder::In(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                    {Literal(1l), Literal(3l)}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({1})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({2})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({3})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 1ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(3ll, 3ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 3ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestNotInNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::NotIn(
+        /*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+        {Literal(1l), Literal(FieldType::BIGINT), Literal(3l)});
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0, 0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({1})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({2})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({3})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 1ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(3ll, 3ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 3ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestLargeIn) {
+    auto bigint_type = arrow::int64();
+    std::vector<Literal> literals;
+    literals.reserve(30);
+    literals.emplace_back(1l);
+    literals.emplace_back(3l);
+    for (int64_t i = 10; i < 30; i++) {
+        literals.emplace_back(i);
+    }
+    auto predicate_base =
+        PredicateBuilder::In(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT, literals);
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({1, 0, 1, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({1})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({2})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({3})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(29ll, 32ll, 0ll)}));
+}
+
+TEST_F(PredicateTest, TestLargeInNull) {
+    auto bigint_type = arrow::int64();
+    std::vector<Literal> literals;
+    literals.reserve(30);
+    literals.emplace_back(1l);
+    literals.emplace_back(FieldType::BIGINT);
+    literals.emplace_back(3l);
+    for (int64_t i = 10; i < 30; i++) {
+        literals.emplace_back(i);
+    }
+    auto predicate_base =
+        PredicateBuilder::In(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT, literals);
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({1, 0, 1, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({1})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({2})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({3})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(29ll, 32ll, 0ll)}));
+}
+
+TEST_F(PredicateTest, TestLargeNotIn) {
+    auto bigint_type = arrow::int64();
+    std::vector<Literal> literals;
+    literals.reserve(30);
+    literals.emplace_back(1l);
+    literals.emplace_back(3l);
+    for (int64_t i = 10; i < 30; i++) {
+        literals.emplace_back(i);
+    }
+    auto predicate_base = PredicateBuilder::NotIn(/*field_index=*/0, /*field_name=*/"f0",
+                                                  FieldType::BIGINT, literals);
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 1, 0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({1})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({2})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({3})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 1ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(3ll, 3ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 3ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(29ll, 32ll, 0ll)}));
+}
+
+TEST_F(PredicateTest, TestLargeNotInNull) {
+    auto bigint_type = arrow::int64();
+    std::vector<Literal> literals;
+    literals.reserve(30);
+    literals.emplace_back(1l);
+    literals.emplace_back(FieldType::BIGINT);
+    literals.emplace_back(3l);
+    for (int64_t i = 10; i < 30; i++) {
+        literals.emplace_back(i);
+    }
+    auto predicate_base = PredicateBuilder::NotIn(/*field_index=*/0, /*field_name=*/"f0",
+                                                  FieldType::BIGINT, literals);
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 2, 1, 0])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0, 0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({1})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({2})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({3})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 1ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(3ll, 3ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 3ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(0ll, 5ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(29ll, 32ll, 0ll)}));
+}
+
+TEST_F(PredicateTest, TestAnd) {
+    auto bigint_type = arrow::int64();
+    ASSERT_OK_AND_ASSIGN(
+        auto predicate_base,
+        PredicateBuilder::And({PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                       FieldType::BIGINT, Literal(3l)),
+                               PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1",
+                                                       FieldType::BIGINT, Literal(5l))}));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, 3, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([5, 6, 5, 5])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0, 1, 0}));
+
+    ASSERT_OK_AND_ASSIGN(
+        auto negate_predicate,
+        PredicateBuilder::Or({PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                         FieldType::BIGINT, Literal(3l)),
+                              PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                         FieldType::BIGINT, Literal(5l))}));
+    ASSERT_EQ(*predicate->Negate(), *negate_predicate);
+
+    // with internal row
+    auto arrow_schema = arrow::schema(
+        arrow::FieldVector({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4, 5})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({3, 6})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({3, 5})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt, 5})).value());
+    // with stats
+    ASSERT_TRUE(
+        StatsCheck(*predicate, 3ll, {FieldStats(3ll, 6ll, 0ll), FieldStats(4ll, 6ll, 0ll)}));
+    ASSERT_FALSE(
+        StatsCheck(*predicate, 3ll, {FieldStats(3ll, 6ll, 0ll), FieldStats(6ll, 8ll, 0ll)}));
+    ASSERT_FALSE(
+        StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll), FieldStats(4ll, 6ll, 0ll)}));
+}
+
+TEST_F(PredicateTest, TestOr) {
+    auto bigint_type = arrow::int64();
+    ASSERT_OK_AND_ASSIGN(
+        auto predicate_base,
+        PredicateBuilder::Or({PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                      FieldType::BIGINT, Literal(3l)),
+                              PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1",
+                                                      FieldType::BIGINT, Literal(5l))}));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, 3, 3, null])").ValueOrDie();
+    auto f1 =
+        arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([6, 6, 5, 5])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 1, 1, 1}));
+
+    ASSERT_OK_AND_ASSIGN(
+        auto negate_predicate,
+        PredicateBuilder::And({PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                          FieldType::BIGINT, Literal(3l)),
+                               PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                          FieldType::BIGINT, Literal(5l))}));
+    ASSERT_EQ(*predicate->Negate(), *negate_predicate);
+
+    // with internal row
+    auto arrow_schema = arrow::schema(
+        arrow::FieldVector({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4, 6})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({3, 6})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({3, 5})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt, 5})).value());
+    // with stats
+    ASSERT_TRUE(
+        StatsCheck(*predicate, 3ll, {FieldStats(3ll, 6ll, 0ll), FieldStats(4ll, 6ll, 0ll)}));
+    ASSERT_TRUE(
+        StatsCheck(*predicate, 3ll, {FieldStats(3ll, 6ll, 0ll), FieldStats(6ll, 8ll, 0ll)}));
+    ASSERT_FALSE(
+        StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll), FieldStats(8ll, 10ll, 0ll)}));
+}
+
+TEST_F(PredicateTest, TestBetween) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base = PredicateBuilder::Between(/*field_index=*/0, /*field_name=*/"f0",
+                                                    FieldType::BIGINT, Literal(3l), Literal(5l));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([3, 4, 5, 100, 1, null])")
+                  .ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2, 3, 4, 5, 6])")
+                  .ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({1, 1, 1, 0, 0, 0}));
+
+    auto less_than = PredicateBuilder::LessThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                FieldType::BIGINT, Literal(3l));
+    auto greater_than = PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                      FieldType::BIGINT, Literal(5l));
+    ASSERT_OK_AND_ASSIGN(auto or_predicate, PredicateBuilder::Or({less_than, greater_than}));
+
+    auto predicate_negate = std::dynamic_pointer_cast<PredicateFilter>(predicate->Negate());
+    ASSERT_EQ(*predicate_negate, *or_predicate);
+    ASSERT_FALSE(*predicate_negate == *predicate_base);
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({1})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+    ASSERT_TRUE(predicate_negate->Test(arrow_schema, CreateBigIntRow({1})).value());
+
+    // with stats
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 10ll, 0ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(3ll, 4ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(6ll, 7ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+    ASSERT_TRUE(StatsCheck(*predicate, 3ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestBetweenNull) {
+    auto bigint_type = arrow::int64();
+    auto predicate_base =
+        PredicateBuilder::Between(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                  Literal(FieldType::BIGINT), Literal(5l));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([4, null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(bigint_type, R"([1, 2])").ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", bigint_type), arrow::field("f1", bigint_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", bigint_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({4})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateBigIntRow({std::nullopt})).value());
+
+    // with stats
+    ASSERT_FALSE(StatsCheck(*predicate, 3ll, {FieldStats(1ll, 10ll, 0ll)}));
+    ASSERT_FALSE(StatsCheck(*predicate, 1ll, {FieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestStartsWith) {
+    auto string_type = arrow::utf8();
+    ASSERT_OK_AND_ASSIGN(
+        const auto predicate_base,
+        PredicateBuilder::StartsWith(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                     Literal(FieldType::STRING, "aab", 3)));
+    const auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(string_type,
+                                                        R"(["ccddee", "bbccdd", "aabbcc", null])")
+                  .ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(
+                  string_type, R"(["gghhii", "ffgghh", "eeffgg", "ddeeff"])")
+                  .ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", string_type), arrow::field("f1", string_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0, 1, 0}));
+
+    ASSERT_EQ(predicate->Negate(), nullptr);
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", string_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"ccddee"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"bbccdd"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"aabbcc"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({std::nullopt})).value());
+
+    // with stats
+    // min="aaa", max="aaz" covers prefix "aab"
+    ASSERT_TRUE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aaa", "aaz", 0ll)}));
+    // min="aab", max="aab" exact match prefix
+    ASSERT_TRUE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aab", "aab", 0ll)}));
+    // min="aabxxx", max="aabzzz" both start with "aab"
+    ASSERT_TRUE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aabxxx", "aabzzz", 0ll)}));
+    // min="bbb", max="ccc" entirely above prefix "aab"
+    ASSERT_FALSE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("bbb", "ccc", 0ll)}));
+    // min="aaa", max="aaa" entirely below prefix "aab"
+    ASSERT_FALSE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aaa", "aaa", 0ll)}));
+    // all nulls
+    ASSERT_FALSE(
+        StringStatsCheck(*predicate, 1ll, {StringFieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestStartsWithNull) {
+    const auto string_type = arrow::utf8();
+    ASSERT_OK_AND_ASSIGN(
+        const auto predicate_base,
+        PredicateBuilder::StartsWith(
+            /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING, Literal(FieldType::STRING)));
+    const auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(string_type, R"(["bbccdd", null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(string_type, R"(["ffgghh", "ccddee"])")
+                  .ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", string_type), arrow::field("f1", string_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", string_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"bbccdd"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({std::nullopt})).value());
+
+    // with stats: null literal always returns false
+    ASSERT_FALSE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aaa", "zzz", 0ll)}));
+    ASSERT_FALSE(
+        StringStatsCheck(*predicate, 1ll, {StringFieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestEndsWith) {
+    auto string_type = arrow::utf8();
+    ASSERT_OK_AND_ASSIGN(
+        const auto predicate_base,
+        PredicateBuilder::EndsWith(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                   Literal(FieldType::STRING, "bcc", 3)));
+    const auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(string_type,
+                                                        R"(["ccddee", "bbccdd", "aabbcc", null])")
+                  .ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(
+                  string_type, R"(["gghhii", "ffgghh", "eeffgg", "ddeeff"])")
+                  .ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", string_type), arrow::field("f1", string_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0, 1, 0}));
+
+    ASSERT_EQ(predicate->Negate(), nullptr);
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", string_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"ccddee"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"bbccdd"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"aabbcc"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({std::nullopt})).value());
+
+    // with stats: EndsWith base class always returns true for non-null stats
+    ASSERT_TRUE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aaa", "zzz", 0ll)}));
+    ASSERT_TRUE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("xxx", "yyy", 0ll)}));
+    // all nulls
+    ASSERT_FALSE(
+        StringStatsCheck(*predicate, 1ll, {StringFieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestEndsWithNull) {
+    const auto string_type = arrow::utf8();
+    ASSERT_OK_AND_ASSIGN(
+        const auto predicate_base,
+        PredicateBuilder::EndsWith(
+            /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING, Literal(FieldType::STRING)));
+    const auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(string_type, R"(["bbccdd", null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(string_type, R"(["ffgghh", "ccddee"])")
+                  .ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", string_type), arrow::field("f1", string_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", string_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"bbccdd"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({std::nullopt})).value());
+
+    // with stats: null literal always returns false
+    ASSERT_FALSE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aaa", "zzz", 0ll)}));
+    ASSERT_FALSE(
+        StringStatsCheck(*predicate, 1ll, {StringFieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestContains) {
+    auto string_type = arrow::utf8();
+    ASSERT_OK_AND_ASSIGN(
+        const auto predicate_base,
+        PredicateBuilder::Contains(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                   Literal(FieldType::STRING, "cde", 3)));
+    const auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 = arrow::ipc::internal::json::ArrayFromJSON(string_type,
+                                                        R"(["ghijkl", "defghi", "abcdef", null])")
+                  .ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(
+                  string_type, R"(["stuvwx", "pqrstu", "mnopqr", "jklmno"])")
+                  .ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", string_type), arrow::field("f1", string_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0, 1, 0}));
+
+    ASSERT_EQ(predicate->Negate(), nullptr);
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", string_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"ghijkl"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"defghi"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"abcdef"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({std::nullopt})).value());
+
+    // with stats: Contains base class always returns true for non-null stats
+    ASSERT_TRUE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aaa", "zzz", 0ll)}));
+    ASSERT_TRUE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("xxx", "yyy", 0ll)}));
+    // all nulls
+    ASSERT_FALSE(
+        StringStatsCheck(*predicate, 1ll, {StringFieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestContainsNull) {
+    const auto string_type = arrow::utf8();
+    ASSERT_OK_AND_ASSIGN(
+        const auto predicate_base,
+        PredicateBuilder::Contains(
+            /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING, Literal(FieldType::STRING)));
+    const auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    auto f0 =
+        arrow::ipc::internal::json::ArrayFromJSON(string_type, R"(["defghi", null])").ValueOrDie();
+    auto f1 = arrow::ipc::internal::json::ArrayFromJSON(string_type, R"(["pqrstu", "jklmno"])")
+                  .ValueOrDie();
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_({arrow::field("f0", string_type), arrow::field("f1", string_type)});
+
+    std::shared_ptr<arrow::Array> struct_array =
+        arrow::StructArray::Make({f0, f1}, src_type->fields()).ValueOrDie();
+
+    ASSERT_OK_AND_ASSIGN(auto is_valid, predicate->Test(*struct_array));
+    ASSERT_EQ(is_valid, std::vector<char>({0, 0}));
+
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", string_type)}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"defghi"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({std::nullopt})).value());
+
+    // with stats: null literal always returns false
+    ASSERT_FALSE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aaa", "zzz", 0ll)}));
+    ASSERT_FALSE(
+        StringStatsCheck(*predicate, 1ll, {StringFieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestLike) {
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a.c", 3)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate);
+    ASSERT_EQ(predicate->Negate(), nullptr);
+    // with internal row
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"abc"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"a.c"})).value());
+
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a.*d", 4)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"abcd"})).value());
+
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "%c.e", 4)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"abcde"})).value());
+
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a\\_c", 4)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"a-c"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"a_c"})).value());
+
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "start%", 6)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"startX"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"not_startX"})).value());
+
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "%middle%", 8)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"xxmiddleyy"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"xxmidxdleyy"})).value());
+
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "%end", 4)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"xxend"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"xxendyy"})).value());
+
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "equal", 5)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"equal"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"equalxx"})).value());
+
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "st_rt%", 6)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"startxx"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"stbrtxx"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"xxstbrtxx"})).value());
+
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "abc%def%", 8)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"abchahadefxx"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"abchahadafxx"})).value());
+
+    // with stats: Like base class always returns true for non-null stats
+    ASSERT_TRUE(StringStatsCheck(*predicate, 3ll, {StringFieldStats("aaa", "zzz", 0ll)}));
+    // all nulls
+    ASSERT_FALSE(
+        StringStatsCheck(*predicate, 1ll, {StringFieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestLikeConsecutivePercent) {
+    // consecutive '%' should be merged into one '%'
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // "%%" should behave the same as "%"
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "%%", 2)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"anything"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({""})).value());
+
+    // "a%%%b" should behave the same as "a%b"
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a%%%b", 5)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"axyzb"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"ab"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"axyzc"})).value());
+}
+
+TEST_F(PredicateTest, TestLikeEmptyField) {
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // empty field should match "%"
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "%", 1)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({""})).value());
+
+    // empty field should NOT match "_"
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "_", 1)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({""})).value());
+
+    // empty field should NOT match a fixed pattern "abc"
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "abc", 3)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({""})).value());
+}
+
+TEST_F(PredicateTest, TestLikeMinLenExceedsField) {
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // pattern "abcdef" requires 6 literal chars, field "ab" has only 2
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "abcdef", 6)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"ab"})).value());
+
+    // pattern "a_b_c" requires 3 literal chars, wildcards = min_len 3, field "ab" has 2
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a_b_c", 5)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"ab"})).value());
+
+    // field length equals min_len should still be possible to match
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"axbxc"})).value());
+}
+
+TEST_F(PredicateTest, TestLikeLongPatternHeapAlloc) {
+    // pattern length > STACK_LIMIT(128) uses heap allocation
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // Build a pattern with > 128 characters: "a" + 130 * "_" + "z"
+    std::string long_pattern = "a";
+    for (int i = 0; i < 130; ++i) {
+        long_pattern += '_';
+    }
+    long_pattern += 'z';
+
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, long_pattern.data(), long_pattern.size())));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+
+    // Build a matching field: "a" + 130 * "x" + "z"
+    std::string matching_field = "a";
+    for (int i = 0; i < 130; ++i) {
+        matching_field += 'x';
+    }
+    matching_field += 'z';
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({matching_field})).value());
+
+    // Non-matching: wrong ending
+    std::string non_matching_field = "a";
+    for (int i = 0; i < 130; ++i) {
+        non_matching_field += 'x';
+    }
+    non_matching_field += 'y';
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({non_matching_field})).value());
+}
+
+TEST_F(PredicateTest, TestCompound) {
+    ASSERT_OK_AND_ASSIGN(
+        const auto startswith_predicate,
+        PredicateBuilder::StartsWith(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                     Literal(FieldType::STRING, "aab", 3)));
+    ASSERT_OK_AND_ASSIGN(
+        const auto endswith_predicate,
+        PredicateBuilder::EndsWith(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                   Literal(FieldType::STRING, "bcc", 3)));
+    ASSERT_OK_AND_ASSIGN(const auto compound_predicate,
+                         PredicateBuilder::And({startswith_predicate, endswith_predicate}));
+    ASSERT_NOK_WITH_MSG(
+        PredicateBuilder::Not(compound_predicate),
+        "Could not construct A NOT predicate from And([StartsWith(f0, aab), EndsWith(f0, bcc)])");
+
+    // with stats: And of StartsWith + EndsWith
+    auto compound_filter = std::dynamic_pointer_cast<PredicateFilter>(compound_predicate);
+    ASSERT_TRUE(compound_filter);
+    // min="aab", max="aaz" covers StartsWith("aab"), EndsWith("bcc") returns true by default
+    ASSERT_TRUE(StringStatsCheck(*compound_filter, 3ll, {StringFieldStats("aab", "aaz", 0ll)}));
+    // min="bbb", max="ccc" does not cover StartsWith("aab")
+    ASSERT_FALSE(StringStatsCheck(*compound_filter, 3ll, {StringFieldStats("bbb", "ccc", 0ll)}));
+    // all nulls
+    ASSERT_FALSE(StringStatsCheck(*compound_filter, 1ll,
+                                  {StringFieldStats(std::nullopt, std::nullopt, 1ll)}));
+}
+
+TEST_F(PredicateTest, TestPredicateToString) {
+    {
+        auto predicate = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                 FieldType::BIGINT, Literal(5l));
+        ASSERT_EQ(predicate->ToString(), "Equal(f0, 5)");
+    }
+    {
+        auto predicate = PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                       FieldType::BIGINT, Literal(5l));
+        ASSERT_EQ(predicate->ToString(), "GreaterThan(f0, 5)");
+    }
+    {
+        auto predicate =
+            PredicateBuilder::IsNotNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT);
+        ASSERT_EQ(predicate->ToString(), "IsNotNull(f0)");
+    }
+    {
+        std::vector<Literal> literals;
+        literals.reserve(30);
+        for (int64_t i = 1; i <= 21; i++) {
+            literals.emplace_back(i);
+        }
+        auto predicate = PredicateBuilder::In(/*field_index=*/0, /*field_name=*/"f0",
+                                              FieldType::BIGINT, literals);
+        ASSERT_TRUE(predicate);
+        ASSERT_EQ(
+            predicate->ToString(),
+            "In(f0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21])");
+    }
+    {
+        std::vector<Literal> literals;
+        literals.reserve(30);
+        for (int64_t i = 1; i <= 21; i++) {
+            literals.emplace_back(i);
+        }
+        auto predicate = PredicateBuilder::NotIn(/*field_index=*/0, /*field_name=*/"f0",
+                                                 FieldType::BIGINT, literals);
+        ASSERT_TRUE(predicate);
+        ASSERT_EQ(predicate->ToString(),
+                  "NotIn(f0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, "
+                  "20, 21])");
+    }
+
+    {
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                           FieldType::BIGINT, Literal(3l)),
+                                   PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1",
+                                                           FieldType::BIGINT, Literal(5l))}));
+        ASSERT_EQ(predicate->ToString(), "And([Equal(f0, 3), Equal(f1, 5)])");
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::Or({PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                          FieldType::BIGINT, Literal(3l)),
+                                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1",
+                                                          FieldType::BIGINT, Literal(5l))}));
+        ASSERT_EQ(predicate->ToString(), "Or([Equal(f0, 3), Equal(f1, 5)])");
+    }
+}
+
+TEST_F(PredicateTest, TestBuildAndOr) {
+    {
+        // literals cannot be empty
+        ASSERT_NOK(PredicateBuilder::Or({}));
+    }
+    {
+        // literals cannot be empty
+        ASSERT_NOK(PredicateBuilder::And({}));
+    }
+}
+}  // namespace paimon::test

--- a/src/paimon/common/predicate/predicate_test.cpp
+++ b/src/paimon/common/predicate/predicate_test.cpp
@@ -1521,6 +1521,125 @@ TEST_F(PredicateTest, TestLikeLongPatternHeapAlloc) {
     ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({non_matching_field})).value());
 }
 
+TEST_F(PredicateTest, TestLikeInvalidEscapeSequence) {
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // Trailing backslash is invalid (Java throws "Invalid escape sequence")
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "abc\\", 4)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_NOK_WITH_MSG(predicate->Test(arrow_schema, CreateStringRow({"abc"})),
+                        "Invalid escape sequence");
+
+    // Backslash followed by non-special char is invalid (only \_, \%, \\ are legal)
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a\\bc", 4)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_NOK_WITH_MSG(predicate->Test(arrow_schema, CreateStringRow({"abc"})),
+                        "Invalid escape sequence");
+
+    // \n is not a valid escape
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a\\nf", 4)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_NOK_WITH_MSG(predicate->Test(arrow_schema, CreateStringRow({"anf"})),
+                        "Invalid escape sequence");
+}
+
+TEST_F(PredicateTest, TestLikeEscapeBackslash) {
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // \\\\ in C++ string literal = "\\" in the pattern = escaped backslash
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a\\\\b", 4)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    // Field "a\b" should match pattern "a\\b" (escaped backslash)
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"a\\b"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"axb"})).value());
+
+    // Escaped percent: "a\%b" matches literal "a%b"
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a\\%b", 4)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"a%b"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"axb"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"axxb"})).value());
+}
+
+TEST_F(PredicateTest, TestLikeUtf8MultibyteUnderscore) {
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // Single '_' should match one Unicode character, not one byte.
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "_", 1)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"中"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"中文"})).value());
+
+    // "a_c" where _ matches one Chinese character
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "a_c", 3)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"a中c"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"a中文c"})).value());
+
+    // "___" should match exactly 3 Unicode characters
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "___", 3)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"中文字"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"中文"})).value());
+
+    // '%' should still work with multi-byte characters
+    std::string pattern_contains = std::string("%") + "中" + "%";
+    ASSERT_OK_AND_ASSIGN(
+        predicate_base,
+        PredicateBuilder::Like(
+            /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+            Literal(FieldType::STRING, pattern_contains.data(), pattern_contains.size())));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"hello中world"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"helloworld"})).value());
+}
+
+TEST_F(PredicateTest, TestLikeJavaRegexLineTerminatorSemantics) {
+    auto arrow_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+
+    // Java regex '.' does not match line terminators, so '_' should not match them either.
+    ASSERT_OK_AND_ASSIGN(auto predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "_", 1)));
+    auto predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"\n"})).value());
+    ASSERT_FALSE(predicate->Test(arrow_schema, CreateStringRow({"\r"})).value());
+
+    // Java LIKE '%' uses (?s:.*), so it should still match line terminators.
+    ASSERT_OK_AND_ASSIGN(predicate_base,
+                         PredicateBuilder::Like(
+                             /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                             Literal(FieldType::STRING, "%", 1)));
+    predicate = std::dynamic_pointer_cast<PredicateFilter>(predicate_base);
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"\n"})).value());
+    ASSERT_TRUE(predicate->Test(arrow_schema, CreateStringRow({"\r"})).value());
+}
+
 TEST_F(PredicateTest, TestCompound) {
     ASSERT_OK_AND_ASSIGN(
         const auto startswith_predicate,

--- a/src/paimon/common/predicate/predicate_utils.cpp
+++ b/src/paimon/common/predicate/predicate_utils.cpp
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/predicate/predicate_utils.h"
+
+#include <utility>
+
+#include "paimon/common/predicate/compound_predicate_impl.h"
+#include "paimon/common/predicate/leaf_predicate_impl.h"
+#include "paimon/predicate/compound_predicate.h"
+#include "paimon/predicate/leaf_predicate.h"
+#include "paimon/predicate/predicate_builder.h"
+
+namespace paimon {
+Result<bool> PredicateUtils::ContainAnyField(const std::shared_ptr<Predicate>& predicate,
+                                             const std::set<std::string>& field_names) {
+    if (auto leaf_predicate = std::dynamic_pointer_cast<LeafPredicate>(predicate)) {
+        return field_names.find(leaf_predicate->FieldName()) != field_names.end();
+    } else if (auto compound_predicate = std::dynamic_pointer_cast<CompoundPredicate>(predicate)) {
+        for (const auto& child : compound_predicate->Children()) {
+            PAIMON_ASSIGN_OR_RAISE(bool contains, ContainAnyField(child, field_names));
+            if (contains) {
+                return true;
+            }
+        }
+        return false;
+    }
+    return Status::Invalid("must be LeafPredicate or CompoundPredicate");
+}
+
+Status PredicateUtils::GetAllNames(const std::shared_ptr<Predicate>& predicate,
+                                   std::set<std::string>* field_names) {
+    if (auto leaf_predicate = std::dynamic_pointer_cast<LeafPredicate>(predicate)) {
+        field_names->insert(leaf_predicate->FieldName());
+        return Status::OK();
+    } else if (auto compound_predicate = std::dynamic_pointer_cast<CompoundPredicate>(predicate)) {
+        for (const auto& child : compound_predicate->Children()) {
+            PAIMON_RETURN_NOT_OK(GetAllNames(child, field_names));
+        }
+        return Status::OK();
+    }
+    return Status::Invalid("must be LeafPredicate or CompoundPredicate");
+}
+
+Result<std::shared_ptr<Predicate>> PredicateUtils::ExcludePredicateWithFields(
+    const std::shared_ptr<Predicate>& predicates, const std::set<std::string>& field_names) {
+    auto sub_predicates = PredicateUtils::SplitAnd(predicates);
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<Predicate>> new_predicates,
+                           PredicateUtils::ExcludePredicateWithFields(sub_predicates, field_names));
+    if (new_predicates.empty()) {
+        return std::shared_ptr<Predicate>();
+    }
+    return PredicateBuilder::And(new_predicates);
+}
+
+Result<std::vector<std::shared_ptr<Predicate>>> PredicateUtils::ExcludePredicateWithFields(
+    const std::vector<std::shared_ptr<Predicate>>& predicates,
+    const std::set<std::string>& field_names) {
+    if (predicates.empty() || field_names.empty()) {
+        return predicates;
+    }
+    std::vector<std::shared_ptr<Predicate>> remain_predicates;
+    for (const auto& predicate : predicates) {
+        PAIMON_ASSIGN_OR_RAISE(bool contain, ContainAnyField(predicate, field_names));
+        if (!contain) {
+            remain_predicates.push_back(predicate);
+        }
+    }
+    return remain_predicates;
+}
+
+std::vector<std::shared_ptr<Predicate>> PredicateUtils::SplitAnd(
+    const std::shared_ptr<Predicate>& predicate) {
+    std::vector<std::shared_ptr<Predicate>> result;
+    if (predicate == nullptr) {
+        return result;
+    }
+    SplitCompound(Function::Type::AND, predicate, &result);
+    return result;
+}
+
+Result<std::shared_ptr<Predicate>> PredicateUtils::CreatePickedFieldFilter(
+    const std::shared_ptr<Predicate>& predicate,
+    const std::map<std::string, int32_t>& picked_field_name_to_idx) {
+    if (!predicate) {
+        return predicate;
+    }
+    auto split_predicates = PredicateUtils::SplitAnd(predicate);
+    std::vector<std::shared_ptr<Predicate>> converted_predicates;
+    converted_predicates.reserve(split_predicates.size());
+    for (const auto& predicate : split_predicates) {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::optional<std::shared_ptr<Predicate>> converted,
+            ReconstructPredicateWithPickedFields(predicate, picked_field_name_to_idx));
+        if (converted != std::nullopt) {
+            converted_predicates.push_back(converted.value());
+        }
+    }
+    if (converted_predicates.empty()) {
+        return std::shared_ptr<Predicate>();
+    }
+    return PredicateBuilder::And(converted_predicates);
+}
+
+Result<std::optional<std::shared_ptr<Predicate>>>
+PredicateUtils::ReconstructPredicateWithPickedFields(
+    const std::shared_ptr<Predicate>& predicate,
+    const std::map<std::string, int32_t>& picked_field_name_to_idx) {
+    if (auto compound_predicate = std::dynamic_pointer_cast<CompoundPredicateImpl>(predicate)) {
+        std::vector<std::shared_ptr<Predicate>> mapped_children;
+        for (const auto& child : compound_predicate->Children()) {
+            PAIMON_ASSIGN_OR_RAISE(
+                std::optional<std::shared_ptr<Predicate>> mapped,
+                ReconstructPredicateWithPickedFields(child, picked_field_name_to_idx));
+            if (mapped != std::nullopt) {
+                mapped_children.push_back(mapped.value());
+            } else {
+                return std::optional<std::shared_ptr<Predicate>>();
+            }
+        }
+        return std::optional<std::shared_ptr<Predicate>>(
+            compound_predicate->NewCompoundPredicate(mapped_children));
+    } else if (auto leaf_predicate = std::dynamic_pointer_cast<LeafPredicateImpl>(predicate)) {
+        auto iter = picked_field_name_to_idx.find(leaf_predicate->FieldName());
+        if (iter == picked_field_name_to_idx.end()) {
+            return std::optional<std::shared_ptr<Predicate>>();
+        } else {
+            return std::optional<std::shared_ptr<Predicate>>(
+                leaf_predicate->NewLeafPredicate(/*new_field_index=*/iter->second));
+        }
+    }
+    return Status::Invalid(fmt::format(
+        "cannot cast predicate {} to CompoundPredicate or LeafPredicate", predicate->ToString()));
+}
+
+void PredicateUtils::SplitCompound(const Function::Type& type,
+                                   const std::shared_ptr<Predicate>& predicate,
+                                   std::vector<std::shared_ptr<Predicate>>* result) {
+    if (auto compound_predicate = std::dynamic_pointer_cast<CompoundPredicate>(predicate)) {
+        if (compound_predicate->GetFunction().GetType() == type) {
+            for (const auto& child : compound_predicate->Children()) {
+                SplitCompound(type, child, result);
+            }
+            return;
+        }
+    }
+    result->push_back(predicate);
+}
+
+}  // namespace paimon

--- a/src/paimon/common/predicate/predicate_utils_test.cpp
+++ b/src/paimon/common/predicate/predicate_utils_test.cpp
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/predicate/predicate_utils.h"
+
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "paimon/defs.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(PredicateUtilsTest, TestSplitAnd) {
+    ASSERT_OK_AND_ASSIGN(
+        auto child1,
+        PredicateBuilder::Or(
+            {PredicateBuilder::IsNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT),
+             PredicateBuilder::IsNull(/*field_index=*/1, /*field_name=*/"f1", FieldType::BIGINT),
+             PredicateBuilder::IsNull(/*field_index=*/2, /*field_name=*/"f2", FieldType::BIGINT)}));
+
+    auto sub_child1 =
+        PredicateBuilder::IsNull(/*field_index=*/3, /*field_name=*/"f3", FieldType::BIGINT);
+    auto sub_child2 =
+        PredicateBuilder::IsNull(/*field_index=*/4, /*field_name=*/"f4", FieldType::BIGINT);
+    auto sub_child3 =
+        PredicateBuilder::IsNull(/*field_index=*/5, /*field_name=*/"f5", FieldType::BIGINT);
+    ASSERT_OK_AND_ASSIGN(auto child2, PredicateBuilder::And({sub_child1, sub_child2, sub_child3}));
+
+    auto child3 =
+        PredicateBuilder::IsNull(/*field_index=*/6, /*field_name=*/"f6", FieldType::BIGINT);
+
+    auto res = PredicateUtils::SplitAnd(PredicateBuilder::And({child1, child2, child3}).value());
+    ASSERT_EQ(res.size(), 5u);
+    ASSERT_EQ(*res[0], *child1);
+    ASSERT_EQ(*res[1], *sub_child1);
+    ASSERT_EQ(*res[2], *sub_child2);
+    ASSERT_EQ(*res[3], *sub_child3);
+    ASSERT_EQ(*res[4], *child3);
+}
+
+TEST(PredicateUtilsTest, TestContainAnyField) {
+    ASSERT_OK_AND_ASSIGN(
+        auto child1,
+        PredicateBuilder::Or(
+            {PredicateBuilder::IsNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT),
+             PredicateBuilder::IsNull(/*field_index=*/1, /*field_name=*/"f1", FieldType::BIGINT),
+             PredicateBuilder::IsNull(/*field_index=*/2, /*field_name=*/"f2", FieldType::BIGINT)}));
+
+    auto sub_child1 =
+        PredicateBuilder::IsNull(/*field_index=*/3, /*field_name=*/"f3", FieldType::BIGINT);
+    auto sub_child2 =
+        PredicateBuilder::IsNull(/*field_index=*/4, /*field_name=*/"f4", FieldType::BIGINT);
+    auto sub_child3 =
+        PredicateBuilder::IsNull(/*field_index=*/5, /*field_name=*/"f5", FieldType::BIGINT);
+    ASSERT_OK_AND_ASSIGN(auto child2, PredicateBuilder::And({sub_child1, sub_child2, sub_child3}));
+
+    auto child3 =
+        PredicateBuilder::IsNull(/*field_index=*/6, /*field_name=*/"f6", FieldType::BIGINT);
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({child1, child2, child3}));
+    ASSERT_TRUE(PredicateUtils::ContainAnyField(predicate, {"f0"}).value());
+    ASSERT_FALSE(PredicateUtils::ContainAnyField(predicate, {"non-exist"}).value());
+}
+
+TEST(PredicateUtilsTest, TestExcludePredicateWithFields) {
+    ASSERT_OK_AND_ASSIGN(
+        auto child1,
+        PredicateBuilder::Or(
+            {PredicateBuilder::IsNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT),
+             PredicateBuilder::IsNull(/*field_index=*/1, /*field_name=*/"f1", FieldType::BIGINT),
+             PredicateBuilder::IsNull(/*field_index=*/2, /*field_name=*/"f2", FieldType::BIGINT)}));
+
+    auto sub_child1 =
+        PredicateBuilder::IsNull(/*field_index=*/3, /*field_name=*/"f3", FieldType::BIGINT);
+    auto sub_child2 =
+        PredicateBuilder::IsNull(/*field_index=*/4, /*field_name=*/"f4", FieldType::BIGINT);
+    auto sub_child3 =
+        PredicateBuilder::IsNull(/*field_index=*/5, /*field_name=*/"f5", FieldType::BIGINT);
+    ASSERT_OK_AND_ASSIGN(auto child2, PredicateBuilder::And({sub_child1, sub_child2, sub_child3}));
+
+    auto child3 =
+        PredicateBuilder::IsNull(/*field_index=*/6, /*field_name=*/"f6", FieldType::BIGINT);
+
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({child1, child2, child3}));
+    std::vector<std::shared_ptr<Predicate>> predicates = {child1, child2, child3};
+    {
+        ASSERT_OK_AND_ASSIGN(auto result,
+                             PredicateUtils::ExcludePredicateWithFields(predicates, {"non-exist"}));
+        ASSERT_EQ(3, result.size());
+        ASSERT_EQ(*child1, *result[0]);
+        ASSERT_EQ(*child2, *result[1]);
+        ASSERT_EQ(*child3, *result[2]);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto result,
+                             PredicateUtils::ExcludePredicateWithFields(predicate, {"non-exist"}));
+        ASSERT_OK_AND_ASSIGN(auto expected, PredicateBuilder::And({child1, sub_child1, sub_child2,
+                                                                   sub_child3, child3}));
+        ASSERT_EQ(*expected, *result)
+            << "result=" << result->ToString() << ", expected=" << predicate->ToString();
+    }
+
+    {
+        ASSERT_OK_AND_ASSIGN(auto result,
+                             PredicateUtils::ExcludePredicateWithFields(predicates, {"f0", "f5"}));
+        ASSERT_EQ(1, result.size());
+        ASSERT_EQ(*child3, *result[0]);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto result,
+                             PredicateUtils::ExcludePredicateWithFields(predicate, {"f0", "f5"}));
+        ASSERT_OK_AND_ASSIGN(auto expected,
+                             PredicateBuilder::And({sub_child1, sub_child2, child3}));
+        ASSERT_EQ(*expected, *result)
+            << "result=" << result->ToString() << ", expected=" << predicate->ToString();
+    }
+
+    {
+        ASSERT_OK_AND_ASSIGN(auto result, PredicateUtils::ExcludePredicateWithFields(
+                                              predicates, {"f0", "f5", "f6"}));
+        ASSERT_TRUE(result.empty());
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto result, PredicateUtils::ExcludePredicateWithFields(
+                                              predicate, {"f0", "f3", "f4", "f5", "f6"}));
+        ASSERT_FALSE(result);
+    }
+}
+
+TEST(PredicateUtilsTest, TestCreatePickedFieldFilter) {
+    std::map<std::string, int32_t> picked_field_name_to_idx = {
+        {"f0", 10}, {"f1", 20}, {"f2", 30}, {"f3", 40}};
+    auto equal = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::INT,
+                                         Literal(10));
+    auto not_equal = PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                FieldType::INT, Literal(20));
+    ASSERT_OK_AND_ASSIGN(auto and_predicate, PredicateBuilder::And({equal, not_equal}));
+
+    auto greater_than = PredicateBuilder::GreaterThan(/*field_index=*/2, /*field_name=*/"v0",
+                                                      FieldType::INT, Literal(30));
+    auto less_than = PredicateBuilder::LessThan(/*field_index=*/3, /*field_name=*/"f3",
+                                                FieldType::INT, Literal(20));
+    ASSERT_OK_AND_ASSIGN(auto or_predicate, PredicateBuilder::Or({greater_than, less_than}));
+
+    auto less_or_equal = PredicateBuilder::LessOrEqual(/*field_index=*/4, /*field_name=*/"f2",
+                                                       FieldType::INT, Literal(50));
+    auto in = PredicateBuilder::In(/*field_index=*/5, /*field_name=*/"f0", FieldType::INT,
+                                   {Literal(20), Literal(60)});
+    ASSERT_OK_AND_ASSIGN(auto or_predicate2, PredicateBuilder::Or({less_or_equal, in}));
+
+    auto greater_or_equal = PredicateBuilder::GreaterOrEqual(/*field_index=*/4, /*field_name=*/"v1",
+                                                             FieldType::INT, Literal(120));
+
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({and_predicate, or_predicate,
+                                                                or_predicate2, greater_or_equal}));
+
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Predicate> result,
+        PredicateUtils::CreatePickedFieldFilter(predicate, picked_field_name_to_idx));
+
+    auto new_equal = PredicateBuilder::Equal(/*field_index=*/10, /*field_name=*/"f0",
+                                             FieldType::INT, Literal(10));
+    auto new_not_equal = PredicateBuilder::NotEqual(/*field_index=*/20, /*field_name=*/"f1",
+                                                    FieldType::INT, Literal(20));
+    auto new_less_or_equal = PredicateBuilder::LessOrEqual(/*field_index=*/30, /*field_name=*/"f2",
+                                                           FieldType::INT, Literal(50));
+    auto new_in = PredicateBuilder::In(/*field_index=*/10, /*field_name=*/"f0", FieldType::INT,
+                                       {Literal(20), Literal(60)});
+    ASSERT_OK_AND_ASSIGN(auto new_or_predicate2, PredicateBuilder::Or({new_less_or_equal, new_in}));
+
+    ASSERT_OK_AND_ASSIGN(auto expected,
+                         PredicateBuilder::And({new_equal, new_not_equal, new_or_predicate2}));
+    ASSERT_EQ(*result, *expected);
+}
+
+TEST(PredicateUtilsTest, TestGetAllNames) {
+    {
+        ASSERT_OK_AND_ASSIGN(
+            auto child1,
+            PredicateBuilder::Or({PredicateBuilder::IsNull(/*field_index=*/0, /*field_name=*/"f0",
+                                                           FieldType::BIGINT),
+                                  PredicateBuilder::IsNull(/*field_index=*/1, /*field_name=*/"f1",
+                                                           FieldType::BIGINT),
+                                  PredicateBuilder::IsNull(/*field_index=*/2, /*field_name=*/"f2",
+                                                           FieldType::BIGINT)}));
+
+        auto sub_child1 =
+            PredicateBuilder::IsNull(/*field_index=*/3, /*field_name=*/"f3", FieldType::BIGINT);
+        auto sub_child2 =
+            PredicateBuilder::IsNull(/*field_index=*/4, /*field_name=*/"f4", FieldType::BIGINT);
+        auto sub_child3 =
+            PredicateBuilder::IsNull(/*field_index=*/5, /*field_name=*/"f5", FieldType::BIGINT);
+        ASSERT_OK_AND_ASSIGN(auto child2,
+                             PredicateBuilder::And({sub_child1, sub_child2, sub_child3}));
+
+        auto child3 =
+            PredicateBuilder::IsNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT);
+
+        ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({child1, child2, child3}));
+        std::set<std::string> field_names;
+        ASSERT_OK(PredicateUtils::GetAllNames(predicate, &field_names));
+        ASSERT_EQ(field_names, std::set<std::string>({"f0", "f1", "f2", "f3", "f4", "f5"}));
+    }
+    {
+        auto equal =
+            PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                    Literal(FieldType::STRING, "apple", 5));
+        auto not_equal = PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                    FieldType::INT, Literal(20));
+        ASSERT_OK_AND_ASSIGN(auto and_predicate, PredicateBuilder::And({equal, not_equal}));
+        auto greater_than = PredicateBuilder::GreaterThan(/*field_index=*/2, /*field_name=*/"f2",
+                                                          FieldType::INT, Literal(30));
+        auto less_than = PredicateBuilder::LessThan(/*field_index=*/3, /*field_name=*/"f3",
+                                                    FieldType::DOUBLE, Literal(20.1));
+        ASSERT_OK_AND_ASSIGN(auto or_predicate, PredicateBuilder::Or({greater_than, less_than}));
+        ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({and_predicate, or_predicate}));
+        std::set<std::string> field_names;
+        ASSERT_OK(PredicateUtils::GetAllNames(predicate, &field_names));
+        ASSERT_EQ(field_names, std::set<std::string>({"f0", "f1", "f2", "f3"}));
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/predicate/predicate_validator.h
+++ b/src/paimon/common/predicate/predicate_validator.h
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/type.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/defs.h"
+#include "paimon/predicate/compound_predicate.h"
+#include "paimon/predicate/leaf_predicate.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class PredicateValidator {
+ public:
+    PredicateValidator() = delete;
+    ~PredicateValidator() = delete;
+
+    static Status ValidatePredicateWithLiterals(const std::shared_ptr<Predicate>& predicate) {
+        if (auto leaf_predicate = std::dynamic_pointer_cast<LeafPredicate>(predicate)) {
+            const auto& field_name = leaf_predicate->FieldName();
+            // check field type (predicate vs. literals)
+            auto field_type = leaf_predicate->GetFieldType();
+            const auto& literals = leaf_predicate->Literals();
+            for (const auto& literal : literals) {
+                if (literal.IsNull()) {
+                    return Status::Invalid(fmt::format(
+                        "literal cannot be null in predicate, field name {}", field_name));
+                }
+                if (field_type != literal.GetType()) {
+                    return Status::Invalid(fmt::format(
+                        "field {} has field type {} in literal, mismatch field type {} "
+                        "in predicate",
+                        field_name, FieldTypeUtils::FieldTypeToString(literal.GetType()),
+                        FieldTypeUtils::FieldTypeToString(field_type)));
+                }
+            }
+        } else if (auto compound_predicate =
+                       std::dynamic_pointer_cast<CompoundPredicate>(predicate)) {
+            const auto& children = compound_predicate->Children();
+            for (const auto& child : children) {
+                PAIMON_RETURN_NOT_OK(ValidatePredicateWithLiterals(child));
+            }
+        }
+        return Status::OK();
+    }
+
+    static Status ValidatePredicateWithSchema(const arrow::Schema& schema,
+                                              const std::shared_ptr<Predicate>& predicate,
+                                              bool validate_field_idx) {
+        if (auto leaf_predicate = std::dynamic_pointer_cast<LeafPredicate>(predicate)) {
+            const auto& field_name = leaf_predicate->FieldName();
+            // check field index
+            int32_t schema_field_idx = schema.GetFieldIndex(field_name);
+            if (schema_field_idx == -1) {
+                return Status::Invalid(
+                    fmt::format("field {} does not exist in schema", field_name));
+            }
+            if (validate_field_idx && schema_field_idx != leaf_predicate->FieldIndex()) {
+                return Status::Invalid(
+                    fmt::format("field {} has field idx {} in input schema, mismatch field idx "
+                                "{} in predicate",
+                                field_name, schema_field_idx, leaf_predicate->FieldIndex()));
+            }
+            // check field type (schema vs. predicate)
+            PAIMON_RETURN_NOT_OK(ValidateDataTypeWithSchemaAndPredicate(
+                *schema.field(schema_field_idx)->type(), leaf_predicate->GetFieldType()));
+        } else if (auto compound_predicate =
+                       std::dynamic_pointer_cast<CompoundPredicate>(predicate)) {
+            const auto& children = compound_predicate->Children();
+            for (const auto& child : children) {
+                PAIMON_RETURN_NOT_OK(
+                    ValidatePredicateWithSchema(schema, child, validate_field_idx));
+            }
+        }
+        return Status::OK();
+    }
+
+ private:
+    static Status ValidateDataTypeWithSchemaAndPredicate(const arrow::DataType& schema_type,
+                                                         const FieldType& field_type) {
+        const auto kind = schema_type.id();
+        switch (kind) {
+            case arrow::Type::type::BOOL: {
+                if (field_type == FieldType::BOOLEAN) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::INT8: {
+                if (field_type == FieldType::TINYINT) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::INT16: {
+                if (field_type == FieldType::SMALLINT) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::INT32: {
+                if (field_type == FieldType::INT) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::INT64: {
+                if (field_type == FieldType::BIGINT) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::FLOAT: {
+                if (field_type == FieldType::FLOAT) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::DOUBLE: {
+                if (field_type == FieldType::DOUBLE) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::STRING: {
+                if (field_type == FieldType::STRING) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::BINARY: {
+                if (field_type == FieldType::BINARY) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::DATE32: {
+                if (field_type == FieldType::DATE) {
+                    return Status::OK();
+                }
+                break;
+            }
+            case arrow::Type::type::DECIMAL128:
+                if (field_type == FieldType::DECIMAL) {
+                    return Status::OK();
+                }
+                break;
+            case arrow::Type::type::TIMESTAMP: {
+                if (field_type == FieldType::TIMESTAMP) {
+                    return Status::OK();
+                }
+                break;
+            }
+            default: {
+                return Status::Invalid(
+                    fmt::format("Invalid type {} for predicate", schema_type.ToString()));
+            }
+        }
+        return Status::Invalid(fmt::format("schema type {} mismatches predicate field type {}",
+                                           schema_type.ToString(),
+                                           FieldTypeUtils::FieldTypeToString(field_type)));
+    }
+};
+}  // namespace paimon

--- a/src/paimon/common/predicate/predicate_validator_test.cpp
+++ b/src/paimon/common/predicate/predicate_validator_test.cpp
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/common/predicate/predicate_validator.h"
+
+#include "arrow/type_fwd.h"
+#include "gtest/gtest.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/result.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon::test {
+TEST(PredicateValidatorTest, TestValidateLiterals) {
+    std::string str("apple");
+    {
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+                PredicateBuilder::Equal(/*field_index=*/4, /*field_name=*/"f4", FieldType::DOUBLE,
+                                        Literal(static_cast<double>(6.5))),
+                PredicateBuilder::Equal(/*field_index=*/5, /*field_name=*/"f5", FieldType::TINYINT,
+                                        Literal(static_cast<int8_t>(20))),
+                PredicateBuilder::Equal(/*field_index=*/6, /*field_name=*/"f6", FieldType::DATE,
+                                        Literal(FieldType::DATE, 3)),
+                PredicateBuilder::Equal(/*field_index=*/7, /*field_name=*/"f7",
+                                        FieldType::TIMESTAMP,
+                                        Literal(Timestamp(1230422400000l, 123460))),
+                PredicateBuilder::Equal(/*field_index=*/8, /*field_name=*/"f8", FieldType::DECIMAL,
+                                        Literal(Decimal(23, 5, 123456))),
+                PredicateBuilder::Equal(/*field_index=*/9, /*field_name=*/"f9", FieldType::BINARY,
+                                        Literal(FieldType::BINARY, str.data(), str.size())),
+            }));
+        ASSERT_OK(PredicateValidator::ValidatePredicateWithLiterals(predicate));
+    }
+    {
+        // f1 field type is FLOAT, literal type is BIGINT
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(5l)),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+        ASSERT_NOK_WITH_MSG(PredicateValidator::ValidatePredicateWithLiterals(predicate),
+                            "field f1 has field type BIGINT in literal, mismatch "
+                            "field type FLOAT in predicate");
+    }
+    {
+        // f2 field type is STRING, literal type is BINARY
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::BINARY, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+        ASSERT_NOK_WITH_MSG(PredicateValidator::ValidatePredicateWithLiterals(predicate),
+                            "field f2 has field type BINARY in literal, mismatch "
+                            "field type STRING in predicate");
+    }
+    {
+        // f2 literal is null
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING)),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+        ASSERT_NOK_WITH_MSG(PredicateValidator::ValidatePredicateWithLiterals(predicate),
+                            "literal cannot be null in predicate, field name f2");
+    }
+}
+
+TEST(PredicateValidatorTest, TestValidateSchema) {
+    std::string str("apple");
+    {
+        std::shared_ptr<arrow::Schema> schema = arrow::schema(arrow::FieldVector({
+            arrow::field("f0", arrow::int64()),
+            arrow::field("f1", arrow::float32()),
+            arrow::field("f2", arrow::utf8()),
+            arrow::field("f3", arrow::boolean()),
+            arrow::field("f4", arrow::date32()),
+            arrow::field("f5", arrow::timestamp(arrow::TimeUnit::NANO)),
+            arrow::field("f6", arrow::decimal128(23, 5)),
+            arrow::field("f7", arrow::binary()),
+            arrow::field("f8", arrow::int8()),
+        }));
+
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+                PredicateBuilder::Equal(/*field_index=*/4, /*field_name=*/"f4", FieldType::DATE,
+                                        Literal(FieldType::DATE, 3)),
+                PredicateBuilder::Equal(/*field_index=*/5, /*field_name=*/"f5",
+                                        FieldType::TIMESTAMP,
+                                        Literal(Timestamp(1230422400000l, 123460))),
+                PredicateBuilder::Equal(/*field_index=*/6, /*field_name=*/"f6", FieldType::DECIMAL,
+                                        Literal(Decimal(23, 5, 123456))),
+                PredicateBuilder::Equal(/*field_index=*/7, /*field_name=*/"f7", FieldType::BINARY,
+                                        Literal(FieldType::BINARY, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/8, /*field_name=*/"f8", FieldType::TINYINT,
+                                        Literal(static_cast<int8_t>(20))),
+            }));
+        ASSERT_OK(PredicateValidator::ValidatePredicateWithSchema(*schema, predicate,
+                                                                  /*validate_field_idx=*/true));
+    }
+    {
+        // f2 schema type is DECIMAL(23,5), predicate type can be different precision and scale,
+        // such as DECIMAL(22,4)
+        std::shared_ptr<arrow::Schema> schema = arrow::schema(arrow::FieldVector({
+            arrow::field("f0", arrow::int16()),
+            arrow::field("f1", arrow::float32()),
+            arrow::field("f2", arrow::decimal128(23, 5)),
+            arrow::field("f3", arrow::boolean()),
+        }));
+
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::SMALLINT,
+                                        Literal(static_cast<int16_t>(3))),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::DECIMAL,
+                                        Literal(Decimal(22, 4, 123456))),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+        ASSERT_OK(PredicateValidator::ValidatePredicateWithLiterals(predicate));
+        ASSERT_OK(PredicateValidator::ValidatePredicateWithSchema(*schema, predicate,
+                                                                  /*validate_field_idx=*/true));
+    }
+    {
+        // predicate field idx mismatch
+        std::shared_ptr<arrow::Schema> schema = arrow::schema(arrow::FieldVector({
+            arrow::field("f0", arrow::int64()),
+            arrow::field("f1", arrow::float32()),
+            arrow::field("f2", arrow::utf8()),
+            arrow::field("f3", arrow::boolean()),
+        }));
+
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+
+        ASSERT_NOK_WITH_MSG(
+            PredicateValidator::ValidatePredicateWithSchema(*schema, predicate,
+                                                            /*validate_field_idx=*/true),
+            "field f1 has field idx 1 in input schema, mismatch "
+            "field idx 2 in predicate");
+    }
+    {
+        // predicate field idx mismatch, but not validate
+        std::shared_ptr<arrow::Schema> schema = arrow::schema(arrow::FieldVector({
+            arrow::field("f0", arrow::int64()),
+            arrow::field("f1", arrow::float32()),
+            arrow::field("f2", arrow::utf8()),
+            arrow::field("f3", arrow::boolean()),
+        }));
+
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+
+        ASSERT_OK(PredicateValidator::ValidatePredicateWithSchema(*schema, predicate,
+                                                                  /*validate_field_idx=*/false));
+    }
+    {
+        // f0 is uint16
+        std::shared_ptr<arrow::Schema> schema = arrow::schema(arrow::FieldVector({
+            arrow::field("f0", arrow::uint16()),
+            arrow::field("f1", arrow::float32()),
+            arrow::field("f2", arrow::utf8()),
+            arrow::field("f3", arrow::boolean()),
+        }));
+
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::SMALLINT,
+                                        Literal(static_cast<int16_t>(3))),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+        ASSERT_NOK_WITH_MSG(
+            PredicateValidator::ValidatePredicateWithSchema(*schema, predicate,
+                                                            /*validate_field_idx=*/true),
+            "Invalid type uint16 for predicate");
+    }
+    {
+        // f2 schema type is DOUBLE, predicate type is STRING
+        std::shared_ptr<arrow::Schema> schema = arrow::schema(arrow::FieldVector({
+            arrow::field("f0", arrow::int64()),
+            arrow::field("f1", arrow::float32()),
+            arrow::field("f2", arrow::float64()),
+            arrow::field("f3", arrow::boolean()),
+        }));
+
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+        ASSERT_NOK_WITH_MSG(
+            PredicateValidator::ValidatePredicateWithSchema(*schema, predicate,
+                                                            /*validate_field_idx=*/true),
+            "schema type double mismatches predicate field type STRING");
+    }
+    {
+        // f2 schema type is BINARY, predicate type is STRING
+        std::shared_ptr<arrow::Schema> schema = arrow::schema(arrow::FieldVector({
+            arrow::field("f0", arrow::int64()),
+            arrow::field("f1", arrow::float32()),
+            arrow::field("f2", arrow::binary()),
+            arrow::field("f3", arrow::boolean()),
+        }));
+
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+        ASSERT_NOK_WITH_MSG(
+            PredicateValidator::ValidatePredicateWithSchema(*schema, predicate,
+                                                            /*validate_field_idx=*/true),
+            "schema type binary mismatches predicate field type STRING");
+    }
+    {
+        // f2 in predicate does not exist in schema
+        std::shared_ptr<arrow::Schema> schema = arrow::schema(arrow::FieldVector({
+            arrow::field("f0", arrow::int16()),
+            arrow::field("f1", arrow::float32()),
+            arrow::field("f3", arrow::boolean()),
+        }));
+
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::SMALLINT,
+                                        Literal(static_cast<int16_t>(3))),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.5))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, str.data(), str.size())),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+
+        ASSERT_NOK_WITH_MSG(
+            PredicateValidator::ValidatePredicateWithSchema(*schema, predicate,
+                                                            /*validate_field_idx=*/true),
+            "field f2 does not exist in schema");
+    }
+}
+}  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

Complete the predicate framework with builder, utilities, validation, and search predicates:

- `PredicateBuilder` — fluent API to construct leaf/compound predicates against a `RowType` (`predicate_builder.h/cpp`)
- `PredicateUtils` — helpers for predicate transformation, splitting by And, and field extraction (`predicate_utils.h/cpp`)
- `PredicateValidator` — validates predicate field references and type compatibility (`predicate_validator.h`)
- `FullTextSearch` — full-text search predicate descriptor (`full_text_search.h`)
- `VectorSearch` — vector similarity search predicate descriptor (`vector_search.h`)


<!-- What is the purpose of the change -->

### Tests
- `predicate_test.cpp` — end-to-end predicate construction and evaluation across all operators
- `predicate_utils_test.cpp` — predicate transformation and splitting
- `predicate_validator_test.cpp` — field reference and type validation

<!-- List UT and IT cases to verify this change -->

### API and Format
New public headers under `include/paimon/predicate/` (`predicate_builder.h`, `predicate_utils.h`, `full_text_search.h`, `vector_search.h`).
<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Migrate-by: Aone Copilot (Claude)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
