### PR TITLE
feat: migrate record reader and IO modules

### DIFF
--- a/src/paimon/core/io/complete_row_tracking_fields_reader.cpp
+++ b/src/paimon/core/io/complete_row_tracking_fields_reader.cpp
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/complete_row_tracking_fields_reader.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "arrow/array/array_base.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+
+namespace paimon {
+CompleteRowTrackingFieldsBatchReader::CompleteRowTrackingFieldsBatchReader(
+    std::unique_ptr<FileBatchReader>&& reader, const std::optional<int64_t>& first_row_id,
+    int64_t snapshot_id, const std::shared_ptr<MemoryPool>& pool)
+    : first_row_id_(first_row_id),
+      snapshot_id_(snapshot_id),
+      arrow_pool_(GetArrowPool(pool)),
+      reader_(std::move(reader)) {}
+
+Status CompleteRowTrackingFieldsBatchReader::SetReadSchema(
+    ::ArrowSchema* read_schema, const std::shared_ptr<Predicate>& predicate,
+    const std::optional<RoaringBitmap32>& selection_bitmap) {
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<::ArrowSchema> c_file_schema, reader_->GetFileSchema());
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Schema> file_schema,
+                                      arrow::ImportSchema(c_file_schema.get()));
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Schema> arrow_schema,
+                                      arrow::ImportSchema(read_schema));
+    read_schema_ = arrow_schema;
+    int32_t row_id_idx = arrow_schema->GetFieldIndex(SpecialFields::RowId().Name());
+    if (row_id_idx != -1 && file_schema->GetFieldIndex(SpecialFields::RowId().Name()) == -1) {
+        // read special fields but file not exist, remove special fields to format reader
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(arrow_schema, arrow_schema->RemoveField(row_id_idx));
+    }
+    int32_t sequence_id_idx = arrow_schema->GetFieldIndex(SpecialFields::SequenceNumber().Name());
+    if (sequence_id_idx != -1 &&
+        file_schema->GetFieldIndex(SpecialFields::SequenceNumber().Name()) == -1) {
+        // read special fields but file not exist, remove special fields to format reader
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(arrow_schema, arrow_schema->RemoveField(sequence_id_idx));
+    }
+    ArrowSchema c_schema;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportSchema(*arrow_schema, &c_schema));
+    return reader_->SetReadSchema(&c_schema, predicate, selection_bitmap);
+}
+
+Result<BatchReader::ReadBatchWithBitmap>
+CompleteRowTrackingFieldsBatchReader::NextBatchWithBitmap() {
+    if (!read_schema_) {
+        return Status::Invalid(
+            "in CompleteRowTrackingFieldsBatchReader SetReadSchema is supposed to be called before "
+            "NextBatch");
+    }
+    PAIMON_ASSIGN_OR_RAISE(ReadBatchWithBitmap src_array_with_bitmap,
+                           reader_->NextBatchWithBitmap());
+    if (BatchReader::IsEofBatch(src_array_with_bitmap)) {
+        // read finish
+        return src_array_with_bitmap;
+    }
+    auto& [read_batch, bitmap] = src_array_with_bitmap;
+    auto& [c_array, c_schema] = read_batch;
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> src_array,
+                                      arrow::ImportArray(c_array.get(), c_schema.get()));
+    auto src_struct_array = arrow::internal::checked_pointer_cast<arrow::StructArray>(src_array);
+    assert(src_struct_array);
+
+    // complete row id array
+    std::shared_ptr<arrow::Array> row_id_array;
+    std::string row_id_field_name = SpecialFields::RowId().Name();
+    if (read_schema_->GetFieldIndex(row_id_field_name) != -1) {
+        row_id_array = src_struct_array->GetFieldByName(row_id_field_name);
+        PAIMON_ASSIGN_OR_RAISE(uint64_t previous_batch_first_row_number,
+                               reader_->GetPreviousBatchFirstRowNumber());
+        auto row_id_convert_func = [previous_batch_first_row_number,
+                                    this](int32_t idx_in_array) -> Result<int64_t> {
+            if (first_row_id_ == std::nullopt) {
+                return Status::Invalid(
+                    "unexpected: read _ROW_ID special field, but first row id is null in meta");
+            }
+            return first_row_id_.value() + previous_batch_first_row_number + idx_in_array;
+        };
+        PAIMON_RETURN_NOT_OK(ConvertRowTrackingField(src_struct_array->length(), /*init_value=*/0,
+                                                     row_id_convert_func, &row_id_array));
+    }
+
+    // complete sequence number array
+    std::string sequence_number_field_name = SpecialFields::SequenceNumber().Name();
+    std::shared_ptr<arrow::Array> sequence_number_array;
+    if (read_schema_->GetFieldIndex(sequence_number_field_name) != -1) {
+        sequence_number_array = src_struct_array->GetFieldByName(sequence_number_field_name);
+        PAIMON_RETURN_NOT_OK(ConvertRowTrackingField(src_struct_array->length(),
+                                                     /*init_value=*/snapshot_id_,
+                                                     /*convert_func=*/nullptr,
+                                                     &sequence_number_array));
+    }
+
+    // re-construct result array with read schema
+    arrow::ArrayVector sub_array_vec;
+    sub_array_vec.reserve(read_schema_->num_fields());
+    for (const auto& field : read_schema_->fields()) {
+        const auto& field_name = field->name();
+        if (field_name == row_id_field_name) {
+            sub_array_vec.push_back(row_id_array);
+        } else if (field_name == sequence_number_field_name) {
+            sub_array_vec.push_back(sequence_number_array);
+        } else {
+            // normal data fields
+            auto sub_array = src_struct_array->GetFieldByName(field_name);
+            if (!sub_array) {
+                return Status::Invalid(fmt::format(
+                    "Data file does not contain field {} in CompleteRowTrackingFieldsBatchReader",
+                    field_name));
+            }
+            sub_array_vec.push_back(sub_array);
+        }
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+        std::shared_ptr<arrow::Array> target_array,
+        arrow::StructArray::Make(sub_array_vec, read_schema_->field_names()));
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        arrow::ExportArray(*target_array, c_array.get(), c_schema.get()));
+    return std::move(src_array_with_bitmap);
+}
+
+Status CompleteRowTrackingFieldsBatchReader::ConvertRowTrackingField(
+    int64_t array_length, int64_t init_value,
+    const std::function<Result<int64_t>(int32_t)>& convert_func,
+    std::shared_ptr<arrow::Array>* special_array_ptr) const {
+    auto& special_array = *special_array_ptr;
+    if (!special_array || special_array->null_count() == special_array->length()) {
+        // condition1: special field not exist in file
+        // condition2: special field all null
+        auto scalar = std::make_shared<arrow::Int64Scalar>(init_value);
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            special_array, arrow::MakeArrayFromScalar(*scalar, array_length, arrow_pool_.get()));
+        auto typed_special_array =
+            arrow::internal::checked_pointer_cast<arrow::NumericArray<arrow::Int64Type>>(
+                special_array);
+        assert(typed_special_array);
+        if (convert_func) {
+            auto raw_value_ptr = const_cast<int64_t*>(typed_special_array->raw_values());
+            assert(raw_value_ptr);
+            // row id = first_row_id_ + previous_batch_first_row_number + idx in batch
+            for (int64_t i = 0; i < array_length; i++) {
+                PAIMON_ASSIGN_OR_RAISE(raw_value_ptr[i], convert_func(i));
+            }
+        }
+    } else if (special_array->null_count() > 0) {
+        // condition3: special field exist, has null
+        auto typed_special_array =
+            arrow::internal::checked_pointer_cast<arrow::NumericArray<arrow::Int64Type>>(
+                special_array);
+        auto raw_value_ptr = const_cast<int64_t*>(typed_special_array->raw_values());
+        // row id = first_row_id_ + previous_batch_first_row_number + idx in batch
+        // sequence number = init_value
+        auto null_bitmap_data = const_cast<uint8_t*>(typed_special_array->null_bitmap_data());
+        assert(raw_value_ptr && null_bitmap_data);
+        for (int64_t i = 0; i < array_length; i++) {
+            if (typed_special_array->IsNull(i)) {
+                if (convert_func) {
+                    PAIMON_ASSIGN_OR_RAISE(raw_value_ptr[i], convert_func(i));
+                } else {
+                    raw_value_ptr[i] = init_value;
+                }
+                arrow::bit_util::SetBit(null_bitmap_data, i + typed_special_array->offset());
+            }
+        }
+        typed_special_array->data()->SetNullCount(arrow::kUnknownNullCount);
+    }
+    return Status::OK();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/complete_row_tracking_fields_reader.h
+++ b/src/paimon/core/io/complete_row_tracking_fields_reader.h
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/reader/file_batch_reader.h"
+namespace paimon {
+
+// Complete special fields:
+// when _ROW_ID is not exist or null, convert to first row id + row idx in file
+// when _SEQUENCE_NUMBER is not exist or null, convert to snapshot id
+// Precondition: read_schema has special fields
+class CompleteRowTrackingFieldsBatchReader : public FileBatchReader {
+ public:
+    CompleteRowTrackingFieldsBatchReader(std::unique_ptr<FileBatchReader>&& reader,
+                                         const std::optional<int64_t>& first_row_id,
+                                         int64_t snapshot_id,
+                                         const std::shared_ptr<MemoryPool>& pool);
+
+    Result<std::unique_ptr<::ArrowSchema>> GetFileSchema() const override {
+        return Status::Invalid(
+            "CompleteRowTrackingFieldsBatchReader does not support GetFileSchema");
+    }
+
+    Status SetReadSchema(::ArrowSchema* read_schema, const std::shared_ptr<Predicate>& predicate,
+                         const std::optional<RoaringBitmap32>& selection_bitmap) override;
+
+    Result<ReadBatch> NextBatch() override {
+        return Status::Invalid(
+            "paimon inner reader CompleteRowTrackingFieldsBatchReader should use "
+            "NextBatchWithBitmap");
+    }
+
+    Result<ReadBatchWithBitmap> NextBatchWithBitmap() override;
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return reader_->GetReaderMetrics();
+    }
+
+    void Close() override {
+        reader_->Close();
+    }
+
+    Result<uint64_t> GetPreviousBatchFirstRowNumber() const override {
+        return reader_->GetPreviousBatchFirstRowNumber();
+    }
+
+    Result<uint64_t> GetNumberOfRows() const override {
+        return reader_->GetNumberOfRows();
+    }
+
+    bool SupportPreciseBitmapSelection() const override {
+        return reader_->SupportPreciseBitmapSelection();
+    }
+
+ private:
+    Status ConvertRowTrackingField(int64_t array_length, int64_t init_value,
+                                   const std::function<Result<int64_t>(int32_t)>& convert_func,
+                                   std::shared_ptr<arrow::Array>* special_array_ptr) const;
+
+ private:
+    std::optional<int64_t> first_row_id_;
+    int64_t snapshot_id_ = -1;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
+    std::shared_ptr<arrow::Schema> read_schema_;
+    std::unique_ptr<FileBatchReader> reader_;
+};
+}  // namespace paimon

--- a/src/paimon/core/io/complete_row_tracking_fields_reader_test.cpp
+++ b/src/paimon/core/io/complete_row_tracking_fields_reader_test.cpp
@@ -1,0 +1,453 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/complete_row_tracking_fields_reader.h"
+
+#include <memory>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/mock/mock_file_batch_reader.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+namespace paimon::test {
+class CompleteRowTrackingFieldsBatchReaderTest : public testing::Test {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+    }
+
+    void CheckResult(const std::shared_ptr<arrow::Array>& src_array, int64_t first_row_id,
+                     int64_t snapshot_id, const std::shared_ptr<arrow::Schema>& read_schema,
+                     const std::shared_ptr<arrow::Array>& expected_array) const {
+        for (auto batch_size : {1, 2, 3, 4, 7, 10}) {
+            auto file_batch_reader =
+                std::make_unique<MockFileBatchReader>(src_array, src_array->type(), batch_size);
+            auto complete_row_tracking_fields_reader =
+                std::make_shared<CompleteRowTrackingFieldsBatchReader>(
+                    std::move(file_batch_reader), first_row_id, snapshot_id, pool_);
+            ArrowSchema c_read_schema;
+            ASSERT_TRUE(arrow::ExportSchema(*read_schema, &c_read_schema).ok());
+            ASSERT_OK(complete_row_tracking_fields_reader->SetReadSchema(
+                &c_read_schema,
+                /*predicate=*/nullptr,
+                /*selection_bitmap=*/std::nullopt));
+            ASSERT_OK_AND_ASSIGN(auto result_with_special_fields,
+                                 paimon::test::ReadResultCollector::CollectResult(
+                                     complete_row_tracking_fields_reader.get()));
+            complete_row_tracking_fields_reader->Close();
+            auto expected_chunk_array = std::make_shared<arrow::ChunkedArray>(expected_array);
+            ASSERT_TRUE(result_with_special_fields->Equals(expected_chunk_array));
+        }
+    }
+
+    void CheckSetReadSchema(
+        const std::shared_ptr<arrow::Schema>& file_schema,
+        const std::shared_ptr<arrow::Schema>& read_schema,
+        const std::shared_ptr<arrow::Schema>& expected_schema_for_inner_reader) const {
+        auto file_batch_reader = std::make_unique<MockFileBatchReader>(
+            /*data=*/nullptr, arrow::struct_(file_schema->fields()), /*read_batch_size=*/1);
+        auto complete_row_tracking_fields_reader =
+            std::make_shared<CompleteRowTrackingFieldsBatchReader>(
+                std::move(file_batch_reader), /*first_row_id=*/10, /*snapshot_id=*/1, pool_);
+        ArrowSchema c_read_schema;
+        ASSERT_TRUE(arrow::ExportSchema(*read_schema, &c_read_schema).ok());
+        ASSERT_OK(
+            complete_row_tracking_fields_reader->SetReadSchema(&c_read_schema,
+                                                               /*predicate=*/nullptr,
+                                                               /*selection_bitmap=*/std::nullopt));
+        auto typed_file_batch_reader =
+            dynamic_cast<MockFileBatchReader*>(complete_row_tracking_fields_reader->reader_.get());
+        ASSERT_TRUE(typed_file_batch_reader);
+        ASSERT_TRUE(
+            expected_schema_for_inner_reader->Equals(typed_file_batch_reader->read_schema_));
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestSetReadSchema) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::int32()),
+        arrow::field("f1", arrow::int32()),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    {
+        // test file contain no special fields
+        auto file_schema = arrow::schema({fields[0], fields[1]});
+        auto read_schema = arrow::schema(fields);
+        auto expected_schema_for_inner_reader = file_schema;
+        CheckSetReadSchema(file_schema, read_schema, expected_schema_for_inner_reader);
+    }
+    {
+        // test file contain special fields
+        auto file_schema = arrow::schema(fields);
+        auto read_schema = arrow::schema(fields);
+        auto expected_schema_for_inner_reader = file_schema;
+        CheckSetReadSchema(file_schema, read_schema, expected_schema_for_inner_reader);
+    }
+    {
+        // test read partial fields, file contain special fields
+        auto file_schema = arrow::schema(fields);
+        auto read_schema = arrow::schema({fields[1], fields[2]});
+        auto expected_schema_for_inner_reader = read_schema;
+        CheckSetReadSchema(file_schema, read_schema, expected_schema_for_inner_reader);
+    }
+    {
+        // test read partial fields, file contain no special fields
+        auto file_schema = arrow::schema({fields[0], fields[1]});
+        auto read_schema = arrow::schema({fields[1], fields[2]});
+        auto expected_schema_for_inner_reader = arrow::schema({fields[1]});
+        CheckSetReadSchema(file_schema, read_schema, expected_schema_for_inner_reader);
+    }
+    {
+        // test file contain partial fields
+        auto file_schema = arrow::schema({fields[1], fields[2], fields[3]});
+        auto read_schema = arrow::schema({fields[1], fields[3]});
+        auto expected_schema_for_inner_reader = read_schema;
+        CheckSetReadSchema(file_schema, read_schema, expected_schema_for_inner_reader);
+    }
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestWithNoRowTrackingFields) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::int32()),
+        arrow::field("f1", arrow::int32()),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema = arrow::schema(fields);
+    std::shared_ptr<arrow::DataType> read_type = arrow::struct_(fields);
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_({fields[0], fields[1]});
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [0, 30],
+        [0, 31],
+        [1, 32],
+        [2, 33]
+    ])")
+            .ValueOrDie());
+    auto target_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [0, 30, 100, 4],
+        [0, 31, 101, 4],
+        [1, 32, 102, 4],
+        [2, 33, 103, 4]
+    ])")
+            .ValueOrDie());
+
+    CheckResult(src_array, /*first_row_id=*/100, /*snapshot_id=*/4, read_schema, target_array);
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestWithAllNotNullRowTrackingFields) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::int32()),
+        arrow::field("f1", arrow::int32()),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema = arrow::schema(fields);
+    std::shared_ptr<arrow::DataType> read_type = arrow::struct_(fields);
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_(fields);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [0, 30, 100, 4],
+        [0, 31, 101, 4],
+        [1, 32, 102, 4],
+        [2, 33, 103, 4]
+    ])")
+            .ValueOrDie());
+
+    CheckResult(src_array, /*first_row_id=*/200, /*snapshot_id=*/8, read_schema, src_array);
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestWithPartialNullRowTrackingFields) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::int32()),
+        arrow::field("f1", arrow::int32()),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema = arrow::schema(fields);
+    std::shared_ptr<arrow::DataType> read_type = arrow::struct_(fields);
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_(fields);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [0, 30, null, null],
+        [0, 31, null, 3],
+        [1, 32, null, 4],
+        [2, 33, 200, 4]
+    ])")
+            .ValueOrDie());
+
+    auto target_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [0, 30, 100, 8],
+        [0, 31, 101, 3],
+        [1, 32, 102, 4],
+        [2, 33, 200, 4]
+    ])")
+            .ValueOrDie());
+
+    CheckResult(src_array, /*first_row_id=*/100, /*snapshot_id=*/8, read_schema, target_array);
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestWithAllNullRowTrackingFields) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::int32()),
+        arrow::field("f1", arrow::int32()),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema = arrow::schema(fields);
+    std::shared_ptr<arrow::DataType> read_type = arrow::struct_(fields);
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_(fields);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [0, 30, null, null],
+        [0, 31, null, null],
+        [1, 32, null, null],
+        [2, 33, null, null]
+    ])")
+            .ValueOrDie());
+
+    auto target_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [0, 30, 100, 8],
+        [0, 31, 101, 8],
+        [1, 32, 102, 8],
+        [2, 33, 103, 8]
+    ])")
+            .ValueOrDie());
+
+    CheckResult(src_array, /*first_row_id=*/100, /*snapshot_id=*/8, read_schema, target_array);
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest,
+       TestPartialNullRowTrackingFieldsWithUnorderFields) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::int32()),
+        arrow::field("f1", arrow::int32()),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema =
+        arrow::schema({fields[0], fields[2], fields[3], fields[1]});
+    std::shared_ptr<arrow::DataType> read_type =
+        arrow::struct_({fields[0], fields[2], fields[3], fields[1]});
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_(fields);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [0, 30, null, null],
+        [0, 31, null, 3],
+        [1, 32, null, 4],
+        [2, 33, 200, 4]
+    ])")
+            .ValueOrDie());
+
+    auto target_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [0, 100, 8, 30],
+        [0, 101, 3, 31],
+        [1, 102, 4, 32],
+        [2, 200, 4, 33]
+    ])")
+            .ValueOrDie());
+    CheckResult(src_array, /*first_row_id=*/100, /*snapshot_id=*/8, read_schema, target_array);
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestNestedType) {
+    arrow::FieldVector fields = {
+        arrow::field("f1", arrow::map(arrow::int8(), arrow::int16())),
+        arrow::field("f2", arrow::list(arrow::float32())),
+        arrow::field("f3", arrow::struct_({arrow::field("f0", arrow::boolean()),
+                                           arrow::field("f1", arrow::int64())})),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema = arrow::schema(fields);
+    std::shared_ptr<arrow::DataType> read_type = arrow::struct_(fields);
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_(fields);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [[[0, 0]], [0.1, 0.2], [true, 2], null, null],
+        [[[0, 1]], [0.1, 0.3], [true, 1], null, 3],
+        [[[10, 10]], [1.1, 1.2], [false, 12], null, 4],
+        [[[127, 32767], [-128, -32768]], [1.1, 1.2], [false, 2222], 200, 4]
+    ])")
+            .ValueOrDie());
+
+    auto target_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [[[0, 0]], [0.1, 0.2], [true, 2], 100, 8],
+        [[[0, 1]], [0.1, 0.3], [true, 1], 101, 3],
+        [[[10, 10]], [1.1, 1.2], [false, 12], 102, 4],
+        [[[127, 32767], [-128, -32768]], [1.1, 1.2], [false, 2222], 200, 4]
+    ])")
+            .ValueOrDie());
+    CheckResult(src_array, /*first_row_id=*/100, /*snapshot_id=*/8, read_schema, target_array);
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestInvalidWithReadNonExistField) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::int32()),
+        arrow::field("f1", arrow::struct_({arrow::field("field_non_exist", arrow::int32())})),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema = arrow::schema(
+        {fields[0], arrow::field("field_non_exist", arrow::int32()), fields[2], fields[3]});
+    std::shared_ptr<arrow::DataType> read_type = arrow::struct_(
+        {fields[0], arrow::field("field_non_exist", arrow::int32()), fields[2], fields[3]});
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_({fields[0]});
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [0],
+        [0],
+        [1],
+        [2]
+    ])")
+            .ValueOrDie());
+
+    auto file_batch_reader =
+        std::make_unique<MockFileBatchReader>(src_array, file_type, /*batch_size=*/10);
+
+    auto complete_row_tracking_fields_reader =
+        std::make_shared<CompleteRowTrackingFieldsBatchReader>(
+            std::move(file_batch_reader), /*first_row_id=*/100, /*snapshot_id=*/8, pool_);
+    ArrowSchema c_read_schema;
+    ASSERT_TRUE(arrow::ExportSchema(*read_schema, &c_read_schema).ok());
+    ASSERT_OK(
+        complete_row_tracking_fields_reader->SetReadSchema(&c_read_schema,
+                                                           /*predicate=*/nullptr,
+                                                           /*selection_bitmap=*/std::nullopt));
+    ASSERT_NOK_WITH_MSG(
+        complete_row_tracking_fields_reader->NextBatchWithBitmap(),
+        "Data file does not contain field field_non_exist in CompleteRowTrackingFieldsBatchReader");
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestInvalidNextBatchBeforeSetReadSchema) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::int32()),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema = arrow::schema({fields[0], fields[1]});
+    std::shared_ptr<arrow::DataType> read_type = arrow::struct_({fields[0], fields[1]});
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_({fields[0]});
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [0],
+        [0],
+        [1],
+        [2]
+    ])")
+            .ValueOrDie());
+
+    auto file_batch_reader =
+        std::make_unique<MockFileBatchReader>(src_array, file_type, /*batch_size=*/10);
+
+    auto complete_row_tracking_fields_reader =
+        std::make_shared<CompleteRowTrackingFieldsBatchReader>(
+            std::move(file_batch_reader), /*first_row_id=*/100, /*snapshot_id=*/8, pool_);
+    ASSERT_NOK_WITH_MSG(complete_row_tracking_fields_reader->NextBatchWithBitmap(),
+                        "in CompleteRowTrackingFieldsBatchReader SetReadSchema is supposed to be "
+                        "called before NextBatch");
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestInvalidNullFirstRowId) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::int32()),
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema = arrow::schema({fields[0], fields[1]});
+    std::shared_ptr<arrow::DataType> read_type = arrow::struct_({fields[0], fields[1]});
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_({fields[0]});
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [0],
+        [0],
+        [1],
+        [2]
+    ])")
+            .ValueOrDie());
+
+    auto file_batch_reader =
+        std::make_unique<MockFileBatchReader>(src_array, file_type, /*batch_size=*/10);
+
+    auto complete_row_tracking_fields_reader =
+        std::make_shared<CompleteRowTrackingFieldsBatchReader>(
+            std::move(file_batch_reader), /*first_row_id=*/std::nullopt, /*snapshot_id=*/8, pool_);
+    ArrowSchema c_read_schema;
+    ASSERT_TRUE(arrow::ExportSchema(*read_schema, &c_read_schema).ok());
+    ASSERT_OK(
+        complete_row_tracking_fields_reader->SetReadSchema(&c_read_schema,
+                                                           /*predicate=*/nullptr,
+                                                           /*selection_bitmap=*/std::nullopt));
+    ASSERT_NOK_WITH_MSG(complete_row_tracking_fields_reader->NextBatchWithBitmap(),
+                        "unexpected: read _ROW_ID special field, but first row id is null in meta");
+}
+
+TEST_F(CompleteRowTrackingFieldsBatchReaderTest, TestOnlyReadRowTrackingFields) {
+    arrow::FieldVector fields = {
+        arrow::field("_ROW_ID", arrow::int64()),
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+    };
+    std::shared_ptr<arrow::Schema> read_schema = arrow::schema(fields);
+    std::shared_ptr<arrow::DataType> read_type = arrow::struct_(fields);
+    std::shared_ptr<arrow::DataType> file_type = arrow::struct_({});
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(file_type, R"([
+        [],
+        [],
+        [],
+        []
+    ])")
+            .ValueOrDie());
+    auto target_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [100, 4],
+        [101, 4],
+        [102, 4],
+        [103, 4]
+    ])")
+            .ValueOrDie());
+
+    CheckResult(src_array, /*first_row_id=*/100, /*snapshot_id=*/4, read_schema, target_array);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/concat_key_value_record_reader.h
+++ b/src/paimon/core/io/concat_key_value_record_reader.h
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "paimon/common/metrics/metrics_impl.h"
+#include "paimon/core/io/key_value_record_reader.h"
+#include "paimon/result.h"
+
+namespace paimon {
+class Metrics;
+
+/// This reader is to concatenate a list of KeyValueRecordReader and read them sequentially.
+/// The input list is already sorted by key and sequence number, and the key intervals do not
+/// overlap each other.
+class ConcatKeyValueRecordReader : public KeyValueRecordReader {
+ public:
+    explicit ConcatKeyValueRecordReader(
+        std::vector<std::unique_ptr<KeyValueRecordReader>>&& readers)
+        : readers_(std::move(readers)) {}
+
+    Result<std::unique_ptr<KeyValueRecordReader::Iterator>> NextBatch() override {
+        while (current_ < readers_.size()) {
+            auto& current_reader = readers_[current_];
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<KeyValueRecordReader::Iterator> iterator,
+                                   current_reader->NextBatch());
+            if (iterator != nullptr) {
+                return iterator;
+            }
+            // current meets eof, move to next reader
+            current_reader->Close();
+            current_++;
+        }
+        // read finish
+        return std::unique_ptr<KeyValueRecordReader::Iterator>();
+    }
+
+    void Close() override {
+        for (; current_ < readers_.size(); current_++) {
+            readers_[current_]->Close();
+        }
+    }
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return MetricsImpl::CollectReadMetrics(readers_);
+    }
+
+ private:
+    std::vector<std::unique_ptr<KeyValueRecordReader>> readers_;
+    size_t current_{0};
+};
+}  // namespace paimon

--- a/src/paimon/core/io/concat_key_value_record_reader_test.cpp
+++ b/src/paimon/core/io/concat_key_value_record_reader_test.cpp
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/concat_key_value_record_reader.h"
+
+#include <cstdint>
+#include <string>
+#include <variant>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "paimon/core/key_value.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/mock/mock_file_batch_reader.h"
+#include "paimon/testing/mock/mock_key_value_data_file_record_reader.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class ConcatKeyValueRecordReaderTest : public testing::Test {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+    }
+
+    void CheckResult(const std::vector<std::shared_ptr<arrow::StructArray>>& src_array_vec,
+                     const std::vector<KeyValue>& expected,
+                     const std::shared_ptr<arrow::Schema>& key_schema,
+                     const std::shared_ptr<arrow::Schema>& value_schema) const {
+        for (auto batch_size : {1, 2, 3, 4, 100}) {
+            std::vector<std::unique_ptr<KeyValueRecordReader>> record_readers;
+            for (const auto& src_array : src_array_vec) {
+                auto src_type = src_array->type();
+                auto file_batch_reader = std::make_unique<MockFileBatchReader>(
+                    src_array, src_type, /*batch_size=*/batch_size);
+                auto record_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+                    std::move(file_batch_reader), key_schema, value_schema, /*level=*/0, pool_);
+                record_readers.push_back(std::move(record_reader));
+            }
+
+            auto concat_record_reader =
+                std::make_unique<ConcatKeyValueRecordReader>(std::move(record_readers));
+            ASSERT_OK_AND_ASSIGN(
+                auto results,
+                (ReadResultCollector::CollectKeyValueResult<ConcatKeyValueRecordReader,
+                                                            KeyValueRecordReader::Iterator>(
+                    concat_record_reader.get())));
+            KeyValueChecker::CheckResult(expected, results, key_schema->num_fields(),
+                                         value_schema->num_fields());
+        }
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+TEST_F(ConcatKeyValueRecordReaderTest, TestSimple) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array1 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, 30],
+        [0, 0, 1, 2, 11, 21, 31],
+        [1, 0, 2, 2, 12, 22, 32],
+        [2, 0, 2, 3, 13, 23, 33]
+    ])")
+            .ValueOrDie());
+    auto src_array2 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 2, 4, 14, 24, 34],
+        [0, 0, 3, 1, 15, 25, 35],
+        [1, 0, 3, 2, 16, 26, 36],
+        [2, 0, 3, 3, 17, 27, 37]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected = KeyValueChecker::GenerateKeyValues(
+        /*seq_vec=*/{0, 0, 1, 2, 0, 0, 1, 2},
+        /*key_vec=*/{{1, 1}, {1, 2}, {2, 2}, {2, 3}, {2, 4}, {3, 1}, {3, 2}, {3, 3}},
+        /*value_vec=*/
+        {{1, 1, 10, 20, 30},
+         {1, 2, 11, 21, 31},
+         {2, 2, 12, 22, 32},
+         {2, 3, 13, 23, 33},
+         {2, 4, 14, 24, 34},
+         {3, 1, 15, 25, 35},
+         {3, 2, 16, 26, 36},
+         {3, 3, 17, 27, 37}},
+        pool_);
+    CheckResult({src_array1, src_array2}, expected, key_schema, value_schema);
+}
+
+TEST_F(ConcatKeyValueRecordReaderTest, TestSingleReaderInConcat) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array1 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, 30],
+        [0, 0, 1, 2, 11, 21, 31],
+        [1, 0, 2, 2, 12, 22, 32],
+        [2, 0, 2, 3, 13, 23, 33]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected = KeyValueChecker::GenerateKeyValues(
+        /*seq_vec=*/{0, 0, 1, 2}, /*key_vec=*/{{1, 1}, {1, 2}, {2, 2}, {2, 3}},
+        /*value_vec=*/
+        {{1, 1, 10, 20, 30}, {1, 2, 11, 21, 31}, {2, 2, 12, 22, 32}, {2, 3, 13, 23, 33}}, pool_);
+    CheckResult({src_array1}, expected, key_schema, value_schema);
+}
+
+TEST_F(ConcatKeyValueRecordReaderTest, TestEmptyResult) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array1 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+    ])")
+            .ValueOrDie());
+
+    CheckResult({src_array1}, {}, key_schema, value_schema);
+}
+
+TEST_F(ConcatKeyValueRecordReaderTest, TestEmptyReader) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array1 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+    ])")
+            .ValueOrDie());
+
+    auto src_array2 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, 30],
+        [0, 0, 1, 2, 11, 21, 31],
+        [1, 0, 2, 2, 12, 22, 32],
+        [2, 0, 2, 3, 13, 23, 33]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected = KeyValueChecker::GenerateKeyValues(
+        /*seq_vec=*/{0, 0, 1, 2}, /*key_vec=*/{{1, 1}, {1, 2}, {2, 2}, {2, 3}},
+        /*value_vec=*/
+        {{1, 1, 10, 20, 30}, {1, 2, 11, 21, 31}, {2, 2, 12, 22, 32}, {2, 3, 13, 23, 33}}, pool_);
+
+    CheckResult({src_array1, src_array2}, expected, key_schema, value_schema);
+    CheckResult({src_array2, src_array1}, expected, key_schema, value_schema);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/file_index_evaluator.cpp
+++ b/src/paimon/core/io/file_index_evaluator.cpp
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/file_index_evaluator.h"
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <set>
+#include <utility>
+
+#include "arrow/c/bridge.h"
+#include "arrow/type.h"
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/file_index/file_index_format.h"
+#include "paimon/file_index/file_index_reader.h"
+#include "paimon/io/byte_array_input_stream.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/predicate/compound_predicate.h"
+#include "paimon/predicate/function.h"
+#include "paimon/predicate/leaf_predicate.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/predicate/predicate_utils.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class MemoryPool;
+enum class FieldType;
+
+Result<std::shared_ptr<FileIndexResult>> FileIndexEvaluator::Evaluate(
+    const std::shared_ptr<arrow::Schema>& data_schema, const std::shared_ptr<Predicate>& predicate,
+    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+    const std::shared_ptr<DataFileMeta>& file_meta, const std::shared_ptr<FileSystem>& file_system,
+    const std::shared_ptr<MemoryPool>& pool) {
+    return Evaluate(/*only_use_embedding_index=*/false, data_schema, predicate,
+                    data_file_path_factory, file_meta, file_system, pool);
+}
+
+Result<std::shared_ptr<FileIndexResult>> FileIndexEvaluator::Evaluate(
+    const std::shared_ptr<arrow::Schema>& data_schema, const std::shared_ptr<Predicate>& predicate,
+    const std::shared_ptr<DataFileMeta>& file_meta, const std::shared_ptr<MemoryPool>& pool) {
+    return Evaluate(/*only_use_embedding_index=*/true, data_schema, predicate,
+                    /*data_file_path_factory=*/nullptr, file_meta, /*file_system=*/nullptr, pool);
+}
+
+Result<std::shared_ptr<FileIndexResult>> FileIndexEvaluator::Evaluate(
+    bool only_use_embedding_index, const std::shared_ptr<arrow::Schema>& data_schema,
+    const std::shared_ptr<Predicate>& predicate,
+    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+    const std::shared_ptr<DataFileMeta>& file_meta, const std::shared_ptr<FileSystem>& file_system,
+    const std::shared_ptr<MemoryPool>& pool) {
+    if (predicate == nullptr) {
+        return FileIndexResult::Remain();
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InputStream> input_stream,
+                           ExtractIndexInputStream(only_use_embedding_index, data_file_path_factory,
+                                                   file_meta, file_system));
+    if (!input_stream) {
+        // no index files, just return REMAIN
+        return FileIndexResult::Remain();
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileIndexFormat::Reader> format_reader,
+                           FileIndexFormat::CreateReader(input_stream, pool));
+    std::set<std::string> required_field_names;
+    PAIMON_RETURN_NOT_OK(PredicateUtils::GetAllNames(predicate, &required_field_names));
+    std::map<std::string, std::vector<std::shared_ptr<FileIndexReader>>>
+        field_name_to_index_readers;
+    for (const auto& field_name : required_field_names) {
+        auto data_field = data_schema->GetFieldByName(field_name);
+        if (data_field == nullptr) {
+            return Status::Invalid(fmt::format("field {} not exist in data schema {}", field_name,
+                                               data_schema->ToString()));
+        }
+        ArrowSchema c_arrow_schema;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(
+            arrow::ExportSchema(*arrow::schema({data_field}), &c_arrow_schema));
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<FileIndexReader>> index_readers,
+                               format_reader->ReadColumnIndex(field_name, &c_arrow_schema));
+        field_name_to_index_readers.emplace(field_name, std::move(index_readers));
+    }
+    return Evaluate(predicate, field_name_to_index_readers);
+}
+
+Result<std::shared_ptr<InputStream>> FileIndexEvaluator::ExtractIndexInputStream(
+    bool only_use_embedding_index,
+    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+    const std::shared_ptr<DataFileMeta>& file_meta,
+    const std::shared_ptr<FileSystem>& file_system) {
+    const auto& embedded_index = file_meta->embedded_index;
+    if (embedded_index != nullptr) {
+        // inline index
+        return std::make_shared<ByteArrayInputStream>(embedded_index->data(),
+                                                      embedded_index->size());
+    }
+    if (only_use_embedding_index) {
+        return std::shared_ptr<InputStream>();
+    }
+    if (!data_file_path_factory || !file_system) {
+        return Status::Invalid(
+            "read process for FileIndexEvaluator must have data_file_path_factory and file_system");
+    }
+    // get input stream from file
+    std::vector<std::string> index_files;
+    for (const auto& extra_file : file_meta->extra_files) {
+        if (extra_file) {
+            if (StringUtils::EndsWith(extra_file.value(), DataFilePathFactory::INDEX_PATH_SUFFIX)) {
+                index_files.emplace_back(extra_file.value());
+            }
+        }
+    }
+    if (!index_files.empty()) {
+        if (index_files.size() > 1) {
+            return Status::Invalid(
+                fmt::format("Found more than one index file for one data file: {}",
+                            fmt::join(index_files, ", ")));
+        }
+        std::string file_index_path =
+            data_file_path_factory->ToAlignedPath(index_files[0], file_meta);
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InputStream> input_stream,
+                               file_system->Open(file_index_path));
+        return input_stream;
+    }
+    // no index
+    return std::shared_ptr<InputStream>();
+}
+
+Result<std::shared_ptr<FileIndexResult>> FileIndexEvaluator::Evaluate(
+    const std::shared_ptr<Predicate>& predicate,
+    const std::map<std::string, std::vector<std::shared_ptr<FileIndexReader>>>&
+        field_name_to_index_readers) {
+    if (auto compound_predicate = std::dynamic_pointer_cast<CompoundPredicate>(predicate)) {
+        return EvaluateCompoundPredicate(compound_predicate, field_name_to_index_readers);
+    } else if (auto leaf_predicate = std::dynamic_pointer_cast<LeafPredicate>(predicate)) {
+        std::shared_ptr<FileIndexResult> compound_result = FileIndexResult::Remain();
+        // TODO(xinyu.lxy): erase predicate, rm predicate which hits bitmap index
+        auto iter = field_name_to_index_readers.find(leaf_predicate->FieldName());
+        if (iter == field_name_to_index_readers.end()) {
+            assert(false);
+            return Status::Invalid(fmt::format(
+                "field name {} in leaf literal does not exist in field_name_to_index_readers",
+                leaf_predicate->FieldName()));
+        }
+        for (const auto& index_reader : iter->second) {
+            PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileIndexResult> sub_result,
+                                   PredicateUtils::VisitPredicate<std::shared_ptr<FileIndexResult>>(
+                                       leaf_predicate, index_reader));
+            PAIMON_ASSIGN_OR_RAISE(compound_result, compound_result->And(sub_result));
+            PAIMON_ASSIGN_OR_RAISE(bool is_remain, compound_result->IsRemain());
+            if (!is_remain) {
+                return compound_result;
+            }
+        }
+        assert(compound_result);
+        // if index readers is empty (the index type is not registered), return
+        // FileIndexResult::Remain()
+        return compound_result;
+    }
+    return Status::Invalid(fmt::format(
+        "cannot cast predicate {} to CompoundPredicate or LeafPredicate", predicate->ToString()));
+}
+
+Result<std::shared_ptr<FileIndexResult>> FileIndexEvaluator::EvaluateCompoundPredicate(
+    const std::shared_ptr<CompoundPredicate>& compound_predicate,
+    const std::map<std::string, std::vector<std::shared_ptr<FileIndexReader>>>&
+        field_name_to_index_readers) {
+    if (compound_predicate->GetFunction().GetType() == Function::Type::OR) {
+        std::shared_ptr<FileIndexResult> compound_result;
+        for (const auto& child : compound_predicate->Children()) {
+            if (compound_result == nullptr) {
+                PAIMON_ASSIGN_OR_RAISE(compound_result,
+                                       Evaluate(child, field_name_to_index_readers));
+            } else {
+                PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileIndexResult> child_result,
+                                       Evaluate(child, field_name_to_index_readers));
+                PAIMON_ASSIGN_OR_RAISE(compound_result, compound_result->Or(child_result));
+            }
+        }
+        assert(compound_result);
+        return compound_result;
+    } else if (compound_predicate->GetFunction().GetType() == Function::Type::AND) {
+        std::shared_ptr<FileIndexResult> compound_result;
+        for (const auto& child : compound_predicate->Children()) {
+            if (compound_result == nullptr) {
+                PAIMON_ASSIGN_OR_RAISE(compound_result,
+                                       Evaluate(child, field_name_to_index_readers));
+            } else {
+                PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileIndexResult> child_result,
+                                       Evaluate(child, field_name_to_index_readers));
+                PAIMON_ASSIGN_OR_RAISE(compound_result, compound_result->And(child_result));
+            }
+            // if not remain, no need to test anymore
+            PAIMON_ASSIGN_OR_RAISE(bool is_remain, compound_result->IsRemain());
+            if (!is_remain) {
+                return compound_result;
+            }
+        }
+        assert(compound_result);
+        return compound_result;
+    }
+    return Status::Invalid("CompoundPredicate only support And/Or function");
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/file_index_evaluator.h
+++ b/src/paimon/core/io/file_index_evaluator.h
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/file_index/file_index_reader.h"
+#include "paimon/file_index/file_index_result.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class LeafPredicate;
+class CompoundPredicate;
+class DataFilePathFactory;
+class FileIndexReader;
+class MemoryPool;
+class Predicate;
+struct DataFileMeta;
+
+class FileIndexEvaluator {
+ public:
+    FileIndexEvaluator() = delete;
+    ~FileIndexEvaluator() = delete;
+
+    // for scan process, will only use embedding file to evaluate
+    static Result<std::shared_ptr<FileIndexResult>> Evaluate(
+        const std::shared_ptr<arrow::Schema>& data_schema,
+        const std::shared_ptr<Predicate>& predicate, const std::shared_ptr<DataFileMeta>& file_meta,
+        const std::shared_ptr<MemoryPool>& pool);
+
+    // for read process, will use embedding file or extra index file to evaluate
+    static Result<std::shared_ptr<FileIndexResult>> Evaluate(
+        const std::shared_ptr<arrow::Schema>& data_schema,
+        const std::shared_ptr<Predicate>& predicate,
+        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+        const std::shared_ptr<DataFileMeta>& file_meta,
+        const std::shared_ptr<FileSystem>& file_system, const std::shared_ptr<MemoryPool>& pool);
+
+ private:
+    static Result<std::shared_ptr<FileIndexResult>> Evaluate(
+        bool only_use_embedding_index, const std::shared_ptr<arrow::Schema>& data_schema,
+        const std::shared_ptr<Predicate>& predicate,
+        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+        const std::shared_ptr<DataFileMeta>& file_meta,
+        const std::shared_ptr<FileSystem>& file_system, const std::shared_ptr<MemoryPool>& pool);
+
+    static Result<std::shared_ptr<InputStream>> ExtractIndexInputStream(
+        bool only_use_embedding_index,
+        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+        const std::shared_ptr<DataFileMeta>& file_meta,
+        const std::shared_ptr<FileSystem>& file_system);
+
+    static Result<std::shared_ptr<FileIndexResult>> Evaluate(
+        const std::shared_ptr<Predicate>& predicate,
+        const std::map<std::string, std::vector<std::shared_ptr<FileIndexReader>>>&
+            field_name_to_index_readers);
+
+    static Result<std::shared_ptr<FileIndexResult>> EvaluateCompoundPredicate(
+        const std::shared_ptr<CompoundPredicate>& compound_predicate,
+        const std::map<std::string, std::vector<std::shared_ptr<FileIndexReader>>>&
+            field_name_to_index_readers);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/file_index_evaluator_test.cpp
+++ b/src/paimon/core/io/file_index_evaluator_test.cpp
@@ -1,0 +1,420 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/file_index_evaluator.h"
+
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <utility>
+
+#include "arrow/type_fwd.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/fs/external_path_provider.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/file_index/bitmap_index_result.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+#include "paimon/utils/roaring_bitmap32.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon::test {
+class FileIndexEvaluatorTest : public ::testing::Test {
+ public:
+    void SetUp() override {
+        std::vector<DataField> read_fields = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                              DataField(1, arrow::field("f1", arrow::int32())),
+                                              DataField(2, arrow::field("f2", arrow::int32())),
+                                              DataField(3, arrow::field("f3", arrow::float64()))};
+        data_schema_ = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+        pool_ = GetDefaultPool();
+        fs_ = std::make_shared<LocalFileSystem>();
+    }
+    void TearDown() override {
+        pool_.reset();
+        fs_.reset();
+        data_schema_.reset();
+    }
+
+    void CheckResult(const std::shared_ptr<FileIndexResult>& result,
+                     const std::vector<int32_t>& expected) const {
+        auto typed_result = std::dynamic_pointer_cast<BitmapIndexResult>(result);
+        ASSERT_TRUE(typed_result);
+        ASSERT_OK_AND_ASSIGN(const RoaringBitmap32* bitmap, typed_result->GetBitmap());
+        ASSERT_TRUE(bitmap);
+        ASSERT_EQ(*(typed_result->GetBitmap().value()), RoaringBitmap32::From(expected))
+            << "result:" << typed_result->GetBitmap().value()->ToString()
+            << ", expected:" << RoaringBitmap32::From(expected).ToString();
+    }
+
+    void CheckResult(const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+                     const std::shared_ptr<DataFileMeta>& data_file_meta) const {
+        {
+            auto predicate =
+                PredicateBuilder::IsNull(/*field_index=*/2, /*field_name=*/"f2", FieldType::INT);
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            CheckResult(file_index_result, {7});
+        }
+        {
+            auto predicate =
+                PredicateBuilder::IsNotNull(/*field_index=*/2, /*field_name=*/"f2", FieldType::INT);
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            CheckResult(file_index_result, {0, 1, 2, 3, 4, 5, 6});
+        }
+        {
+            auto predicate =
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                        Literal(FieldType::STRING, "Alice", 5));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            CheckResult(file_index_result, {0, 7});
+        }
+        {
+            auto predicate = PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                        FieldType::STRING,
+                                                        Literal(FieldType::STRING, "Alice", 5));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            CheckResult(file_index_result, {1, 2, 3, 4, 5, 6});
+        }
+        {
+            auto predicate = PredicateBuilder::GreaterThan(/*field_index=*/1, /*field_name=*/"f1",
+                                                           FieldType::INT, Literal(10));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            ASSERT_FALSE(dynamic_cast<BitmapIndexResult*>(file_index_result.get()));
+        }
+        {
+            auto predicate = PredicateBuilder::GreaterOrEqual(
+                /*field_index=*/1, /*field_name=*/"f1", FieldType::INT, Literal(10));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            ASSERT_FALSE(dynamic_cast<BitmapIndexResult*>(file_index_result.get()));
+        }
+        {
+            auto predicate = PredicateBuilder::LessThan(/*field_index=*/1, /*field_name=*/"f1",
+                                                        FieldType::INT, Literal(10));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            ASSERT_FALSE(dynamic_cast<BitmapIndexResult*>(file_index_result.get()));
+        }
+        {
+            auto predicate = PredicateBuilder::LessOrEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                           FieldType::INT, Literal(10));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            ASSERT_FALSE(dynamic_cast<BitmapIndexResult*>(file_index_result.get()));
+        }
+        {
+            auto predicate = PredicateBuilder::In(
+                /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                {Literal(FieldType::STRING, "Alice", 5), Literal(FieldType::STRING, "Bob", 3),
+                 Literal(FieldType::STRING, "Lucy", 4)});
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            CheckResult(file_index_result, {0, 1, 4, 5, 7});
+        }
+        {
+            auto predicate = PredicateBuilder::NotIn(
+                /*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                {Literal(FieldType::STRING, "Alice", 5), Literal(FieldType::STRING, "Bob", 3),
+                 Literal(FieldType::STRING, "Lucy", 4)});
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            CheckResult(file_index_result, {2, 3, 6});
+        }
+        {
+            auto f0_predicate =
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                        Literal(FieldType::STRING, "Alice", 5));
+            auto f1_predicate = PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1",
+                                                        FieldType::INT, Literal(20));
+            ASSERT_OK_AND_ASSIGN(auto predicate,
+                                 PredicateBuilder::And({f0_predicate, f1_predicate}));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            CheckResult(file_index_result, {7});
+        }
+        {
+            auto f0_predicate =
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                        Literal(FieldType::STRING, "Alice", 5));
+            auto f1_predicate = PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1",
+                                                        FieldType::INT, Literal(20));
+            ASSERT_OK_AND_ASSIGN(auto predicate,
+                                 PredicateBuilder::Or({f0_predicate, f1_predicate}));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            CheckResult(file_index_result, {0, 4, 6, 7});
+        }
+        {
+            // test non result
+            auto predicate =
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                        Literal(FieldType::STRING, "unknown", 7));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_FALSE(file_index_result->IsRemain().value());
+        }
+        {
+            // test early stop
+            auto f1_predicate = PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1",
+                                                        FieldType::INT, Literal(10));
+            auto f2_predicate = PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2",
+                                                        FieldType::INT, Literal(6));
+            auto f0_predicate =
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                        Literal(FieldType::STRING, "Alice", 5));
+
+            ASSERT_OK_AND_ASSIGN(auto predicate,
+                                 PredicateBuilder::And({f1_predicate, f2_predicate, f0_predicate}));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, predicate, data_file_path_factory,
+                                             data_file_meta, fs_, pool_));
+            ASSERT_FALSE(file_index_result->IsRemain().value());
+        }
+        {
+            // test no predicate
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, /*predicate=*/nullptr,
+                                             data_file_path_factory, data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            ASSERT_FALSE(dynamic_cast<BitmapIndexResult*>(file_index_result.get()));
+        }
+        {
+            // test predicate on f3 (do not have index)
+            auto predicate = PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                                     FieldType::DOUBLE, Literal(14.1));
+            ASSERT_OK_AND_ASSIGN(
+                auto file_index_result,
+                FileIndexEvaluator::Evaluate(data_schema_, /*predicate=*/nullptr,
+                                             data_file_path_factory, data_file_meta, fs_, pool_));
+            ASSERT_TRUE(file_index_result->IsRemain().value());
+            ASSERT_FALSE(dynamic_cast<BitmapIndexResult*>(file_index_result.get()));
+        }
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<FileSystem> fs_;
+    std::shared_ptr<arrow::Schema> data_schema_;
+};
+
+TEST_F(FileIndexEvaluatorTest, TestEvaluateEmbeddingIndex) {
+    std::string path =
+        paimon::test::GetDataDir() + "/orc/append_with_bitmap.db/append_with_bitmap/";
+    std::vector<uint8_t> embedded_bytes = {
+        0,  5,   78,  78,  208, 26,  53,  174, 0,   0,   0,   1,   0,   0,   0,   96,  0,   0,
+        0,  3,   0,   2,   102, 48,  0,   0,   0,   1,   0,   6,   98,  105, 116, 109, 97,  112,
+        0,  0,   0,   96,  0,   0,   0,   176, 0,   2,   102, 49,  0,   0,   0,   1,   0,   6,
+        98, 105, 116, 109, 97,  112, 0,   0,   1,   16,  0,   0,   0,   102, 0,   2,   102, 50,
+        0,  0,   0,   1,   0,   6,   98,  105, 116, 109, 97,  112, 0,   0,   1,   118, 0,   0,
+        0,  108, 0,   0,   0,   0,   2,   0,   0,   0,   8,   0,   0,   0,   5,   0,   0,   0,
+        0,  1,   0,   0,   0,   5,   65,  108, 105, 99,  101, 0,   0,   0,   0,   0,   0,   0,
+        85, 0,   0,   0,   5,   0,   0,   0,   5,   65,  108, 105, 99,  101, 0,   0,   0,   0,
+        0,  0,   0,   20,  0,   0,   0,   3,   66,  111, 98,  0,   0,   0,   20,  0,   0,   0,
+        20, 0,   0,   0,   5,   69,  109, 105, 108, 121, 255, 255, 255, 253, 255, 255, 255, 255,
+        0,  0,   0,   4,   76,  117, 99,  121, 255, 255, 255, 251, 255, 255, 255, 255, 0,   0,
+        0,  4,   84,  111, 110, 121, 0,   0,   0,   40,  0,   0,   0,   20,  58,  48,  0,   0,
+        1,  0,   0,   0,   0,   0,   1,   0,   16,  0,   0,   0,   0,   0,   7,   0,   58,  48,
+        0,  0,   1,   0,   0,   0,   0,   0,   1,   0,   16,  0,   0,   0,   1,   0,   5,   0,
+        58, 48,  0,   0,   1,   0,   0,   0,   0,   0,   1,   0,   16,  0,   0,   0,   3,   0,
+        6,  0,   2,   0,   0,   0,   8,   0,   0,   0,   2,   0,   0,   0,   0,   1,   0,   0,
+        0,  10,  0,   0,   0,   0,   0,   0,   0,   28,  0,   0,   0,   2,   0,   0,   0,   10,
+        0,  0,   0,   22,  0,   0,   0,   26,  0,   0,   0,   20,  0,   0,   0,   0,   0,   0,
+        0,  22,  58,  48,  0,   0,   1,   0,   0,   0,   0,   0,   2,   0,   16,  0,   0,   0,
+        4,  0,   6,   0,   7,   0,   58,  48,  0,   0,   1,   0,   0,   0,   0,   0,   4,   0,
+        16, 0,   0,   0,   0,   0,   1,   0,   2,   0,   3,   0,   5,   0,   2,   0,   0,   0,
+        8,  0,   0,   0,   2,   1,   255, 255, 255, 248, 0,   0,   0,   18,  0,   0,   0,   1,
+        0,  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   28,  0,   0,   0,   2,   0,   0,
+        0,  0,   0,   0,   0,   0,   0,   0,   0,   22,  0,   0,   0,   1,   0,   0,   0,   22,
+        0,  0,   0,   24,  58,  48,  0,   0,   1,   0,   0,   0,   0,   0,   2,   0,   16,  0,
+        0,  0,   2,   0,   3,   0,   6,   0,   58,  48,  0,   0,   1,   0,   0,   0,   0,   0,
+        3,  0,   16,  0,   0,   0,   0,   0,   1,   0,   4,   0,   5,   0};
+    auto embedded_index = std::make_shared<Bytes>(embedded_bytes.size(), pool_.get());
+    memcpy(embedded_index->data(), reinterpret_cast<char*>(embedded_bytes.data()),
+           embedded_bytes.size());
+    auto data_file_meta = std::make_shared<DataFileMeta>(
+        "data-62feb610-c83f-4217-9b50-bbad9cd08eb4-0.orc", /*file_size=*/689,
+        /*row_count=*/8, /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(), /*key_stats=*/SimpleStats::EmptyStats(),
+        /*value_stats=*/SimpleStats::EmptyStats(), /*min_sequence_number=*/0,
+        /*max_sequence_number=*/7, /*schema_id=*/0,
+        /*level=*/0,
+        /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(0ll, 0), /*delete_row_count=*/0,
+        /*embedded_index=*/embedded_index, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+    CheckResult(/*data_file_path_factory=*/nullptr, data_file_meta);
+}
+
+TEST_F(FileIndexEvaluatorTest, TestEvaluateNoEmbeddingIndex) {
+    std::string path = paimon::test::GetDataDir() +
+                       "/orc/append_with_bitmap_no_embedding.db/append_with_bitmap_no_embedding/";
+    auto data_file_meta = std::make_shared<DataFileMeta>(
+        "data-414509f5-e40c-4245-b992-bbf486778ac9-0.orc", /*file_size=*/689,
+        /*row_count=*/8, /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(), /*key_stats=*/SimpleStats::EmptyStats(),
+        /*value_stats=*/SimpleStats::EmptyStats(), /*min_sequence_number=*/0,
+        /*max_sequence_number=*/7, /*schema_id=*/0,
+        /*level=*/0,
+        /*extra_files=*/
+        std::vector<std::optional<std::string>>(
+            {"data-414509f5-e40c-4245-b992-bbf486778ac9-0.orc.index"}),
+        /*creation_time=*/Timestamp(0ll, 0), /*delete_row_count=*/0,
+        /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+    auto data_file_path_factory = std::make_shared<DataFilePathFactory>();
+    ASSERT_OK(data_file_path_factory->Init(path + "/bucket-0/", /*format_identifier=*/"orc",
+                                           /*data_file_prefix=*/"data-", nullptr));
+    CheckResult(data_file_path_factory, data_file_meta);
+}
+
+TEST_F(FileIndexEvaluatorTest, TestTimestampType) {
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    arrow::FieldVector fields = {
+        arrow::field("ts_sec", arrow::timestamp(arrow::TimeUnit::SECOND)),
+        arrow::field("ts_milli", arrow::timestamp(arrow::TimeUnit::MILLI)),
+        arrow::field("ts_micro", arrow::timestamp(arrow::TimeUnit::MICRO)),
+        arrow::field("ts_nano", arrow::timestamp(arrow::TimeUnit::NANO)),
+        arrow::field("ts_tz_sec", arrow::timestamp(arrow::TimeUnit::SECOND, timezone)),
+        arrow::field("ts_tz_milli", arrow::timestamp(arrow::TimeUnit::MILLI, timezone)),
+        arrow::field("ts_tz_micro", arrow::timestamp(arrow::TimeUnit::MICRO, timezone)),
+        arrow::field("ts_tz_nano", arrow::timestamp(arrow::TimeUnit::NANO, timezone)),
+    };
+    auto data_schema = arrow::schema(fields);
+
+    std::string path = paimon::test::GetDataDir() + "/orc/timestamp_index.db/timestamp_index/";
+    auto data_file_meta = std::make_shared<DataFileMeta>(
+        "data-18569866-0c37-45e9-9d88-2eaf6dd084b0-0.orc", /*file_size=*/689,
+        /*row_count=*/8, /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(), /*key_stats=*/SimpleStats::EmptyStats(),
+        /*value_stats=*/SimpleStats::EmptyStats(), /*min_sequence_number=*/0,
+        /*max_sequence_number=*/7, /*schema_id=*/0,
+        /*level=*/0,
+        /*extra_files=*/
+        std::vector<std::optional<std::string>>(
+            {"data-18569866-0c37-45e9-9d88-2eaf6dd084b0-0.orc.index"}),
+        /*creation_time=*/Timestamp(0ll, 0), /*delete_row_count=*/0,
+        /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+    auto data_file_path_factory = std::make_shared<DataFilePathFactory>();
+    ASSERT_OK(data_file_path_factory->Init(path + "/bucket-0/", /*format_identifier=*/"orc",
+                                           /*data_file_prefix=*/"data-", nullptr));
+    // {0,2,3,6}
+    auto in_predicate = PredicateBuilder::In(
+        /*field_index=*/0, /*field_name=*/"ts_sec", FieldType::TIMESTAMP,
+        {Literal(Timestamp(1745542802000l, 0)), Literal(Timestamp(-1745000l, 0)),
+         Literal(Timestamp(1745542602000l, 0))});
+    // {0, 6}
+    auto greater_than = PredicateBuilder::GreaterThan(
+        /*field_index=*/6, /*field_name=*/"ts_tz_micro", FieldType::TIMESTAMP,
+        Literal(Timestamp(1745542602001l, 1000)));
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({in_predicate, greater_than}));
+    ASSERT_OK_AND_ASSIGN(auto file_index_result, FileIndexEvaluator::Evaluate(
+                                                     data_schema, predicate, data_file_path_factory,
+                                                     data_file_meta, /*file_system=*/fs_, pool_));
+    CheckResult(file_index_result, {0, 6});
+}
+
+TEST_F(FileIndexEvaluatorTest, TestInvalidEvaluate) {
+    auto data_file_meta = std::make_shared<DataFileMeta>(
+        "data-414509f5-e40c-4245-b992-bbf486778ac9-0.orc", /*file_size=*/689,
+        /*row_count=*/8, /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(), /*key_stats=*/SimpleStats::EmptyStats(),
+        /*value_stats=*/SimpleStats::EmptyStats(), /*min_sequence_number=*/0,
+        /*max_sequence_number=*/7, /*schema_id=*/0,
+        /*level=*/0,
+        /*extra_files=*/
+        std::vector<std::optional<std::string>>(
+            {"data-414509f5-e40c-4245-b992-bbf486778ac9-0.orc.index"}),
+        /*creation_time=*/Timestamp(0ll, 0), /*delete_row_count=*/0,
+        /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+    auto predicate =
+        PredicateBuilder::IsNull(/*field_index=*/2, /*field_name=*/"f2", FieldType::INT);
+    ASSERT_NOK_WITH_MSG(
+        FileIndexEvaluator::Evaluate(data_schema_, predicate, /*data_file_path_factory=*/nullptr,
+                                     data_file_meta, /*file_system=*/nullptr, pool_),
+        "read process for FileIndexEvaluator must have data_file_path_factory and file_system");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/key_value_data_file_record_reader.cpp
+++ b/src/paimon/core/io/key_value_data_file_record_reader.cpp
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/key_value_data_file_record_reader.h"
+
+#include <cassert>
+#include <utility>
+
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_dict.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/array/array_primitive.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "fmt/format.h"
+#include "paimon/common/data/columnar/columnar_row_ref.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/common/utils/arrow/arrow_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/status.h"
+namespace paimon {
+class MemoryPool;
+
+KeyValueDataFileRecordReader::KeyValueDataFileRecordReader(
+    std::unique_ptr<FileBatchReader>&& reader, const std::shared_ptr<arrow::Schema>& key_schema,
+    const std::shared_ptr<arrow::Schema>& value_schema, int32_t level,
+    const std::shared_ptr<MemoryPool>& pool)
+    : level_(level),
+      pool_(pool),
+      reader_(std::move(reader)),
+      key_schema_(key_schema),
+      value_schema_(value_schema),
+      value_names_(value_schema_->field_names()) {}
+
+Result<bool> KeyValueDataFileRecordReader::Iterator::HasNext() const {
+    int64_t array_length = reader_->row_kind_array_->length();
+    const auto& selection_bitmap = reader_->selection_bitmap_;
+    if (selection_bitmap.Cardinality() == array_length) {
+        // all rows are selected in bitmap
+        return cursor_ < array_length;
+    }
+    auto iter = selection_bitmap.EqualOrLarger(cursor_);
+    if (iter == selection_bitmap.End()) {
+        // no row are selected
+        return false;
+    }
+    // find the first selected row
+    cursor_ = *iter;
+    assert(cursor_ < array_length);
+    return true;
+}
+
+Result<KeyValue> KeyValueDataFileRecordReader::Iterator::Next() {
+    // key is only used in merge sort; key context does not hold parent struct array
+    auto key = std::make_unique<ColumnarRowRef>(reader_->key_ctx_, cursor_);
+    // value is used in merge sort and projection (maybe async and multi-thread), so value context
+    // holds parent struct array to ensure data remains valid
+    auto value = std::make_unique<ColumnarRowRef>(reader_->value_ctx_, cursor_);
+    PAIMON_ASSIGN_OR_RAISE(const RowKind* row_kind,
+                           RowKind::FromByteValue(reader_->row_kind_array_->Value(cursor_)));
+    int64_t sequence_number = reader_->sequence_number_array_->Value(cursor_);
+    cursor_++;
+    return KeyValue(row_kind, sequence_number, reader_->level_, std::move(key), std::move(value));
+}
+
+Result<std::pair<int64_t, KeyValue>> KeyValueDataFileRecordReader::Iterator::NextWithFilePos() {
+    PAIMON_ASSIGN_OR_RAISE(KeyValue kv, Next());
+    return std::make_pair(previous_batch_first_row_number_ + cursor_ - 1, std::move(kv));
+}
+
+Result<std::unique_ptr<KeyValueRecordReader::Iterator>> KeyValueDataFileRecordReader::NextBatch() {
+    Reset();
+    PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatchWithBitmap batch_with_bitmap,
+                           reader_->NextBatchWithBitmap());
+    PAIMON_ASSIGN_OR_RAISE(int64_t previous_batch_first_row_number,
+                           reader_->GetPreviousBatchFirstRowNumber());
+    if (BatchReader::IsEofBatch(batch_with_bitmap)) {
+        // reader eof, just return
+        return std::unique_ptr<KeyValueRecordReader::Iterator>();
+    }
+    auto& [array, bitmap] = batch_with_bitmap;
+    auto& [c_array, c_schema] = array;
+    if (bitmap.IsEmpty()) {
+        return Status::Invalid("KeyValueRecordReader should not accept empty batch");
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                      arrow::ImportArray(c_array.get(), c_schema.get()));
+    auto data_batch = arrow::internal::checked_pointer_cast<arrow::StructArray>(arrow_array);
+    assert(data_batch);
+    // do not use arrow::checked_pointer_cast as in release compile, checked_pointer_cast is
+    // static_cast without check
+    sequence_number_array_ =
+        std::dynamic_pointer_cast<arrow::NumericArray<arrow::Int64Type>>(data_batch->field(0));
+    if (!sequence_number_array_) {
+        return Status::Invalid("cannot cast SEQUENCE_NUMBER column to int64 arrow array");
+    }
+    row_kind_array_ =
+        std::dynamic_pointer_cast<arrow::NumericArray<arrow::Int8Type>>(data_batch->field(1));
+    if (!row_kind_array_) {
+        return Status::Invalid("cannot cast VALUE_KIND column to int8 arrow array");
+    }
+    arrow::ArrayVector key_fields;
+    key_fields.reserve(key_schema_->num_fields());
+    for (const auto& key_field : key_schema_->fields()) {
+        // skip special fields
+        key_fields.emplace_back(data_batch->GetFieldByName(key_field->name()));
+    }
+    // e.g., file schema:    seq, kind, key1, key2, s1, s2, v1, v2
+    // user raw read schema: key1, v1, s1
+    // format reader read schema: seq, kind, key1, key2, v1, s1, s2
+    // in KeyValue object: key: key1, key2 / value: key1, v1, s1, s2
+    arrow::ArrayVector value_fields;
+    value_fields.reserve(value_schema_->num_fields());
+    for (const auto& value_field : value_schema_->fields()) {
+        auto field_array = data_batch->GetFieldByName(value_field->name());
+        if (!field_array) {
+            return Status::Invalid(
+                fmt::format("cannot find field {} in data batch", value_field->name()));
+        }
+        value_fields.emplace_back(field_array);
+    }
+
+    selection_bitmap_ = std::move(bitmap);
+    key_ctx_ = std::make_shared<ColumnarBatchContext>(key_fields, pool_);
+    value_ctx_ = std::make_shared<ColumnarBatchContext>(value_fields, pool_);
+    ArrowUtils::TraverseArray(data_batch);
+    return std::make_unique<KeyValueDataFileRecordReader::Iterator>(
+        this, previous_batch_first_row_number);
+}
+
+void KeyValueDataFileRecordReader::Reset() {
+    selection_bitmap_ = RoaringBitmap32();
+    key_ctx_.reset();
+    value_ctx_.reset();
+    sequence_number_array_.reset();
+    row_kind_array_.reset();
+}
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_data_file_record_reader.h
+++ b/src/paimon/core/io/key_value_data_file_record_reader.h
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/type_fwd.h"
+#include "paimon/core/io/key_value_record_reader.h"
+#include "paimon/core/key_value.h"
+#include "paimon/reader/file_batch_reader.h"
+#include "paimon/result.h"
+#include "paimon/utils/roaring_bitmap32.h"
+
+namespace arrow {
+class Array;
+class Int64Type;
+class Int8Type;
+class Schema;
+class StructArray;
+template <typename TypeClass>
+class NumericArray;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+class Metrics;
+struct ColumnarBatchContext;
+
+// Convert the arrow array of data file into a KeyValue object iterator (parsing SEQUENCE_NUMBER and
+// VALUE_KIND columns)
+class KeyValueDataFileRecordReader : public KeyValueRecordReader {
+ public:
+    KeyValueDataFileRecordReader(std::unique_ptr<FileBatchReader>&& reader,
+                                 const std::shared_ptr<arrow::Schema>& key_schema,
+                                 const std::shared_ptr<arrow::Schema>& value_schema, int32_t level,
+                                 const std::shared_ptr<MemoryPool>& pool);
+
+    class Iterator : public KeyValueRecordReader::Iterator {
+     public:
+        Iterator(KeyValueDataFileRecordReader* reader, int64_t previous_batch_first_row_number)
+            : previous_batch_first_row_number_(previous_batch_first_row_number), reader_(reader) {}
+        Result<bool> HasNext() const override;
+        Result<KeyValue> Next() override;
+        Result<std::pair<int64_t, KeyValue>> NextWithFilePos();
+
+     private:
+        int64_t previous_batch_first_row_number_;
+        mutable int64_t cursor_ = 0;
+        KeyValueDataFileRecordReader* reader_ = nullptr;
+    };
+
+    Result<std::unique_ptr<KeyValueRecordReader::Iterator>> NextBatch() override;
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return reader_->GetReaderMetrics();
+    }
+
+    void Close() override {
+        Reset();
+        reader_->Close();
+    }
+
+    // virtual for test
+    virtual void Reset();
+
+ private:
+    int32_t level_;
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<FileBatchReader> reader_;
+    std::shared_ptr<arrow::Schema> key_schema_;
+    std::shared_ptr<arrow::Schema> value_schema_;
+    std::vector<std::string> value_names_;
+    RoaringBitmap32 selection_bitmap_;
+    std::shared_ptr<arrow::NumericArray<arrow::Int64Type>> sequence_number_array_;
+    std::shared_ptr<arrow::NumericArray<arrow::Int8Type>> row_kind_array_;
+
+ protected:
+    std::shared_ptr<ColumnarBatchContext> key_ctx_;
+    std::shared_ptr<ColumnarBatchContext> value_ctx_;
+};
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_data_file_record_reader_test.cpp
+++ b/src/paimon/core/io/key_value_data_file_record_reader_test.cpp
@@ -1,0 +1,459 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/key_value_data_file_record_reader.h"
+
+#include <utility>
+#include <variant>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/mock/mock_file_batch_reader.h"
+#include "paimon/testing/mock/mock_key_value_data_file_record_reader.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class KeyValueDataFileRecordReaderTest : public testing::Test {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+TEST_F(KeyValueDataFileRecordReaderTest, TestSimple) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, 30],
+        [0, 1, 1, 2, 11, 21, 31],
+        [1, 2, 2, 2, 12, 22, 32],
+        [2, 3, 2, 3, 13, 23, 33]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected;
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/0, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 1}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 1, 10, 20, 30}, pool_.get()));
+    expected.emplace_back(
+        RowKind::UpdateBefore(), /*sequence_number=*/0, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 2, 11, 21, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::UpdateAfter(), /*sequence_number=*/1, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 12, 22, 32}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Delete(), /*sequence_number=*/2, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 3}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 3, 13, 23, 33}, pool_.get()));
+
+    for (auto batch_size : {1, 2, 3, 4, 100}) {
+        auto file_batch_reader =
+            std::make_unique<MockFileBatchReader>(src_array, src_type, /*batch_size=*/batch_size);
+        auto record_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+            std::move(file_batch_reader), key_schema, value_schema, /*level=*/2, pool_);
+        ASSERT_OK_AND_ASSIGN(
+            auto results,
+            (ReadResultCollector::CollectKeyValueResult<KeyValueDataFileRecordReader,
+                                                        KeyValueRecordReader::Iterator>(
+                record_reader.get())));
+        KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2, /*value_arity=*/5);
+    }
+}
+
+TEST_F(KeyValueDataFileRecordReaderTest, TestValueSchemaContainsPartialKey) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, 30],
+        [0, 1, 1, 2, 11, 21, 31],
+        [1, 2, 2, 2, 12, 22, 32],
+        [2, 3, 2, 3, 13, 23, 33]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected;
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/0, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 1}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 10, 20, 30}, pool_.get()));
+    expected.emplace_back(
+        RowKind::UpdateBefore(), /*sequence_number=*/0, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 11, 21, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::UpdateAfter(), /*sequence_number=*/1, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 12, 22, 32}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Delete(), /*sequence_number=*/2, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 3}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({3, 13, 23, 33}, pool_.get()));
+
+    for (auto batch_size : {1, 2, 3, 4, 100}) {
+        auto file_batch_reader =
+            std::make_unique<MockFileBatchReader>(src_array, src_type, /*batch_size=*/batch_size);
+        auto record_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+            std::move(file_batch_reader), key_schema, value_schema, /*level=*/2, pool_);
+        ASSERT_OK_AND_ASSIGN(
+            auto results,
+            (ReadResultCollector::CollectKeyValueResult<KeyValueDataFileRecordReader,
+                                                        KeyValueRecordReader::Iterator>(
+                record_reader.get())));
+        KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2, /*value_arity=*/4);
+    }
+}
+
+TEST_F(KeyValueDataFileRecordReaderTest, TestWithSelectedBitmap) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, 30],
+        [1, 0, 1, 2, 11, 21, 31],
+        [2, 1, 2, 2, 12, 22, 32],
+        [3, 2, 2, 3, 13, 23, 33],
+        [5, 0, 3, 3, 14, 24, 34],
+        [8, 0, 3, 4, 15, 25, 35],
+        [4, 1, 5, 4, 16, 26, 36],
+        [6, 3, 6, 5, 17, 27, 37]
+    ])")
+            .ValueOrDie());
+
+    auto get_all_key_values = [&]() {
+        std::vector<KeyValue> all_values;
+        all_values.emplace_back(
+            RowKind::Insert(), /*sequence_number=*/0, /*level=*/2,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 1}, pool_.get()),
+            /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 1, 10, 20, 30}, pool_.get()));
+        all_values.emplace_back(
+            RowKind::Insert(), /*sequence_number=*/1, /*level=*/2,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 2}, pool_.get()),
+            /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 2, 11, 21, 31}, pool_.get()));
+        all_values.emplace_back(
+            RowKind::UpdateBefore(), /*sequence_number=*/2, /*level=*/2,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+            /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 12, 22, 32}, pool_.get()));
+        all_values.emplace_back(
+            RowKind::UpdateAfter(), /*sequence_number=*/3, /*level=*/2,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 3}, pool_.get()),
+            /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 3, 13, 23, 33}, pool_.get()));
+        all_values.emplace_back(
+            RowKind::Insert(), /*sequence_number=*/5, /*level=*/2,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({3, 3}, pool_.get()),
+            /*value=*/BinaryRowGenerator::GenerateRowPtr({3, 3, 14, 24, 34}, pool_.get()));
+        all_values.emplace_back(
+            RowKind::Insert(), /*sequence_number=*/8, /*level=*/2,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({3, 4}, pool_.get()),
+            /*value=*/BinaryRowGenerator::GenerateRowPtr({3, 4, 15, 25, 35}, pool_.get()));
+        all_values.emplace_back(
+            RowKind::UpdateBefore(), /*sequence_number=*/4, /*level=*/2,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({5, 4}, pool_.get()),
+            /*value=*/BinaryRowGenerator::GenerateRowPtr({5, 4, 16, 26, 36}, pool_.get()));
+        all_values.emplace_back(
+            RowKind::Delete(), /*sequence_number=*/6, /*level=*/2,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({6, 5}, pool_.get()),
+            /*value=*/BinaryRowGenerator::GenerateRowPtr({6, 5, 17, 27, 37}, pool_.get()));
+        return all_values;
+    };
+
+    auto check_result = [&](const std::vector<int32_t>& selected_rows) -> void {
+        RoaringBitmap32 selected_bitmap = RoaringBitmap32::From(selected_rows);
+        for (auto batch_size : {1, 2, 3, 4, 100}) {
+            auto file_batch_reader = std::make_unique<MockFileBatchReader>(
+                src_array, src_type, /*bitmap=*/selected_bitmap, /*batch_size=*/batch_size);
+            auto record_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+                std::move(file_batch_reader), key_schema, value_schema, /*level=*/2, pool_);
+            ASSERT_OK_AND_ASSIGN(
+                auto results,
+                (ReadResultCollector::CollectKeyValueResult<KeyValueDataFileRecordReader,
+                                                            KeyValueRecordReader::Iterator>(
+                    record_reader.get())));
+            std::vector<KeyValue> all_values = get_all_key_values();
+            std::vector<KeyValue> expected;
+            for (const auto& row : selected_rows) {
+                expected.push_back(std::move(all_values[row]));
+            }
+            KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2,
+                                         /*value_arity=*/5);
+        }
+    };
+    // check result with selected bitmap
+    check_result({0, 1, 2, 3, 4, 5, 6, 7});
+    check_result({0, 1, 2, 6, 7});
+    check_result({1, 2, 4, 6});
+    check_result({0, 2, 4, 6});
+    check_result({1, 3, 5, 7});
+    check_result({3, 4, 5});
+    check_result({3});
+}
+
+TEST_F(KeyValueDataFileRecordReaderTest, TestWithSelectedBitmapWithFilePos) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, 30],
+        [1, 0, 1, 2, 11, 21, 31],
+        [2, 1, 2, 2, 12, 22, 32],
+        [3, 2, 2, 3, 13, 23, 33],
+        [5, 0, 3, 3, 14, 24, 34],
+        [8, 0, 3, 4, 15, 25, 35],
+        [4, 1, 5, 4, 16, 26, 36],
+        [6, 3, 6, 5, 17, 27, 37]
+    ])")
+            .ValueOrDie());
+
+    RoaringBitmap32 selected_bitmap = RoaringBitmap32::From({1, 2, 4, 6});
+    auto file_batch_reader = std::make_unique<MockFileBatchReader>(
+        src_array, src_type, /*bitmap=*/selected_bitmap, /*batch_size=*/4);
+    file_batch_reader->EnableRandomizeBatchSize(false);
+    auto record_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+        std::move(file_batch_reader), key_schema, value_schema, /*level=*/2, pool_);
+
+    auto check_result = [](const std::vector<int64_t>& expected_pos_vector,
+                           KeyValueRecordReader::Iterator* iter) {
+        auto typed_iter = dynamic_cast<KeyValueDataFileRecordReader::Iterator*>(iter);
+        ASSERT_TRUE(typed_iter);
+        size_t pos_iter = 0;
+        while (true) {
+            ASSERT_OK_AND_ASSIGN(bool has_next, iter->HasNext());
+            if (!has_next) {
+                break;
+            }
+            ASSERT_OK_AND_ASSIGN(auto kv_and_pos, typed_iter->NextWithFilePos());
+            const auto& [pos, kv] = kv_and_pos;
+            ASSERT_EQ(pos, expected_pos_vector[pos_iter++]);
+        }
+        ASSERT_EQ(pos_iter, expected_pos_vector.size());
+    };
+
+    // first read row 1, 2
+    ASSERT_OK_AND_ASSIGN(auto iter, record_reader->NextBatch());
+    check_result({1, 2}, iter.get());
+
+    // second read row 4, 6
+    ASSERT_OK_AND_ASSIGN(iter, record_reader->NextBatch());
+    check_result({4, 6}, iter.get());
+
+    // eof
+    ASSERT_OK_AND_ASSIGN(iter, record_reader->NextBatch());
+    ASSERT_FALSE(iter);
+}
+TEST_F(KeyValueDataFileRecordReaderTest, TestEmptyReader) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+    ])")
+            .ValueOrDie());
+    auto file_batch_reader =
+        std::make_unique<MockFileBatchReader>(src_array, src_type, /*batch_size=*/2);
+    auto record_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+        std::move(file_batch_reader), key_schema, value_schema, /*level=*/2, pool_);
+
+    ASSERT_OK_AND_ASSIGN(
+        auto results, (ReadResultCollector::CollectKeyValueResult<KeyValueDataFileRecordReader,
+                                                                  KeyValueRecordReader::Iterator>(
+                          record_reader.get())));
+    ASSERT_TRUE(results.empty());
+}
+
+TEST_F(KeyValueDataFileRecordReaderTest, TestInvalidSequenceNumerColumn) {
+    // _SEQUENCE_NUMBER must be int64
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::utf8()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        ["0", 0, 1, 1, 10, 20, 30]
+    ])")
+            .ValueOrDie());
+    auto file_batch_reader =
+        std::make_unique<MockFileBatchReader>(src_array, src_type, /*batch_size=*/2);
+    auto record_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+        std::move(file_batch_reader), key_schema, value_schema, /*level=*/2, pool_);
+    ASSERT_NOK_WITH_MSG((ReadResultCollector::CollectKeyValueResult<KeyValueDataFileRecordReader,
+                                                                    KeyValueRecordReader::Iterator>(
+                            record_reader.get())),
+                        "cannot cast SEQUENCE_NUMBER column to int64 arrow array");
+}
+
+TEST_F(KeyValueDataFileRecordReaderTest, TestInvalidValueKindColumn) {
+    // VALUE_KIND must in {0, 1, 2, 3}
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 100, 1, 1, 10, 20, 30]
+    ])")
+            .ValueOrDie());
+    auto file_batch_reader =
+        std::make_unique<MockFileBatchReader>(src_array, src_type, /*batch_size=*/2);
+    auto record_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+        std::move(file_batch_reader), key_schema, value_schema, /*level=*/2, pool_);
+    ASSERT_NOK_WITH_MSG((ReadResultCollector::CollectKeyValueResult<KeyValueDataFileRecordReader,
+                                                                    KeyValueRecordReader::Iterator>(
+                            record_reader.get())),
+                        "Unsupported byte value 100 for row kind.");
+}
+TEST_F(KeyValueDataFileRecordReaderTest, TestKeyFieldAfterValueField) {
+    // Key fields (k0, k1) are placed after value fields (v0, v1, v2) in the struct layout.
+    // This verifies that KeyValueDataFileRecordReader correctly locates fields by name
+    // regardless of their physical position in the struct.
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int32()),
+                                 arrow::field("v2", arrow::int32()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("k1", arrow::int32())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[5], fields[6]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[5], fields[6], fields[2], fields[3], fields[4]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+
+    // Data layout: [seq, kind, v0, v1, v2, k0, k1]
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 10, 20, 30, 1, 1],
+        [0, 1, 11, 21, 31, 1, 2],
+        [1, 2, 12, 22, 32, 2, 2],
+        [2, 3, 13, 23, 33, 2, 3]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected;
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/0, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 1}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 1, 10, 20, 30}, pool_.get()));
+    expected.emplace_back(
+        RowKind::UpdateBefore(), /*sequence_number=*/0, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 2, 11, 21, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::UpdateAfter(), /*sequence_number=*/1, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 12, 22, 32}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Delete(), /*sequence_number=*/2, /*level=*/2,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 3}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 3, 13, 23, 33}, pool_.get()));
+
+    for (auto batch_size : {1, 2, 3, 4, 100}) {
+        auto file_batch_reader =
+            std::make_unique<MockFileBatchReader>(src_array, src_type, /*batch_size=*/batch_size);
+        auto record_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+            std::move(file_batch_reader), key_schema, value_schema, /*level=*/2, pool_);
+        ASSERT_OK_AND_ASSIGN(
+            auto results,
+            (ReadResultCollector::CollectKeyValueResult<KeyValueDataFileRecordReader,
+                                                        KeyValueRecordReader::Iterator>(
+                record_reader.get())));
+        KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2, /*value_arity=*/5);
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/key_value_in_memory_record_reader.cpp
+++ b/src/paimon/core/io/key_value_in_memory_record_reader.cpp
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/key_value_in_memory_record_reader.h"
+
+#include <cassert>
+#include <utility>
+
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/array/array_primitive.h"
+#include "arrow/compute/api.h"
+#include "arrow/compute/ordering.h"
+#include "arrow/util/checked_cast.h"
+#include "fmt/format.h"
+#include "paimon/common/data/columnar/columnar_row_ref.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/common/utils/arrow/arrow_utils.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/status.h"
+namespace paimon {
+class MemoryPool;
+
+Result<KeyValue> KeyValueInMemoryRecordReader::Iterator::Next() {
+    uint64_t index = reader_->sort_indices_->Value(cursor_++);
+    const RowKind* row_kind = RowKind::Insert();
+    if (!reader_->row_kinds_.empty()) {
+        PAIMON_ASSIGN_OR_RAISE(
+            row_kind, RowKind::FromByteValue(static_cast<int8_t>(reader_->row_kinds_[index])));
+    }
+
+    // key must hold value_struct_array as min/max key may be used after projection
+    auto key = std::make_unique<ColumnarRowRef>(reader_->key_ctx_, index);
+    auto value = std::make_unique<ColumnarRowRef>(reader_->value_ctx_, index);
+    return KeyValue(row_kind, reader_->last_sequence_num_ + index,
+                    /*level=*/KeyValue::UNKNOWN_LEVEL, std::move(key), std::move(value));
+}
+
+KeyValueInMemoryRecordReader::KeyValueInMemoryRecordReader(
+    int64_t last_sequence_num, const std::shared_ptr<arrow::StructArray>& struct_array,
+    const std::vector<RecordBatch::RowKind>& row_kinds,
+    const std::vector<std::string>& primary_keys,
+    const std::vector<std::string>& user_defined_sequence_fields, bool sequence_fields_ascending,
+    const std::shared_ptr<FieldsComparator>& key_comparator,
+    const std::shared_ptr<MemoryPool>& pool)
+    : last_sequence_num_(last_sequence_num),
+      primary_keys_(primary_keys),
+      user_defined_sequence_fields_(user_defined_sequence_fields),
+      sequence_fields_ascending_(sequence_fields_ascending),
+      pool_(pool),
+      arrow_pool_(GetArrowPool(pool)),
+      value_struct_array_(struct_array),
+      row_kinds_(row_kinds),
+      key_comparator_(key_comparator) {
+    assert(value_struct_array_);
+    ArrowUtils::TraverseArray(value_struct_array_);
+}
+
+Result<std::unique_ptr<KeyValueRecordReader::Iterator>> KeyValueInMemoryRecordReader::NextBatch() {
+    if (visited_) {
+        return std::unique_ptr<KeyValueInMemoryRecordReader::Iterator>();
+    }
+    visited_ = true;
+    arrow::ArrayVector key_fields;
+    key_fields.reserve(primary_keys_.size());
+    for (const auto& key : primary_keys_) {
+        auto key_array = value_struct_array_->GetFieldByName(key);
+        if (!key_array) {
+            return Status::Invalid(fmt::format("cannot find field {} in data batch", key));
+        }
+        key_fields.emplace_back(key_array);
+    }
+    arrow::ArrayVector value_fields;
+    value_fields.reserve(value_struct_array_->num_fields());
+    for (int32_t i = 0; i < value_struct_array_->num_fields(); i++) {
+        value_fields.push_back(value_struct_array_->field(i));
+    }
+    key_ctx_ = std::make_shared<ColumnarBatchContext>(key_fields, pool_);
+    value_ctx_ = std::make_shared<ColumnarBatchContext>(value_fields, pool_);
+
+    PAIMON_ASSIGN_OR_RAISE(sort_indices_, SortBatch());
+    return std::make_unique<KeyValueInMemoryRecordReader::Iterator>(this);
+}
+
+void KeyValueInMemoryRecordReader::Close() {
+    visited_ = true;
+    value_struct_array_.reset();
+    row_kinds_.clear();
+    sort_indices_.reset();
+    key_ctx_.reset();
+    value_ctx_.reset();
+}
+
+Result<std::shared_ptr<arrow::NumericArray<arrow::UInt64Type>>>
+KeyValueInMemoryRecordReader::SortBatch() const {
+    std::vector<arrow::compute::SortKey> sort_keys;
+    sort_keys.reserve(primary_keys_.size() + user_defined_sequence_fields_.size());
+    for (const auto& name : primary_keys_) {
+        sort_keys.emplace_back(name, arrow::compute::SortOrder::Ascending);
+    }
+    const auto sequence_sort_order = sequence_fields_ascending_
+                                         ? arrow::compute::SortOrder::Ascending
+                                         : arrow::compute::SortOrder::Descending;
+    for (const auto& name : user_defined_sequence_fields_) {
+        sort_keys.emplace_back(name, sequence_sort_order);
+    }
+    auto sort_options =
+        arrow::compute::SortOptions(sort_keys, arrow::compute::NullPlacement::AtStart);
+    arrow::compute::ExecContext exec_context(arrow_pool_.get());
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> sorted_indices,
+                                      arrow::compute::SortIndices(arrow::Datum(value_struct_array_),
+                                                                  sort_options, &exec_context));
+    auto typed_indices =
+        arrow::internal::checked_pointer_cast<arrow::NumericArray<arrow::UInt64Type>>(
+            sorted_indices);
+    if (!typed_indices) {
+        return Status::Invalid("cannot cast sorted indices to UInt64Array");
+    }
+    return typed_indices;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_in_memory_record_reader.h
+++ b/src/paimon/core/io/key_value_in_memory_record_reader.h
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/array/array_primitive.h"
+#include "paimon/common/metrics/metrics_impl.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/io/key_value_record_reader.h"
+#include "paimon/core/key_value.h"
+#include "paimon/record_batch.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+struct ColumnarBatchContext;
+class FieldsComparator;
+class MemoryPool;
+class Metrics;
+
+class KeyValueInMemoryRecordReader : public KeyValueRecordReader {
+ public:
+    KeyValueInMemoryRecordReader(int64_t last_sequence_num,
+                                 const std::shared_ptr<arrow::StructArray>& struct_array,
+                                 const std::vector<RecordBatch::RowKind>& row_kinds,
+                                 const std::vector<std::string>& primary_keys,
+                                 const std::vector<std::string>& user_defined_sequence_fields,
+                                 bool sequence_fields_ascending,
+                                 const std::shared_ptr<FieldsComparator>& key_comparator,
+                                 const std::shared_ptr<MemoryPool>& pool);
+
+    class Iterator : public KeyValueRecordReader::Iterator {
+     public:
+        explicit Iterator(KeyValueInMemoryRecordReader* reader) : reader_(reader) {}
+        Result<bool> HasNext() const override {
+            return cursor_ < reader_->value_struct_array_->length();
+        }
+        Result<KeyValue> Next() override;
+
+     private:
+        int64_t cursor_ = 0;
+        KeyValueInMemoryRecordReader* reader_ = nullptr;
+    };
+
+    Result<std::unique_ptr<KeyValueRecordReader::Iterator>> NextBatch() override;
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return std::make_shared<MetricsImpl>();
+    }
+
+    void Close() override;
+
+ private:
+    Result<std::shared_ptr<arrow::NumericArray<arrow::UInt64Type>>> SortBatch() const;
+
+ private:
+    bool visited_ = false;
+    int64_t last_sequence_num_ = -1;
+    std::vector<std::string> primary_keys_;
+    std::vector<std::string> user_defined_sequence_fields_;
+    bool sequence_fields_ascending_ = true;
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::shared_ptr<arrow::StructArray> value_struct_array_;
+    std::vector<RecordBatch::RowKind> row_kinds_;
+    std::shared_ptr<FieldsComparator> key_comparator_;
+
+    std::shared_ptr<arrow::NumericArray<arrow::UInt64Type>> sort_indices_;
+    std::shared_ptr<ColumnarBatchContext> key_ctx_;
+    std::shared_ptr<ColumnarBatchContext> value_ctx_;
+};
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_in_memory_record_reader_test.cpp
+++ b/src/paimon/core/io/key_value_in_memory_record_reader_test.cpp
@@ -1,0 +1,531 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/key_value_in_memory_record_reader.h"
+
+#include <map>
+#include <utility>
+#include <variant>
+
+#include "arrow/api.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class KeyValueInMemoryRecordReaderTest : public testing::Test {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+    }
+
+    void TearDown() override {
+        pool_.reset();
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+TEST_F(KeyValueInMemoryRecordReaderTest, TestSimple) {
+    std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::int32())),
+                                     DataField(1, arrow::field("k1", arrow::int32())),
+                                     DataField(2, arrow::field("v0", arrow::int32())),
+                                     DataField(3, arrow::field("v1", arrow::int32())),
+                                     DataField(4, arrow::field("v2", arrow::int32()))};
+
+    std::shared_ptr<arrow::DataType> src_type =
+        DataField::ConvertDataFieldsToArrowStructType(fields);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [1, 2, 11, 21, 31],
+        [1, 1, 10, 20, 30],
+        [2, 3, 13, 23, 33],
+        [2, 2, 12, 22, 32]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected;
+    expected.emplace_back(
+        RowKind::UpdateBefore(), /*sequence_number=*/1, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 1}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 1, 10, 20, 30}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/0, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 2, 11, 21, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Delete(), /*sequence_number=*/3, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 12, 22, 32}, pool_.get()));
+    expected.emplace_back(
+        RowKind::UpdateAfter(), /*sequence_number=*/2, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 3}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 3, 13, 23, 33}, pool_.get()));
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({fields[0], fields[1]},
+                                                  /*is_ascending_order=*/true));
+
+    auto record_reader = std::make_unique<KeyValueInMemoryRecordReader>(
+        /*last_sequence_num=*/0, src_array,
+        std::vector<RecordBatch::RowKind>(
+            {RecordBatch::RowKind::INSERT, RecordBatch::RowKind::UPDATE_BEFORE,
+             RecordBatch::RowKind::UPDATE_AFTER, RecordBatch::RowKind::DELETE}),
+        std::vector<std::string>({"k0", "k1"}),
+        /*user_defined_sequence_fields=*/std::vector<std::string>(),
+        /*sequence_fields_ascending=*/true, key_comparator, pool_);
+    ASSERT_OK_AND_ASSIGN(
+        auto results, (ReadResultCollector::CollectKeyValueResult<KeyValueInMemoryRecordReader,
+                                                                  KeyValueRecordReader::Iterator>(
+                          record_reader.get())));
+    KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2, /*value_arity=*/5);
+
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<KeyValueRecordReader::Iterator> eof_iter,
+                         record_reader->NextBatch());
+    ASSERT_FALSE(eof_iter);
+    auto metrics = record_reader->GetReaderMetrics();
+    ASSERT_TRUE(metrics);
+    ASSERT_EQ(0, metrics->GetAllCounters().size());
+}
+
+TEST_F(KeyValueInMemoryRecordReaderTest, TestUserDefinedSequenceFields) {
+    std::vector<DataField> fields = {DataField(0, arrow::field("k1", arrow::int32())),
+                                     DataField(1, arrow::field("k0", arrow::int32())),
+                                     DataField(2, arrow::field("v0", arrow::int32())),
+                                     DataField(3, arrow::field("s1", arrow::int32())),
+                                     DataField(4, arrow::field("s0", arrow::int32()))};
+
+    std::shared_ptr<arrow::DataType> src_type =
+        DataField::ConvertDataFieldsToArrowStructType(fields);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [2, 2, 11, 21, 31],
+        [1, 2, 11, 21, 31],
+        [1, 1, 10, 20, 30],
+        [2, 2, 11, 21, null],
+        [2, 3, 13, 23, 33],
+        [2, 2, 11, 22, 31],
+        [2, 2, 12, 22, 32]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected;
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/2, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 1}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 1, 10, 20, 30}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/1, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 1}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 2, 11, 21, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/3, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/
+        BinaryRowGenerator::GenerateRowPtr({2, 2, 11, 21, std::monostate()}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/0, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 11, 21, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/5, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 11, 22, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/6, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 12, 22, 32}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/4, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({3, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 3, 13, 23, 33}, pool_.get()));
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({fields[1], fields[0]},
+                                                  /*is_ascending_order=*/true));
+
+    auto record_reader = std::make_unique<KeyValueInMemoryRecordReader>(
+        /*last_sequence_num=*/0, src_array, std::vector<RecordBatch::RowKind>(),
+        std::vector<std::string>({"k0", "k1"}),
+        /*user_defined_sequence_fields=*/std::vector<std::string>({"s0", "s1"}),
+        /*sequence_fields_ascending=*/true, key_comparator, pool_);
+    ASSERT_OK_AND_ASSIGN(
+        auto results, (ReadResultCollector::CollectKeyValueResult<KeyValueInMemoryRecordReader,
+                                                                  KeyValueRecordReader::Iterator>(
+                          record_reader.get())));
+    KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2, /*value_arity=*/5);
+}
+
+TEST_F(KeyValueInMemoryRecordReaderTest, TestUserDefinedSequenceFieldsDescending) {
+    std::vector<DataField> fields = {DataField(0, arrow::field("k1", arrow::int32())),
+                                     DataField(1, arrow::field("k0", arrow::int32())),
+                                     DataField(2, arrow::field("v0", arrow::int32())),
+                                     DataField(3, arrow::field("s1", arrow::int32())),
+                                     DataField(4, arrow::field("s0", arrow::int32()))};
+
+    std::shared_ptr<arrow::DataType> src_type =
+        DataField::ConvertDataFieldsToArrowStructType(fields);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [2, 2, 11, 21, 31],
+        [1, 2, 11, 21, 31],
+        [1, 1, 10, 20, 30],
+        [2, 2, 11, 21, null],
+        [2, 3, 13, 23, 33],
+        [2, 2, 11, 22, 31],
+        [2, 2, 12, 22, 32]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected;
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/2, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 1}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 1, 10, 20, 30}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/1, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 1}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 2, 11, 21, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/3, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/
+        BinaryRowGenerator::GenerateRowPtr({2, 2, 11, 21, std::monostate()}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/6, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 12, 22, 32}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/5, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 11, 22, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/0, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 2, 11, 21, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/4, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({3, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 3, 13, 23, 33}, pool_.get()));
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({fields[1], fields[0]},
+                                                  /*is_ascending_order=*/true));
+
+    auto record_reader = std::make_unique<KeyValueInMemoryRecordReader>(
+        /*last_sequence_num=*/0, src_array, std::vector<RecordBatch::RowKind>(),
+        std::vector<std::string>({"k0", "k1"}),
+        /*user_defined_sequence_fields=*/std::vector<std::string>({"s0", "s1"}),
+        /*sequence_fields_ascending=*/false, key_comparator, pool_);
+    ASSERT_OK_AND_ASSIGN(
+        auto results, (ReadResultCollector::CollectKeyValueResult<KeyValueInMemoryRecordReader,
+                                                                  KeyValueRecordReader::Iterator>(
+                          record_reader.get())));
+    KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2, /*value_arity=*/5);
+}
+
+TEST_F(KeyValueInMemoryRecordReaderTest, TestNonExistPK) {
+    std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::int32())),
+                                     DataField(1, arrow::field("k1", arrow::int32())),
+                                     DataField(2, arrow::field("v0", arrow::int32())),
+                                     DataField(3, arrow::field("v1", arrow::int32())),
+                                     DataField(4, arrow::field("v2", arrow::int32()))};
+
+    std::shared_ptr<arrow::DataType> src_type =
+        DataField::ConvertDataFieldsToArrowStructType(fields);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [1, 2, 11, 21, 31],
+        [1, 1, 10, 20, 30],
+        [2, 3, 13, 23, 33],
+        [2, 2, 12, 22, 32]
+    ])")
+            .ValueOrDie());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({fields[0], fields[1]},
+                                                  /*is_ascending_order=*/true));
+
+    auto record_reader = std::make_unique<KeyValueInMemoryRecordReader>(
+        /*last_sequence_num=*/0, src_array, std::vector<RecordBatch::RowKind>(),
+        std::vector<std::string>({"non_exist_key"}),
+        /*user_defined_sequence_fields=*/std::vector<std::string>(),
+        /*sequence_fields_ascending=*/true, key_comparator, pool_);
+    ASSERT_NOK_WITH_MSG((ReadResultCollector::CollectKeyValueResult<KeyValueInMemoryRecordReader,
+                                                                    KeyValueRecordReader::Iterator>(
+                            record_reader.get())),
+                        "cannot find field non_exist_key");
+}
+
+TEST_F(KeyValueInMemoryRecordReaderTest, TestStableSortWithDuplicateKeys) {
+    std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::int32())),
+                                     DataField(1, arrow::field("k1", arrow::int32())),
+                                     DataField(2, arrow::field("v0", arrow::int32())),
+                                     DataField(3, arrow::field("v1", arrow::int32())),
+                                     DataField(4, arrow::field("v2", arrow::int32()))};
+
+    std::shared_ptr<arrow::DataType> src_type =
+        DataField::ConvertDataFieldsToArrowStructType(fields);
+
+    // the first row and the last row are both k0,k1: 1, 2, as stable sort, the first row will be
+    // return before the last
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [1, 2, 11, 21, 31],
+        [1, 1, 10, 20, 30],
+        [2, 3, 13, 23, 33],
+        [1, 2, 12, 22, 32]
+    ])")
+            .ValueOrDie());
+
+    std::vector<KeyValue> expected;
+    expected.emplace_back(
+        RowKind::UpdateBefore(), /*sequence_number=*/1, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 1}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 1, 10, 20, 30}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Insert(), /*sequence_number=*/0, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 2, 11, 21, 31}, pool_.get()));
+    expected.emplace_back(
+        RowKind::Delete(), /*sequence_number=*/3, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({1, 2}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({1, 2, 12, 22, 32}, pool_.get()));
+    expected.emplace_back(
+        RowKind::UpdateAfter(), /*sequence_number=*/2, /*level=*/KeyValue::UNKNOWN_LEVEL,
+        /*key=*/BinaryRowGenerator::GenerateRowPtr({2, 3}, pool_.get()),
+        /*value=*/BinaryRowGenerator::GenerateRowPtr({2, 3, 13, 23, 33}, pool_.get()));
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({fields[0], fields[1]},
+                                                  /*is_ascending_order=*/true));
+
+    auto record_reader = std::make_unique<KeyValueInMemoryRecordReader>(
+        /*last_sequence_num=*/0, src_array,
+        std::vector<RecordBatch::RowKind>(
+            {RecordBatch::RowKind::INSERT, RecordBatch::RowKind::UPDATE_BEFORE,
+             RecordBatch::RowKind::UPDATE_AFTER, RecordBatch::RowKind::DELETE}),
+        std::vector<std::string>({"k0", "k1"}),
+        /*user_defined_sequence_fields=*/std::vector<std::string>(),
+        /*sequence_fields_ascending=*/true, key_comparator, pool_);
+    ASSERT_OK_AND_ASSIGN(
+        auto results, (ReadResultCollector::CollectKeyValueResult<KeyValueInMemoryRecordReader,
+                                                                  KeyValueRecordReader::Iterator>(
+                          record_reader.get())));
+    KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2, /*value_arity=*/5);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<KeyValueRecordReader::Iterator> eof_iter,
+                         record_reader->NextBatch());
+    ASSERT_FALSE(eof_iter);
+}
+
+TEST_F(KeyValueInMemoryRecordReaderTest, TestVariantType) {
+    // test null, repeated key, sequence fields, out of order in variant data type
+    // precondition: fields[0] is key fields, fields[1] is sequence field, src_array are like:
+    // (k2>k1, s2>s1) [k2, s2, 11, 21, 31], [k1, s1, 10, 20, 30], [k2, s1, 13, 23, 33], [k1, null,
+    // 12, 22, 32]
+    auto CheckVariantType = [&](const std::vector<DataField>& fields,
+                                std::shared_ptr<arrow::StructArray>&& src_array,
+                                const BinaryRowGenerator::ValueType& key,
+                                const BinaryRowGenerator::ValueType& sequence) {
+        std::vector<KeyValue> expected;
+        expected.emplace_back(RowKind::Insert(), /*sequence_number=*/3,
+                              /*level=*/KeyValue::UNKNOWN_LEVEL,
+                              /*key=*/BinaryRowGenerator::GenerateRowPtr({key[0]}, pool_.get()),
+                              /*value=*/
+                              BinaryRowGenerator::GenerateRowPtr(
+                                  {key[0], std::monostate{}, 12, 22, 32}, pool_.get()));
+        expected.emplace_back(
+            RowKind::Insert(), /*sequence_number=*/1, /*level=*/KeyValue::UNKNOWN_LEVEL,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({key[0]}, pool_.get()),
+            /*value=*/
+            BinaryRowGenerator::GenerateRowPtr({key[0], sequence[0], 10, 20, 30}, pool_.get()));
+        expected.emplace_back(
+            RowKind::Insert(), /*sequence_number=*/2, /*level=*/KeyValue::UNKNOWN_LEVEL,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({key[1]}, pool_.get()),
+            /*value=*/
+            BinaryRowGenerator::GenerateRowPtr({key[1], sequence[0], 13, 23, 33}, pool_.get()));
+        expected.emplace_back(
+            RowKind::Insert(), /*sequence_number=*/0, /*level=*/KeyValue::UNKNOWN_LEVEL,
+            /*key=*/BinaryRowGenerator::GenerateRowPtr({key[1]}, pool_.get()),
+            /*value=*/
+            BinaryRowGenerator::GenerateRowPtr({key[1], sequence[1], 11, 21, 31}, pool_.get()));
+
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                             FieldsComparator::Create({fields[0]},
+                                                      /*is_ascending_order=*/true));
+
+        auto record_reader = std::make_unique<KeyValueInMemoryRecordReader>(
+            /*last_sequence_num=*/0, src_array, std::vector<RecordBatch::RowKind>(),
+            std::vector<std::string>({"k0"}),
+            /*user_defined_sequence_fields=*/std::vector<std::string>({"s0"}),
+            /*sequence_fields_ascending=*/true, key_comparator, pool_);
+        ASSERT_OK_AND_ASSIGN(
+            auto results,
+            (ReadResultCollector::CollectKeyValueResult<KeyValueInMemoryRecordReader,
+                                                        KeyValueRecordReader::Iterator>(
+                record_reader.get())));
+        KeyValueChecker::CheckResult(expected, results,
+                                     /*key_fields=*/{fields[0]},
+                                     /*value_fields=*/fields);
+    };
+    {
+        // test int8 and int16
+        std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::int8())),
+                                         DataField(1, arrow::field("s0", arrow::int16())),
+                                         DataField(2, arrow::field("v0", arrow::int32())),
+                                         DataField(3, arrow::field("v1", arrow::int32())),
+                                         DataField(4, arrow::field("v2", arrow::int32()))};
+
+        auto src_type = DataField::ConvertDataFieldsToArrowStructType(fields);
+        auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [2, 2, 11, 21, 31],
+        [1, 1, 10, 20, 30],
+        [2, 1, 13, 23, 33],
+        [1, null, 12, 22, 32]
+    ])")
+                .ValueOrDie());
+        CheckVariantType(fields, std::move(src_array),
+                         {static_cast<int8_t>(1), static_cast<int8_t>(2)},
+                         {static_cast<int16_t>(1), static_cast<int16_t>(2)});
+    }
+    {
+        // test int32 and int64
+        std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::int32())),
+                                         DataField(1, arrow::field("s0", arrow::int64())),
+                                         DataField(2, arrow::field("v0", arrow::int32())),
+                                         DataField(3, arrow::field("v1", arrow::int32())),
+                                         DataField(4, arrow::field("v2", arrow::int32()))};
+
+        auto src_type = DataField::ConvertDataFieldsToArrowStructType(fields);
+        auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [2, 2, 11, 21, 31],
+        [1, 1, 10, 20, 30],
+        [2, 1, 13, 23, 33],
+        [1, null, 12, 22, 32]
+    ])")
+                .ValueOrDie());
+        CheckVariantType(fields, std::move(src_array),
+                         {static_cast<int32_t>(1), static_cast<int32_t>(2)},
+                         {static_cast<int64_t>(1), static_cast<int64_t>(2)});
+    }
+    {
+        // test float and double
+        std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::float32())),
+                                         DataField(1, arrow::field("s0", arrow::float64())),
+                                         DataField(2, arrow::field("v0", arrow::int32())),
+                                         DataField(3, arrow::field("v1", arrow::int32())),
+                                         DataField(4, arrow::field("v2", arrow::int32()))};
+
+        auto src_type = DataField::ConvertDataFieldsToArrowStructType(fields);
+        auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [2.1, 2.12, 11, 21, 31],
+        [1.1, 1.12, 10, 20, 30],
+        [2.1, 1.12, 13, 23, 33],
+        [1.1, null, 12, 22, 32]
+    ])")
+                .ValueOrDie());
+        CheckVariantType(fields, std::move(src_array),
+                         {static_cast<float>(1.1), static_cast<float>(2.1)}, {1.12, 2.12});
+    }
+    {
+        // test string and binary
+        std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::utf8())),
+                                         DataField(1, arrow::field("s0", arrow::binary())),
+                                         DataField(2, arrow::field("v0", arrow::int32())),
+                                         DataField(3, arrow::field("v1", arrow::int32())),
+                                         DataField(4, arrow::field("v2", arrow::int32()))};
+
+        auto src_type = DataField::ConvertDataFieldsToArrowStructType(fields);
+        auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        ["2.1", "2.12", 11, 21, 31],
+        ["1.1", "1.12", 10, 20, 30],
+        ["2.1", "1.12", 13, 23, 33],
+        ["1.1", null, 12, 22, 32]
+    ])")
+                .ValueOrDie());
+
+        CheckVariantType(fields, std::move(src_array), {std::string("1.1"), std::string("2.1")},
+                         {std::make_shared<Bytes>("1.12", pool_.get()),
+                          std::make_shared<Bytes>("2.12", pool_.get())});
+    }
+    {
+        // test date and bool
+        std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::date32())),
+                                         DataField(1, arrow::field("s0", arrow::boolean())),
+                                         DataField(2, arrow::field("v0", arrow::int32())),
+                                         DataField(3, arrow::field("v1", arrow::int32())),
+                                         DataField(4, arrow::field("v2", arrow::int32()))};
+
+        auto src_type = DataField::ConvertDataFieldsToArrowStructType(fields);
+        auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [2, true, 11, 21, 31],
+        [1, false, 10, 20, 30],
+        [2, false, 13, 23, 33],
+        [1, null, 12, 22, 32]
+    ])")
+                .ValueOrDie());
+        CheckVariantType(fields, std::move(src_array),
+                         {static_cast<int32_t>(1), static_cast<int32_t>(2)}, {false, true});
+    }
+    {
+        // test timestamp and decimal
+        std::vector<DataField> fields = {
+            DataField(0, arrow::field("k0", arrow::timestamp(arrow::TimeUnit::NANO))),
+            DataField(1, arrow::field("s0", arrow::decimal128(5, 3))),
+            DataField(2, arrow::field("v0", arrow::int32())),
+            DataField(3, arrow::field("v1", arrow::int32())),
+            DataField(4, arrow::field("v2", arrow::int32()))};
+
+        auto src_type = DataField::ConvertDataFieldsToArrowStructType(fields);
+        auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        ["2033-05-18 03:33:20.0", "12.345", 11, 21, 31],
+        ["1923-05-18 03:33:20.0", "-12.345", 10, 20, 30],
+        ["2033-05-18 03:33:20.0", "-12.345", 13, 23, 33],
+        ["1923-05-18 03:33:20.0", null, 12, 22, 32]
+    ])")
+                .ValueOrDie());
+        CheckVariantType(fields, std::move(src_array),
+                         {TimestampType(Timestamp(-1471379200000l, 0), 9),
+                          TimestampType(Timestamp(2000000000000l, 0), 9)},
+                         {Decimal(5, 3, -12345), Decimal(5, 3, 12345)});
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/key_value_record_reader.h
+++ b/src/paimon/core/io/key_value_record_reader.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "paimon/core/key_value.h"
+#include "paimon/metrics.h"
+#include "paimon/result.h"
+namespace paimon {
+class KeyValueRecordReader {
+ public:
+    virtual ~KeyValueRecordReader() = default;
+
+    class Iterator {
+     public:
+        virtual ~Iterator() = default;
+        virtual Result<bool> HasNext() const = 0;
+        virtual Result<KeyValue> Next() = 0;
+    };
+
+    virtual Result<std::unique_ptr<KeyValueRecordReader::Iterator>> NextBatch() = 0;
+
+    virtual std::shared_ptr<Metrics> GetReaderMetrics() const = 0;
+
+    virtual void Close() = 0;
+};
+}  // namespace paimon

--- a/src/paimon/core/io/merged_key_value_record_reader.cpp
+++ b/src/paimon/core/io/merged_key_value_record_reader.cpp
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/merged_key_value_record_reader.h"
+
+#include <cassert>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "paimon/common/utils/fields_comparator.h"
+
+namespace paimon {
+
+MergedKeyValueRecordReader::MergedKeyValueRecordReader(
+    std::unique_ptr<KeyValueRecordReader>&& reader,
+    const std::shared_ptr<FieldsComparator>& key_comparator,
+    const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper)
+    : reader_(std::move(reader)),
+      key_comparator_(key_comparator),
+      merge_function_wrapper_(merge_function_wrapper) {
+    assert(reader_ != nullptr);
+    assert(key_comparator_ != nullptr);
+    assert(merge_function_wrapper_ != nullptr);
+}
+
+Result<bool> MergedKeyValueRecordReader::Iterator::HasNext() const {
+    if (merged_key_value_.has_value()) {
+        return true;
+    }
+    return PrepareNextMergedKeyValue();
+}
+
+Result<KeyValue> MergedKeyValueRecordReader::Iterator::Next() {
+    if (!merged_key_value_.has_value()) {
+        return Status::Invalid("No more merged key values in current iterator");
+    }
+
+    KeyValue result = std::move(*merged_key_value_);
+    merged_key_value_.reset();
+    return result;
+}
+
+Result<bool> MergedKeyValueRecordReader::Iterator::PrepareNextMergedKeyValue() const {
+    while (true) {
+        PAIMON_ASSIGN_OR_RAISE(bool has_next, MergeNextKey());
+        if (!has_next) {
+            return false;
+        }
+        // if merged_key_value_ is empty(maybe all filtered out), continue to fetch next key and
+        // merge until we get a non-empty merged result or no more keys
+        if (merged_key_value_.has_value()) {
+            return true;
+        }
+    }
+}
+
+Result<bool> MergedKeyValueRecordReader::Iterator::MergeNextKey() const {
+    PAIMON_RETURN_NOT_OK(LoadNextRawKeyValue());
+    if (!next_raw_key_value_.has_value()) {
+        return false;
+    }
+
+    reader_->merge_function_wrapper_->Reset();
+    auto current_key = next_raw_key_value_->key;
+
+    do {
+        PAIMON_RETURN_NOT_OK(
+            reader_->merge_function_wrapper_->Add(std::move(*next_raw_key_value_)));
+        next_raw_key_value_.reset();
+        PAIMON_RETURN_NOT_OK(LoadNextRawKeyValue());
+    } while (next_raw_key_value_.has_value() &&
+             reader_->key_comparator_->CompareTo(*current_key, *next_raw_key_value_->key) == 0);
+
+    PAIMON_ASSIGN_OR_RAISE(std::optional<KeyValue> result,
+                           reader_->merge_function_wrapper_->GetResult());
+    merged_key_value_ = std::move(result);
+    return true;
+}
+
+Status MergedKeyValueRecordReader::Iterator::LoadNextRawKeyValue() const {
+    if (next_raw_key_value_.has_value()) {
+        return Status::OK();
+    }
+
+    while (true) {
+        if (current_iterator_ != nullptr) {
+            PAIMON_ASSIGN_OR_RAISE(bool has_next, current_iterator_->HasNext());
+            if (has_next) {
+                PAIMON_ASSIGN_OR_RAISE(KeyValue key_value, current_iterator_->Next());
+                next_raw_key_value_.emplace(std::move(key_value));
+                return Status::OK();
+            }
+        }
+
+        current_iterator_.reset();
+        PAIMON_ASSIGN_OR_RAISE(current_iterator_, reader_->reader_->NextBatch());
+        if (current_iterator_ == nullptr) {
+            return Status::OK();
+        }
+    }
+}
+
+Result<std::unique_ptr<KeyValueRecordReader::Iterator>> MergedKeyValueRecordReader::NextBatch() {
+    if (visited_) {
+        return std::unique_ptr<KeyValueRecordReader::Iterator>();
+    }
+    visited_ = true;
+
+    auto iterator = std::make_unique<Iterator>(this);
+    PAIMON_ASSIGN_OR_RAISE(bool has_next, iterator->HasNext());
+    if (!has_next) {
+        return std::unique_ptr<KeyValueRecordReader::Iterator>();
+    }
+    return iterator;
+}
+
+std::shared_ptr<Metrics> MergedKeyValueRecordReader::GetReaderMetrics() const {
+    return reader_->GetReaderMetrics();
+}
+
+void MergedKeyValueRecordReader::Close() {
+    visited_ = true;
+    reader_->Close();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/merged_key_value_record_reader.h
+++ b/src/paimon/core/io/merged_key_value_record_reader.h
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+
+#include "paimon/core/io/key_value_record_reader.h"
+#include "paimon/core/mergetree/compact/merge_function_wrapper.h"
+
+namespace paimon {
+class FieldsComparator;
+
+/// Merges consecutive key-value records with the same primary key from the wrapped reader.
+/// The wrapped reader must return records ordered by primary key, so all records for the same
+/// primary key are contiguous.
+class MergedKeyValueRecordReader : public KeyValueRecordReader {
+ public:
+    MergedKeyValueRecordReader(
+        std::unique_ptr<KeyValueRecordReader>&& reader,
+        const std::shared_ptr<FieldsComparator>& key_comparator,
+        const std::shared_ptr<MergeFunctionWrapper<KeyValue>>& merge_function_wrapper);
+
+    class Iterator : public KeyValueRecordReader::Iterator {
+     public:
+        explicit Iterator(MergedKeyValueRecordReader* reader) : reader_(reader) {}
+
+        Result<bool> HasNext() const override;
+
+        Result<KeyValue> Next() override;
+
+     private:
+        Result<bool> PrepareNextMergedKeyValue() const;
+        Result<bool> MergeNextKey() const;
+        Status LoadNextRawKeyValue() const;
+
+     private:
+        MergedKeyValueRecordReader* reader_;
+        mutable std::unique_ptr<KeyValueRecordReader::Iterator> current_iterator_;
+        // Lookahead raw kv used to detect the boundary between two keys.
+        mutable std::optional<KeyValue> next_raw_key_value_;
+        // Merged kv prepared by HasNext() and consumed by Next().
+        mutable std::optional<KeyValue> merged_key_value_;
+    };
+
+    Result<std::unique_ptr<KeyValueRecordReader::Iterator>> NextBatch() override;
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override;
+
+    void Close() override;
+
+ private:
+    bool visited_ = false;
+    std::unique_ptr<KeyValueRecordReader> reader_;
+    std::shared_ptr<FieldsComparator> key_comparator_;
+    std::shared_ptr<MergeFunctionWrapper<KeyValue>> merge_function_wrapper_;
+};
+}  // namespace paimon

--- a/src/paimon/core/io/merged_key_value_record_reader_test.cpp
+++ b/src/paimon/core/io/merged_key_value_record_reader_test.cpp
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/merged_key_value_record_reader.h"
+
+#include <memory>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
+#include "paimon/core/mergetree/compact/reducer_merge_function_wrapper.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/mock/mock_file_batch_reader.h"
+#include "paimon/testing/mock/mock_key_value_data_file_record_reader.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class MergedKeyValueRecordReaderTest : public testing::Test {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+        auto mfunc = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/false);
+        merge_function_wrapper_ = std::make_shared<ReducerMergeFunctionWrapper>(std::move(mfunc));
+    }
+
+ protected:
+    std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<ReducerMergeFunctionWrapper> merge_function_wrapper_;
+};
+
+TEST_F(MergedKeyValueRecordReaderTest, TestMergeAcrossUnderlyingBatches) {
+    std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::int32())),
+                                     DataField(1, arrow::field("k1", arrow::int32())),
+                                     DataField(2, arrow::field("v0", arrow::int32())),
+                                     DataField(3, arrow::field("v1", arrow::int32())),
+                                     DataField(4, arrow::field("v2", arrow::int32()))};
+
+    auto value_schema = DataField::ConvertDataFieldsToArrowSchema(fields);
+    auto arrow_fields = value_schema->fields();
+    auto key_schema = arrow::schema({arrow_fields[0], arrow_fields[1]});
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_(SpecialFields::CompleteSequenceAndValueKindField(value_schema)->fields());
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, 30],
+        [1, 0, 1, 1, 11, 21, 31],
+        [2, 0, 2, 2, 12, 22, 32],
+        [3, 0, 2, 2, 13, 23, 33]
+    ])")
+            .ValueOrDie());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({fields[0], fields[1]},
+                                                  /*is_ascending_order=*/true));
+
+    auto expected = KeyValueChecker::GenerateKeyValues(
+        /*seq_vec=*/{1, 3}, /*key_vec=*/{{1, 1}, {2, 2}},
+        /*value_vec=*/{{1, 1, 11, 21, 31}, {2, 2, 13, 23, 33}}, pool_);
+
+    for (auto batch_size : {1, 2, 3}) {
+        auto file_batch_reader = std::make_unique<MockFileBatchReader>(src_array, src_type,
+                                                                       /*batch_size=*/batch_size);
+        auto raw_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+            std::move(file_batch_reader), key_schema, value_schema, /*level=*/0, pool_);
+        auto merged_reader = std::make_unique<MergedKeyValueRecordReader>(
+            std::move(raw_reader), key_comparator, merge_function_wrapper_);
+
+        ASSERT_OK_AND_ASSIGN(
+            auto results,
+            (ReadResultCollector::CollectKeyValueResult<
+                MergedKeyValueRecordReader, KeyValueRecordReader::Iterator>(merged_reader.get())));
+        KeyValueChecker::CheckResult(expected, results, /*key_arity=*/2, /*value_arity=*/5);
+    }
+}
+
+TEST_F(MergedKeyValueRecordReaderTest, TestSkipMergedNulloptResultInHasNext) {
+    auto mfunc = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/true);
+    auto merge_function_wrapper = std::make_shared<ReducerMergeFunctionWrapper>(std::move(mfunc));
+
+    std::vector<DataField> fields = {DataField(0, arrow::field("k0", arrow::int32())),
+                                     DataField(1, arrow::field("v0", arrow::int32()))};
+
+    auto value_schema = DataField::ConvertDataFieldsToArrowSchema(fields);
+    auto arrow_fields = value_schema->fields();
+    auto key_schema = arrow::schema({arrow_fields[0]});
+    std::shared_ptr<arrow::DataType> src_type =
+        arrow::struct_(SpecialFields::CompleteSequenceAndValueKindField(value_schema)->fields());
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 3, 1, 10],
+        [3, 3, 1, 11],
+        [2, 3, 2, 200],
+        [4, 3, 2, 240],
+        [1, 0, 3, 300],
+        [5, 3, 3, 30]
+    ])")
+            .ValueOrDie());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({fields[0]}, /*is_ascending_order=*/true));
+
+    auto expected = KeyValueChecker::GenerateKeyValues(
+        /*seq_vec=*/{1}, /*key_vec=*/{{3}}, /*value_vec=*/{{3, 300}}, pool_);
+
+    for (auto batch_size : {1, 2, 3}) {
+        auto file_batch_reader =
+            std::make_unique<MockFileBatchReader>(src_array, src_type, /*batch_size=*/batch_size);
+        auto raw_reader = std::make_unique<MockKeyValueDataFileRecordReader>(
+            std::move(file_batch_reader), key_schema, value_schema, /*level=*/0, pool_);
+        auto merged_reader = std::make_unique<MergedKeyValueRecordReader>(
+            std::move(raw_reader), key_comparator, merge_function_wrapper);
+
+        ASSERT_OK_AND_ASSIGN(
+            auto results,
+            (ReadResultCollector::CollectKeyValueResult<
+                MergedKeyValueRecordReader, KeyValueRecordReader::Iterator>(merged_reader.get())));
+        KeyValueChecker::CheckResult(expected, results, /*key_arity=*/1, /*value_arity=*/2);
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/meta_to_arrow_array_converter.cpp
+++ b/src/paimon/core/io/meta_to_arrow_array_converter.cpp
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "paimon/core/io/meta_to_arrow_array_converter.h"
+
+namespace paimon {
+Result<std::unique_ptr<MetaToArrowArrayConverter>> MetaToArrowArrayConverter::Create(
+    const std::shared_ptr<arrow::DataType>& meta_data_type,
+    const std::shared_ptr<MemoryPool>& pool) {
+    auto struct_type = std::dynamic_pointer_cast<arrow::StructType>(meta_data_type);
+    if (!struct_type) {
+        return Status::Invalid("meta_data_type in MetaToArrowArrayConverter must be struct type");
+    }
+    auto arrow_pool = GetArrowPool(pool);
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::MakeBuilder(
+        arrow_pool.get(), arrow::struct_(struct_type->fields()), &array_builder));
+
+    auto struct_builder =
+        arrow::internal::checked_pointer_cast<arrow::StructBuilder>(std::move(array_builder));
+    assert(struct_builder);
+    std::vector<RowToArrowArrayConverter::AppendValueFunc> appenders;
+    appenders.reserve(struct_type->num_fields());
+    // first is the root struct array
+    int32_t reserve_count = 1;
+    for (int32_t i = 0; i < struct_type->num_fields(); i++) {
+        PAIMON_ASSIGN_OR_RAISE(
+            RowToArrowArrayConverter::AppendValueFunc func,
+            AppendField(/*use_view=*/true, struct_builder->field_builder(i), &reserve_count));
+        appenders.emplace_back(func);
+    }
+    return std::unique_ptr<MetaToArrowArrayConverter>(new MetaToArrowArrayConverter(
+        reserve_count, std::move(appenders), std::move(struct_builder), std::move(arrow_pool)));
+}
+
+Result<std::shared_ptr<arrow::Array>> MetaToArrowArrayConverter::NextBatch(
+    const std::vector<BinaryRow>& meta_rows) {
+    PAIMON_RETURN_NOT_OK(ResetAndReserve());
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        array_builder_->AppendValues(meta_rows.size(), /*valid_bytes=*/nullptr));
+    for (size_t i = 0; i < appenders_.size(); i++) {
+        for (const auto& row : meta_rows) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(appenders_[i](row, i));
+        }
+    }
+
+    std::shared_ptr<arrow::Array> array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(array_builder_->Finish(&array));
+
+    int32_t reserve_idx = 0;
+    PAIMON_RETURN_NOT_OK(Accumulate(array.get(), &reserve_idx));
+    return array;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/meta_to_arrow_array_converter.h
+++ b/src/paimon/core/io/meta_to_arrow_array_converter.h
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/core/io/row_to_arrow_array_converter.h"
+#include "paimon/result.h"
+namespace arrow {
+class MemoryPool;
+class Schema;
+class StructBuilder;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+
+/// Project meta (e.g., manifest) from BinaryRow to arrow array.
+class MetaToArrowArrayConverter
+    : public RowToArrowArrayConverter<BinaryRow, std::shared_ptr<arrow::Array>> {
+ public:
+    static Result<std::unique_ptr<MetaToArrowArrayConverter>> Create(
+        const std::shared_ptr<arrow::DataType>& meta_data_type,
+        const std::shared_ptr<MemoryPool>& pool);
+
+    Result<std::shared_ptr<arrow::Array>> NextBatch(
+        const std::vector<BinaryRow>& meta_rows) override;
+
+ private:
+    MetaToArrowArrayConverter(int32_t reserve_count, std::vector<AppendValueFunc>&& appenders,
+                              std::unique_ptr<arrow::StructBuilder>&& array_builder,
+                              std::unique_ptr<arrow::MemoryPool>&& arrow_pool)
+        : RowToArrowArrayConverter(reserve_count, std::move(appenders), std::move(array_builder),
+                                   std::move(arrow_pool)) {}
+};
+}  // namespace paimon


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

Migrate record reader interface, implementations, and IO utility modules:

Record readers (`src/paimon/core/io/`):
- `KeyValueRecordReader` — abstract record reader interface (`key_value_record_reader.h`)
- `KeyValueDataFileRecordReader` — data file backed key-value reader (`key_value_data_file_record_reader.h/cpp`)
- `KeyValueInMemoryRecordReader` — in-memory key-value reader (`key_value_in_memory_record_reader.h/cpp`)
- `ConcatKeyValueRecordReader` — concatenating multiple readers sequentially (`concat_key_value_record_reader.h`)
- `MergedKeyValueRecordReader` — merge-sorted reader over multiple inputs (`merged_key_value_record_reader.h/cpp`)

IO utilities (`src/paimon/core/io/`):
- `FileIndexEvaluator` — file index predicate evaluation for data file pruning (`file_index_evaluator.h/cpp`)
- `CompleteRowTrackingFieldsReader` — completes row tracking fields during read (`complete_row_tracking_fields_reader.h/cpp`)
- `MetaToArrowArrayConverter` — converts file metadata to Arrow arrays (`meta_to_arrow_array_converter.h/cpp`)

<!-- What is the purpose of the change -->

### Tests
- `key_value_data_file_record_reader_test.cpp` — data file reader round-trip, schema projection
- `key_value_in_memory_record_reader_test.cpp` — in-memory reader iteration, key-value ordering
- `concat_key_value_record_reader_test.cpp` — concatenation across multiple readers
- `merged_key_value_record_reader_test.cpp` — merge-sort correctness
- `file_index_evaluator_test.cpp` — predicate evaluation against file indexes
- `complete_row_tracking_fields_reader_test.cpp` — row tracking field completion
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Migrate-by: Aone Copilot (Claude)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
