### PR TITLE
feat: add core table metadata utilities

### DIFF
--- a/src/paimon/core/utils/batch_writer.h
+++ b/src/paimon/core/utils/batch_writer.h
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "paimon/result.h"
+
+struct ArrowArray;
+
+namespace paimon {
+
+class CommitIncrement;
+class RecordBatch;
+
+/// The BatchWriter is responsible for writing data and handling in-progress files used to
+/// write yet un-staged data. The incremental files ready to commit is returned to the system by the
+/// `PrepareCommit(bool)`.
+class BatchWriter {
+ public:
+    BatchWriter() = default;
+    virtual ~BatchWriter() = default;
+
+    /// Return current in-memory data usage in bytes
+    virtual uint64_t GetMemoryUsage() const = 0;
+
+    /// Flush in-memory data.
+    virtual Status FlushMemory() = 0;
+
+    /// Add a record batch to the writer.
+    virtual Status Write(std::unique_ptr<RecordBatch>&& batch) = 0;
+
+    /// Compact files related to the writer. Note that compaction process is only submitted and may
+    /// not be completed when the method returns.
+    ///
+    /// @param full_compaction whether to trigger full compaction or just normal compaction
+    virtual Status Compact(bool full_compaction) = 0;
+
+    /// Prepare for a commit.
+    ///
+    /// @param wait_compaction if this method need to wait for current compaction to complete
+    /// @return Incremental files in this snapshot cycle
+    virtual Result<CommitIncrement> PrepareCommit(bool wait_compaction) = 0;
+
+    /// Check if a compaction is in progress, or if a compaction result remains to be fetched, or if
+    /// a compaction should be triggered later.
+    virtual Result<bool> CompactNotCompleted() = 0;
+
+    /// Sync the writer. The structure related to file reading and writing is thread unsafe, there
+    /// are asynchronous threads inside the writer, which should be synced before reading data.
+    virtual Status Sync() = 0;
+
+    /// Close this writer, the call will delete newly generated but not committed files.
+    virtual Status Close() = 0;
+
+    virtual std::shared_ptr<Metrics> GetMetrics() const = 0;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/utils/branch_manager.h
+++ b/src/paimon/core/utils/branch_manager.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <string>
+
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/string_utils.h"
+
+namespace paimon {
+class BranchManager {
+ public:
+    BranchManager() = delete;
+    ~BranchManager() = delete;
+
+    static constexpr char DEFAULT_MAIN_BRANCH[] = "main";
+    static constexpr char BRANCH_PREFIX[] = "branch-";
+
+    static std::string NormalizeBranch(const std::string& branch) {
+        return StringUtils::IsNullOrWhitespaceOnly(branch) ? DEFAULT_MAIN_BRANCH : branch;
+    }
+
+    static std::string BranchPath(const std::string& table_root, const std::string& branch) {
+        return IsMainBranch(branch)
+                   ? table_root
+                   : PathUtil::JoinPath(table_root,
+                                        "/branch/" + std::string(BRANCH_PREFIX) + branch);
+    }
+
+    static bool IsMainBranch(const std::string& branch) {
+        return branch == DEFAULT_MAIN_BRANCH;
+    }
+};
+}  // namespace paimon

--- a/src/paimon/core/utils/branch_manager_test.cpp
+++ b/src/paimon/core/utils/branch_manager_test.cpp
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/branch_manager.h"
+
+#include "gtest/gtest.h"
+
+namespace paimon::test {
+TEST(BranchManagerTest, TestIsMainBranch) {
+    ASSERT_TRUE(BranchManager::IsMainBranch("main"));
+    ASSERT_TRUE(BranchManager::IsMainBranch(BranchManager::DEFAULT_MAIN_BRANCH));
+
+    ASSERT_FALSE(BranchManager::IsMainBranch("m a i n"));
+    ASSERT_FALSE(BranchManager::IsMainBranch(""));
+}
+
+TEST(BranchManagerTest, TestNormalizeBranch) {
+    ASSERT_EQ(BranchManager::NormalizeBranch(""), BranchManager::DEFAULT_MAIN_BRANCH);
+    ASSERT_EQ(BranchManager::NormalizeBranch("   "), BranchManager::DEFAULT_MAIN_BRANCH);
+
+    ASSERT_EQ(BranchManager::NormalizeBranch("data"), "data");
+    ASSERT_EQ(BranchManager::NormalizeBranch("d a t a"), "d a t a");
+}
+
+TEST(BranchManagerTest, TestBranchPath) {
+    ASSERT_EQ(BranchManager::BranchPath("/root", BranchManager::DEFAULT_MAIN_BRANCH), "/root");
+    ASSERT_EQ(BranchManager::BranchPath("/root", "data"), "/root/branch/branch-data");
+}
+}  // namespace paimon::test

--- a/src/paimon/core/utils/file_store_path_factory.cpp
+++ b/src/paimon/core/utils/file_store_path_factory.cpp
@@ -54,7 +54,7 @@ FileStorePathFactory::FileStorePathFactory(
       global_index_external_path_(global_index_external_path),
       index_file_in_data_file_dir_(index_file_in_data_file_dir) {}
 
-Result<std::unique_ptr<FileStorePathFactory>> FileStorePathFactory::Create(
+Result<std::shared_ptr<FileStorePathFactory>> FileStorePathFactory::Create(
     const std::string& root, const std::shared_ptr<arrow::Schema>& schema,
     const std::vector<std::string>& partition_keys, const std::string& default_part_value,
     const std::string& identifier, const std::string& data_file_prefix,
@@ -72,7 +72,7 @@ Result<std::unique_ptr<FileStorePathFactory>> FileStorePathFactory::Create(
         std::unique_ptr<BinaryRowPartitionComputer> partition_computer,
         BinaryRowPartitionComputer::Create(partition_keys, schema, default_part_value,
                                            legacy_partition_name_enabled, memory_pool));
-    return std::unique_ptr<FileStorePathFactory>(new FileStorePathFactory(
+    return std::shared_ptr<FileStorePathFactory>(new FileStorePathFactory(
         root, identifier, data_file_prefix, uuid, std::move(partition_computer), external_paths,
         global_index_external_path, index_file_in_data_file_dir));
 }
@@ -228,7 +228,7 @@ Result<std::string> FileStorePathFactory::GetPartitionString(const BinaryRow& pa
     std::vector<std::pair<std::string, std::string>> part_values;
     PAIMON_ASSIGN_OR_RAISE(part_values, partition_computer_->GeneratePartitionVector(partition));
     PAIMON_ASSIGN_OR_RAISE(std::string part_str,
-                           PartitionPathUtils::GeneratePartitionPath(part_values))
+                           PartitionPathUtils::GeneratePartitionPath(part_values));
     return row_to_str_cache_.insert({partition, part_str}).first->second;
 }
 

--- a/src/paimon/core/utils/file_store_path_factory.cpp
+++ b/src/paimon/core/utils/file_store_path_factory.cpp
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/file_store_path_factory.h"
+
+#include <cassert>
+
+#include "paimon/common/fs/external_path_provider.h"
+#include "paimon/common/memory/memory_segment.h"
+#include "paimon/common/utils/uuid.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/index/index_in_data_file_dir_path_factory.h"
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/core/table/bucket_mode.h"
+#include "paimon/core/utils/partition_path_utils.h"
+#include "paimon/core/utils/path_factory.h"
+#include "paimon/macros.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+
+FileStorePathFactory::FileStorePathFactory(
+    const std::string& root, const std::string& format_identifier,
+    const std::string& data_file_prefix, const std::string& uuid,
+    std::unique_ptr<BinaryRowPartitionComputer> partition_computer,
+    const std::vector<std::string>& external_paths,
+    const std::optional<std::string>& global_index_external_path, bool index_file_in_data_file_dir)
+    : root_(root),
+      format_identifier_(format_identifier),
+      data_file_prefix_(data_file_prefix),
+      uuid_(uuid),
+      partition_computer_(std::move(partition_computer)),
+      external_paths_(external_paths),
+      global_index_external_path_(global_index_external_path),
+      index_file_in_data_file_dir_(index_file_in_data_file_dir) {}
+
+Result<std::unique_ptr<FileStorePathFactory>> FileStorePathFactory::Create(
+    const std::string& root, const std::shared_ptr<arrow::Schema>& schema,
+    const std::vector<std::string>& partition_keys, const std::string& default_part_value,
+    const std::string& identifier, const std::string& data_file_prefix,
+    bool legacy_partition_name_enabled, const std::vector<std::string>& external_paths,
+    const std::optional<std::string>& global_index_external_path, bool index_file_in_data_file_dir,
+    const std::shared_ptr<MemoryPool>& memory_pool) {
+    if (memory_pool == nullptr) {
+        return Status::Invalid("memory pool is null pointer");
+    }
+    std::string uuid;
+    if (PAIMON_UNLIKELY(!UUID::Generate(&uuid))) {
+        return Status::Invalid("fail to generate uuid for file store path factory");
+    }
+    PAIMON_ASSIGN_OR_RAISE(
+        std::unique_ptr<BinaryRowPartitionComputer> partition_computer,
+        BinaryRowPartitionComputer::Create(partition_keys, schema, default_part_value,
+                                           legacy_partition_name_enabled, memory_pool));
+    return std::unique_ptr<FileStorePathFactory>(new FileStorePathFactory(
+        root, identifier, data_file_prefix, uuid, std::move(partition_computer), external_paths,
+        global_index_external_path, index_file_in_data_file_dir));
+}
+
+std::unique_ptr<PathFactory> FileStorePathFactory::CreateManifestFileFactory() {
+    class ManifestFileFactory : public PathFactory {
+     public:
+        explicit ManifestFileFactory(const std::shared_ptr<FileStorePathFactory>& factory)
+            : factory_(factory) {
+            assert(factory_);
+        }
+
+        std::string NewPath() const override {
+            return factory_->NewManifestFile();
+        }
+        std::string ToPath(const std::string& file_name) const override {
+            return factory_->ToManifestFilePath(file_name);
+        }
+
+     private:
+        std::shared_ptr<FileStorePathFactory> factory_ = nullptr;
+    };
+    return std::make_unique<ManifestFileFactory>(shared_from_this());
+}
+std::unique_ptr<PathFactory> FileStorePathFactory::CreateManifestListFactory() {
+    class ManifestListFactory : public PathFactory {
+     public:
+        explicit ManifestListFactory(const std::shared_ptr<FileStorePathFactory>& factory)
+            : factory_(factory) {
+            assert(factory_);
+        }
+
+        std::string NewPath() const override {
+            return factory_->NewManifestList();
+        }
+        std::string ToPath(const std::string& file_name) const override {
+            return factory_->ToManifestListPath(file_name);
+        }
+
+     private:
+        std::shared_ptr<FileStorePathFactory> factory_;
+    };
+    return std::make_unique<ManifestListFactory>(shared_from_this());
+}
+std::unique_ptr<PathFactory> FileStorePathFactory::CreateIndexManifestFileFactory() {
+    class IndexManifestFileFactory : public PathFactory {
+     public:
+        explicit IndexManifestFileFactory(const std::shared_ptr<FileStorePathFactory>& factory)
+            : factory_(factory) {
+            assert(factory_);
+        }
+
+        std::string NewPath() const override {
+            return factory_->NewIndexManifestFile();
+        }
+        std::string ToPath(const std::string& file_name) const override {
+            return factory_->ToManifestFilePath(file_name);
+        }
+
+     private:
+        std::shared_ptr<FileStorePathFactory> factory_;
+    };
+    return std::make_unique<IndexManifestFileFactory>(shared_from_this());
+}
+
+Result<std::unique_ptr<IndexPathFactory>> FileStorePathFactory::CreateIndexFileFactory(
+    const BinaryRow& partition, int32_t bucket) {
+    if (index_file_in_data_file_dir_) {
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<DataFilePathFactory> data_file_path_factory,
+                               CreateDataFilePathFactory(partition, bucket));
+        return std::make_unique<IndexInDataFileDirPathFactory>(uuid_, index_file_count_,
+                                                               data_file_path_factory);
+    }
+    return CreateGlobalIndexFileFactory();
+}
+
+std::unique_ptr<IndexPathFactory> FileStorePathFactory::CreateGlobalIndexFileFactory() {
+    class IndexPathFactoryImpl : public IndexPathFactory {
+     public:
+        explicit IndexPathFactoryImpl(const std::shared_ptr<FileStorePathFactory>& factory)
+            : factory_(factory) {
+            assert(factory_);
+        }
+        std::string NewPath() const override {
+            return factory_->NewIndexFile();
+        }
+        std::string ToPath(const std::shared_ptr<IndexFileMeta>& file) const override {
+            const auto& external_path = file->ExternalPath();
+            if (external_path) {
+                return external_path.value();
+            }
+            return PathUtil::JoinPath(factory_->IndexPath(factory_->RootPath()), file->FileName());
+        }
+        std::string ToPath(const std::string& file_name) const override {
+            const auto& external_path = factory_->GetGlobalIndexExternalPath();
+            if (external_path) {
+                return PathUtil::JoinPath(external_path.value(), file_name);
+            }
+            return PathUtil::JoinPath(factory_->IndexPath(factory_->RootPath()), file_name);
+        }
+        bool IsExternalPath() const override {
+            return factory_->GetGlobalIndexExternalPath() != std::nullopt;
+        }
+
+     private:
+        std::shared_ptr<FileStorePathFactory> factory_;
+    };
+    return std::make_unique<IndexPathFactoryImpl>(shared_from_this());
+}
+
+Result<std::shared_ptr<DataFilePathFactory>> FileStorePathFactory::CreateDataFilePathFactory(
+    const BinaryRow& partition, int32_t bucket) const {
+    auto data_file_path_factory = std::make_shared<DataFilePathFactory>();
+    PAIMON_ASSIGN_OR_RAISE(std::string bucket_path, BucketPath(partition, bucket));
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ExternalPathProvider> external_path_provider,
+                           CreateExternalPathProvider(partition, bucket));
+    PAIMON_RETURN_NOT_OK(data_file_path_factory->Init(
+        bucket_path, format_identifier_, data_file_prefix_, std::move(external_path_provider)));
+    return data_file_path_factory;
+}
+
+Result<std::unique_ptr<ExternalPathProvider>> FileStorePathFactory::CreateExternalPathProvider(
+    const BinaryRow& partition, int32_t bucket) const {
+    if (external_paths_.empty()) {
+        return std::unique_ptr<ExternalPathProvider>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::string bucket_path, RelativeBucketPath(partition, bucket));
+    return ExternalPathProvider::Create(external_paths_, bucket_path);
+}
+
+Result<std::string> FileStorePathFactory::RelativeBucketPath(const BinaryRow& partition,
+                                                             int32_t bucket) const {
+    PAIMON_ASSIGN_OR_RAISE(std::string partition_path, GetPartitionString(partition));
+    std::string bucket_name =
+        bucket == BucketModeDefine::POSTPONE_BUCKET ? "postpone" : std::to_string(bucket);
+    return PathUtil::JoinPath(partition_path, std::string(BUCKET_PATH_PREFIX) + bucket_name);
+}
+
+Result<std::string> FileStorePathFactory::BucketPath(const BinaryRow& partition,
+                                                     int32_t bucket) const {
+    PAIMON_ASSIGN_OR_RAISE(std::string relative_bucket_path, RelativeBucketPath(partition, bucket));
+    return PathUtil::JoinPath(root_, relative_bucket_path);
+}
+
+Result<std::string> FileStorePathFactory::GetPartitionString(const BinaryRow& partition) const {
+    if (partition.GetSizeInBytes() == 0) {
+        return Status::Invalid("invalid binary row partition");
+    }
+    auto iter = row_to_str_cache_.find(partition);
+    if (PAIMON_LIKELY(iter != row_to_str_cache_.end())) {
+        return iter->second;
+    }
+    std::vector<std::pair<std::string, std::string>> part_values;
+    PAIMON_ASSIGN_OR_RAISE(part_values, partition_computer_->GeneratePartitionVector(partition));
+    PAIMON_ASSIGN_OR_RAISE(std::string part_str,
+                           PartitionPathUtils::GeneratePartitionPath(part_values))
+    return row_to_str_cache_.insert({partition, part_str}).first->second;
+}
+
+Result<BinaryRow> FileStorePathFactory::ToBinaryRow(
+    const std::map<std::string, std::string>& partition) const {
+    auto iter = map_to_row_cache_.find(partition);
+    if (PAIMON_LIKELY(iter != map_to_row_cache_.end())) {
+        return iter->second;
+    }
+    PAIMON_ASSIGN_OR_RAISE(BinaryRow row, partition_computer_->ToBinaryRow(partition));
+    return map_to_row_cache_.insert({partition, row}).first->second;
+}
+
+Result<std::vector<std::string>> FileStorePathFactory::GetHierarchicalPartitionPath(
+    const BinaryRow& partition) const {
+    std::vector<std::pair<std::string, std::string>> part_values;
+    PAIMON_ASSIGN_OR_RAISE(part_values, partition_computer_->GeneratePartitionVector(partition));
+    std::vector<std::string> result;
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> relative_paths,
+                           PartitionPathUtils::GenerateHierarchicalPartitionPaths(part_values));
+    for (const auto& relative_path : relative_paths) {
+        result.push_back(PathUtil::JoinPath(root_, relative_path));
+    }
+    return result;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/utils/file_store_path_factory.h
+++ b/src/paimon/core/utils/file_store_path_factory.h
@@ -50,7 +50,7 @@ class FileStorePathFactory : public std::enable_shared_from_this<FileStorePathFa
  public:
     static constexpr char BUCKET_PATH_PREFIX[] = "bucket-";
 
-    static Result<std::unique_ptr<FileStorePathFactory>> Create(
+    static Result<std::shared_ptr<FileStorePathFactory>> Create(
         const std::string& root, const std::shared_ptr<arrow::Schema>& schema,
         const std::vector<std::string>& partition_keys, const std::string& default_part_value,
         const std::string& identifier, const std::string& data_file_prefix,

--- a/src/paimon/core/utils/file_store_path_factory.h
+++ b/src/paimon/core/utils/file_store_path_factory.h
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "arrow/c/bridge.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/binary_row_partition_computer.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/index/index_path_factory.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/type_fwd.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class DataFilePathFactory;
+class ExternalPathProvider;
+class PathFactory;
+class MemoryPool;
+
+class FileStorePathFactory : public std::enable_shared_from_this<FileStorePathFactory> {
+ public:
+    static constexpr char BUCKET_PATH_PREFIX[] = "bucket-";
+
+    static Result<std::unique_ptr<FileStorePathFactory>> Create(
+        const std::string& root, const std::shared_ptr<arrow::Schema>& schema,
+        const std::vector<std::string>& partition_keys, const std::string& default_part_value,
+        const std::string& identifier, const std::string& data_file_prefix,
+        bool legacy_partition_name_enabled, const std::vector<std::string>& external_paths,
+        const std::optional<std::string>& global_index_external_path,
+        bool index_file_in_data_file_dir, const std::shared_ptr<MemoryPool>& memory_pool);
+
+    static std::string ManifestPath(const std::string& root) {
+        return PathUtil::JoinPath(root, "/manifest");
+    }
+    static std::string IndexPath(const std::string& root) {
+        return PathUtil::JoinPath(root, "/index");
+    }
+    static std::string StatisticsPath(const std::string& root) {
+        return PathUtil::JoinPath(root, "/statistics");
+    }
+
+    std::unique_ptr<PathFactory> CreateManifestFileFactory();
+    std::unique_ptr<PathFactory> CreateManifestListFactory();
+    std::unique_ptr<PathFactory> CreateIndexManifestFileFactory();
+    Result<std::unique_ptr<IndexPathFactory>> CreateIndexFileFactory(const BinaryRow& partition,
+                                                                     int32_t bucket);
+    std::unique_ptr<IndexPathFactory> CreateGlobalIndexFileFactory();
+    Result<std::shared_ptr<DataFilePathFactory>> CreateDataFilePathFactory(
+        const BinaryRow& partition, int32_t bucket) const;
+    Result<BinaryRow> ToBinaryRow(const std::map<std::string, std::string>& partition) const;
+    Result<std::string> BucketPath(const BinaryRow& partition, int32_t bucket) const;
+    Result<std::string> RelativeBucketPath(const BinaryRow& partition, int32_t bucket) const;
+    Result<std::vector<std::pair<std::string, std::string>>> GeneratePartitionVector(
+        const BinaryRow& partition) const {
+        return partition_computer_->GeneratePartitionVector(partition);
+    }
+    Result<std::vector<std::string>> GetHierarchicalPartitionPath(const BinaryRow& partition) const;
+
+    const std::string& RootPath() const {
+        return root_;
+    }
+    const std::string& UUID() const {
+        return uuid_;
+    }
+    const std::vector<std::string>& GetExternalPaths() const {
+        return external_paths_;
+    }
+
+    const std::optional<std::string>& GetGlobalIndexExternalPath() const {
+        return global_index_external_path_;
+    }
+
+    /// @note This method is NOT THREAD SAFE.
+    Result<std::string> GetPartitionString(const BinaryRow& partition) const;
+    std::string NewManifestFile() const {
+        return PathUtil::JoinPath(
+            ManifestPath(root_),
+            "manifest-" + uuid_ + "-" + std::to_string(manifest_file_count_.fetch_add(1)));
+    }
+    std::string NewManifestList() const {
+        return PathUtil::JoinPath(
+            ManifestPath(root_),
+            "manifest-list-" + uuid_ + "-" + std::to_string(manifest_list_count_.fetch_add(1)));
+    }
+    std::string NewIndexManifestFile() const {
+        return PathUtil::JoinPath(
+            ManifestPath(root_),
+            "index-manifest-" + uuid_ + "-" + std::to_string(index_manifest_count_.fetch_add(1)));
+    }
+    std::string NewIndexFile() const {
+        return PathUtil::JoinPath(IndexPath(root_),
+                                  IndexPathFactory::INDEX_PREFIX + uuid_ + "-" +
+                                      std::to_string(index_file_count_->fetch_add(1)));
+    }
+    std::string NewStatsFile() const {
+        return PathUtil::JoinPath(
+            StatisticsPath(root_),
+            "stats-" + uuid_ + "-" + std::to_string(stats_file_count_.fetch_add(1)));
+    }
+    std::string ToManifestFilePath(const std::string& file_name) const {
+        return PathUtil::JoinPath(ManifestPath(root_), file_name);
+    }
+    std::string ToManifestListPath(const std::string& file_name) const {
+        return PathUtil::JoinPath(ManifestPath(root_), file_name);
+    }
+    std::string ToIndexFilePath(const std::string& file_name) const {
+        return PathUtil::JoinPath(IndexPath(root_), file_name);
+    }
+    std::string ToStatsFilePath(const std::string& file_name) const {
+        return PathUtil::JoinPath(StatisticsPath(root_), file_name);
+    }
+
+ private:
+    FileStorePathFactory(const std::string& root, const std::string& format_identifier,
+                         const std::string& data_file_prefix, const std::string& uuid,
+                         std::unique_ptr<BinaryRowPartitionComputer> partition_computer,
+                         const std::vector<std::string>& external_paths,
+                         const std::optional<std::string>& global_index_external_path,
+                         bool index_file_in_data_file_dir);
+
+    Result<std::unique_ptr<ExternalPathProvider>> CreateExternalPathProvider(
+        const BinaryRow& partition, int32_t bucket) const;
+
+ private:
+    std::string root_;
+    std::string format_identifier_;
+    std::string data_file_prefix_;
+    std::string uuid_;
+    std::unique_ptr<BinaryRowPartitionComputer> partition_computer_;
+    std::vector<std::string> external_paths_;
+    std::optional<std::string> global_index_external_path_;
+    bool index_file_in_data_file_dir_;
+
+    mutable std::atomic<int32_t> manifest_file_count_ = 0;
+    mutable std::atomic<int32_t> manifest_list_count_ = 0;
+    mutable std::atomic<int32_t> index_manifest_count_ = 0;
+    std::shared_ptr<std::atomic<int32_t>> index_file_count_ =
+        std::make_shared<std::atomic<int32_t>>(0);
+    mutable std::atomic<int32_t> stats_file_count_ = 0;
+
+    mutable std::map<std::map<std::string, std::string>, BinaryRow> map_to_row_cache_;
+    mutable std::unordered_map<BinaryRow, std::string> row_to_str_cache_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/utils/file_store_path_factory_cache.h
+++ b/src/paimon/core/utils/file_store_path_factory_cache.h
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "paimon/core/core_options.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+namespace paimon {
+class FileStorePathFactoryCache {
+ public:
+    FileStorePathFactoryCache(const std::string& root,
+                              const std::shared_ptr<TableSchema>& table_schema,
+                              const CoreOptions& options, const std::shared_ptr<MemoryPool>& pool)
+        : root_(root), table_schema_(table_schema), options_(options), pool_(pool) {}
+
+    Result<std::shared_ptr<FileStorePathFactory>> GetOrCreatePathFactory(
+        const std::string& format) {
+        auto iter = format_to_path_factory_.find(format);
+        if (iter != format_to_path_factory_.end()) {
+            return iter->second;
+        }
+        auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema_->Fields());
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> external_paths,
+                               options_.CreateExternalPaths());
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::string> global_index_external_path,
+                               options_.CreateGlobalIndexExternalPath());
+
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<FileStorePathFactory> path_factory,
+            FileStorePathFactory::Create(
+                root_, arrow_schema, table_schema_->PartitionKeys(),
+                options_.GetPartitionDefaultName(), format, options_.DataFilePrefix(),
+                options_.LegacyPartitionNameEnabled(), external_paths, global_index_external_path,
+                options_.IndexFileInDataFileDir(), pool_));
+        format_to_path_factory_[format] = path_factory;
+        return path_factory;
+    }
+
+    const std::string& RootPath() const {
+        return root_;
+    }
+
+ private:
+    std::string root_;
+    std::shared_ptr<TableSchema> table_schema_;
+    CoreOptions options_;
+    std::shared_ptr<MemoryPool> pool_;
+    std::map<std::string, std::shared_ptr<FileStorePathFactory>> format_to_path_factory_;
+};
+}  // namespace paimon

--- a/src/paimon/core/utils/file_store_path_factory_cache_test.cpp
+++ b/src/paimon/core/utils/file_store_path_factory_cache_test.cpp
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/file_store_path_factory_cache.h"
+
+#include "gtest/gtest.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(FileStorePathFactoryCacheTest, TestSimple) {
+    std::vector<DataField> fields = {DataField(0, arrow::field("f0", arrow::int32())),
+                                     DataField(1, arrow::field("f1", arrow::utf8()))};
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<TableSchema> table_schema,
+        TableSchema::InitSchema(/*schema_id=*/0, fields, /*highest_field_id=*/fields.size(),
+                                /*partition_keys=*/{},
+                                /*primary_keys=*/{}, /*options=*/{}, /*comment=*/std::nullopt,
+                                /*time_millis=*/0));
+
+    ASSERT_OK_AND_ASSIGN(auto options, CoreOptions::FromMap({}));
+    FileStorePathFactoryCache cache("/test_root/", table_schema, options, GetDefaultPool());
+
+    ASSERT_EQ(cache.format_to_path_factory_.size(), 0);
+
+    ASSERT_OK_AND_ASSIGN(auto factory, cache.GetOrCreatePathFactory("orc"));
+    ASSERT_TRUE(factory);
+    ASSERT_EQ(factory->format_identifier_, "orc");
+    ASSERT_EQ(cache.format_to_path_factory_.size(), 1);
+
+    ASSERT_OK_AND_ASSIGN(factory, cache.GetOrCreatePathFactory("parquet"));
+    ASSERT_TRUE(factory);
+    ASSERT_EQ(factory->format_identifier_, "parquet");
+    ASSERT_EQ(cache.format_to_path_factory_.size(), 2);
+
+    ASSERT_OK_AND_ASSIGN(factory, cache.GetOrCreatePathFactory("orc"));
+    ASSERT_TRUE(factory);
+    ASSERT_EQ(factory->format_identifier_, "orc");
+    ASSERT_EQ(cache.format_to_path_factory_.size(), 2);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/utils/file_store_path_factory_test.cpp
+++ b/src/paimon/core/utils/file_store_path_factory_test.cpp
@@ -43,7 +43,7 @@ class FileStorePathFactoryTest : public ::testing::Test {
     }
     void TearDown() override {}
 
-    std::unique_ptr<FileStorePathFactory> CreateFactory(const std::string& root) const {
+    std::shared_ptr<FileStorePathFactory> CreateFactory(const std::string& root) const {
         arrow::FieldVector fields = {arrow::field("f0", arrow::boolean()),
                                      arrow::field("f1", arrow::int8()),
                                      arrow::field("f2", arrow::int8()),

--- a/src/paimon/core/utils/file_store_path_factory_test.cpp
+++ b/src/paimon/core/utils/file_store_path_factory_test.cpp
@@ -1,0 +1,497 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/file_store_path_factory.h"
+
+#include <optional>
+#include <variant>
+
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/common/data/data_define.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/defs.h"
+#include "paimon/format/file_format.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class FileStorePathFactoryTest : public ::testing::Test {
+ public:
+    void SetUp() override {
+        mem_pool_ = GetDefaultPool();
+    }
+    void TearDown() override {}
+
+    std::unique_ptr<FileStorePathFactory> CreateFactory(const std::string& root) const {
+        arrow::FieldVector fields = {arrow::field("f0", arrow::boolean()),
+                                     arrow::field("f1", arrow::int8()),
+                                     arrow::field("f2", arrow::int8()),
+                                     arrow::field("f3", arrow::int16()),
+                                     arrow::field("f4", arrow::int16()),
+                                     arrow::field("f5", arrow::int32()),
+                                     arrow::field("f6", arrow::int32()),
+                                     arrow::field("f7", arrow::int64()),
+                                     arrow::field("f8", arrow::int64()),
+                                     arrow::field("f9", arrow::float32()),
+                                     arrow::field("f10", arrow::float64()),
+                                     arrow::field("f11", arrow::utf8()),
+                                     arrow::field("f12", arrow::binary()),
+                                     arrow::field("non-partition-field", arrow::int32())};
+        auto schema = arrow::schema(fields);
+
+        std::map<std::string, std::string> raw_options;
+        raw_options[Options::FILE_FORMAT] = "mock_format";
+        raw_options[Options::MANIFEST_FORMAT] = "mock_format";
+        raw_options[Options::FILE_SYSTEM] = "local";
+        EXPECT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap(raw_options));
+        EXPECT_OK_AND_ASSIGN(std::vector<std::string> external_paths,
+                             options.CreateExternalPaths());
+        EXPECT_OK_AND_ASSIGN(auto path_factory,
+                             FileStorePathFactory::Create(
+                                 root, schema, {"f0", "f3"}, options.GetPartitionDefaultName(),
+                                 options.GetFileFormat()->Identifier(), options.DataFilePrefix(),
+                                 options.LegacyPartitionNameEnabled(), external_paths,
+                                 /*global_index_external_path=*/std::nullopt,
+                                 options.IndexFileInDataFileDir(), mem_pool_));
+        return path_factory;
+    }
+
+    void CheckPartition(const std::optional<int64_t>& dt, const std::optional<int32_t> hr,
+                        const FileStorePathFactory& path_factory,
+                        const std::string& expected) const {
+        BinaryRow partition(2);
+        BinaryRowWriter writer(&partition, 1024, mem_pool_.get());
+        if (dt != std::nullopt) {
+            writer.WriteLong(0, dt.value());
+        } else {
+            writer.SetNullAt(0);
+        }
+        if (hr != std::nullopt) {
+            writer.WriteInt(1, hr.value());
+        } else {
+            writer.SetNullAt(1);
+        }
+        writer.Complete();
+        ASSERT_OK_AND_ASSIGN(auto data_file_path_factory,
+                             path_factory.CreateDataFilePathFactory(partition, 123));
+        ASSERT_EQ(data_file_path_factory->ToPath("my-data-file-name"),
+                  path_factory.root_ + expected + "/bucket-123/my-data-file-name");
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> mem_pool_;
+};
+
+TEST_F(FileStorePathFactoryTest, TestManifestPaths) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+
+    auto path_factory = CreateFactory(dir->Str());
+    std::string uuid = path_factory->UUID();
+    ASSERT_EQ(FileStorePathFactory::ManifestPath(dir->Str()), dir->Str() + "/manifest");
+    for (int32_t i = 0; i < 20; i++) {
+        std::string manifest_path = path_factory->NewManifestFile();
+        ASSERT_EQ(manifest_path,
+                  dir->Str() + "/manifest/manifest-" + uuid + "-" + std::to_string(i));
+    }
+    std::string manifest_file_path = path_factory->ToManifestFilePath("my-manifest-file-name");
+    ASSERT_EQ(manifest_file_path, dir->Str() + "/manifest/my-manifest-file-name");
+
+    for (int32_t i = 0; i < 20; i++) {
+        std::string manifest_path = path_factory->NewManifestList();
+        ASSERT_EQ(manifest_path,
+                  dir->Str() + "/manifest/manifest-list-" + uuid + "-" + std::to_string(i));
+    }
+    std::string manifest_list_path = path_factory->ToManifestListPath("my-manifest-list-file-name");
+    ASSERT_EQ(manifest_list_path, dir->Str() + "/manifest/my-manifest-list-file-name");
+}
+
+TEST_F(FileStorePathFactoryTest, TestCreateFactoryWithEmptyRow) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+
+    auto path_factory = CreateFactory(dir->Str());
+    BinaryRow empty_row = BinaryRow::EmptyRow();
+    ASSERT_NOK(path_factory->CreateDataFilePathFactory(empty_row, 123));
+}
+
+TEST_F(FileStorePathFactoryTest, TestCreateFactoryWithNoPartition) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::boolean()),  arrow::field("f1", arrow::uint8()),
+        arrow::field("f2", arrow::int8()),     arrow::field("f3", arrow::uint16()),
+        arrow::field("f4", arrow::int16()),    arrow::field("f5", arrow::uint32()),
+        arrow::field("hr", arrow::int32()),    arrow::field("f7", arrow::uint64()),
+        arrow::field("dt", arrow::int64()),    arrow::field("f9", arrow::float32()),
+        arrow::field("f10", arrow::float64()), arrow::field("f11", arrow::utf8()),
+        arrow::field("f12", arrow::binary()),  arrow::field("non-partition-field", arrow::int32())};
+    auto schema = arrow::schema(fields);
+    ASSERT_OK_AND_ASSIGN(auto path_factory,
+                         FileStorePathFactory::Create(
+                             dir->Str(), schema, {}, "default", /*identifier=*/"mock_format",
+                             /*data_file_prefix=*/"data-", /*legacy_partition_name_enabled=*/true,
+                             /*external_paths=*/std::vector<std::string>(),
+                             /*global_index_external_path=*/std::nullopt,
+                             /*index_file_in_data_file_dir=*/false, mem_pool_));
+    ASSERT_OK_AND_ASSIGN(auto data_file_path_factory,
+                         path_factory->CreateDataFilePathFactory(BinaryRow::EmptyRow(), 123));
+    ASSERT_EQ(data_file_path_factory->ToPath("my-data-file-name"),
+              path_factory->root_ + "/bucket-123/my-data-file-name");
+}
+
+TEST_F(FileStorePathFactoryTest, TestIndexManifestAndStatsPaths) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+
+    auto path_factory = CreateFactory(dir->Str());
+    std::string uuid = path_factory->UUID();
+    ASSERT_EQ(FileStorePathFactory::ManifestPath(dir->Str()), dir->Str() + "/manifest");
+    ASSERT_EQ(FileStorePathFactory::IndexPath(dir->Str()), dir->Str() + "/index");
+    ASSERT_EQ(FileStorePathFactory::StatisticsPath(dir->Str()), dir->Str() + "/statistics");
+
+    for (int32_t i = 0; i < 20; i++) {
+        std::string manifest_path = path_factory->NewIndexManifestFile();
+        ASSERT_EQ(manifest_path,
+                  dir->Str() + "/manifest/index-manifest-" + uuid + "-" + std::to_string(i));
+    }
+    for (int32_t i = 0; i < 20; i++) {
+        std::string stats_file_path = path_factory->NewStatsFile();
+        ASSERT_EQ(stats_file_path,
+                  dir->Str() + "/statistics/stats-" + uuid + "-" + std::to_string(i));
+    }
+    for (int32_t i = 0; i < 20; i++) {
+        std::string index_file_path = path_factory->NewIndexFile();
+        ASSERT_EQ(index_file_path, dir->Str() + "/index/index-" + uuid + "-" + std::to_string(i));
+    }
+    std::string index_file_path = path_factory->ToIndexFilePath("my-index-file-name");
+    ASSERT_EQ(index_file_path, dir->Str() + "/index/my-index-file-name");
+    std::string stats_file_path = path_factory->ToStatsFilePath("my-stats-file-name");
+    ASSERT_EQ(stats_file_path, dir->Str() + "/statistics/my-stats-file-name");
+}
+
+TEST_F(FileStorePathFactoryTest, TestCreateDataFilePathFactoryWithPartition) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::boolean()),  arrow::field("f1", arrow::uint8()),
+        arrow::field("f2", arrow::int8()),     arrow::field("f3", arrow::uint16()),
+        arrow::field("f4", arrow::int16()),    arrow::field("f5", arrow::uint32()),
+        arrow::field("hr", arrow::int32()),    arrow::field("f7", arrow::uint64()),
+        arrow::field("dt", arrow::int64()),    arrow::field("f9", arrow::float32()),
+        arrow::field("f10", arrow::float64()), arrow::field("f11", arrow::utf8()),
+        arrow::field("f12", arrow::binary()),  arrow::field("non-partition-field", arrow::int32())};
+    auto schema = arrow::schema(fields);
+
+    ASSERT_OK_AND_ASSIGN(auto path_factory, FileStorePathFactory::Create(
+                                                dir->Str(), schema, {"dt", "hr"}, "default",
+                                                /*identifier=*/"mock_format",
+                                                /*data_file_prefix=*/"data-",
+                                                /*legacy_partition_name_enabled=*/true,
+                                                /*external_paths=*/std::vector<std::string>(),
+                                                /*global_index_external_path=*/std::nullopt,
+                                                /*index_file_in_data_file_dir=*/false, mem_pool_));
+    CheckPartition(20211224, 18, *path_factory, "/dt=20211224/hr=18");
+    CheckPartition(20211224, std::nullopt, *path_factory, "/dt=20211224/hr=default");
+    CheckPartition(std::nullopt, 16, *path_factory, "/dt=default/hr=16");
+    CheckPartition(std::nullopt, std::nullopt, *path_factory, "/dt=default/hr=default");
+}
+
+TEST_F(FileStorePathFactoryTest, TestGetHierarchicalPartitionPath) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::boolean()),  arrow::field("f1", arrow::uint8()),
+        arrow::field("f2", arrow::int8()),     arrow::field("f3", arrow::uint16()),
+        arrow::field("f4", arrow::int16()),    arrow::field("f5", arrow::uint32()),
+        arrow::field("hr", arrow::int32()),    arrow::field("f7", arrow::uint64()),
+        arrow::field("dt", arrow::int64()),    arrow::field("f9", arrow::float32()),
+        arrow::field("f10", arrow::float64()), arrow::field("f11", arrow::utf8()),
+        arrow::field("f12", arrow::binary()),  arrow::field("non-partition-field", arrow::int32())};
+    auto schema = arrow::schema(fields);
+
+    ASSERT_OK_AND_ASSIGN(
+        auto path_factory,
+        FileStorePathFactory::Create(dir->Str(), schema, {"dt", "hr"}, "default",
+                                     /*identifier=*/"mock_format", /*data_file_prefix=*/"data-",
+                                     /*legacy_partition_name_enabled=*/true,
+                                     /*external_paths=*/std::vector<std::string>(),
+                                     /*global_index_external_path=*/std::nullopt,
+                                     /*index_file_in_data_file_dir=*/false, mem_pool_));
+
+    {
+        BinaryRow row = BinaryRowGenerator::GenerateRow({10l, 5}, mem_pool_.get());
+        ASSERT_OK_AND_ASSIGN(auto paths, path_factory->GetHierarchicalPartitionPath(row));
+        ASSERT_EQ(2u, paths.size());
+        ASSERT_EQ(PathUtil::JoinPath(dir->Str(), "/dt=10/"), paths[0]);
+        ASSERT_EQ(PathUtil::JoinPath(dir->Str(), "/dt=10/hr=5/"), paths[1]);
+    }
+    {
+        BinaryRow row = BinaryRowGenerator::GenerateRow({15l, NullType()}, mem_pool_.get());
+        ASSERT_OK_AND_ASSIGN(auto paths, path_factory->GetHierarchicalPartitionPath(row));
+        ASSERT_EQ(2u, paths.size());
+        ASSERT_EQ(PathUtil::JoinPath(dir->Str(), "/dt=15/"), paths[0]);
+        ASSERT_EQ(PathUtil::JoinPath(dir->Str(), "/dt=15/hr=default/"), paths[1]);
+    }
+}
+
+TEST_F(FileStorePathFactoryTest, TestToBinaryRowAndToPartitionString) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::boolean()),  arrow::field("f1", arrow::int8()),
+        arrow::field("f2", arrow::int8()),     arrow::field("f3", arrow::int16()),
+        arrow::field("f4", arrow::int16()),    arrow::field("f5", arrow::int32()),
+        arrow::field("hr", arrow::int32()),    arrow::field("f7", arrow::int64()),
+        arrow::field("dt", arrow::utf8()),     arrow::field("f9", arrow::float32()),
+        arrow::field("f10", arrow::float64()), arrow::field("f11", arrow::utf8()),
+        arrow::field("f12", arrow::binary()),  arrow::field("non-partition-field", arrow::int32())};
+    auto schema = arrow::schema(fields);
+    ASSERT_OK_AND_ASSIGN(auto path_factory, FileStorePathFactory::Create(
+                                                dir->Str(), schema, {"dt", "hr"}, "default",
+                                                /*identifier=*/"mock_format",
+                                                /*data_file_prefix=*/"data-",
+                                                /*legacy_partition_name_enabled=*/true,
+                                                /*external_paths=*/std::vector<std::string>(),
+                                                /*global_index_external_path=*/std::nullopt,
+                                                /*index_file_in_data_file_dir=*/false, mem_pool_));
+    {
+        std::map<std::string, std::string> partition_map;
+        partition_map["dt"] = "20211224";
+        partition_map["hr"] = "23";
+        std::string expected = "dt=20211224/hr=23/";
+        ASSERT_OK_AND_ASSIGN(BinaryRow binary_row, path_factory->ToBinaryRow(partition_map));
+        ASSERT_OK_AND_ASSIGN(std::string actual, path_factory->GetPartitionString(binary_row));
+        ASSERT_EQ(expected, actual);
+    }
+    {
+        std::map<std::string, std::string> partition_map;
+        partition_map["dt"] = "default";
+        partition_map["hr"] = "default";
+        std::string expected = "dt=default/hr=default/";
+        ASSERT_OK_AND_ASSIGN(BinaryRow binary_row, path_factory->ToBinaryRow(partition_map));
+        ASSERT_OK_AND_ASSIGN(std::string actual, path_factory->GetPartitionString(binary_row));
+        ASSERT_EQ(expected, actual);
+    }
+    {
+        std::map<std::string, std::string> partition_map;
+        partition_map["dt"] = " a ";
+        partition_map["hr"] = "22";
+        std::string expected = "dt= a /hr=22/";
+        ASSERT_OK_AND_ASSIGN(BinaryRow binary_row, path_factory->ToBinaryRow(partition_map));
+        ASSERT_OK_AND_ASSIGN(std::string actual, path_factory->GetPartitionString(binary_row));
+        ASSERT_EQ(expected, actual);
+    }
+    {
+        std::map<std::string, std::string> partition_map;
+        partition_map["dt"] = "   ";
+        partition_map["hr"] = "22";
+        std::string expected = "dt=default/hr=22/";
+        ASSERT_OK_AND_ASSIGN(BinaryRow binary_row, path_factory->ToBinaryRow(partition_map));
+        ASSERT_OK_AND_ASSIGN(std::string actual, path_factory->GetPartitionString(binary_row));
+        ASSERT_EQ(expected, actual);
+    }
+    {
+        std::map<std::string, std::string> partition_map;
+        partition_map["dt"] = "";
+        partition_map["hr"] = "22";
+        std::string expected = "dt=default/hr=22/";
+        ASSERT_OK_AND_ASSIGN(BinaryRow binary_row, path_factory->ToBinaryRow(partition_map));
+        ASSERT_OK_AND_ASSIGN(std::string actual, path_factory->GetPartitionString(binary_row));
+        ASSERT_EQ(expected, actual);
+    }
+    {
+        std::map<std::string, std::string> partition_map;
+        partition_map["dt"] = "[a=bc]";
+        partition_map["hr"] = "23";
+        std::string expected = "dt=%5Ba%3Dbc%5D/hr=23/";
+        ASSERT_OK_AND_ASSIGN(BinaryRow binary_row, path_factory->ToBinaryRow(partition_map));
+        ASSERT_OK_AND_ASSIGN(std::string actual, path_factory->GetPartitionString(binary_row));
+        ASSERT_EQ(expected, actual);
+    }
+    {
+        std::map<std::string, std::string> partition_map;
+        partition_map["dt"] = "20240812";
+        partition_map["hr"] = "default";
+        std::string expected = "dt=20240812/hr=default/";
+        ASSERT_OK_AND_ASSIGN(BinaryRow binary_row, path_factory->ToBinaryRow(partition_map));
+        ASSERT_OK_AND_ASSIGN(std::string actual, path_factory->GetPartitionString(binary_row));
+        ASSERT_EQ(expected, actual);
+    }
+    {
+        std::map<std::string, std::string> partition_map;
+        partition_map["dt"] = "default";
+        partition_map["hr"] = "17";
+        std::string expected = "dt=default/hr=17/";
+        ASSERT_OK_AND_ASSIGN(BinaryRow binary_row, path_factory->ToBinaryRow(partition_map));
+        ASSERT_OK_AND_ASSIGN(std::string actual, path_factory->GetPartitionString(binary_row));
+        ASSERT_EQ(expected, actual);
+    }
+    {
+        std::map<std::string, std::string> partition_map;
+        partition_map["dt"] = "20240812";
+        partition_map["hr"] = "somestr";
+        ASSERT_NOK(path_factory->ToBinaryRow(partition_map));
+    }
+}
+
+TEST_F(FileStorePathFactoryTest, TestCreateIndexFileFactory) {
+    {
+        // test without external path & index_file_in_data_file_dir = false
+        auto dir = UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir);
+        arrow::FieldVector fields = {
+            arrow::field("f0", arrow::boolean()), arrow::field("f1", arrow::int32()),
+            arrow::field("f2", arrow::int64()), arrow::field("f3", arrow::int16())};
+        auto schema = arrow::schema(fields);
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<FileStorePathFactory> file_store_path_factory,
+            FileStorePathFactory::Create(dir->Str(), schema, {"f0", "f1"}, "default",
+                                         /*identifier=*/"mock_format",
+                                         /*data_file_prefix=*/"data-",
+                                         /*legacy_partition_name_enabled=*/true,
+                                         /*external_paths=*/{},
+                                         /*global_index_external_path=*/std::nullopt,
+                                         /*index_file_in_data_file_dir=*/false, mem_pool_));
+        auto partition = BinaryRowGenerator::GenerateRow({true, 10}, mem_pool_.get());
+        ASSERT_OK_AND_ASSIGN(
+            auto index_path_factory,
+            file_store_path_factory->CreateIndexFileFactory(partition, /*bucket=*/2));
+        ASSERT_EQ(index_path_factory->NewPath(),
+                  dir->Str() + "/index/index-" + file_store_path_factory->uuid_ + "-0");
+        ASSERT_EQ(index_path_factory->ToPath("global_bitmap.index"),
+                  dir->Str() + "/index/global_bitmap.index");
+    }
+    {
+        // test with external path & index_file_in_data_file_dir = false
+        auto dir = UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir);
+        arrow::FieldVector fields = {
+            arrow::field("f0", arrow::boolean()), arrow::field("f1", arrow::int32()),
+            arrow::field("f2", arrow::int64()), arrow::field("f3", arrow::int16())};
+        auto schema = arrow::schema(fields);
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<FileStorePathFactory> file_store_path_factory,
+            FileStorePathFactory::Create(dir->Str(), schema, {"f0", "f1"}, "default",
+                                         /*identifier=*/"mock_format",
+                                         /*data_file_prefix=*/"data-",
+                                         /*legacy_partition_name_enabled=*/true,
+                                         /*external_paths=*/{"/tmp/external-path"},
+                                         /*global_index_external_path=*/std::nullopt,
+                                         /*index_file_in_data_file_dir=*/false, mem_pool_));
+        auto partition = BinaryRowGenerator::GenerateRow({true, 10}, mem_pool_.get());
+        ASSERT_OK_AND_ASSIGN(
+            auto index_path_factory,
+            file_store_path_factory->CreateIndexFileFactory(partition, /*bucket=*/2));
+        ASSERT_EQ(index_path_factory->NewPath(),
+                  dir->Str() + "/index/index-" + file_store_path_factory->uuid_ + "-0");
+        ASSERT_EQ(index_path_factory->ToPath("global_bitmap.index"),
+                  dir->Str() + "/index/global_bitmap.index");
+    }
+    {
+        // test without external path & index_file_in_data_file_dir = true
+        auto dir = UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir);
+        arrow::FieldVector fields = {
+            arrow::field("f0", arrow::boolean()), arrow::field("f1", arrow::int32()),
+            arrow::field("f2", arrow::int64()), arrow::field("f3", arrow::int16())};
+        auto schema = arrow::schema(fields);
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<FileStorePathFactory> file_store_path_factory,
+            FileStorePathFactory::Create(dir->Str(), schema, {"f0", "f1"}, "default",
+                                         /*identifier=*/"mock_format",
+                                         /*data_file_prefix=*/"data-",
+                                         /*legacy_partition_name_enabled=*/true,
+                                         /*external_paths=*/{},
+                                         /*global_index_external_path=*/std::nullopt,
+                                         /*index_file_in_data_file_dir=*/true, mem_pool_));
+        auto partition = BinaryRowGenerator::GenerateRow({true, 10}, mem_pool_.get());
+        ASSERT_OK_AND_ASSIGN(
+            auto index_path_factory,
+            file_store_path_factory->CreateIndexFileFactory(partition, /*bucket=*/2));
+        ASSERT_EQ(index_path_factory->NewPath(), dir->Str() + "/f0=true/f1=10/bucket-2/index-" +
+                                                     file_store_path_factory->uuid_ + "-0");
+    }
+    {
+        // test with external path & index_file_in_data_file_dir = true
+        auto dir = UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir);
+        arrow::FieldVector fields = {
+            arrow::field("f0", arrow::boolean()), arrow::field("f1", arrow::int32()),
+            arrow::field("f2", arrow::int64()), arrow::field("f3", arrow::int16())};
+        auto schema = arrow::schema(fields);
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<FileStorePathFactory> file_store_path_factory,
+            FileStorePathFactory::Create(dir->Str(), schema, {"f0", "f1"}, "default",
+                                         /*identifier=*/"mock_format",
+                                         /*data_file_prefix=*/"data-",
+                                         /*legacy_partition_name_enabled=*/true,
+                                         /*external_paths=*/{"/tmp/external-path"},
+                                         /*global_index_external_path=*/std::nullopt,
+                                         /*index_file_in_data_file_dir=*/true, mem_pool_));
+        auto partition = BinaryRowGenerator::GenerateRow({true, 10}, mem_pool_.get());
+        ASSERT_OK_AND_ASSIGN(
+            auto index_path_factory,
+            file_store_path_factory->CreateIndexFileFactory(partition, /*bucket=*/2));
+        ASSERT_EQ(index_path_factory->NewPath(),
+                  "/tmp/external-path/f0=true/f1=10/bucket-2/index-" +
+                      file_store_path_factory->uuid_ + "-0");
+    }
+    {
+        // test with global index external path
+        auto dir = UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir);
+        arrow::FieldVector fields = {
+            arrow::field("f0", arrow::boolean()), arrow::field("f1", arrow::int32()),
+            arrow::field("f2", arrow::int64()), arrow::field("f3", arrow::int16())};
+        auto schema = arrow::schema(fields);
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<FileStorePathFactory> file_store_path_factory,
+            FileStorePathFactory::Create(dir->Str(), schema, {"f0", "f1"}, "default",
+                                         /*identifier=*/"mock_format",
+                                         /*data_file_prefix=*/"data-",
+                                         /*legacy_partition_name_enabled=*/true,
+                                         /*external_paths=*/std::vector<std::string>(),
+                                         /*global_index_external_path=*/{"/tmp/external-path"},
+                                         /*index_file_in_data_file_dir=*/false, mem_pool_));
+        auto partition = BinaryRowGenerator::GenerateRow({true, 10}, mem_pool_.get());
+        ASSERT_OK_AND_ASSIGN(
+            auto index_path_factory,
+            file_store_path_factory->CreateIndexFileFactory(partition, /*bucket=*/2));
+        ASSERT_EQ(index_path_factory->ToPath("bitmap.index"), "/tmp/external-path/bitmap.index");
+        ASSERT_TRUE(index_path_factory->IsExternalPath());
+
+        auto index_file_meta = std::make_shared<IndexFileMeta>(
+            /*index_type=*/"bitmap", /*file_name=*/"bitmap.index", /*file_size=*/10,
+            /*row_count=*/5, /*dv_ranges=*/std::nullopt,
+            /*external_path=*/"/tmp/external-path/bitmap.index",
+            /*global_index_meta=*/std::nullopt);
+        ASSERT_EQ(index_path_factory->ToPath(index_file_meta), "/tmp/external-path/bitmap.index");
+    }
+}
+}  // namespace paimon::test

--- a/src/paimon/core/utils/index_file_path_factories.h
+++ b/src/paimon/core/utils/index_file_path_factories.h
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/concurrent_hash_map.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/result.h"
+
+namespace paimon {
+class IndexPathFactory;
+
+/// Cache for index `PathFactory`s.
+class IndexFilePathFactories {
+ public:
+    explicit IndexFilePathFactories(const std::shared_ptr<FileStorePathFactory>& path_factory)
+        : path_factory_(path_factory) {}
+
+    Result<std::shared_ptr<IndexPathFactory>> Get(const BinaryRow& partition, int32_t bucket) {
+        auto key = std::make_pair(partition, bucket);
+        auto cached_factory = cache_.Find(key);
+        if (cached_factory) {
+            return cached_factory.value();
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<IndexPathFactory> index_path_factory,
+                               path_factory_->CreateIndexFileFactory(partition, bucket));
+        cache_.Insert(key, index_path_factory);
+        return index_path_factory;
+    }
+
+ private:
+    class PartitionBucketCmp {
+     public:
+        size_t hash(const std::pair<BinaryRow, int32_t>& key) const {
+            return std::hash<std::pair<BinaryRow, int32_t>>{}(key);
+        }
+
+        bool equal(const std::pair<BinaryRow, int32_t>& a,
+                   const std::pair<BinaryRow, int32_t>& b) const {
+            return a.first == b.first && a.second == b.second;
+        }
+    };
+
+ private:
+    std::shared_ptr<FileStorePathFactory> path_factory_;
+    ConcurrentHashMap<std::pair<BinaryRow, int32_t>, std::shared_ptr<IndexPathFactory>,
+                      PartitionBucketCmp>
+        cache_;
+};
+}  // namespace paimon

--- a/src/paimon/core/utils/index_file_path_factories_test.cpp
+++ b/src/paimon/core/utils/index_file_path_factories_test.cpp
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/index_file_path_factories.h"
+
+#include <string>
+#include <variant>
+#include <vector>
+
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/core/index/index_path_factory.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(IndexFilePathFactoriesTest, TestSimple) {
+    auto pool = GetDefaultPool();
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::boolean()), arrow::field("f1", arrow::int32()),
+        arrow::field("f2", arrow::int64()), arrow::field("f3", arrow::int16())};
+    auto schema = arrow::schema(fields);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStorePathFactory> file_store_path_factory,
+                         FileStorePathFactory::Create("/tmp", schema, {"f0", "f1"}, "default",
+                                                      /*identifier=*/"mock_format",
+                                                      /*data_file_prefix=*/"data-",
+                                                      /*legacy_partition_name_enabled=*/true,
+                                                      /*external_paths=*/{},
+                                                      /*global_index_external_path=*/std::nullopt,
+                                                      /*index_file_in_data_file_dir=*/false, pool));
+    auto uuid = file_store_path_factory->uuid_;
+    auto factories = std::make_shared<IndexFilePathFactories>(file_store_path_factory);
+    ASSERT_EQ(factories->cache_.Size(), 0);
+    std::shared_ptr<IndexPathFactory> cached_factory;
+    {
+        // partition {true, 10}, bucket 2
+        auto partition = BinaryRowGenerator::GenerateRow({true, 10}, pool.get());
+        ASSERT_OK_AND_ASSIGN(auto index_path_factory, factories->Get(partition, /*bucket=*/2));
+        cached_factory = index_path_factory;
+        ASSERT_EQ(index_path_factory->NewPath(), "/tmp/index/index-" + uuid + "-0");
+        ASSERT_EQ(factories->cache_.Size(), 1);
+    }
+    {
+        // partition {false, 20}, bucket 1, not in cache
+        auto partition = BinaryRowGenerator::GenerateRow({false, 20}, pool.get());
+        ASSERT_OK_AND_ASSIGN(auto index_path_factory, factories->Get(partition, /*bucket=*/1));
+        // test different index path factory ptr
+        ASSERT_NE(index_path_factory.get(), cached_factory.get());
+
+        ASSERT_EQ(index_path_factory->NewPath(), "/tmp/index/index-" + uuid + "-1");
+        ASSERT_EQ(factories->cache_.Size(), 2);
+    }
+    {
+        // partition {true, 10}, bucket 2, already in cache
+        auto partition = BinaryRowGenerator::GenerateRow({true, 10}, pool.get());
+        ASSERT_OK_AND_ASSIGN(auto index_path_factory, factories->Get(partition, /*bucket=*/2));
+        // test same index path factory ptr
+        ASSERT_EQ(index_path_factory.get(), cached_factory.get());
+
+        ASSERT_EQ(index_path_factory->NewPath(), "/tmp/index/index-" + uuid + "-2");
+        ASSERT_EQ(factories->cache_.Size(), 2);
+    }
+}
+
+TEST(IndexFilePathFactoriesTest, TestWithExternalPath) {
+    auto pool = GetDefaultPool();
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::boolean()), arrow::field("f1", arrow::int32()),
+        arrow::field("f2", arrow::int64()), arrow::field("f3", arrow::int16())};
+    auto schema = arrow::schema(fields);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStorePathFactory> file_store_path_factory,
+                         FileStorePathFactory::Create("/tmp", schema, {"f0", "f1"}, "default",
+                                                      /*identifier=*/"mock_format",
+                                                      /*data_file_prefix=*/"data-",
+                                                      /*legacy_partition_name_enabled=*/true,
+                                                      /*external_paths=*/{"/tmp/external-path"},
+                                                      /*global_index_external_path=*/std::nullopt,
+                                                      /*index_file_in_data_file_dir=*/true, pool));
+    auto uuid = file_store_path_factory->uuid_;
+    auto factories = std::make_shared<IndexFilePathFactories>(file_store_path_factory);
+    ASSERT_EQ(factories->cache_.Size(), 0);
+    std::shared_ptr<IndexPathFactory> cached_factory;
+    {
+        // partition {true, 10}, bucket 2
+        auto partition = BinaryRowGenerator::GenerateRow({true, 10}, pool.get());
+        ASSERT_OK_AND_ASSIGN(auto index_path_factory, factories->Get(partition, /*bucket=*/2));
+        cached_factory = index_path_factory;
+        ASSERT_EQ(index_path_factory->NewPath(),
+                  "/tmp/external-path/f0=true/f1=10/bucket-2/index-" + uuid + "-0");
+        ASSERT_EQ(factories->cache_.Size(), 1);
+    }
+    {
+        // partition {false, 20}, bucket 1, not in cache
+        auto partition = BinaryRowGenerator::GenerateRow({false, 20}, pool.get());
+        ASSERT_OK_AND_ASSIGN(auto index_path_factory, factories->Get(partition, /*bucket=*/1));
+        // test different index path factory ptr
+        ASSERT_NE(index_path_factory.get(), cached_factory.get());
+
+        ASSERT_EQ(index_path_factory->NewPath(),
+                  "/tmp/external-path/f0=false/f1=20/bucket-1/index-" + uuid + "-1");
+        ASSERT_EQ(factories->cache_.Size(), 2);
+    }
+    {
+        // partition {true, 10}, bucket 2, already in cache
+        auto partition = BinaryRowGenerator::GenerateRow({true, 10}, pool.get());
+        ASSERT_OK_AND_ASSIGN(auto index_path_factory, factories->Get(partition, /*bucket=*/2));
+        // test same index path factory ptr
+        ASSERT_EQ(index_path_factory.get(), cached_factory.get());
+
+        ASSERT_EQ(index_path_factory->NewPath(),
+                  "/tmp/external-path/f0=true/f1=10/bucket-2/index-" + uuid + "-2");
+        ASSERT_EQ(factories->cache_.Size(), 2);
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/utils/manifest_meta_reader.cpp
+++ b/src/paimon/core/utils/manifest_meta_reader.cpp
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/manifest_meta_reader.h"
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/array/array_primitive.h"
+#include "arrow/array/util.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class MemoryPool;
+
+ManifestMetaReader::ManifestMetaReader(std::unique_ptr<BatchReader>&& reader,
+                                       const std::shared_ptr<arrow::DataType>& target_type,
+                                       const std::shared_ptr<MemoryPool>& pool)
+    : reader_(std::move(reader)), target_type_(target_type), pool_(GetArrowPool(pool)) {}
+
+Result<BatchReader::ReadBatch> ManifestMetaReader::NextBatch() {
+    PAIMON_ASSIGN_OR_RAISE(ReadBatch src_result, reader_->NextBatch());
+    auto& c_array = src_result.first;
+    auto& c_schema = src_result.second;
+    if (!c_array) {
+        return BatchReader::MakeEofBatch();
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                      arrow::ImportArray(c_array.get(), c_schema.get()));
+
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> target_array,
+                           AlignArrayWithSchema(arrow_array, target_type_, pool_.get()));
+    std::unique_ptr<ArrowArray> target_c_arrow_array = std::make_unique<ArrowArray>();
+    std::unique_ptr<ArrowSchema> target_c_schema = std::make_unique<ArrowSchema>();
+
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        arrow::ExportArray(*target_array, target_c_arrow_array.get(), target_c_schema.get()));
+    return std::make_pair(std::move(target_c_arrow_array), std::move(target_c_schema));
+}
+
+Result<std::shared_ptr<arrow::Array>> ManifestMetaReader::AlignArrayWithSchema(
+    const std::shared_ptr<arrow::Array>& src_array,
+    const std::shared_ptr<arrow::DataType>& target_type, arrow::MemoryPool* pool) {
+    const auto src_kind = src_array->type()->id();
+    switch (src_kind) {
+        case arrow::Type::type::LIST: {
+            auto list_src_array =
+                arrow::internal::checked_pointer_cast<arrow::ListArray>(src_array);
+            auto list_target_type =
+                arrow::internal::checked_pointer_cast<arrow::ListType>(target_type);
+            if (!list_target_type) {
+                return Status::Invalid(
+                    "Complete non exist field failed, target type cannot cast to a list data "
+                    "type");
+            }
+            PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> converted,
+                                   AlignArrayWithSchema(list_src_array->values(),
+                                                        list_target_type->value_type(), pool));
+            auto new_list_type = std::make_shared<arrow::ListType>(converted->type());
+            return std::make_shared<arrow::ListArray>(
+                new_list_type, list_src_array->length(), list_src_array->value_offsets(), converted,
+                list_src_array->null_bitmap(), list_src_array->null_count(),
+                list_src_array->offset());
+        }
+        case arrow::Type::type::MAP: {
+            auto map_src_array = arrow::internal::checked_pointer_cast<arrow::MapArray>(src_array);
+            auto map_target_type =
+                arrow::internal::checked_pointer_cast<arrow::MapType>(target_type);
+            if (!map_target_type) {
+                return Status::Invalid(
+                    "Complete non exist field failed, target type cannot cast to a map data "
+                    "type");
+            }
+            PAIMON_ASSIGN_OR_RAISE(
+                std::shared_ptr<arrow::Array> key_converted,
+                AlignArrayWithSchema(map_src_array->keys(), map_target_type->key_type(), pool));
+            PAIMON_ASSIGN_OR_RAISE(
+                std::shared_ptr<arrow::Array> value_converted,
+                AlignArrayWithSchema(map_src_array->items(), map_target_type->item_type(), pool));
+            auto new_map_type =
+                std::make_shared<arrow::MapType>(key_converted->type(), value_converted->type());
+            return std::make_shared<arrow::MapArray>(
+                new_map_type, map_src_array->length(), map_src_array->value_offsets(),
+                key_converted, value_converted, map_src_array->null_bitmap(),
+                map_src_array->null_count(), map_src_array->offset());
+        }
+        case arrow::Type::type::STRUCT: {
+            auto struct_src_array =
+                arrow::internal::checked_pointer_cast<arrow::StructArray>(src_array);
+            auto struct_target_type =
+                arrow::internal::checked_pointer_cast<arrow::StructType>(target_type);
+            if (!struct_target_type) {
+                return Status::Invalid(
+                    "Complete non exist field failed, target type cannot cast to a struct data "
+                    "type");
+            }
+            std::vector<std::string> field_names;
+            arrow::ArrayVector converted_array;
+            field_names.reserve(target_type->num_fields());
+            converted_array.reserve(target_type->num_fields());
+            for (int32_t i = 0; i < struct_target_type->num_fields(); i++) {
+                const auto& target_field = struct_target_type->field(i);
+                const std::string& target_name = target_field->name();
+                field_names.push_back(target_name);
+                auto src_field = struct_src_array->GetFieldByName(target_name);
+                if (src_field) {
+                    PAIMON_ASSIGN_OR_RAISE(
+                        std::shared_ptr<arrow::Array> converted,
+                        AlignArrayWithSchema(src_field, target_field->type(), pool));
+                    converted_array.push_back(converted);
+                } else {
+                    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                        std::shared_ptr<arrow::Array> null_array,
+                        arrow::MakeArrayOfNull(target_field->type(), struct_src_array->length(),
+                                               pool));
+                    converted_array.push_back(null_array);
+                }
+            }
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                std::shared_ptr<arrow::Array> arrow_array,
+                arrow::StructArray::Make(
+                    converted_array, field_names, struct_src_array->null_bitmap(),
+                    struct_src_array->null_count(), struct_src_array->offset()));
+            return arrow_array;
+        }
+        case arrow::Type::type::INT32:
+            // cast for avro format, avro store int8,int16,int32 as int32, so need to cast to
+            // correct type
+            if (src_kind != target_type->id()) {
+                arrow::compute::CastOptions cast_options;
+                cast_options.allow_int_overflow = false;
+                auto int32_array =
+                    arrow::internal::checked_pointer_cast<arrow::Int32Array>(src_array);
+                PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                    std::shared_ptr<arrow::Array> result,
+                    arrow::compute::Cast(*int32_array, target_type, cast_options));
+                return result;
+            }
+        default:
+            return src_array;
+    }
+}
+
+}  // namespace paimon

--- a/src/paimon/core/utils/manifest_meta_reader.h
+++ b/src/paimon/core/utils/manifest_meta_reader.h
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "arrow/c/bridge.h"
+#include "arrow/memory_pool.h"
+#include "arrow/type.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/result.h"
+#include "paimon/visibility.h"
+
+namespace arrow {
+class DataType;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+class Metrics;
+
+class PAIMON_EXPORT ManifestMetaReader : public BatchReader {
+ public:
+    ManifestMetaReader(std::unique_ptr<BatchReader>&& reader,
+                       const std::shared_ptr<arrow::DataType>& target_type,
+                       const std::shared_ptr<MemoryPool>& pool);
+
+    ~ManifestMetaReader() override {
+        DoClose();
+    }
+
+    Result<ReadBatch> NextBatch() override;
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return reader_->GetReaderMetrics();
+    }
+    void Close() override {
+        DoClose();
+    }
+    void DoClose() {
+        reader_->Close();
+    }
+
+ private:
+    // fill non exist field and correct int precision
+    static Result<std::shared_ptr<arrow::Array>> AlignArrayWithSchema(
+        const std::shared_ptr<arrow::Array>& src_array,
+        const std::shared_ptr<arrow::DataType>& target_type, arrow::MemoryPool* pool);
+
+    std::unique_ptr<BatchReader> reader_;
+    std::shared_ptr<arrow::DataType> target_type_;
+    std::unique_ptr<arrow::MemoryPool> pool_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/utils/manifest_meta_reader_test.cpp
+++ b/src/paimon/core/utils/manifest_meta_reader_test.cpp
@@ -1,0 +1,181 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/manifest_meta_reader.h"
+
+#include <string>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/ipc/json_simple.h"
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(ManifestMetaReaderTest, TestNoNeedCompleteNonExistField) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::list(arrow::int32())),
+        arrow::field("f1", arrow::map(arrow::utf8(), arrow::int64())),
+        arrow::field("f2",
+                     arrow::struct_({field("sub1", arrow::int64()), field("sub2", arrow::float64()),
+                                     field("sub3", arrow::boolean())})),
+    };
+    auto src_array = arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        [[1, 2, 3],    [["apple", 3], ["banana", 4]],          [10, 10.1, false]],
+        [[4, 5],       [["cat", 5], ["dog", 6], ["mouse", 7]], [20, 20.1, true]],
+        [[6],          [["elephant", 7], ["fox", 8]],          [null, 30.1, true]],
+        [[7],          [["giraffe", 9]],                       [null, 40.1, true]],
+        [null,         [["horse", 10], ["Panda", 11]],         [50, 50.1, null]],
+        [[9],          null,                                   [60, 60.1, false]],
+        [[10, 11, 12], [["rabbit", null], ["tiger", 13]],      null]
+    ])")
+                         .ValueOrDie();
+    arrow::FieldVector target_fields = fields;
+    auto target_arrow_type = arrow::struct_(target_fields);
+    auto arrow_pool = GetArrowPool(GetDefaultPool());
+    ASSERT_OK_AND_ASSIGN(auto ret, ManifestMetaReader::AlignArrayWithSchema(
+                                       src_array, target_arrow_type, arrow_pool.get()));
+    ASSERT_TRUE(src_array->Equals(ret)) << ret->ToString();
+}
+TEST(ManifestMetaReaderTest, TestCompleteNonExistFieldSimple) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::list(arrow::int32())),
+        arrow::field("f1", arrow::map(arrow::utf8(), arrow::int64())),
+        arrow::field("f2",
+                     arrow::struct_({field("sub1", arrow::int64()), field("sub2", arrow::float64()),
+                                     field("sub3", arrow::boolean())})),
+    };
+    auto src_array = arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        [[1, 2, 3],    [["apple", 3], ["banana", 4]],          [10, 10.1, false]],
+        [[4, 5],       [["cat", 5], ["dog", 6], ["mouse", 7]], [20, 20.1, true]],
+        [[6],          [["elephant", 7], ["fox", 8]],          [null, 30.1, true]],
+        [[7],          [["giraffe", 9]],                       [null, 40.1, true]],
+        [null,         [["horse", 10], ["Panda", 11]],         [50, 50.1, null]],
+        [[9],          null,                                   [60, 60.1, false]],
+        [[10, 11, 12], [["rabbit", null], ["tiger", 13]],      null]
+    ])")
+                         .ValueOrDie();
+    arrow::FieldVector target_fields = {
+        arrow::field("f0", arrow::list(arrow::int32())),
+        arrow::field("f1", arrow::map(arrow::utf8(), arrow::int64())),
+        arrow::field("f3", arrow::list(arrow::utf8())),
+        arrow::field(
+            "f2", arrow::struct_({field("sub1", arrow::int64()), field("sub2", arrow::float64()),
+                                  field("sub3", arrow::boolean()), field("sub4", arrow::int8())})),
+    };
+    auto target_arrow_type = arrow::struct_(target_fields);
+    auto arrow_pool = GetArrowPool(GetDefaultPool());
+    ASSERT_OK_AND_ASSIGN(auto ret, ManifestMetaReader::AlignArrayWithSchema(
+                                       src_array, target_arrow_type, arrow_pool.get()));
+
+    auto expected_array =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(target_fields), R"([
+        [[1, 2, 3],    [["apple", 3], ["banana", 4]],          null, [10, 10.1, false, null]],
+        [[4, 5],       [["cat", 5], ["dog", 6], ["mouse", 7]], null, [20, 20.1, true, null]],
+        [[6],          [["elephant", 7], ["fox", 8]],          null, [null, 30.1, true, null]],
+        [[7],          [["giraffe", 9]],                       null, [null, 40.1, true, null]],
+        [null,         [["horse", 10], ["Panda", 11]],         null, [50, 50.1, null, null]],
+        [[9],          null,                                   null, [60, 60.1, false, null]],
+        [[10, 11, 12], [["rabbit", null], ["tiger", 13]],      null, null]
+    ])")
+            .ValueOrDie();
+    ASSERT_TRUE(expected_array->Equals(ret)) << ret->ToString();
+}
+
+TEST(ManifestMetaReaderTest, TestCompleteNonExistFieldNested) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::list(arrow::struct_(
+                               {field("a", arrow::int64()), field("b", arrow::boolean())}))),
+        arrow::field("f1", arrow::map(arrow::struct_({field("a", arrow::int64()),
+                                                      field("b", arrow::boolean())}),
+                                      arrow::boolean()))};
+    auto src_array = arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        [[null, [1, true], null], [[[1, true], true]]],
+        [[[2, false], null], null],
+        [[[2, false], [3, true], [4, null]], [[[1, true], true], [[5, false], null]]],
+        [null, null]
+    ])")
+                         .ValueOrDie();
+    arrow::FieldVector target_fields = {
+        arrow::field("f0", arrow::list(arrow::struct_({field("a", arrow::int64()),
+                                                       field("b", arrow::boolean()),
+                                                       field("c", arrow::int64())}))),
+        arrow::field("f1", arrow::map(arrow::struct_({field("a", arrow::int64()),
+                                                      field("b", arrow::boolean()),
+                                                      field("c", arrow::int64())}),
+                                      arrow::boolean()))};
+    auto target_arrow_type = arrow::struct_(target_fields);
+    auto arrow_pool = GetArrowPool(GetDefaultPool());
+    ASSERT_OK_AND_ASSIGN(auto ret, ManifestMetaReader::AlignArrayWithSchema(
+                                       src_array, target_arrow_type, arrow_pool.get()));
+
+    auto expected_array =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(target_fields), R"([
+        [[null, [1, true, null], null], [[[1, true, null], true]]],
+        [[[2, false, null], null], null],
+        [[[2, false, null], [3, true, null], [4, null, null]], [[[1, true, null], true], [[5, false, null], null]]],
+        [null, null]
+    ])")
+            .ValueOrDie();
+    ASSERT_TRUE(expected_array->Equals(ret)) << ret->ToString();
+}
+
+TEST(ManifestMetaReaderTest, TestCastInt32Type) {
+    arrow::FieldVector src_fields = {
+        arrow::field("f0", arrow::list(arrow::int32())),
+        arrow::field("f1", arrow::map(arrow::utf8(), arrow::int32())),
+        arrow::field("f2",
+                     arrow::struct_({field("sub1", arrow::int32()), field("sub2", arrow::float64()),
+                                     field("sub3", arrow::boolean())})),
+        arrow::field("f3", arrow::int32()),
+    };
+    std::string array_json = R"([
+        [[1, 2, 3],    [["apple", 3], ["banana", 4]],          [10, 10.1, false],  10],
+        [[4, 5],       [["cat", 5], ["dog", 6], ["mouse", 7]], [20, 20.1, true],   20],
+        [[6],          [["elephant", 7], ["fox", 8]],          [null, 30.1, true], 30],
+        [[7],          [["giraffe", 9]],                       [null, 40.1, true], 40],
+        [null,         [["horse", 10], ["Panda", 11]],         [50, 50.1, null],   50],
+        [[9],          null,                                   [60, 60.1, false],  60],
+        [[10, 11, 12], [["rabbit", null], ["tiger", 13]],      null,               70]
+    ])";
+    auto src_array =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(src_fields), array_json)
+            .ValueOrDie();
+
+    arrow::FieldVector target_fields = {
+        arrow::field("f0", arrow::list(arrow::int8())),
+        arrow::field("f1", arrow::map(arrow::utf8(), arrow::int16())),
+        arrow::field("f2",
+                     arrow::struct_({field("sub1", arrow::int8()), field("sub2", arrow::float64()),
+                                     field("sub3", arrow::boolean())})),
+        arrow::field("f3", arrow::int16()),
+    };
+    auto target_arrow_type = arrow::struct_(target_fields);
+    auto target_array =
+        arrow::ipc::internal::json::ArrayFromJSON(target_arrow_type, array_json).ValueOrDie();
+    auto arrow_pool = GetArrowPool(GetDefaultPool());
+    ASSERT_OK_AND_ASSIGN(auto result_array, ManifestMetaReader::AlignArrayWithSchema(
+                                                src_array, target_arrow_type, arrow_pool.get()));
+    ASSERT_TRUE(target_array->Equals(result_array)) << result_array->ToString();
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/utils/object_serializer.h
+++ b/src/paimon/core/utils/object_serializer.h
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "paimon/common/data/serializer/binary_row_serializer.h"
+#include "paimon/common/io/memory_segment_output_stream.h"
+#include "paimon/io/data_input_stream.h"
+
+struct ArrowArray;
+
+namespace paimon {
+
+/// A serializer to serialize object by `BinaryRowSerializer`.
+template <typename T>
+class ObjectSerializer {
+ public:
+    ObjectSerializer(const std::shared_ptr<arrow::DataType>& data_type,
+                     const std::shared_ptr<MemoryPool>& pool)
+        : pool_(pool), data_type_(data_type), row_serializer_(data_type_->num_fields(), pool) {}
+
+    virtual ~ObjectSerializer() = default;
+
+    /// Convert a `T` to `BinaryRow`.
+    virtual Result<BinaryRow> ToRow(const T& record) const = 0;
+
+    /// Convert an `InternalRow` to `T`.
+    virtual Result<T> FromRow(const InternalRow& row_data) const = 0;
+
+    /// Get the number of fields.
+    int32_t NumFields() const {
+        return data_type_->num_fields();
+    }
+
+    const std::shared_ptr<arrow::DataType>& GetDataType() const {
+        return data_type_;
+    }
+    /// Serializes the given record to the given target output stream.
+    ///
+    /// @param record The record to serialize.
+    /// @param target The output stream to write the serialized data to.
+    /// @return status returned, if the serialization encountered an I/O related error. Typically
+    /// raised by the output stream, which may have an underlying I/O channel to which it
+    /// delegates.
+    Status Serialize(const T& record, MemorySegmentOutputStream* target) const {
+        PAIMON_ASSIGN_OR_RAISE(BinaryRow row, ToRow(record));
+        return row_serializer_.Serialize(row, target);
+    }
+
+    /// De-serializes a record from the given source input stream.
+    ///
+    /// @param source The input stream from which to read the data.
+    /// @return The deserialized element.
+    Result<T> Deserialize(DataInputStream* source) const {
+        PAIMON_ASSIGN_OR_RAISE(BinaryRow row, row_serializer_.Deserialize(source));
+        return FromRow(row);
+    }
+
+    /// Serializes the given record list to the given target output stream.
+    Status SerializeList(const std::vector<T>& records, MemorySegmentOutputStream* target) {
+        target->WriteValue<int32_t>(records.size());
+        for (const T& record : records) {
+            PAIMON_RETURN_NOT_OK(Serialize(record, target));
+        }
+        return Status::OK();
+    }
+
+    /// De-serializes a record list from the given source input view.
+    Result<std::vector<T>> DeserializeList(DataInputStream* source) const {
+        int32_t size = 0;
+        PAIMON_ASSIGN_OR_RAISE(size, source->ReadValue<int32_t>());
+        std::vector<T> records;
+        records.reserve(size);
+        for (int32_t i = 0; i < size; i++) {
+            PAIMON_ASSIGN_OR_RAISE(T meta, Deserialize(source));
+            records.emplace_back(std::move(meta));
+        }
+        return records;
+    }
+
+ protected:
+    std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<arrow::DataType> data_type_;
+    BinaryRowSerializer row_serializer_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/utils/objects_file.h
+++ b/src/paimon/core/utils/objects_file.h
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/c/bridge.h"
+#include "arrow/c/helpers.h"
+#include "paimon/common/data/columnar/columnar_row.h"
+#include "paimon/common/utils/arrow/arrow_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/io/meta_to_arrow_array_converter.h"
+#include "paimon/core/utils/manifest_meta_reader.h"
+#include "paimon/core/utils/object_serializer.h"
+#include "paimon/core/utils/path_factory.h"
+#include "paimon/format/format_writer.h"
+#include "paimon/format/reader_builder.h"
+#include "paimon/format/writer_builder.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/record_batch.h"
+
+namespace paimon {
+/// A file which contains several `T`s, provides read and write.
+class PredicateFilter;
+template <typename T>
+class ObjectsFile {
+ public:
+    ObjectsFile(const std::shared_ptr<FileSystem>& file_system,
+                const std::shared_ptr<ReaderBuilder>& reader_builder,
+                const std::shared_ptr<WriterBuilder>& writer_builder,
+                std::unique_ptr<ObjectSerializer<T>>&& serializer, const std::string& compression,
+                const std::shared_ptr<PathFactory>& path_factory,
+                const std::shared_ptr<MemoryPool>& pool);
+
+    virtual ~ObjectsFile() = default;
+
+    Status Read(const std::string& file_name, const std::function<Result<bool>(const T&)>& filter,
+                std::vector<T>* result) const;
+    Status ReadIfFileExist(const std::string& file_name,
+                           const std::function<Result<bool>(const T&)>& filter,
+                           std::vector<T>* result) const;
+
+    void DeleteQuietly(const std::string& file_name) {
+        std::string path = path_factory_->ToPath(file_name);
+        auto status = file_system_->Delete(path);
+        // delete quietly will ignore any status error
+        (void)status;
+    }
+
+    Result<std::pair<std::string, int64_t>> WriteWithoutRolling(const std::vector<T>& records);
+
+ protected:
+    std::shared_ptr<PathFactory> path_factory_;
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<ObjectSerializer<T>> serializer_;
+    std::shared_ptr<WriterBuilder> writer_builder_;
+    std::unique_ptr<MetaToArrowArrayConverter> to_array_converter_;
+
+ private:
+    std::shared_ptr<FileSystem> file_system_;
+    std::shared_ptr<ReaderBuilder> reader_builder_;
+    std::string compression_;
+};
+
+template <typename T>
+ObjectsFile<T>::ObjectsFile(const std::shared_ptr<FileSystem>& file_system,
+                            const std::shared_ptr<ReaderBuilder>& reader_builder,
+                            const std::shared_ptr<WriterBuilder>& writer_builder,
+                            std::unique_ptr<ObjectSerializer<T>>&& serializer,
+                            const std::string& compression,
+                            const std::shared_ptr<PathFactory>& path_factory,
+                            const std::shared_ptr<MemoryPool>& pool)
+    : path_factory_(path_factory),
+      pool_(pool),
+      serializer_(std::move(serializer)),
+      writer_builder_(std::move(writer_builder)),
+      file_system_(file_system),
+      reader_builder_(std::move(reader_builder)),
+      compression_(compression) {
+    // TODO(xinyu.lxy): add cache
+}
+
+template <typename T>
+Status ObjectsFile<T>::ReadIfFileExist(const std::string& file_name,
+                                       const std::function<Result<bool>(const T&)>& filter,
+                                       std::vector<T>* result) const {
+    std::string file_path = path_factory_->ToPath(file_name);
+    PAIMON_ASSIGN_OR_RAISE(bool path_exist, file_system_->Exists(file_path));
+    if (path_exist) {
+        return Read(file_name, filter, result);
+    }
+    return Status::OK();
+}
+
+template <typename T>
+Status ObjectsFile<T>::Read(const std::string& file_name,
+                            const std::function<Result<bool>(const T&)>& filter,
+                            std::vector<T>* result) const {
+    std::string file_path = path_factory_->ToPath(file_name);
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InputStream> file_input_stream,
+                           file_system_->Open(file_path));
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileBatchReader> batch_reader,
+                           reader_builder_->Build(file_input_stream));
+    auto reader = std::make_unique<ManifestMetaReader>(std::move(batch_reader),
+                                                       serializer_->GetDataType(), pool_);
+    while (true) {
+        PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch arrow_array, reader->NextBatch());
+        auto& c_array = arrow_array.first;
+        auto& c_schema = arrow_array.second;
+        if (!c_array) {
+            break;
+        }
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> typed_array,
+                                          arrow::ImportArray(c_array.get(), c_schema.get()));
+        auto* struct_array = dynamic_cast<arrow::StructArray*>(typed_array.get());
+        if (!struct_array) {
+            return Status::Invalid(fmt::format("file {}, cannot cast to struct array", file_name));
+        }
+        result->reserve(struct_array->length());
+        for (int64_t i = 0; i < struct_array->length(); i++) {
+            ColumnarRow row(struct_array->fields(), pool_, i);
+            PAIMON_ASSIGN_OR_RAISE(T obj, serializer_->FromRow(row));
+            if (filter) {
+                PAIMON_ASSIGN_OR_RAISE(bool filter_res, filter(obj));
+                if (filter_res) {
+                    result->push_back(std::move(obj));
+                }
+            } else {
+                result->push_back(std::move(obj));
+            }
+        }
+    }
+    reader->Close();
+    return Status::OK();
+}
+
+template <typename T>
+Result<std::pair<std::string, int64_t>> ObjectsFile<T>::WriteWithoutRolling(
+    const std::vector<T>& records) {
+    std::string file_path = path_factory_->NewPath();
+    std::vector<BinaryRow> rows;
+    rows.reserve(records.size());
+    for (const auto& record : records) {
+        PAIMON_ASSIGN_OR_RAISE(BinaryRow row, serializer_->ToRow(record));
+        rows.push_back(std::move(row));
+    }
+    if (!to_array_converter_) {
+        PAIMON_ASSIGN_OR_RAISE(to_array_converter_, MetaToArrowArrayConverter::Create(
+                                                        serializer_->GetDataType(), pool_));
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> array,
+                           to_array_converter_->NextBatch(rows));
+    ::ArrowArray c_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*array, &c_array));
+    ScopeGuard guard([&]() {
+        ArrowArrayRelease(&c_array);
+        DeleteQuietly(file_path);
+    });
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<OutputStream> out,
+                           file_system_->Create(file_path, /*overwrite=*/false));
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FormatWriter> format_writer,
+                           writer_builder_->Build(out, compression_));
+    PAIMON_RETURN_NOT_OK(format_writer->AddBatch(&c_array));
+    PAIMON_RETURN_NOT_OK(format_writer->Flush());
+    PAIMON_RETURN_NOT_OK(format_writer->Finish());
+    PAIMON_RETURN_NOT_OK(out->Flush());
+    PAIMON_ASSIGN_OR_RAISE(int64_t pos, out->GetPos());
+    PAIMON_RETURN_NOT_OK(out->Close());
+    guard.Release();
+    return std::make_pair(PathUtil::GetName(file_path), pos);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/utils/primary_key_table_utils.cpp
+++ b/src/paimon/core/utils/primary_key_table_utils.cpp
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/primary_key_table_utils.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <set>
+#include <utility>
+
+#include "fmt/format.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/common/utils/object_utils.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/mergetree/compact/aggregate/aggregate_merge_function.h"
+#include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
+#include "paimon/core/mergetree/compact/first_row_merge_function.h"
+#include "paimon/core/mergetree/compact/merge_function.h"
+#include "paimon/core/mergetree/compact/partial_update_merge_function.h"
+#include "paimon/core/options/merge_engine.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+Result<std::unique_ptr<MergeFunction>> PrimaryKeyTableUtils::CreateMergeFunction(
+    const std::shared_ptr<arrow::Schema>& value_schema,
+    const std::vector<std::string>& primary_keys, const CoreOptions& options) {
+    auto merge_engine = options.GetMergeEngine();
+    std::unique_ptr<MergeFunction> merge_function;
+    if (merge_engine == MergeEngine::DEDUPLICATE) {
+        merge_function = std::make_unique<DeduplicateMergeFunction>(options.IgnoreDelete());
+    } else if (merge_engine == MergeEngine::FIRST_ROW) {
+        merge_function = std::make_unique<FirstRowMergeFunction>(options.IgnoreDelete());
+    } else if (merge_engine == MergeEngine::AGGREGATE) {
+        PAIMON_ASSIGN_OR_RAISE(merge_function,
+                               AggregateMergeFunction::Create(value_schema, primary_keys, options));
+    } else if (merge_engine == MergeEngine::PARTIAL_UPDATE) {
+        std::map<std::string, std::vector<std::string>> value_field_to_seq_group_field;
+        std::set<std::string> seq_group_key_set;
+        PAIMON_RETURN_NOT_OK(PartialUpdateMergeFunction::ParseSequenceGroupFields(
+            options, &value_field_to_seq_group_field, &seq_group_key_set));
+        PAIMON_ASSIGN_OR_RAISE(
+            merge_function,
+            PartialUpdateMergeFunction::Create(value_schema, primary_keys, options,
+                                               value_field_to_seq_group_field, seq_group_key_set));
+    } else {
+        return Status::Invalid(
+            "only support deduplicate/partial-update/aggregation/first-row merge engine.");
+    }
+    return merge_function;
+}
+
+Result<std::unique_ptr<FieldsComparator>> PrimaryKeyTableUtils::CreateSequenceFieldsComparator(
+    const std::vector<DataField>& value_fields, const CoreOptions& options) {
+    auto sequence_field_names = options.GetSequenceField();
+    if (sequence_field_names.empty()) {
+        return std::unique_ptr<FieldsComparator>();
+    }
+    std::map<std::string, int32_t> value_field_name_to_idx =
+        ObjectUtils::CreateIdentifierToIndexMap(
+            value_fields, [](const DataField& field) -> std::string { return field.Name(); });
+
+    std::vector<int32_t> sort_field_idxs;
+    for (const auto& seq_field_name : sequence_field_names) {
+        auto iter = value_field_name_to_idx.find(seq_field_name);
+        if (iter == value_field_name_to_idx.end()) {
+            return Status::Invalid(
+                fmt::format("sequence field {} does not in value fields", seq_field_name));
+        } else {
+            sort_field_idxs.push_back(iter->second);
+        }
+    }
+    return FieldsComparator::Create(value_fields, sort_field_idxs,
+                                    options.SequenceFieldSortOrderIsAscending());
+}
+
+}  // namespace paimon

--- a/src/paimon/core/utils/primary_key_table_utils.h
+++ b/src/paimon/core/utils/primary_key_table_utils.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/type.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+class MergeFunction;
+class CoreOptions;
+class FieldsComparator;
+class DataField;
+
+class PrimaryKeyTableUtils {
+ public:
+    PrimaryKeyTableUtils() = delete;
+    ~PrimaryKeyTableUtils() = delete;
+
+    static Result<std::unique_ptr<MergeFunction>> CreateMergeFunction(
+        const std::shared_ptr<arrow::Schema>& value_schema,
+        const std::vector<std::string>& primary_keys, const CoreOptions& options);
+
+    static Result<std::unique_ptr<FieldsComparator>> CreateSequenceFieldsComparator(
+        const std::vector<DataField>& value_fields, const CoreOptions& options);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/utils/primary_key_table_utils_test.cpp
+++ b/src/paimon/core/utils/primary_key_table_utils_test.cpp
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/primary_key_table_utils.h"
+
+#include <cstdint>
+#include <map>
+#include <utility>
+
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/core_options.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+TEST(PrimaryKeyTableUtilsTest, TestCreateSequenceFieldsComparator) {
+    {
+        std::vector<DataField> value_fields = {DataField(0, arrow::field("k0", arrow::int32())),
+                                               DataField(1, arrow::field("v1", arrow::int32())),
+                                               DataField(1, arrow::field("s0", arrow::int32())),
+                                               DataField(1, arrow::field("s1", arrow::int32()))};
+        ASSERT_OK_AND_ASSIGN(CoreOptions core_options,
+                             CoreOptions::FromMap({{Options::SEQUENCE_FIELD, "s0,s1"}}));
+        ASSERT_OK_AND_ASSIGN(auto comparator, PrimaryKeyTableUtils::CreateSequenceFieldsComparator(
+                                                  value_fields, core_options));
+        ASSERT_EQ(comparator->CompareFields(), std::vector<int32_t>({2, 3}));
+    }
+    {
+        std::vector<DataField> value_fields = {DataField(0, arrow::field("k0", arrow::int32())),
+                                               DataField(1, arrow::field("v1", arrow::int32()))};
+        ASSERT_OK_AND_ASSIGN(CoreOptions core_options,
+                             CoreOptions::FromMap({{Options::SEQUENCE_FIELD, "s0,s1"}}));
+        ASSERT_NOK_WITH_MSG(
+            PrimaryKeyTableUtils::CreateSequenceFieldsComparator(value_fields, core_options),
+            "sequence field s0 does not in value fields");
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/utils/snapshot_manager.cpp
+++ b/src/paimon/core/utils/snapshot_manager.cpp
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/snapshot_manager.h"
+
+#include <algorithm>
+#include <chrono>
+#include <random>
+#include <thread>
+#include <utility>
+
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/utils/branch_manager.h"
+#include "paimon/core/utils/file_utils.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/result.h"
+
+namespace paimon {
+
+SnapshotManager::SnapshotManager(const std::shared_ptr<FileSystem>& fs,
+                                 const std::string& root_path)
+    : SnapshotManager(fs, root_path, BranchManager::DEFAULT_MAIN_BRANCH) {}
+
+SnapshotManager::SnapshotManager(const std::shared_ptr<FileSystem>& fs,
+                                 const std::string& root_path, const std::string& branch)
+    : fs_(fs), root_path_(root_path), branch_(BranchManager::NormalizeBranch(branch)) {}
+
+SnapshotManager::~SnapshotManager() = default;
+
+const std::shared_ptr<FileSystem>& SnapshotManager::Fs() const {
+    return fs_;
+}
+
+const std::string& SnapshotManager::RootPath() const {
+    return root_path_;
+}
+
+const std::string& SnapshotManager::Branch() const {
+    return branch_;
+}
+
+Result<std::optional<Snapshot>> SnapshotManager::LatestSnapshotOfUser(const std::string& user) {
+    PAIMON_ASSIGN_OR_RAISE(std::optional<int64_t> latest_id, LatestSnapshotId());
+    if (latest_id == std::nullopt) {
+        return std::optional<Snapshot>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::optional<int64_t> earliest_id, EarliestSnapshotId());
+    if (earliest_id == std::nullopt) {
+        return Status::Invalid(
+            "Latest snapshot id is not null, but earliest snapshot id is null. This is "
+            "unexpected.");
+    }
+
+    for (int64_t id = latest_id.value(); id >= earliest_id.value(); id--) {
+        PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, LoadSnapshot(id));
+        if (snapshot.CommitUser() == user) {
+            return std::optional<Snapshot>(snapshot);
+        }
+    }
+    return std::optional<Snapshot>();
+}
+
+Result<Snapshot> SnapshotManager::LoadSnapshot(int64_t snapshot_id) const {
+    return Snapshot::FromPath(fs_, SnapshotPath(snapshot_id));
+}
+
+Result<std::optional<Snapshot>> SnapshotManager::LatestSnapshot() const {
+    PAIMON_ASSIGN_OR_RAISE(std::optional<int64_t> snapshot_id, LatestSnapshotId());
+    if (snapshot_id == std::nullopt) {
+        return std::optional<Snapshot>();
+    } else {
+        PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, LoadSnapshot(snapshot_id.value()));
+        return std::optional<Snapshot>(snapshot);
+    }
+}
+
+Result<std::optional<int64_t>> SnapshotManager::LatestSnapshotId() const {
+    return FindLatest(
+        SnapshotDirectory(), std::string(SNAPSHOT_PREFIX),
+        [this](int64_t snapshot_id) -> std::string { return SnapshotPath(snapshot_id); });
+}
+
+Result<std::optional<int64_t>> SnapshotManager::EarliestSnapshotId() const {
+    return FindEarliest(
+        SnapshotDirectory(), std::string(SNAPSHOT_PREFIX),
+        [this](int64_t snapshot_id) -> std::string { return SnapshotPath(snapshot_id); });
+}
+
+std::string SnapshotManager::BranchPath() const {
+    return BranchManager::BranchPath(root_path_, branch_);
+}
+
+std::string SnapshotManager::SnapshotDirectory() const {
+    return PathUtil::JoinPath(BranchPath(), "/snapshot");
+}
+
+Result<bool> SnapshotManager::SnapshotExists(int64_t snapshot_id) const {
+    return fs_->Exists(SnapshotPath(snapshot_id));
+}
+std::string SnapshotManager::SnapshotPath(int64_t snapshot_id) const {
+    return PathUtil::JoinPath(
+        BranchPath(), "/snapshot/" + std::string(SNAPSHOT_PREFIX) + std::to_string(snapshot_id));
+}
+
+Result<std::optional<int64_t>> SnapshotManager::FindEarliest(
+    const std::string& dir, const std::string& prefix,
+    const std::function<std::string(int64_t)>& path_func) const {
+    PAIMON_ASSIGN_OR_RAISE(bool is_exist, fs_->Exists(dir));
+    if (!is_exist) {
+        return std::optional<int64_t>();
+    }
+    std::optional<int64_t> snapshot_id = ReadHint(EARLIEST, dir);
+    if (snapshot_id != std::nullopt) {
+        std::string path = path_func(snapshot_id.value());
+        PAIMON_ASSIGN_OR_RAISE(bool is_exist, fs_->Exists(path));
+        if (is_exist) {
+            return snapshot_id;
+        }
+    }
+    return FindByListFiles([](int64_t lhs, int64_t rhs) -> int64_t { return std::min(lhs, rhs); },
+                           dir, prefix);
+}
+
+Result<std::optional<int64_t>> SnapshotManager::FindLatest(
+    const std::string& dir, const std::string& prefix,
+    const std::function<std::string(int64_t)>& path_func) const {
+    PAIMON_ASSIGN_OR_RAISE(bool is_exist, fs_->Exists(dir));
+    if (!is_exist) {
+        return std::optional<int64_t>();
+    }
+    std::optional<int64_t> snapshot_id = ReadHint(LATEST, dir);
+    if (snapshot_id != std::nullopt && snapshot_id.value() > 0) {
+        int64_t next_snapshot = snapshot_id.value() + 1;
+        // it is the latest only there is no next one
+        std::string path = path_func(next_snapshot);
+        PAIMON_ASSIGN_OR_RAISE(bool is_exist, fs_->Exists(path));
+        if (!is_exist) {
+            return snapshot_id;
+        }
+    }
+    return FindByListFiles([](int64_t lhs, int64_t rhs) -> int64_t { return std::max(lhs, rhs); },
+                           dir, prefix);
+}
+
+Result<std::optional<int64_t>> SnapshotManager::FindByListFiles(
+    const std::function<int64_t(int64_t, int64_t)> reducer_func, const std::string& dir,
+    const std::string& prefix) const {
+    std::vector<int64_t> versions;
+    PAIMON_RETURN_NOT_OK(FileUtils::ListVersionedFiles(fs_, dir, prefix, &versions));
+    if (versions.empty()) {
+        return std::optional<int64_t>();
+    }
+    int64_t ret = versions[0];
+    for (const auto& version : versions) {
+        ret = reducer_func(ret, version);
+    }
+    return std::optional<int64_t>(ret);
+}
+
+Result<std::set<std::string>> SnapshotManager::TryGetNonSnapshotFiles(int64_t older_than_ms) const {
+    std::set<std::string> non_snapshot_files;
+
+    std::vector<std::unique_ptr<FileStatus>> file_status_list;
+    PAIMON_RETURN_NOT_OK(fs_->ListFileStatus(SnapshotDirectory(), &file_status_list));
+    for (const auto& file_status : file_status_list) {
+        std::string file_name = PathUtil::GetName(file_status->GetPath());
+        if (!StringUtils::StartsWith(file_name, std::string(SNAPSHOT_PREFIX)) &&
+            file_name != std::string(EARLIEST) && file_name != std::string(LATEST)) {
+            if (file_status->GetModificationTime() < older_than_ms) {
+                non_snapshot_files.insert(file_status->GetPath());
+            }
+        }
+    }
+    return non_snapshot_files;
+}
+
+// Noted that: try best to read hint to avoid unnecessary list dir operation, if failed, do not
+// return error
+std::optional<int64_t> SnapshotManager::ReadHint(const std::string& file_name,
+                                                 const std::string& dir) const {
+    std::string path = PathUtil::JoinPath(dir, file_name);
+    int32_t retry_number = 0;
+    while (retry_number++ < READ_HINT_RETRY_NUM) {
+        std::string content;
+        Status s = fs_->ReadFile(path, &content);
+        if (s.ok()) {
+            return StringUtils::StringToValue<int64_t>(content);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(READ_HINT_RETRY_INTERVAL));
+    }
+    return std::nullopt;
+}
+
+Status SnapshotManager::CommitLatestHint(int64_t snapshot_id) {
+    return CommitHint(snapshot_id, LATEST, SnapshotDirectory());
+}
+
+Status SnapshotManager::CommitEarliestHint(int64_t snapshot_id) {
+    return CommitHint(snapshot_id, EARLIEST, SnapshotDirectory());
+}
+
+Status SnapshotManager::CommitHint(int64_t snapshot_id, const std::string& file_name,
+                                   const std::string& dir) {
+    std::string path = PathUtil::JoinPath(dir, file_name);
+    std::string snapshot_id_str = std::to_string(snapshot_id);
+    int32_t loop_time = 3;
+    Status s;
+    while (loop_time-- > 0) {
+        s = fs_->WriteFile(path, snapshot_id_str, /*overwrite=*/true);
+        if (s.ok()) {
+            return s;
+        } else {
+            std::random_device rd;
+            std::mt19937 gen(rd());
+            std::uniform_int_distribution<int> dist(0, 999);
+            int64_t sleep_time = dist(gen) + 500;
+            std::this_thread::sleep_for(std::chrono::milliseconds(sleep_time));
+        }
+    }
+    return s;
+}
+
+Result<std::vector<Snapshot>> SnapshotManager::GetAllSnapshots() const {
+    std::vector<Snapshot> snapshots;
+    std::vector<std::unique_ptr<BasicFileStatus>> file_statuses;
+    PAIMON_RETURN_NOT_OK(FileUtils::ListVersionedFileStatus(fs_, SnapshotDirectory(),
+                                                            SNAPSHOT_PREFIX, &file_statuses));
+    for (const auto& file_status : file_statuses) {
+        auto snapshot_path = file_status->GetPath();
+        PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, Snapshot::FromPath(fs_, snapshot_path));
+        snapshots.push_back(snapshot);
+    }
+    return snapshots;
+}
+
+Result<std::optional<Snapshot>> SnapshotManager::EarlierOrEqualTimeMillis(
+    int64_t timestamp_millis) const {
+    return FindSnapshotBeforeTimestamp(timestamp_millis, std::less_equal<int64_t>{});
+}
+
+Result<std::optional<Snapshot>> SnapshotManager::EarlierThanTimeMillis(
+    int64_t timestamp_millis) const {
+    return FindSnapshotBeforeTimestamp(timestamp_millis, std::less<int64_t>{});
+}
+
+Result<std::optional<Snapshot>> SnapshotManager::FindSnapshotBeforeTimestamp(
+    int64_t timestamp_millis, const std::function<bool(int64_t, int64_t)>& compare) const {
+    PAIMON_ASSIGN_OR_RAISE(std::optional<int64_t> latest_id, LatestSnapshotId());
+    if (latest_id == std::nullopt) {
+        return std::optional<Snapshot>();
+    }
+
+    PAIMON_ASSIGN_OR_RAISE(std::optional<int64_t> earliest_id, EarliestSnapshotId());
+    if (earliest_id == std::nullopt) {
+        return std::optional<Snapshot>();
+    }
+
+    PAIMON_ASSIGN_OR_RAISE(Snapshot earliest_snapshot, LoadSnapshot(earliest_id.value()));
+    if (!compare(earliest_snapshot.TimeMillis(), timestamp_millis)) {
+        return std::optional<Snapshot>();
+    }
+
+    int64_t lo = earliest_id.value();
+    int64_t hi = latest_id.value();
+    std::optional<Snapshot> result;
+
+    while (lo <= hi) {
+        int64_t mid = lo + (hi - lo) / 2;
+        PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, LoadSnapshot(mid));
+        if (compare(snapshot.TimeMillis(), timestamp_millis)) {
+            lo = mid + 1;
+            result = std::move(snapshot);
+        } else {
+            hi = mid - 1;
+        }
+    }
+
+    return result;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/utils/snapshot_manager.h
+++ b/src/paimon/core/utils/snapshot_manager.h
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/type_fwd.h"
+
+namespace paimon {
+
+class Snapshot;
+class FileSystem;
+
+/// Manager for `Snapshot`, providing utility methods related to paths and snapshot hints.
+class SnapshotManager {
+ public:
+    static constexpr char SNAPSHOT_PREFIX[] = "snapshot-";
+    static constexpr char EARLIEST[] = "EARLIEST";
+    static constexpr char LATEST[] = "LATEST";
+
+    SnapshotManager(const std::shared_ptr<FileSystem>& fs, const std::string& root_path);
+    SnapshotManager(const std::shared_ptr<FileSystem>& fs, const std::string& root_path,
+                    const std::string& branch);
+    ~SnapshotManager();
+
+    const std::shared_ptr<FileSystem>& Fs() const;
+    const std::string& RootPath() const;
+    const std::string& Branch() const;
+    Result<std::optional<Snapshot>> LatestSnapshot() const;
+    std::string SnapshotDirectory() const;
+    std::string SnapshotPath(int64_t snapshot_id) const;
+    Result<std::optional<Snapshot>> LatestSnapshotOfUser(const std::string& user);
+    Status CommitLatestHint(int64_t snapshot_id);
+    Status CommitEarliestHint(int64_t snapshot_id);
+    Result<Snapshot> LoadSnapshot(int64_t snapshot_id) const;
+    Result<std::optional<int64_t>> EarliestSnapshotId() const;
+    Result<std::optional<int64_t>> LatestSnapshotId() const;
+    Result<bool> SnapshotExists(int64_t snapshot_id) const;
+    Result<std::set<std::string>> TryGetNonSnapshotFiles(int64_t older_than_ms) const;
+    Result<std::vector<Snapshot>> GetAllSnapshots() const;
+    Result<std::optional<Snapshot>> EarlierOrEqualTimeMillis(int64_t timestamp_millis) const;
+    Result<std::optional<Snapshot>> EarlierThanTimeMillis(int64_t timestamp_millis) const;
+
+ private:
+    static constexpr int32_t READ_HINT_RETRY_NUM = 3;
+    static constexpr int32_t READ_HINT_RETRY_INTERVAL = 1;
+
+    std::string BranchPath() const;
+
+    Result<std::optional<int64_t>> FindEarliest(
+        const std::string& dir, const std::string& prefix,
+        const std::function<std::string(int64_t)>& path_func) const;
+    Result<std::optional<int64_t>> FindLatest(
+        const std::string& dir, const std::string& prefix,
+        const std::function<std::string(int64_t)>& path_func) const;
+    Result<std::optional<int64_t>> FindByListFiles(
+        const std::function<int64_t(int64_t, int64_t)> reducer_func, const std::string& dir,
+        const std::string& prefix) const;
+    std::optional<int64_t> ReadHint(const std::string& file_name, const std::string& dir) const;
+    Status CommitHint(int64_t snapshot_id, const std::string& file_name, const std::string& dir);
+    Result<std::optional<Snapshot>> FindSnapshotBeforeTimestamp(
+        int64_t timestamp_millis, const std::function<bool(int64_t, int64_t)>& compare) const;
+
+ private:
+    std::shared_ptr<FileSystem> fs_;
+    std::string root_path_;
+    std::string branch_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/utils/snapshot_manager_test.cpp
+++ b/src/paimon/core/utils/snapshot_manager_test.cpp
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/snapshot_manager.h"
+
+#include <filesystem>
+#include <limits>
+
+#include "gtest/gtest.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/utils/branch_manager.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+TEST(SnapshotManagerTest, TestSnapshotDirectory) {
+    auto fs = std::make_shared<LocalFileSystem>();
+    SnapshotManager manager(fs, paimon::test::GetDataDir() + "/append_09.db/append_09");
+    ASSERT_EQ(manager.SnapshotDirectory(),
+              paimon::test::GetDataDir() + "/append_09.db/append_09/snapshot");
+    ASSERT_EQ(manager.Branch(), BranchManager::DEFAULT_MAIN_BRANCH);
+}
+
+TEST(SnapshotManagerTest, TestSnapshotDirectoryWithBranch) {
+    auto fs = std::make_shared<LocalFileSystem>();
+    SnapshotManager manager(
+        fs,
+        paimon::test::GetDataDir() + "/append_table_with_rt_branch.db/append_table_with_rt_branch",
+        /*branch=*/"rt");
+    ASSERT_EQ(manager.SnapshotDirectory(),
+              paimon::test::GetDataDir() +
+                  "/append_table_with_rt_branch.db/append_table_with_rt_branch/branch/branch-rt/"
+                  "snapshot");
+    ASSERT_EQ(manager.Branch(), "rt");
+}
+
+TEST(SnapshotManagerTest, TestSimple) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> id1, mgr.EarliestSnapshotId());
+    ASSERT_EQ(id1.value(), 1);
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> id2, mgr.LatestSnapshotId());
+    ASSERT_EQ(id2.value(), 5);
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.LatestSnapshotOfUser("b02e4322-9c5f-41e1-a560-c0156fdf7b9c"));
+    ASSERT_EQ(snapshot.value().CommitUser(), "b02e4322-9c5f-41e1-a560-c0156fdf7b9c");
+    ASSERT_EQ(snapshot.value().CommitIdentifier(), 9223372036854775807);
+}
+
+TEST(SnapshotManagerTest, TestSimpleWithBranch) {
+    std::string test_data_path = paimon::test::GetDataDir() +
+                                 "/orc/append_table_with_rt_branch.db/append_table_with_rt_branch";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path, /*branch=*/"rt");
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> id1, mgr.EarliestSnapshotId());
+    ASSERT_EQ(id1.value(), 1);
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> id2, mgr.LatestSnapshotId());
+    ASSERT_EQ(id2.value(), 1);
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.LatestSnapshotOfUser("884df499-c17a-4c78-a865-6fbbfea02f0b"));
+    ASSERT_EQ(snapshot.value().CommitUser(), "884df499-c17a-4c78-a865-6fbbfea02f0b");
+    ASSERT_EQ(snapshot.value().CommitIdentifier(), 1);
+}
+
+TEST(SnapshotManagerTest, TestGetAllSnapshots) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    ASSERT_OK_AND_ASSIGN(std::vector<Snapshot> snapshots, mgr.GetAllSnapshots());
+    ASSERT_EQ(snapshots.size(), 5u);
+}
+
+TEST(SnapshotManagerTest, TestGetAllSnapshotsWithBranch) {
+    std::string test_data_path =
+        paimon::test::GetDataDir() +
+        "/orc/append_table_with_append_pt_branch.db/append_table_with_append_pt_branch";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path, /*branch=*/"test");
+    ASSERT_OK_AND_ASSIGN(std::vector<Snapshot> snapshots, mgr.GetAllSnapshots());
+    ASSERT_EQ(snapshots.size(), 2u);
+}
+
+TEST(SnapshotManagerTest, TestGetNonSnapshotFiles) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    std::string table_path = dir->Str();
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    ASSERT_TRUE(TestUtil::CopyDirectory(test_data_path, table_path));
+
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, table_path);
+    ASSERT_OK(file_system->Mkdirs(PathUtil::JoinPath(table_path, "snapshot/orphan_dir")));
+    ASSERT_OK(file_system->WriteFile(PathUtil::JoinPath(table_path, "snapshot/orphan_file"),
+                                     "orphan", true));
+    auto check_result = [](const std::set<std::string>& actual,
+                           const std::set<std::string>& expected) -> bool {
+        std::set<std::string> file_names;
+        for (const auto& file_path : actual) {
+            file_names.insert(PathUtil::GetName(file_path));
+        }
+        return file_names == expected;
+    };
+    ASSERT_OK_AND_ASSIGN(std::set<std::string> non_snapshot_files,
+                         mgr.TryGetNonSnapshotFiles(std::numeric_limits<int64_t>::max()));
+    ASSERT_TRUE(check_result(non_snapshot_files, {"orphan_dir", "orphan_file"}));
+    ASSERT_OK_AND_ASSIGN(non_snapshot_files,
+                         mgr.TryGetNonSnapshotFiles(std::numeric_limits<int64_t>::min()));
+    ASSERT_EQ(non_snapshot_files.size(), 0);
+}
+
+TEST(SnapshotManagerTest, TestPathNotExist) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/not_exist";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> id1, mgr.EarliestSnapshotId());
+    ASSERT_EQ(id1, std::nullopt);
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> id2, mgr.LatestSnapshotId());
+    ASSERT_EQ(id2, std::nullopt);
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.LatestSnapshotOfUser("b02e4322-9c5f-41e1-a560-c0156fdf7b9c"));
+    ASSERT_EQ(snapshot, std::nullopt);
+}
+
+TEST(SnapshotManagerTest, TestEarlierOrEqualTimeMillisExactMatch) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    // snapshot-3 has timeMillis = 1721614515032
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.EarlierOrEqualTimeMillis(1721614515032));
+    ASSERT_TRUE(snapshot.has_value());
+    ASSERT_EQ(snapshot->Id(), 3);
+}
+
+TEST(SnapshotManagerTest, TestEarlierOrEqualTimeMillisBetweenSnapshots) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    // Between snapshot-3 (1721614515032) and snapshot-4 (1721615035363), should return snapshot-3
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.EarlierOrEqualTimeMillis(1721614600000));
+    ASSERT_TRUE(snapshot.has_value());
+    ASSERT_EQ(snapshot->Id(), 3);
+}
+
+TEST(SnapshotManagerTest, TestEarlierOrEqualTimeMillisBeforeAll) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    // Before snapshot-1 (1721614343270), should return nullopt
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.EarlierOrEqualTimeMillis(1721614343269));
+    ASSERT_FALSE(snapshot.has_value());
+}
+
+TEST(SnapshotManagerTest, TestEarlierOrEqualTimeMillisAfterAll) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    // After snapshot-5 (1721615035453), should return snapshot-5
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.EarlierOrEqualTimeMillis(1721615099999));
+    ASSERT_TRUE(snapshot.has_value());
+    ASSERT_EQ(snapshot->Id(), 5);
+}
+
+TEST(SnapshotManagerTest, TestEarlierOrEqualTimeMillisFirstSnapshot) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    // Exact match on snapshot-1
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.EarlierOrEqualTimeMillis(1721614343270));
+    ASSERT_TRUE(snapshot.has_value());
+    ASSERT_EQ(snapshot->Id(), 1);
+}
+
+TEST(SnapshotManagerTest, TestEarlierOrEqualTimeMillisNoSnapshots) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/not_exist";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.EarlierOrEqualTimeMillis(1721614343270));
+    ASSERT_FALSE(snapshot.has_value());
+}
+
+TEST(SnapshotManagerTest, TestEarlierThanTimeMillisExactMatch) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    // Exact match on snapshot-1 (1721614343270) should not include snapshot-1 for strict <
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.EarlierThanTimeMillis(1721614343270));
+    ASSERT_FALSE(snapshot.has_value());
+}
+
+TEST(SnapshotManagerTest, TestEarlierThanTimeMillisBetweenSnapshots) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    // Between snapshot-1 (1721614343270) and snapshot-2 (1721614468258), should return snapshot-1
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.EarlierThanTimeMillis(1721614400000));
+    ASSERT_TRUE(snapshot.has_value());
+    ASSERT_EQ(snapshot->Id(), 1);
+}
+
+TEST(SnapshotManagerTest, TestEarlierThanTimeMillisBeforeAll) {
+    std::string test_data_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    // Before snapshot-1 (1721614343270), should return no snapshot
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> snapshot,
+                         mgr.EarlierThanTimeMillis(1721614343269));
+    ASSERT_FALSE(snapshot.has_value());
+}
+
+TEST(SnapshotManagerTest, TestCommitLatestHint) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    std::string test_data_path = dir->Str();
+    auto file_system = std::make_shared<LocalFileSystem>();
+    SnapshotManager mgr(file_system, test_data_path);
+    ASSERT_OK(mgr.CommitLatestHint(1));
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> latest_snapshot_id, mgr.LatestSnapshotId());
+    ASSERT_EQ(latest_snapshot_id.value(), 1);
+
+    ASSERT_OK_AND_ASSIGN(bool exists, file_system->Exists(test_data_path));
+    ASSERT_TRUE(exists);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/utils/tag_manager.cpp
+++ b/src/paimon/core/utils/tag_manager.cpp
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/tag_manager.h"
+
+#include <memory>
+#include <stdexcept>
+#include <string>
+
+#include "fmt/format.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/tag/tag.h"
+#include "paimon/core/utils/branch_manager.h"
+#include "paimon/fs/file_system.h"
+
+namespace paimon {
+
+TagManager::TagManager(const std::shared_ptr<FileSystem>& fs, const std::string& root_path)
+    : TagManager(fs, root_path, BranchManager::DEFAULT_MAIN_BRANCH) {}
+
+TagManager::TagManager(const std::shared_ptr<FileSystem>& fs, const std::string& root_path,
+                       const std::string& branch)
+    : fs_(fs), root_path_(root_path), branch_(BranchManager::NormalizeBranch(branch)) {}
+
+Result<Tag> TagManager::GetOrThrow(const std::string& tag_name) const {
+    PAIMON_ASSIGN_OR_RAISE(std::optional<Tag> tag, Get(tag_name));
+    if (tag == std::nullopt) {
+        return Status::NotExist(fmt::format("Tag '{}' doesn't exist.", tag_name));
+    }
+    return tag.value();
+}
+
+Result<std::optional<Tag>> TagManager::Get(const std::string& tag_name) const {
+    std::string tag_path = TagPath(tag_name);
+    PAIMON_ASSIGN_OR_RAISE(bool is_exist, fs_->Exists(tag_path));
+    if (!is_exist) {
+        return std::optional<Tag>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(Tag tag, Tag::FromPath(fs_, tag_path));
+    return std::optional<Tag>(std::move(tag));
+}
+
+std::string TagManager::TagPath(const std::string& tag_name) const {
+    return PathUtil::JoinPath(BranchManager::BranchPath(root_path_, branch_),
+                              "/tag/" + std::string(TAG_PREFIX) + tag_name);
+}
+}  // namespace paimon

--- a/src/paimon/core/utils/tag_manager.h
+++ b/src/paimon/core/utils/tag_manager.h
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "paimon/core/tag/tag.h"
+
+namespace paimon {
+
+class FileSystem;
+
+/// Manager for `Tag`.
+class TagManager {
+ public:
+    static constexpr char TAG_PREFIX[] = "tag-";
+
+    TagManager(const std::shared_ptr<FileSystem>& fs, const std::string& root_path);
+    TagManager(const std::shared_ptr<FileSystem>& fs, const std::string& root_path,
+               const std::string& branch);
+
+    Result<Tag> GetOrThrow(const std::string& tag_name) const;
+
+    Result<std::optional<Tag>> Get(const std::string& tag_name) const;
+
+    std::string TagPath(const std::string& tag_name) const;
+
+ private:
+    std::shared_ptr<FileSystem> fs_;
+    std::string root_path_;
+    std::string branch_;
+};
+}  // namespace paimon

--- a/src/paimon/core/utils/tag_manager_test.cpp
+++ b/src/paimon/core/utils/tag_manager_test.cpp
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/tag_manager.h"
+
+#include "gtest/gtest.h"
+#include "paimon/core/utils/branch_manager.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+TEST(TagManagerTest, TestGet) {
+    ASSERT_OK_AND_ASSIGN(auto tag_opt,
+                         TagManager(std::make_shared<LocalFileSystem>(),
+                                    paimon::test::GetDataDir() +
+                                        "/orc/append_table_with_tag.db/append_table_with_tag")
+                             .Get("1"));
+    ASSERT_TRUE(tag_opt.has_value());
+    const auto& tag = *tag_opt;
+    ASSERT_EQ(std::vector<int64_t>({2026, 2, 4, 6, 8, 10, 12}), tag.TagCreateTime());
+    ASSERT_EQ(3.0, tag.TagTimeRetained());
+}
+
+TEST(TagManagerTest, TestTagPath) {
+    ASSERT_EQ("/root/tag/tag-data", TagManager(nullptr, "/root").TagPath("data"));
+    ASSERT_EQ("/root/branch/branch-data/tag/tag-data",
+              TagManager(nullptr, "/root", "data").TagPath("data"));
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/utils/versioned_object_serializer.h
+++ b/src/paimon/core/utils/versioned_object_serializer.h
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "paimon/core/utils/object_serializer.h"
+#include "paimon/core/utils/offset_row.h"
+
+namespace paimon {
+/// An `ObjectSerializer` for versioned serialization.
+template <typename T>
+class PAIMON_EXPORT VersionedObjectSerializer : public ObjectSerializer<T> {
+ public:
+    explicit VersionedObjectSerializer(const std::shared_ptr<MemoryPool>& pool)
+        : ObjectSerializer<T>(VersionType(T::DataType()), pool) {}
+
+    static std::shared_ptr<arrow::DataType> VersionType(
+        const std::shared_ptr<arrow::DataType>& data_type) {
+        auto struct_type = arrow::internal::checked_pointer_cast<arrow::StructType>(data_type);
+        if (!struct_type) {
+            assert(false);
+            return nullptr;
+        }
+        return struct_type
+            ->AddField(0, arrow::field("_VERSION", arrow::int32(), /*nullable=*/false))
+            .ValueOr(nullptr);
+    }
+
+    /// Gets the version with which this serializer serializes.
+    ///
+    /// @return The version of the serialization schema.
+    virtual int32_t GetVersion() const = 0;
+
+    virtual Result<T> ConvertFrom(int32_t version, const InternalRow& row) const = 0;
+
+    Result<T> FromRow(const InternalRow& row) const override {
+        int32_t version = row.GetInt(0);
+        OffsetRow offset_row(row, /*arity=*/row.GetFieldCount() - 1, /*offset=*/1);
+        return ConvertFrom(version, offset_row);
+    }
+
+    Result<BinaryRow> ToRow(const T& record) const override {
+        return Status::NotImplemented("ToRow for VersionedObjectSerializer is not implemented");
+    }
+};
+}  // namespace paimon


### PR DESCRIPTION
### Purpose

Linked issue: No linked issue

This change adds core utility support for table metadata path construction, snapshot/tag/branch management, manifest metadata reading, object serialization, and primary-key table helpers.

Included changes:

- File store and index path utilities:
  - Adds `FileStorePathFactory` and file store path factory cache utilities.
  - Adds index file path factory helpers.
  - Adds test coverage for file store path factory, cache, and index path factory behavior.
- Snapshot, tag, and branch utilities:
  - Adds snapshot manager support for snapshot discovery, lookup, commit handling, and expiration-related helpers.
  - Adds tag manager and branch manager helpers.
  - Adds test coverage for snapshot, tag, and branch manager behavior.
- Manifest and object utilities:
  - Adds manifest metadata reader utilities.
  - Adds object file, object serializer, and versioned object serializer helpers.
  - Adds batch writer support.
  - Adds test coverage for manifest metadata reader behavior.
- Primary-key table utilities:
  - Adds primary-key table helper functions.
  - Adds test coverage for primary-key table utility behavior.

### Tests

Not run. Local compile, CMake, and gtest environment checks are not part of this PR description.

Test coverage included in this change:

- `file_store_path_factory_test.cpp`
- `file_store_path_factory_cache_test.cpp`
- `snapshot_manager_test.cpp`
- `tag_manager_test.cpp`
- `branch_manager_test.cpp`
- `manifest_meta_reader_test.cpp`
- `index_file_path_factories_test.cpp`
- `primary_key_table_utils_test.cpp`

### API and Format

No public API, storage format, or protocol changes.

### Documentation

No documentation changes required.

### Generative AI tooling

Migrate-by: Aone Copilot (GPT5.5)
