### PR TITLE
feat: Migrate projection reader and IO modules

### DIFF
--- a/src/paimon/core/io/async_key_value_producer_and_consumer.cpp
+++ b/src/paimon/core/io/async_key_value_producer_and_consumer.cpp
@@ -1,0 +1,240 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/async_key_value_producer_and_consumer.h"
+
+#include <unistd.h>
+
+#include <chrono>
+#include <type_traits>
+
+#include "arrow/c/abi.h"
+#include "arrow/c/helpers.h"
+#include "paimon/common/reader/reader_utils.h"
+#include "paimon/reader/batch_reader.h"
+
+namespace paimon {
+class MemoryPool;
+
+template <typename T, typename R>
+AsyncKeyValueProducerAndConsumer<T, R>::AsyncKeyValueProducerAndConsumer(
+    std::unique_ptr<SortMergeReader>&& sort_merge_reader, ConsumerCreator create_consumer,
+    int32_t batch_size, int32_t consumer_thread_num, const std::shared_ptr<MemoryPool>& pool)
+    : batch_size_(std::min(batch_size, MAX_PROJECTION_BATCH_SIZE)),
+      consumer_thread_num_(consumer_thread_num),
+      pool_(pool),
+      sort_merge_reader_(std::move(sort_merge_reader)),
+      create_consumer_(std::move(create_consumer)) {
+    kv_queue_.set_capacity(batch_size);
+    result_queue_.set_capacity(RESULT_BATCH_COUNT);
+}
+
+template <typename T, typename R>
+Status AsyncKeyValueProducerAndConsumer<T, R>::CheckStatus() const {
+    // check producer status
+    std::chrono::microseconds span(0);
+    std::future_status status = producer_future_.wait_for(span);
+    if (status == std::future_status::ready) {
+        PAIMON_RETURN_NOT_OK(producer_future_.get());
+    }
+    // check consumer status
+    for (const auto& consumer : consumers_) {
+        PAIMON_RETURN_NOT_OK(consumer->GetStatus());
+    }
+    return Status::OK();
+}
+
+template <typename T, typename R>
+Status AsyncKeyValueProducerAndConsumer<T, R>::CheckStatusAndCleanUp() {
+    auto status = CheckStatus();
+    if (!status.ok()) {
+        CleanUp();
+    }
+    return status;
+}
+
+template <typename T, typename R>
+Result<R> AsyncKeyValueProducerAndConsumer<T, R>::NextBatch() {
+    if (!producer_future_.valid()) {
+        producer_future_ = std::async(std::launch::async,
+                                      &AsyncKeyValueProducerAndConsumer<T, R>::ProduceLoop, this)
+                               .share();
+    }
+    if (consumers_.empty()) {
+        consumers_.reserve(consumer_thread_num_);
+        for (int32_t i = 0; i < consumer_thread_num_; i++) {
+            Result<std::unique_ptr<RowToArrowArrayConverter<T, R>>> consumer = create_consumer_();
+            PAIMON_RETURN_NOT_OK(consumer.status());
+            auto async_consumer = std::make_unique<AsyncKeyValueConsumer<T, R>>(
+                batch_size_ / consumer_thread_num_, std::move(consumer).value(), consume_finished_,
+                consumer_finished_count_, kv_queue_, result_queue_);
+            consumers_.push_back(std::move(async_consumer));
+        }
+    }
+    PAIMON_RETURN_NOT_OK(CheckStatusAndCleanUp());
+
+    if (next_batch_finished_) {
+        // projection reader is eof
+        return R();
+    }
+
+    R result;
+    while (!result_queue_.try_pop(result)) {
+        PAIMON_RETURN_NOT_OK(CheckStatusAndCleanUp());
+        if (consumer_finished_count_ == consumer_thread_num_ && result_queue_.empty()) {
+            // all consume thread finished
+            next_batch_finished_ = true;
+            return R();
+        }
+        usleep(1000);
+    }
+
+    return result;
+}
+
+template <typename T, typename R>
+Status AsyncKeyValueProducerAndConsumer<T, R>::ProduceLoop() {
+    while (!consume_finished_) {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<SortMergeReader::Iterator> iterator,
+                               sort_merge_reader_->NextBatch());
+        if (iterator == nullptr) {
+            // all iterator is all visited
+            kv_queue_.push(std::nullopt);
+            break;
+        }
+        while (!consume_finished_) {
+            PAIMON_ASSIGN_OR_RAISE(bool has_next, iterator->HasNext());
+            if (!has_next) {
+                // current iterator is all visited
+                break;
+            }
+            std::optional<KeyValue> kv = std::move(iterator->Next());
+            kv_queue_.push(std::move(kv));
+        }
+    }
+    return Status::OK();
+}
+
+template <typename T, typename R>
+void AsyncKeyValueProducerAndConsumer<T, R>::CleanUp() {
+    consume_finished_ = true;
+    next_batch_finished_ = true;
+    CleanUpQueue();
+    if (producer_future_.valid()) {
+        [[maybe_unused]] Status status = producer_future_.get();
+    }
+    for (auto& consumer : consumers_) {
+        consumer->CleanUp();
+    }
+    CleanUpQueue();
+}
+
+template <typename T, typename R>
+void AsyncKeyValueProducerAndConsumer<T, R>::CleanUpQueue() {
+    R read_batch;
+    while (result_queue_.try_pop(read_batch)) {
+        if constexpr (std::is_same_v<R, BatchReader::ReadBatch>) {
+            if (!BatchReader::IsEofBatch(read_batch)) {
+                ReaderUtils::ReleaseReadBatch(std::move(read_batch));
+            }
+        } else if constexpr (std::is_same_v<R, KeyValueBatch>) {
+            if (read_batch.batch) {
+                ArrowArrayRelease(read_batch.batch.get());
+            }
+        }
+    }
+
+    std::optional<KeyValue> kv;
+    while (kv_queue_.try_pop(kv)) {
+    }
+}
+
+template class AsyncKeyValueProducerAndConsumer<KeyValue, BatchReader::ReadBatch>;
+template class AsyncKeyValueProducerAndConsumer<KeyValue, KeyValueBatch>;
+
+template <typename T, typename R>
+AsyncKeyValueConsumer<T, R>::AsyncKeyValueConsumer(
+    int32_t batch_size, std::unique_ptr<RowToArrowArrayConverter<T, R>>&& key_value_consumer,
+    std::atomic<bool>& consume_finished, std::atomic<int32_t>& consumer_finished_count,
+    tbb::concurrent_bounded_queue<std::optional<KeyValue>>& kv_queue,
+    tbb::concurrent_bounded_queue<R>& result_queue)
+    : batch_size_(batch_size),
+      key_value_consumer_(std::move(key_value_consumer)),
+      consume_finished_(consume_finished),
+      consumer_finished_count_(consumer_finished_count),
+      kv_queue_(kv_queue),
+      result_queue_(result_queue) {
+    consumer_future_ =
+        std::async(std::launch::async, &AsyncKeyValueConsumer<T, R>::ConsumeLoop, this).share();
+}
+
+template <typename T, typename R>
+Status AsyncKeyValueConsumer<T, R>::GetStatus() const {
+    // check consumer status
+    std::chrono::microseconds span(0);
+    std::future_status status = consumer_future_.wait_for(span);
+    if (status == std::future_status::ready) {
+        PAIMON_RETURN_NOT_OK(consumer_future_.get());
+    }
+    return Status::OK();
+}
+
+template <typename T, typename R>
+Status AsyncKeyValueConsumer<T, R>::ConsumeLoop() {
+    while (!consume_finished_) {
+        int32_t cur_batch_size = 0;
+        std::vector<KeyValue> key_value_vec;
+        key_value_vec.reserve(batch_size_);
+        while (!consume_finished_) {
+            std::optional<KeyValue> kv;
+            if (!kv_queue_.try_pop(kv)) {
+                usleep(1);
+                continue;
+            }
+            if (!kv) {
+                consume_finished_ = true;
+                break;
+            }
+            key_value_vec.push_back(std::move(kv).value());
+            cur_batch_size++;
+            if (cur_batch_size >= batch_size_) {
+                break;
+            }
+        }
+
+        if (cur_batch_size > 0) {
+            PAIMON_ASSIGN_OR_RAISE(R result, key_value_consumer_->NextBatch(key_value_vec));
+            result_queue_.push(std::move(result));
+        }
+    }
+    consumer_finished_count_++;
+    return Status::OK();
+}
+
+template <typename T, typename R>
+void AsyncKeyValueConsumer<T, R>::CleanUp() {
+    if (consumer_future_.valid()) {
+        [[maybe_unused]] Status status = consumer_future_.get();
+    }
+    key_value_consumer_->CleanUp();
+}
+
+template class AsyncKeyValueConsumer<KeyValue, BatchReader::ReadBatch>;
+template class AsyncKeyValueConsumer<KeyValue, KeyValueBatch>;
+
+}  // namespace paimon

--- a/src/paimon/core/io/async_key_value_producer_and_consumer.h
+++ b/src/paimon/core/io/async_key_value_producer_and_consumer.h
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <future>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "paimon/core/io/row_to_arrow_array_converter.h"
+#include "paimon/core/key_value.h"
+#include "paimon/core/mergetree/compact/sort_merge_reader.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "tbb/concurrent_queue.h"
+
+namespace paimon {
+template <typename T, typename R>
+class AsyncKeyValueConsumer;
+class MemoryPool;
+class Metrics;
+
+// Asynchronous iterate SortMergeReader (producer) and row-to-array conversion (consumer), support
+// multi-threaded conversion, R can be BatchReader::ReadBatch, KeyValueBatch
+template <typename T, typename R>
+class AsyncKeyValueProducerAndConsumer {
+ public:
+    using ConsumerCreator =
+        std::function<Result<std::unique_ptr<RowToArrowArrayConverter<T, R>>>()>;
+
+    AsyncKeyValueProducerAndConsumer(std::unique_ptr<SortMergeReader>&& sort_merge_reader,
+                                     ConsumerCreator create_consumer, int32_t batch_size,
+                                     int32_t consumer_thread_num,
+                                     const std::shared_ptr<MemoryPool>& pool);
+
+    ~AsyncKeyValueProducerAndConsumer() {
+        CleanUp();
+    }
+
+    Result<R> NextBatch();
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const {
+        return sort_merge_reader_->GetReaderMetrics();
+    }
+
+    void Close() {
+        CleanUp();
+        sort_merge_reader_->Close();
+    }
+
+ private:
+    static constexpr int32_t RESULT_BATCH_COUNT = 3;
+
+    // in case write batch size is too large and overflow arrow array
+    static constexpr int32_t MAX_PROJECTION_BATCH_SIZE = 100000;
+
+    void CleanUpQueue();
+    Status ProduceLoop();
+    void CleanUp();
+    Status CheckStatus() const;
+    Status CheckStatusAndCleanUp();
+
+ private:
+    int32_t batch_size_;
+    int32_t consumer_thread_num_;
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<SortMergeReader> sort_merge_reader_;
+    ConsumerCreator create_consumer_;
+
+    // produce: merge sort KeyValue and push result KeyValue to kv_queue_, consume: project KeyValue
+    // to arrow array and push result array to result_queue_
+    std::atomic<bool> consume_finished_ = false;
+    std::atomic<bool> next_batch_finished_ = false;
+    std::shared_future<Status> producer_future_;
+    std::vector<std::unique_ptr<AsyncKeyValueConsumer<T, R>>> consumers_;
+    std::atomic<int32_t> consumer_finished_count_ = 0;
+    tbb::concurrent_bounded_queue<std::optional<KeyValue>> kv_queue_;
+    tbb::concurrent_bounded_queue<R> result_queue_;
+};
+
+template <typename T, typename R>
+class AsyncKeyValueConsumer {
+ public:
+    AsyncKeyValueConsumer(int32_t batch_size,
+                          std::unique_ptr<RowToArrowArrayConverter<T, R>>&& key_value_consumer,
+                          std::atomic<bool>& consume_finished,
+                          std::atomic<int32_t>& consumer_finished_count,
+                          tbb::concurrent_bounded_queue<std::optional<KeyValue>>& kv_queue,
+                          tbb::concurrent_bounded_queue<R>& result_queue);
+
+    ~AsyncKeyValueConsumer() {
+        CleanUp();
+    }
+
+    Status GetStatus() const;
+    void CleanUp();
+
+ private:
+    Status ConsumeLoop();
+
+ private:
+    int32_t batch_size_;
+    std::unique_ptr<RowToArrowArrayConverter<T, R>> key_value_consumer_;
+    std::shared_future<Status> consumer_future_;
+    std::atomic<bool>& consume_finished_;
+    std::atomic<int32_t>& consumer_finished_count_;
+    tbb::concurrent_bounded_queue<std::optional<KeyValue>>& kv_queue_;
+    tbb::concurrent_bounded_queue<R>& result_queue_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/async_key_value_projection_reader.h
+++ b/src/paimon/core/io/async_key_value_projection_reader.h
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "paimon/core/io/async_key_value_producer_and_consumer.h"
+#include "paimon/core/io/key_value_projection_consumer.h"
+#include "paimon/reader/batch_reader.h"
+
+namespace paimon {
+class AsyncKeyValueProjectionReader : public BatchReader {
+ public:
+    AsyncKeyValueProjectionReader(std::unique_ptr<SortMergeReader>&& sort_merge_reader,
+                                  const std::shared_ptr<arrow::Schema>& target_schema,
+                                  const std::vector<int32_t>& target_to_src_mapping,
+                                  int32_t batch_size, int32_t projection_thread_num,
+                                  const std::shared_ptr<MemoryPool>& pool) {
+        auto create_consumer = [target_schema, target_to_src_mapping, pool]()
+            -> Result<std::unique_ptr<RowToArrowArrayConverter<KeyValue, BatchReader::ReadBatch>>> {
+            return KeyValueProjectionConsumer::Create(target_schema, target_to_src_mapping, pool);
+        };
+        producer_and_consumer_ =
+            std::make_unique<AsyncKeyValueProducerAndConsumer<KeyValue, BatchReader::ReadBatch>>(
+                std::move(sort_merge_reader), create_consumer, batch_size, projection_thread_num,
+                pool);
+    }
+
+    Result<BatchReader::ReadBatch> NextBatch() override {
+        return producer_and_consumer_->NextBatch();
+    }
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return producer_and_consumer_->GetReaderMetrics();
+    }
+
+    void Close() override {
+        producer_and_consumer_->Close();
+    }
+
+ private:
+    std::unique_ptr<AsyncKeyValueProducerAndConsumer<KeyValue, BatchReader::ReadBatch>>
+        producer_and_consumer_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/field_mapping_reader.cpp
+++ b/src/paimon/core/io/field_mapping_reader.cpp
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "paimon/core/io/field_mapping_reader.h"
+
+#include <cassert>
+#include <cstddef>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/array/util.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "arrow/scalar.h"
+#include "arrow/util/checked_cast.h"
+#include "fmt/format.h"
+#include "paimon/common/data/binary_string.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/core/utils/field_mapping.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/reader/batch_reader.h"
+
+namespace paimon {
+class MemoryPool;
+
+FieldMappingReader::FieldMappingReader(int32_t field_count,
+                                       std::unique_ptr<FileBatchReader>&& reader,
+                                       const BinaryRow& partition,
+                                       std::unique_ptr<FieldMapping>&& mapping,
+                                       const std::shared_ptr<MemoryPool>& pool)
+    : field_count_(field_count),
+      arrow_pool_(GetArrowPool(pool)),
+      reader_(std::move(reader)),
+      partition_(partition),
+      partition_info_(mapping->partition_info),
+      non_partition_info_(mapping->non_partition_info),
+      non_exist_field_info_(mapping->non_exist_field_info) {
+    if (non_exist_field_info_ != std::nullopt || partition_info_ != std::nullopt) {
+        need_mapping_ = true;
+    }
+
+    for (int32_t i = 0;
+         i < static_cast<int32_t>(non_partition_info_.idx_in_target_read_schema.size()); i++) {
+        if (i != non_partition_info_.idx_in_target_read_schema[i]) {
+            need_mapping_ = true;
+        }
+        if (non_partition_info_.cast_executors[i] != nullptr) {
+            need_casting_ = true;
+        }
+        // Field name change (RENAME COLUMN) also requires mapping: data schema
+        // carries the file's physical name while read schema carries the
+        // post-rename logical name. If we skipped mapping, the inner reader's
+        // batch would be passed through with the old physical name and the
+        // consumer's name-based lookup against the read schema would fail.
+        if (non_partition_info_.non_partition_data_schema[i].Name() !=
+            non_partition_info_.non_partition_read_schema[i].Name()) {
+            need_mapping_ = true;
+        }
+    }
+}
+
+Result<std::shared_ptr<arrow::Array>> FieldMappingReader::CastNonPartitionArrayIfNeed(
+    const std::shared_ptr<arrow::Array>& src_array) const {
+    if (!need_casting_) {
+        return src_array;
+    }
+    auto* struct_array = arrow::internal::checked_cast<arrow::StructArray*>(src_array.get());
+    int32_t field_count = struct_array->num_fields();
+    assert(static_cast<size_t>(field_count) == non_partition_info_.cast_executors.size());
+    arrow::ArrayVector casted_array;
+    std::vector<std::string> casted_field_names;
+    casted_array.reserve(field_count);
+    casted_field_names.reserve(field_count);
+    for (int32_t i = 0; i < field_count; i++) {
+        if (non_partition_info_.cast_executors[i] != nullptr) {
+            auto single_column_array = struct_array->field(i);
+            // if src array is dict, cast to string first
+            auto dict_array =
+                std::dynamic_pointer_cast<arrow::DictionaryArray>(single_column_array);
+            if (dict_array) {
+                PAIMON_ASSIGN_OR_RAISE(
+                    single_column_array,
+                    CastingUtils::Cast(dict_array, /*target_type=*/arrow::utf8(),
+                                       arrow::compute::CastOptions::Safe(), arrow_pool_.get()));
+            }
+            PAIMON_ASSIGN_OR_RAISE(
+                std::shared_ptr<arrow::Array> casted,
+                non_partition_info_.cast_executors[i]->Cast(
+                    single_column_array, non_partition_info_.non_partition_read_schema[i].Type(),
+                    arrow_pool_.get()));
+            casted_array.push_back(casted);
+            casted_field_names.push_back(non_partition_info_.non_partition_data_schema[i].Name());
+        } else {
+            // read and data type may both be string type, but after adapter transform, type may be
+            // dictionary, need reconstruct struct type
+            casted_array.push_back(struct_array->field(i));
+            casted_field_names.push_back(non_partition_info_.non_partition_data_schema[i].Name());
+        }
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                      arrow::StructArray::Make(casted_array, casted_field_names));
+    return arrow_array;
+}
+
+Result<BatchReader::ReadBatchWithBitmap> FieldMappingReader::NextBatchWithBitmap() {
+    PAIMON_ASSIGN_OR_RAISE(ReadBatchWithBitmap non_partition_result_with_bitmap,
+                           reader_->NextBatchWithBitmap());
+    if (!need_mapping_ && !need_casting_) {
+        return non_partition_result_with_bitmap;
+    }
+    if (BatchReader::IsEofBatch(non_partition_result_with_bitmap)) {
+        // read finish
+        partition_array_.reset();
+        non_exist_array_.reset();
+        return non_partition_result_with_bitmap;
+    }
+    auto& [non_partition_result, bitmap] = non_partition_result_with_bitmap;
+    auto& [c_array, c_schema] = non_partition_result;
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> non_partition_array,
+                                      arrow::ImportArray(c_array.get(), c_schema.get()));
+
+    arrow::ArrayVector target_array(field_count_);
+    std::vector<std::string> target_field_names(field_count_);
+    // mapping non-partition array
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> casted_non_partition_array,
+                           CastNonPartitionArrayIfNeed(non_partition_array));
+    MappingFields(casted_non_partition_array, non_partition_info_.non_partition_read_schema,
+                  non_partition_info_.idx_in_target_read_schema, &target_array,
+                  &target_field_names);
+
+    // mapping partition array
+    if (partition_info_ != std::nullopt) {
+        if (!partition_array_ || partition_array_->length() < non_partition_array->length()) {
+            PAIMON_ASSIGN_OR_RAISE(partition_array_,
+                                   GeneratePartitionArray(non_partition_array->length()));
+        }
+        auto trim_partition_array = partition_array_->Slice(0, non_partition_array->length());
+        MappingFields(trim_partition_array, partition_info_.value().partition_read_schema,
+                      partition_info_.value().idx_in_target_read_schema, &target_array,
+                      &target_field_names);
+    }
+    // mapping non-exist array
+    if (non_exist_field_info_ != std::nullopt) {
+        if (!non_exist_array_ || non_exist_array_->length() < non_partition_array->length()) {
+            PAIMON_ASSIGN_OR_RAISE(non_exist_array_,
+                                   GenerateNonExistArray(non_partition_array->length()));
+        }
+        auto trim_non_exist_array = non_exist_array_->Slice(0, non_partition_array->length());
+        MappingFields(trim_non_exist_array, non_exist_field_info_.value().non_exist_read_schema,
+                      non_exist_field_info_.value().idx_in_target_read_schema, &target_array,
+                      &target_field_names);
+    }
+
+    // construct target array
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                      arrow::StructArray::Make(target_array, target_field_names));
+    std::unique_ptr<ArrowArray> target_c_arrow_array = std::make_unique<ArrowArray>();
+    std::unique_ptr<ArrowSchema> target_c_schema = std::make_unique<ArrowSchema>();
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        arrow::ExportArray(*arrow_array, target_c_arrow_array.get(), target_c_schema.get()));
+    auto target_batch = std::make_pair(std::move(target_c_arrow_array), std::move(target_c_schema));
+    return std::make_pair(std::move(target_batch), std::move(bitmap));
+}
+
+Result<std::shared_ptr<arrow::Array>> FieldMappingReader::GenerateSinglePartitionArray(
+    int32_t idx, int32_t batch_size) const {
+    const auto& type = partition_info_.value().partition_read_schema[idx].Type();
+    if (partition_.IsNullAt(partition_info_.value().idx_in_partition[idx])) {
+        // for null partition value
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            std::shared_ptr<arrow::Array> null_array,
+            arrow::MakeArrayOfNull(type, batch_size, arrow_pool_.get()));
+        return null_array;
+    }
+    auto type_id = type->id();
+    std::shared_ptr<arrow::Scalar> scalar;
+    switch (type_id) {
+        case arrow::Type::type::BOOL: {
+            bool value = partition_.GetBoolean(partition_info_.value().idx_in_partition[idx]);
+            scalar = std::make_shared<arrow::BooleanScalar>(value);
+            break;
+        }
+        case arrow::Type::type::INT8: {
+            int8_t value = partition_.GetByte(partition_info_.value().idx_in_partition[idx]);
+            scalar = std::make_shared<arrow::Int8Scalar>(value);
+            break;
+        }
+        case arrow::Type::type::INT16: {
+            int16_t value = partition_.GetShort(partition_info_.value().idx_in_partition[idx]);
+            scalar = std::make_shared<arrow::Int16Scalar>(value);
+            break;
+        }
+        case arrow::Type::type::INT32: {
+            int32_t value = partition_.GetInt(partition_info_.value().idx_in_partition[idx]);
+            scalar = std::make_shared<arrow::Int32Scalar>(value);
+            break;
+        }
+        case arrow::Type::type::INT64: {
+            int64_t value = partition_.GetLong(partition_info_.value().idx_in_partition[idx]);
+            scalar = std::make_shared<arrow::Int64Scalar>(value);
+            break;
+        }
+        case arrow::Type::type::FLOAT: {
+            float value = partition_.GetFloat(partition_info_.value().idx_in_partition[idx]);
+            scalar = std::make_shared<arrow::FloatScalar>(value);
+            break;
+        }
+        case arrow::Type::type::DOUBLE: {
+            double value = partition_.GetDouble(partition_info_.value().idx_in_partition[idx]);
+            scalar = std::make_shared<arrow::DoubleScalar>(value);
+            break;
+        }
+        case arrow::Type::type::STRING: {
+            BinaryString value =
+                partition_.GetString(partition_info_.value().idx_in_partition[idx]);
+            scalar = std::make_shared<arrow::StringScalar>(value.ToString());
+            break;
+        }
+        case arrow::Type::type::BINARY: {
+            auto value = partition_.GetBinary(partition_info_.value().idx_in_partition[idx]);
+            std::string value_str(value->data(), value->size());
+            scalar = std::make_shared<arrow::BinaryScalar>(value_str);
+            break;
+        }
+        case arrow::Type::type::DATE32: {
+            int32_t value = partition_.GetDate(partition_info_.value().idx_in_partition[idx]);
+            scalar = std::make_shared<arrow::Date32Scalar>(value);
+            break;
+        }
+        default:
+            return Status::Invalid(
+                fmt::format("Not support arrow type {} for partition",
+                            partition_info_.value().partition_read_schema[idx].Type()->ToString()));
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+        std::shared_ptr<arrow::Array> arrow_array,
+        arrow::MakeArrayFromScalar(*scalar, batch_size, arrow_pool_.get()));
+    return arrow_array;
+}
+
+Result<std::shared_ptr<arrow::Array>> FieldMappingReader::GeneratePartitionArray(
+    int32_t batch_size) const {
+    arrow::ArrayVector partition_array;
+    std::vector<std::string> partition_field_names;
+    partition_array.reserve(partition_info_.value().partition_read_schema.size());
+    partition_field_names.reserve(partition_info_.value().partition_read_schema.size());
+    for (size_t i = 0; i < partition_info_.value().partition_read_schema.size(); i++) {
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> single_partition_array,
+                               GenerateSinglePartitionArray(i, batch_size));
+        partition_array.push_back(single_partition_array);
+        partition_field_names.push_back(partition_info_.value().partition_read_schema[i].Name());
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+        std::shared_ptr<arrow::Array> arrow_array,
+        arrow::StructArray::Make(partition_array, partition_field_names));
+    return arrow_array;
+}
+
+Result<std::shared_ptr<arrow::Array>> FieldMappingReader::GenerateNonExistArray(
+    int32_t batch_size) const {
+    arrow::ArrayVector non_exist_array;
+    std::vector<std::string> non_exist_field_names;
+    non_exist_array.reserve(non_exist_field_info_.value().non_exist_read_schema.size());
+    non_exist_field_names.reserve(non_exist_field_info_.value().non_exist_read_schema.size());
+    for (const auto& non_exist_field : non_exist_field_info_.value().non_exist_read_schema) {
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            std::shared_ptr<arrow::Array> null_array,
+            arrow::MakeArrayOfNull(non_exist_field.Type(), batch_size, arrow_pool_.get()));
+        non_exist_array.push_back(null_array);
+        non_exist_field_names.push_back(non_exist_field.Name());
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+        std::shared_ptr<arrow::Array> arrow_array,
+        arrow::StructArray::Make(non_exist_array, non_exist_field_names));
+    return arrow_array;
+}
+
+void FieldMappingReader::MappingFields(const std::shared_ptr<arrow::Array>& data_array,
+                                       const std::vector<DataField>& read_fields_of_data_array,
+                                       const std::vector<int32_t>& idx_in_target_schema,
+                                       arrow::ArrayVector* target_array,
+                                       std::vector<std::string>* target_field_names) {
+    auto* struct_array = arrow::internal::checked_cast<arrow::StructArray*>(data_array.get());
+    assert(struct_array);
+    assert(struct_array->fields().size() == idx_in_target_schema.size());
+    for (size_t i = 0; i < idx_in_target_schema.size(); i++) {
+        // target type may be string type, but after adapter transform, type may be dictionary,
+        // need reconstruct struct type
+        (*target_array)[idx_in_target_schema[i]] = struct_array->field(i);
+        (*target_field_names)[idx_in_target_schema[i]] = read_fields_of_data_array[i].Name();
+    }
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/field_mapping_reader.h
+++ b/src/paimon/core/io/field_mapping_reader.h
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/core/partition/partition_info.h"
+#include "paimon/core/utils/field_mapping.h"
+#include "paimon/reader/file_batch_reader.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class DataField;
+class MemoryPool;
+class Metrics;
+struct FieldMapping;
+
+class FieldMappingReader : public FileBatchReader {
+ public:
+    FieldMappingReader(int32_t field_count, std::unique_ptr<FileBatchReader>&& reader,
+                       const BinaryRow& partition, std::unique_ptr<FieldMapping>&& mapping,
+                       const std::shared_ptr<MemoryPool>& pool);
+
+    Result<ReadBatch> NextBatch() override {
+        return Status::Invalid(
+            "paimon inner reader FieldMappingReader should use NextBatchWithBitmap");
+    }
+
+    Result<ReadBatchWithBitmap> NextBatchWithBitmap() override;
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return reader_->GetReaderMetrics();
+    }
+
+    void Close() override {
+        reader_->Close();
+    }
+
+    Result<std::unique_ptr<::ArrowSchema>> GetFileSchema() const override {
+        return Status::Invalid("FieldMappingReader does not support GetFileSchema");
+    }
+
+    Status SetReadSchema(::ArrowSchema* read_schema, const std::shared_ptr<Predicate>& predicate,
+                         const std::optional<RoaringBitmap32>& selection_bitmap) override {
+        return Status::Invalid("FieldMappingReader does not support SetReadSchema");
+    }
+
+    Result<uint64_t> GetPreviousBatchFirstRowNumber() const override {
+        return reader_->GetPreviousBatchFirstRowNumber();
+    }
+
+    Result<uint64_t> GetNumberOfRows() const override {
+        return reader_->GetNumberOfRows();
+    }
+
+    bool SupportPreciseBitmapSelection() const override {
+        return reader_->SupportPreciseBitmapSelection();
+    }
+
+ private:
+    Result<std::shared_ptr<arrow::Array>> GenerateSinglePartitionArray(int32_t idx,
+                                                                       int32_t batch_size) const;
+
+    Result<std::shared_ptr<arrow::Array>> GeneratePartitionArray(int32_t batch_size) const;
+
+    Result<std::shared_ptr<arrow::Array>> GenerateNonExistArray(int32_t batch_size) const;
+    Result<std::shared_ptr<arrow::Array>> CastNonPartitionArrayIfNeed(
+        const std::shared_ptr<arrow::Array>& src_array) const;
+
+    static void MappingFields(const std::shared_ptr<arrow::Array>& src_array,
+                              const std::vector<DataField>& read_fields_of_data_array,
+                              const std::vector<int32_t>& idx_in_target_schema,
+                              arrow::ArrayVector* target_array,
+                              std::vector<std::string>* target_field_names);
+
+ private:
+    bool need_mapping_ = false;
+    bool need_casting_ = false;
+    int32_t field_count_;
+    std::shared_ptr<arrow::MemoryPool> arrow_pool_;
+    std::unique_ptr<FileBatchReader> reader_;
+    BinaryRow partition_ = BinaryRow::EmptyRow();
+
+    std::optional<PartitionInfo> partition_info_;
+    NonPartitionInfo non_partition_info_;
+    std::optional<NonExistFieldInfo> non_exist_field_info_;
+
+    std::shared_ptr<arrow::Array> partition_array_;
+    std::shared_ptr<arrow::Array> non_exist_array_;
+};
+}  // namespace paimon

--- a/src/paimon/core/io/field_mapping_reader_test.cpp
+++ b/src/paimon/core/io/field_mapping_reader_test.cpp
@@ -1,0 +1,753 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/field_mapping_reader.h"
+
+#include <map>
+#include <ostream>
+#include <string>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_binary.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/array/array_primitive.h"
+#include "arrow/array/util.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "arrow/ipc/json_simple.h"
+#include "arrow/util/checked_cast.h"
+#include "gtest/gtest.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/core/utils/field_mapping.h"
+#include "paimon/defs.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/file_format_factory.h"
+#include "paimon/format/format_writer.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon {
+class Predicate;
+}  // namespace paimon
+
+namespace paimon::test {
+class FieldMappingReaderTest : public ::testing::Test {
+ public:
+    void SetUp() override {
+        partition_ = BinaryRowGenerator::GenerateRow({10, 0}, pool_.get());
+    }
+    void TearDown() override {}
+
+    std::unique_ptr<FileBatchReader> PrepareFileBatchReader(
+        const std::string& file_name, const std::shared_ptr<FileSystem>& fs,
+        const std::map<std::string, std::string>& options, const arrow::Schema* read_schema,
+        const std::shared_ptr<Predicate>& predicate, int32_t batch_size) const {
+        EXPECT_OK_AND_ASSIGN(auto file_format, FileFormatFactory::Get("orc", options));
+        EXPECT_OK_AND_ASSIGN(auto reader_builder, file_format->CreateReaderBuilder(batch_size));
+        EXPECT_OK_AND_ASSIGN(std::shared_ptr<InputStream> input_stream, fs->Open(file_name));
+        EXPECT_OK_AND_ASSIGN(auto orc_batch_reader, reader_builder->Build(input_stream));
+        std::unique_ptr<ArrowSchema> c_schema = std::make_unique<ArrowSchema>();
+        auto arrow_status = arrow::ExportSchema(*read_schema, c_schema.get());
+        EXPECT_TRUE(arrow_status.ok());
+        EXPECT_OK(orc_batch_reader->SetReadSchema(c_schema.get(), predicate,
+                                                  /*selection_bitmap=*/std::nullopt));
+        return orc_batch_reader;
+    }
+
+    std::unique_ptr<FileBatchReader> PrepareFileBatchReaderWithCustomizedData(
+        const std::string& data_path, const std::shared_ptr<FileSystem>& fs,
+        const arrow::Schema* src_schema, const std::shared_ptr<arrow::Array>& src_array,
+        const arrow::Schema* read_schema, const std::shared_ptr<Predicate>& predicate,
+        int32_t batch_size) const {
+        std::map<std::string, std::string> write_options = {
+            {"orc.dictionary-key-size-threshold", "1.0"}};
+        EXPECT_OK_AND_ASSIGN(auto file_format, FileFormatFactory::Get("orc", write_options));
+        std::unique_ptr<ArrowSchema> write_schema = std::make_unique<ArrowSchema>();
+        EXPECT_TRUE(arrow::ExportSchema(*src_schema, write_schema.get()).ok());
+        EXPECT_OK_AND_ASSIGN(auto writer_builder,
+                             file_format->CreateWriterBuilder(write_schema.get(), batch_size));
+        EXPECT_OK_AND_ASSIGN(std::shared_ptr<paimon::OutputStream> output_stream,
+                             fs->Create(data_path, /*overwrite=*/true));
+        EXPECT_TRUE(output_stream);
+        EXPECT_OK_AND_ASSIGN(auto writer, writer_builder->Build(output_stream, "zstd"));
+
+        ::ArrowArray c_array;
+        EXPECT_TRUE(arrow::ExportArray(*src_array, &c_array).ok());
+        EXPECT_OK(writer->AddBatch(&c_array));
+        EXPECT_OK(writer->Flush());
+        EXPECT_OK(writer->Finish());
+        EXPECT_OK(output_stream->Flush());
+        EXPECT_OK(output_stream->Close());
+
+        EXPECT_OK_AND_ASSIGN(std::shared_ptr<paimon::InputStream> input_stream,
+                             fs->Open(data_path));
+        EXPECT_TRUE(input_stream);
+        std::map<std::string, std::string> read_options = {
+            {"orc.read.enable-lazy-decoding", "true"}};
+        return PrepareFileBatchReader(data_path, fs, read_options, read_schema, predicate,
+                                      batch_size);
+    }
+
+    void CheckResult(const std::shared_ptr<arrow::Schema>& read_schema,
+                     const std::shared_ptr<Predicate>& predicate,
+                     const std::shared_ptr<arrow::Array>& expect_array) {
+        std::string file_name = paimon::test::GetDataDir() +
+                                "/orc/multi_partition_append_table.db/"
+                                "multi_partition_append_table/f1=10/f2=0/"
+                                "bucket-0/"
+                                "data-1c547e5f-48b2-4917-a996-71d306377661-0.orc";
+
+        ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                             FieldMappingBuilder::Create(read_schema, partition_keys_, predicate));
+        ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(data_fields_));
+
+        auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(
+            mapping->non_partition_info.non_partition_data_schema);
+        std::shared_ptr<FileSystem> fs = std::make_shared<LocalFileSystem>();
+        auto orc_batch_reader =
+            PrepareFileBatchReader(file_name, fs, /*options=*/{}, arrow_schema.get(),
+                                   mapping->non_partition_info.non_partition_filter,
+                                   /*batch_size=*/1);
+
+        auto reader = std::make_shared<FieldMappingReader>(
+            /*field_count=*/read_schema->num_fields(), std::move(orc_batch_reader), partition_,
+            std::move(mapping), pool_);
+        ASSERT_OK_AND_ASSIGN(auto result_array, ReadResultCollector::CollectResult(reader.get()));
+        if (expect_array == nullptr && result_array == nullptr) {
+            // expect empty result
+            return;
+        }
+        auto expected_chunk_array =
+            std::make_shared<arrow::ChunkedArray>(arrow::ArrayVector({expect_array}));
+
+        ASSERT_TRUE(result_array->type()->Equals(expected_chunk_array->type()))
+            << expected_chunk_array->type()->ToString() << std::endl
+            << result_array->type()->ToString();
+        ASSERT_TRUE(result_array->Equals(expected_chunk_array))
+            << result_array->ToString() << expected_chunk_array->ToString();
+    }
+
+    void CheckResult(const std::shared_ptr<arrow::Schema>& data_schema,
+                     const std::shared_ptr<arrow::Array>& data_array,
+                     const std::shared_ptr<arrow::Schema>& read_schema,
+                     const std::shared_ptr<Predicate>& predicate,
+                     const std::vector<std::string>& partition_keys, const BinaryRow& partition,
+                     const std::shared_ptr<arrow::Array>& expect_array) const {
+        auto dir = paimon::test::UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir);
+        auto fs = dir->GetFileSystem();
+        std::string data_path = dir->Str() + "/test.data";
+
+        ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                             FieldMappingBuilder::Create(read_schema, partition_keys, predicate));
+        ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(data_schema));
+
+        auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(
+            mapping->non_partition_info.non_partition_data_schema);
+        auto orc_batch_reader = PrepareFileBatchReaderWithCustomizedData(
+            data_path, fs, data_schema.get(), data_array, arrow_schema.get(),
+            /*predicate=*/mapping->non_partition_info.non_partition_filter, /*batch_size=*/1);
+
+        auto reader = std::make_shared<FieldMappingReader>(
+            /*field_count=*/read_schema->num_fields(), std::move(orc_batch_reader), partition,
+            std::move(mapping), pool_);
+        ASSERT_OK_AND_ASSIGN(auto result_array, ReadResultCollector::CollectResult(reader.get()));
+        if (expect_array == nullptr && result_array == nullptr) {
+            // expect empty result
+            return;
+        }
+        auto expected_chunk_array =
+            std::make_shared<arrow::ChunkedArray>(arrow::ArrayVector({expect_array}));
+
+        ASSERT_TRUE(result_array->Equals(expected_chunk_array))
+            << result_array->ToString() << expected_chunk_array->ToString();
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+    std::vector<DataField> data_fields_ = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                           DataField(1, arrow::field("f1", arrow::int32())),
+                                           DataField(2, arrow::field("f2", arrow::int32())),
+                                           DataField(3, arrow::field("f3", arrow::float64()))};
+    std::shared_ptr<arrow::Array> f0_ =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::utf8(), R"(["Emily", "Bob", "Alex"])")
+            .ValueOrDie();
+    std::shared_ptr<arrow::Array> f1_ =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::int32(), R"([10, 10, 10])").ValueOrDie();
+    std::shared_ptr<arrow::Array> f2_ =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::int32(), R"([0, 0, 0])").ValueOrDie();
+    std::shared_ptr<arrow::Array> f3_ =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::float64(), R"([15.1, 12.1, 16.1])")
+            .ValueOrDie();
+    std::vector<std::string> partition_keys_ = {"f1", "f2"};
+    BinaryRow partition_ = BinaryRow::EmptyRow();
+};
+
+TEST_F(FieldMappingReaderTest, TestGenerateSinglePartitionArray) {
+    PartitionInfo partition_info;
+    // read schema: p9-p0
+    // partition key: p0-p9
+    partition_info.partition_read_schema = {DataField(9, arrow::field("p9", arrow::date32())),
+                                            DataField(8, arrow::field("p8", arrow::binary())),
+                                            DataField(7, arrow::field("p7", arrow::utf8())),
+                                            DataField(6, arrow::field("p6", arrow::float64())),
+                                            DataField(5, arrow::field("p5", arrow::float32())),
+                                            DataField(4, arrow::field("p4", arrow::int64())),
+                                            DataField(3, arrow::field("p3", arrow::int32())),
+                                            DataField(2, arrow::field("p2", arrow::int16())),
+                                            DataField(1, arrow::field("p1", arrow::int8())),
+                                            DataField(0, arrow::field("p0", arrow::boolean()))};
+    partition_info.idx_in_target_read_schema = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    partition_info.idx_in_partition = {9, 8, 7, 6, 5, 4, 3, 2, 1, 0};
+
+    NonPartitionInfo non_part_info;
+    auto field_mapping = std::make_unique<FieldMapping>(partition_info, non_part_info,
+                                                        /*non_exist_field_info=*/std::nullopt);
+    auto partition = BinaryRowGenerator::GenerateRow(
+        {false, static_cast<int8_t>(1), static_cast<int16_t>(2), static_cast<int32_t>(3),
+         static_cast<int64_t>(4), static_cast<float>(5.1), 6.21, std::string("7"),
+         std::make_shared<Bytes>("8", pool_.get()), 100},
+        pool_.get());
+    auto mapping_reader = std::make_unique<FieldMappingReader>(
+        /*field_count=*/10, /*reader=*/nullptr, partition, std::move(field_mapping), pool_);
+
+    {
+        ASSERT_OK_AND_ASSIGN(auto p9_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 0, /*batch_size=*/2));
+        ASSERT_EQ(p9_array->length(), 2);
+        ASSERT_EQ(arrow::internal::checked_cast<arrow::Date32Array*>(p9_array.get())->Value(0),
+                  100);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto p8_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 1, /*batch_size=*/2));
+        ASSERT_EQ(p8_array->length(), 2);
+        ASSERT_EQ(arrow::internal::checked_cast<arrow::BinaryArray*>(p8_array.get())->Value(0),
+                  "8");
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto p7_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 2, /*batch_size=*/1));
+        ASSERT_EQ(p7_array->length(), 1);
+        ASSERT_EQ(arrow::internal::checked_cast<arrow::StringArray*>(p7_array.get())->Value(0),
+                  "7");
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto p6_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 3, /*batch_size=*/1));
+        ASSERT_EQ(
+            arrow::internal::checked_cast<arrow::NumericArray<arrow::DoubleType>*>(p6_array.get())
+                ->Value(0),
+            static_cast<double>(6.21));
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto p5_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 4, /*batch_size=*/1));
+        ASSERT_EQ(
+            arrow::internal::checked_cast<arrow::NumericArray<arrow::FloatType>*>(p5_array.get())
+                ->Value(0),
+            static_cast<float>(5.1));
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto p4_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 5, /*batch_size=*/1));
+        ASSERT_EQ(
+            arrow::internal::checked_cast<arrow::NumericArray<arrow::Int64Type>*>(p4_array.get())
+                ->Value(0),
+            static_cast<int64_t>(4));
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto p3_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 6, /*batch_size=*/1));
+        ASSERT_EQ(
+            arrow::internal::checked_cast<arrow::NumericArray<arrow::Int32Type>*>(p3_array.get())
+                ->Value(0),
+            static_cast<int32_t>(3));
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto p2_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 7, /*batch_size=*/1));
+        ASSERT_EQ(
+            arrow::internal::checked_cast<arrow::NumericArray<arrow::Int16Type>*>(p2_array.get())
+                ->Value(0),
+            static_cast<int16_t>(2));
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto p1_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 8, /*batch_size=*/1));
+        ASSERT_EQ(
+            arrow::internal::checked_cast<arrow::NumericArray<arrow::Int8Type>*>(p1_array.get())
+                ->Value(0),
+            static_cast<int64_t>(1));
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto p0_array, mapping_reader->GenerateSinglePartitionArray(
+                                                /*idx in read schema*/ 9, /*batch_size=*/1));
+        ASSERT_EQ(arrow::internal::checked_cast<arrow::BooleanArray*>(p0_array.get())->Value(0),
+                  false);
+    }
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithOnlyPartitionField) {
+    std::vector<DataField> read_fields = {DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(1, arrow::field("f1", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    std::shared_ptr<arrow::Array> expect_data =
+        arrow::StructArray::Make({f2_, f1_}, read_schema->fields()).ValueOrDie();
+    CheckResult(read_schema, /*predicate=*/nullptr, expect_data);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithOnlyNonExistField) {
+    std::vector<DataField> read_fields = {DataField(10, arrow::field("non-exist", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+    auto null_array =
+        arrow::MakeArrayOfNull(arrow::list(arrow::int32()), /*length=*/3).ValueOrDie();
+    std::shared_ptr<arrow::Array> expect_data =
+        arrow::StructArray::Make({null_array}, read_schema->fields()).ValueOrDie();
+    CheckResult(read_schema, /*predicate=*/nullptr, expect_data);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithPartitionField) {
+    std::vector<DataField> read_fields = {DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(3, arrow::field("f3", arrow::float64())),
+                                          DataField(1, arrow::field("f1", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    std::shared_ptr<arrow::Array> expect_data =
+        arrow::StructArray::Make({f2_, f0_, f3_, f1_}, read_schema->fields()).ValueOrDie();
+    CheckResult(read_schema, /*predicate=*/nullptr, expect_data);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithNonExistField) {
+    std::vector<DataField> read_fields = {
+        DataField(2, arrow::field("f2", arrow::int32())),
+        DataField(0, arrow::field("f0", arrow::utf8())),
+        DataField(100, arrow::field("non-exist", arrow::list(arrow::utf8()))),
+        DataField(3, arrow::field("f3", arrow::float64())),
+        DataField(1, arrow::field("f1", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto null_array = arrow::MakeArrayOfNull(arrow::list(arrow::utf8()), /*length=*/3).ValueOrDie();
+    std::shared_ptr<arrow::Array> expect_data =
+        arrow::StructArray::Make({f2_, f0_, null_array, f3_, f1_}, read_schema->fields())
+            .ValueOrDie();
+    CheckResult(read_schema, /*predicate=*/nullptr, expect_data);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithAllPartitionField) {
+    std::vector<DataField> read_fields = {
+        DataField(2, arrow::field("f2", arrow::int32())),
+        DataField(100, arrow::field("non-exist", arrow::list(arrow::utf8()))),
+        DataField(1, arrow::field("f1", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto null_array = arrow::MakeArrayOfNull(arrow::list(arrow::utf8()), /*length=*/3).ValueOrDie();
+    std::shared_ptr<arrow::Array> expect_data =
+        arrow::StructArray::Make({f2_, null_array, f1_}, read_schema->fields()).ValueOrDie();
+    CheckResult(read_schema, /*predicate=*/nullptr, expect_data);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithAllNonPartitionField) {
+    std::vector<DataField> read_fields = {DataField(3, arrow::field("f3", arrow::float64())),
+                                          DataField(0, arrow::field("f0", arrow::utf8()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    std::shared_ptr<arrow::Array> expect_data =
+        arrow::StructArray::Make({f3_, f0_}, read_schema->fields()).ValueOrDie();
+    CheckResult(read_schema, /*predicate=*/nullptr, expect_data);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithSchemaEvolution) {
+    std::vector<DataField> read_fields = {
+        DataField(2, arrow::field("f2", arrow::int32())),
+        DataField(0, arrow::field("f3", arrow::utf8())),
+        DataField(100, arrow::field("non-exist", arrow::list(arrow::utf8()))),
+        DataField(3, arrow::field("f0", arrow::float64())),
+        DataField(1, arrow::field("f1", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto null_array = arrow::MakeArrayOfNull(arrow::list(arrow::utf8()), /*length=*/3).ValueOrDie();
+    std::shared_ptr<arrow::Array> expect_data =
+        arrow::StructArray::Make({f2_, f0_, null_array, f3_, f1_}, read_schema->fields())
+            .ValueOrDie();
+
+    CheckResult(read_schema, /*predicate=*/nullptr, expect_data);
+}
+
+TEST_F(FieldMappingReaderTest, TestDictionaryTypeWithSchemaEvolution) {
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(1, arrow::field("f1", arrow::float32())),
+                                          DataField(2, arrow::field("f2", arrow::float64())),
+                                          DataField(3, arrow::field("f3", arrow::int8())),
+                                          DataField(4, arrow::field("f4", arrow::int16())),
+                                          DataField(5, arrow::field("f5", arrow::int32())),
+                                          DataField(6, arrow::field("f6", arrow::int64())),
+                                          DataField(7, arrow::field("f7", arrow::boolean()))};
+    std::shared_ptr<arrow::Schema> data_schema =
+        DataField::ConvertDataFieldsToArrowSchema(data_fields);
+    auto data_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(data_schema->fields()), R"([
+        ["apple", 4.0, 5.1, 10, 100, 1000, 10000, true],
+        ["banana", 4.1, 6.2, 10, 200, 1000, 20000, null],
+        [null, 4.2, null, 10, 300, 1000, 30000, true],
+        ["data", 4.3, 8.4, 10, 400, 1000, 40000, false],
+        ["data", 4.5, 8.4, 10, 400, 1000, 40000, false],
+        ["data", 4.0, 8.0, 10, 500, 1000, 40000, true]
+    ])")
+            .ValueOrDie());
+
+    std::vector<DataField> read_fields = {DataField(6, arrow::field("ff6", arrow::int64())),
+                                          DataField(2, arrow::field("ff2", arrow::float64())),
+                                          DataField(0, arrow::field("ff0", arrow::utf8())),
+                                          DataField(1, arrow::field("ff1", arrow::float32())),
+                                          DataField(5, arrow::field("f5", arrow::int32())),
+                                          DataField(3, arrow::field("f3", arrow::int8())),
+                                          DataField(8, arrow::field("non-exist", arrow::utf8())),
+                                          DataField(7, arrow::field("ff7", arrow::boolean())),
+                                          DataField(4, arrow::field("ff4", arrow::int16()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    std::vector<std::string> partition_keys = {"f3", "f5"};
+    BinaryRow partition = BinaryRowGenerator::GenerateRow({10, 1000}, pool_.get());
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(read_schema->fields()), R"([
+        [10000, 5.1, "apple", 4.0, 1000, 10, null, true, 100],
+        [20000, 6.2, "banana", 4.1, 1000, 10, null, null, 200],
+        [30000, null, null, 4.2, 1000,  10, null, true, 300],
+        [40000, 8.4, "data", 4.3, 1000, 10, null, false, 400],
+        [40000, 8.4, "data", 4.5, 1000, 10, null, false, 400],
+        [40000, 8.0, "data", 4.0, 1000, 10, null, true, 500]
+    ])")
+            .ValueOrDie());
+    CheckResult(data_schema, data_array, read_schema, /*predicate=*/nullptr, partition_keys,
+                partition, expected_array);
+}
+
+TEST_F(FieldMappingReaderTest, TestSchemaEvolutionWithModifyType) {
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(1, arrow::field("f1", arrow::float32())),
+                                          DataField(2, arrow::field("f2", arrow::float64())),
+                                          DataField(3, arrow::field("f3", arrow::int8()))};
+    std::shared_ptr<arrow::Schema> data_schema =
+        DataField::ConvertDataFieldsToArrowSchema(data_fields);
+    auto data_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(data_schema->fields()), R"([
+        ["true", 4.0, 5.1, 10],
+        ["False", 4.1, 6.2, 10],
+        [null, 4.2, null, 10],
+        ["yes", 4.3, 8.4, 10],
+        ["nO", 4.5, 8.4, 10],
+        ["1", 4.0, 8.0, 10]
+    ])")
+            .ValueOrDie());
+
+    std::vector<DataField> read_fields = {DataField(0, arrow::field("f0", arrow::boolean())),
+                                          DataField(1, arrow::field("f1", arrow::utf8())),
+                                          DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(3, arrow::field("f3", arrow::int8()))};
+
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    std::vector<std::string> partition_keys = {"f3"};
+    BinaryRow partition = BinaryRowGenerator::GenerateRow({10}, pool_.get());
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(read_schema->fields()), R"([
+        [true, "4", 5, 10],
+        [false, "4.1", 6, 10],
+        [null, "4.2", null,  10],
+        [true, "4.3", 8, 10],
+        [false, "4.5", 8, 10],
+        [true, "4", 8, 10]
+    ])")
+            .ValueOrDie());
+    CheckResult(data_schema, data_array, read_schema, /*predicate=*/nullptr, partition_keys,
+                partition, expected_array);
+}
+
+TEST_F(FieldMappingReaderTest, TestSchemaEvolutionWithModifyTypeWithDict) {
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(1, arrow::field("f1", arrow::float32())),
+                                          DataField(2, arrow::field("f2", arrow::float64())),
+                                          DataField(3, arrow::field("f3", arrow::int8()))};
+    std::shared_ptr<arrow::Schema> data_schema =
+        DataField::ConvertDataFieldsToArrowSchema(data_fields);
+    auto data_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(data_schema->fields()), R"([
+        ["true", 4.0, 5.1, 10],
+        ["false", 4.1, 6.2, 10],
+        [null, 4.2, null, 10],
+        ["true", 4.3, 8.4, 10],
+        ["false", 4.5, 8.4, 10],
+        ["1", 4.0, 8.0, 10]
+    ])")
+            .ValueOrDie());
+
+    std::vector<DataField> read_fields = {DataField(0, arrow::field("f0", arrow::boolean())),
+                                          DataField(1, arrow::field("f1", arrow::utf8())),
+                                          DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(3, arrow::field("f3", arrow::int8()))};
+
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    std::vector<std::string> partition_keys = {"f3"};
+    BinaryRow partition = BinaryRowGenerator::GenerateRow({10}, pool_.get());
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(read_schema->fields()), R"([
+        [true, "4", 5, 10],
+        [false, "4.1", 6, 10],
+        [null, "4.2", null,  10],
+        [true, "4.3", 8, 10],
+        [false, "4.5", 8, 10],
+        [true, "4", 8, 10]
+    ])")
+            .ValueOrDie());
+    CheckResult(data_schema, data_array, read_schema, /*predicate=*/nullptr, partition_keys,
+                partition, expected_array);
+}
+
+TEST_F(FieldMappingReaderTest, TestSchemaEvolutionWithModifyTypeWithPredicate) {
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(1, arrow::field("f1", arrow::float32())),
+                                          DataField(2, arrow::field("f2", arrow::int16())),
+                                          DataField(3, arrow::field("f3", arrow::int8()))};
+    std::shared_ptr<arrow::Schema> data_schema =
+        DataField::ConvertDataFieldsToArrowSchema(data_fields);
+    auto data_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(data_schema->fields()), R"([
+        ["true", 4.0, 5, 10],
+        ["False", 4.1, 6, 10],
+        [null, 4.2, null, 10],
+        ["yes", 4.3, 8, 10],
+        ["nO", 4.5, 8, 10],
+        ["1", 4.0, 9, 10]
+    ])")
+            .ValueOrDie());
+
+    std::vector<DataField> read_fields = {DataField(0, arrow::field("f0", arrow::boolean())),
+                                          DataField(1, arrow::field("f1", arrow::utf8())),
+                                          DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(3, arrow::field("f3", arrow::int8()))};
+
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+    auto predicate = PredicateBuilder::GreaterThan(
+        /*field_index=*/2, /*field_name=*/"f2", FieldType::INT, {Literal(10)});
+
+    std::vector<std::string> partition_keys = {"f3"};
+    BinaryRow partition = BinaryRowGenerator::GenerateRow({10}, pool_.get());
+    CheckResult(data_schema, data_array, read_schema, predicate, partition_keys, partition,
+                /*expect_array=*/nullptr);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithSchemaEvolutionWithRenameAndModifyType) {
+    // field_0 and field_3 are rename and modify type
+    std::vector<DataField> read_fields = {
+        DataField(2, arrow::field("f2", arrow::int32())),
+        DataField(0, arrow::field("f3", arrow::binary())),
+        DataField(100, arrow::field("non-exist", arrow::list(arrow::utf8()))),
+        DataField(3, arrow::field("f0", arrow::utf8())),
+        DataField(1, arrow::field("f1", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto null_array = arrow::MakeArrayOfNull(arrow::list(arrow::utf8()), /*length=*/3).ValueOrDie();
+    std::shared_ptr<arrow::Array> f0_new =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::binary(), R"(["Emily", "Bob", "Alex"])")
+            .ValueOrDie();
+    std::shared_ptr<arrow::Array> f3_new =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::utf8(), R"(["15.1", "12.1", "16.1"])")
+            .ValueOrDie();
+    std::shared_ptr<arrow::Array> expect_data =
+        arrow::StructArray::Make({f2_, f0_new, null_array, f3_new, f1_}, read_schema->fields())
+            .ValueOrDie();
+    CheckResult(read_schema, /*predicate=*/nullptr, expect_data);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithSchemaEvolutionPureRename) {
+    // Regression: pure RENAME (same field ids, same types, identity order, no
+    // partition / non-exist) used to leave need_mapping_ false, taking the
+    // FieldMappingReader PASSTHRU path. The inner reader's batch was emitted
+    // unchanged carrying the file's physical column names, so a consumer that
+    // looked columns up by name against the read schema (post-rename logical
+    // names) failed to find them.
+
+    // File schema: physical names f0, f1
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(1, arrow::field("f1", arrow::int32()))};
+    auto data_schema = DataField::ConvertDataFieldsToArrowSchema(data_fields);
+    auto data_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(data_schema->fields()),
+                                                  R"([
+        ["Alice", 1],
+        ["Bob", 2],
+        ["Carol", 3]
+    ])")
+            .ValueOrDie());
+
+    // Read schema: same field ids, RENAMED names, same types, identity order
+    std::vector<DataField> read_fields = {DataField(0, arrow::field("name_new", arrow::utf8())),
+                                          DataField(1, arrow::field("age_new", arrow::int32()))};
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    // Expected output uses the post-rename names; verifies mapping actually
+    // ran (PASSTHRU would keep f0/f1 and Equals would fail).
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(read_schema->fields()),
+                                                  R"([
+        ["Alice", 1],
+        ["Bob", 2],
+        ["Carol", 3]
+    ])")
+            .ValueOrDie());
+
+    CheckResult(data_schema, data_array, read_schema, /*predicate=*/nullptr,
+                /*partition_keys=*/{}, BinaryRow::EmptyRow(), expected);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithSchemaEvolutionWithRenameAndModifyTypeAndPredicate) {
+    // field_0 and field_3 are rename and modify type
+    // result is not filtered by predicate, as DOUBLE->STRING alter table does not support predicate
+    // push down
+    std::vector<DataField> read_fields = {
+        DataField(2, arrow::field("f2", arrow::int32())),
+        DataField(0, arrow::field("f3", arrow::binary())),
+        DataField(100, arrow::field("non-exist", arrow::list(arrow::utf8()))),
+        DataField(3, arrow::field("f0", arrow::utf8())),
+        DataField(1, arrow::field("f1", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+    std::string literal_str = "17";
+    auto predicate = PredicateBuilder::GreaterOrEqual(
+        /*field_index=*/3, /*field_name=*/"f0", FieldType::STRING,
+        Literal(FieldType::STRING, literal_str.data(), literal_str.size()));
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(read_schema->fields()), R"([
+        [0, "Emily", null, "15.1", 10],
+        [0, "Bob", null, "12.1", 10],
+        [0, "Alex", null, "16.1", 10]
+    ])")
+            .ValueOrDie());
+    CheckResult(read_schema, predicate, expected_array);
+}
+
+TEST_F(FieldMappingReaderTest, TestSchemaEvolutionWithDictType) {
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(1, arrow::field("f1", arrow::float32())),
+                                          DataField(2, arrow::field("f2", arrow::float64())),
+                                          DataField(3, arrow::field("f3", arrow::int8()))};
+    std::shared_ptr<arrow::Schema> data_schema =
+        DataField::ConvertDataFieldsToArrowSchema(data_fields);
+    auto data_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(data_schema->fields()), R"([
+        ["Bob", 4.0, 5.1, 10],
+        ["Emily", 4.1, 6.2, 10],
+        ["Alice", 4.2, null, 10],
+        ["Bob", 4.3, 8.4, 10],
+        ["Emily", 4.5, 8.4, 10],
+        ["Bob", 4.0, 8.0, 10]
+    ])")
+            .ValueOrDie());
+
+    std::vector<DataField> read_fields = {DataField(3, arrow::field("f3", arrow::int8())),
+                                          DataField(1, arrow::field("f1", arrow::utf8())),
+                                          DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(2, arrow::field("f2", arrow::int32()))};
+
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    std::vector<std::string> partition_keys = {"f3"};
+    BinaryRow partition = BinaryRowGenerator::GenerateRow({10}, pool_.get());
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(read_schema->fields()), R"([
+        [10, "4", "Bob", 5],
+        [10, "4.1", "Emily", 6],
+        [10, "4.2", "Alice", null],
+        [10, "4.3", "Bob", 8],
+        [10, "4.5", "Emily", 8],
+        [10, "4", "Bob", 8]
+    ])")
+            .ValueOrDie());
+    CheckResult(data_schema, data_array, read_schema, /*predicate=*/nullptr, partition_keys,
+                partition, expected_array);
+}
+
+TEST_F(FieldMappingReaderTest, TestReadWithSchemaEvolutionRenameCombinedCast) {
+    // Test all 4 combinations of rename × cast:
+    //   f0: no rename, no cast   (utf8 → utf8, name unchanged)
+    //   f1: rename only           (int32 → int32, f1 → new_f1)
+    //   f2: cast only             (int32 → utf8, name unchanged)
+    //   f3: rename + cast         (int32 → utf8, f3 → new_f2)
+    std::vector<DataField> data_fields = {
+        DataField(0, arrow::field("f0", arrow::utf8())),
+        DataField(1, arrow::field("f1", arrow::int32())),
+        DataField(2, arrow::field("f2", arrow::int32())),
+        DataField(3, arrow::field("f3", arrow::int32())),
+    };
+    auto data_schema = DataField::ConvertDataFieldsToArrowSchema(data_fields);
+    auto data_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(data_schema->fields()),
+                                                  R"([
+        ["Bob", 100, 10, 1],
+        ["Emily", 200, 20, 2],
+        ["Alice", 300, 30, 3]
+    ])")
+            .ValueOrDie());
+
+    std::vector<DataField> read_fields = {
+        DataField(0, arrow::field("f0", arrow::utf8())),
+        DataField(1, arrow::field("new_f1", arrow::int32())),
+        DataField(2, arrow::field("f2", arrow::utf8())),
+        DataField(3, arrow::field("new_f3", arrow::utf8())),
+    };
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(read_schema->fields()),
+                                                  R"([
+        ["Bob", 100, "10", "1"],
+        ["Emily", 200, "20", "2"],
+        ["Alice", 300, "30", "3"]
+    ])")
+            .ValueOrDie());
+
+    CheckResult(data_schema, data_array, read_schema, /*predicate=*/nullptr,
+                /*partition_keys=*/{}, BinaryRow::EmptyRow(), expected);
+}
+}  // namespace paimon::test

--- a/src/paimon/core/io/key_value_meta_projection_consumer.cpp
+++ b/src/paimon/core/io/key_value_meta_projection_consumer.cpp
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/key_value_meta_projection_consumer.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <functional>
+#include <numeric>
+
+#include "arrow/api.h"
+#include "arrow/array/builder_dict.h"
+#include "arrow/array/builder_nested.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/helpers.h"
+#include "arrow/util/checked_cast.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class MemoryPool;
+Result<std::unique_ptr<KeyValueMetaProjectionConsumer>> KeyValueMetaProjectionConsumer::Create(
+    const std::shared_ptr<arrow::Schema>& target_schema, const std::shared_ptr<MemoryPool>& pool) {
+    std::vector<int32_t> target_to_src_mapping(target_schema->num_fields() -
+                                               SpecialFields::KEY_VALUE_SPECIAL_FIELD_COUNT);
+    std::iota(target_to_src_mapping.begin(), target_to_src_mapping.end(), 0);
+    return Create(target_schema, target_to_src_mapping, pool);
+}
+Result<std::unique_ptr<KeyValueMetaProjectionConsumer>> KeyValueMetaProjectionConsumer::Create(
+    const std::shared_ptr<arrow::Schema>& target_schema,
+    const std::vector<int32_t>& target_to_src_mapping, const std::shared_ptr<MemoryPool>& pool) {
+    if (static_cast<size_t>(target_schema->num_fields() -
+                            SpecialFields::KEY_VALUE_SPECIAL_FIELD_COUNT) !=
+        target_to_src_mapping.size()) {
+        return Status::Invalid(
+            fmt::format("target_schema field count without special fields {} and "
+                        "target_to_src_mapping size {} mismatch in KeyValueMetaProjectionConsumer",
+                        target_schema->num_fields() - SpecialFields::KEY_VALUE_SPECIAL_FIELD_COUNT,
+                        target_to_src_mapping.size()));
+    }
+
+    auto arrow_pool = GetArrowPool(pool);
+    // target fields of output array: special fields + value fields
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::MakeBuilder(
+        arrow_pool.get(), arrow::struct_(target_schema->fields()), &array_builder));
+
+    auto struct_builder =
+        arrow::internal::checked_pointer_cast<arrow::StructBuilder>(std::move(array_builder));
+    assert(struct_builder);
+    auto* sequence_appender =
+        arrow::internal::checked_cast<arrow::Int64Builder*>(struct_builder->field_builder(0));
+    if (sequence_appender == nullptr) {
+        return Status::Invalid("sequence_appender cannot cast to Int64Builder");
+    }
+    auto* value_kind_appender =
+        arrow::internal::checked_cast<arrow::Int8Builder*>(struct_builder->field_builder(1));
+    if (value_kind_appender == nullptr) {
+        return Status::Invalid("value_kind_appender cannot cast to Int8Builder");
+    }
+    // appenders only contains array_builder of value schema, sequence_appender and
+    // value_kind_appender are not in appenders
+    std::vector<RowToArrowArrayConverter::AppendValueFunc> appenders;
+    appenders.reserve(target_schema->num_fields() - SpecialFields::KEY_VALUE_SPECIAL_FIELD_COUNT);
+    // first is the root struct array, and 2 special fields
+    int32_t reserve_count = 1 + SpecialFields::KEY_VALUE_SPECIAL_FIELD_COUNT;
+    for (int32_t i = SpecialFields::KEY_VALUE_SPECIAL_FIELD_COUNT; i < target_schema->num_fields();
+         i++) {
+        PAIMON_ASSIGN_OR_RAISE(
+            RowToArrowArrayConverter::AppendValueFunc func,
+            AppendField(/*use_view=*/true, struct_builder->field_builder(i), &reserve_count));
+        appenders.emplace_back(func);
+    }
+    return std::unique_ptr<KeyValueMetaProjectionConsumer>(new KeyValueMetaProjectionConsumer(
+        reserve_count, std::move(appenders), std::move(struct_builder), std::move(arrow_pool),
+        target_to_src_mapping, sequence_appender, value_kind_appender));
+}
+
+Result<KeyValueBatch> KeyValueMetaProjectionConsumer::NextBatch(
+    const std::vector<KeyValue>& key_value_vec) {
+    if (key_value_vec.empty()) {
+        return Status::Invalid("invalid key value batch, cannot be empty");
+    }
+    KeyValueBatch key_value_batch;
+    PAIMON_RETURN_NOT_OK(ResetAndReserve());
+
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        array_builder_->AppendValues(key_value_vec.size(), /*valid_bytes=*/nullptr));
+
+    key_value_batch.min_key = key_value_vec[0].key;
+    key_value_batch.max_key = key_value_vec.back().key;
+
+    // append special fields
+    for (const auto& row : key_value_vec) {
+        if (row.value_kind->IsRetract()) {
+            key_value_batch.delete_row_count++;
+        }
+        key_value_batch.min_sequence_number =
+            std::min(key_value_batch.min_sequence_number, row.sequence_number);
+        key_value_batch.max_sequence_number =
+            std::max(key_value_batch.max_sequence_number, row.sequence_number);
+
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(sequence_appender_->Append(row.sequence_number));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(
+            value_kind_appender_->Append(row.value_kind->ToByteValue()));
+    }
+    // append value fields
+    for (size_t i = 0; i < appenders_.size(); i++) {
+        for (const auto& row : key_value_vec) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(appenders_[i](*(row.value), target_to_src_mapping_[i]));
+        }
+    }
+    PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch result_batch, FinishAndAccumulate());
+    key_value_batch.batch = std::move(result_batch.first);
+    ArrowSchemaRelease(result_batch.second.get());
+    return std::move(key_value_batch);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_meta_projection_consumer.h
+++ b/src/paimon/core/io/key_value_meta_projection_consumer.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "arrow/array/builder_primitive.h"
+#include "paimon/core/io/row_to_arrow_array_converter.h"
+#include "paimon/core/key_value.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class MemoryPool;
+class Schema;
+class StructBuilder;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+
+// project KeyValue.value according to value_schema, output KeyValueBatch, collect delete row count
+// and min/max key, also add special fields to output array (e.g., sequence num)
+class KeyValueMetaProjectionConsumer : public RowToArrowArrayConverter<KeyValue, KeyValueBatch> {
+ public:
+    static Result<std::unique_ptr<KeyValueMetaProjectionConsumer>> Create(
+        const std::shared_ptr<arrow::Schema>& target_schema,
+        const std::shared_ptr<MemoryPool>& pool);
+
+    // target_to_src_mapping is the mapping excluding special fields.
+    static Result<std::unique_ptr<KeyValueMetaProjectionConsumer>> Create(
+        const std::shared_ptr<arrow::Schema>& target_schema,
+        const std::vector<int32_t>& target_to_src_mapping, const std::shared_ptr<MemoryPool>& pool);
+
+    Result<KeyValueBatch> NextBatch(const std::vector<KeyValue>& key_value_vec) override;
+
+ private:
+    KeyValueMetaProjectionConsumer(int32_t reserve_count, std::vector<AppendValueFunc>&& appenders,
+                                   std::unique_ptr<arrow::StructBuilder>&& array_builder,
+                                   std::unique_ptr<arrow::MemoryPool>&& arrow_pool,
+                                   const std::vector<int32_t>& target_to_src_mapping,
+                                   arrow::Int64Builder* sequence_appender,
+                                   arrow::Int8Builder* value_kind_appender)
+        : RowToArrowArrayConverter(reserve_count, std::move(appenders), std::move(array_builder),
+                                   std::move(arrow_pool)),
+          target_to_src_mapping_(target_to_src_mapping),
+          sequence_appender_(sequence_appender),
+          value_kind_appender_(value_kind_appender) {}
+
+ private:
+    std::vector<int32_t> target_to_src_mapping_;
+    arrow::Int64Builder* sequence_appender_;
+    arrow::Int8Builder* value_kind_appender_;
+};
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_projection_consumer.cpp
+++ b/src/paimon/core/io/key_value_projection_consumer.cpp
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/key_value_projection_consumer.h"
+
+#include <cassert>
+#include <cstddef>
+#include <functional>
+
+#include "arrow/api.h"
+#include "arrow/array/builder_base.h"
+#include "arrow/array/builder_nested.h"
+#include "arrow/c/abi.h"
+#include "arrow/util/checked_cast.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/core/key_value.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class MemoryPool;
+
+Result<std::unique_ptr<KeyValueProjectionConsumer>> KeyValueProjectionConsumer::Create(
+    const std::shared_ptr<arrow::Schema>& target_schema,
+    const std::vector<int32_t>& target_to_src_mapping, const std::shared_ptr<MemoryPool>& pool) {
+    if (static_cast<size_t>(target_schema->num_fields()) != target_to_src_mapping.size()) {
+        return Status::Invalid(
+            "target_schema and target_to_src_mapping mismatch in KeyValueProjectionConsumer");
+    }
+    auto arrow_pool = GetArrowPool(pool);
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::MakeBuilder(
+        arrow_pool.get(), std::make_shared<arrow::StructType>(target_schema->fields()),
+        &array_builder));
+
+    auto struct_builder =
+        arrow::internal::checked_pointer_cast<arrow::StructBuilder>(std::move(array_builder));
+    assert(struct_builder);
+    std::vector<RowToArrowArrayConverter::AppendValueFunc> appenders;
+    appenders.reserve(target_to_src_mapping.size());
+    // first is the root struct array
+    int32_t reserve_count = 1;
+    for (int32_t i = 0; i < static_cast<int32_t>(target_to_src_mapping.size()); i++) {
+        PAIMON_ASSIGN_OR_RAISE(
+            RowToArrowArrayConverter::AppendValueFunc func,
+            AppendField(/*use_view=*/true, struct_builder->field_builder(i), &reserve_count));
+        appenders.emplace_back(func);
+    }
+    return std::unique_ptr<KeyValueProjectionConsumer>(new KeyValueProjectionConsumer(
+        reserve_count, std::move(appenders), std::move(struct_builder), std::move(arrow_pool),
+        target_to_src_mapping));
+}
+
+Result<BatchReader::ReadBatch> KeyValueProjectionConsumer::NextBatch(
+    const std::vector<KeyValue>& key_value_vec) {
+    PAIMON_RETURN_NOT_OK(ResetAndReserve());
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        array_builder_->AppendValues(key_value_vec.size(), /*valid_bytes=*/nullptr));
+    for (int32_t i = 0; i < static_cast<int32_t>(target_to_src_mapping_.size()); i++) {
+        for (const auto& row : key_value_vec) {
+            if (target_to_src_mapping_[i] == kSequenceNumberProjection) {
+                auto* builder =
+                    dynamic_cast<arrow::Int64Builder*>(array_builder_->field_builder(i));
+                if (builder == nullptr) {
+                    return Status::Invalid("cannot append sequence number to non-int64 field");
+                }
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(builder->Append(row.sequence_number));
+                continue;
+            }
+            if (target_to_src_mapping_[i] == kValueKindProjection) {
+                auto* builder = dynamic_cast<arrow::Int8Builder*>(array_builder_->field_builder(i));
+                if (builder == nullptr) {
+                    return Status::Invalid("cannot append value kind to non-int8 field");
+                }
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(builder->Append(row.value_kind->ToByteValue()));
+                continue;
+            }
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(appenders_[i](*(row.value), target_to_src_mapping_[i]));
+        }
+    }
+    return FinishAndAccumulate();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_projection_consumer.h
+++ b/src/paimon/core/io/key_value_projection_consumer.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "paimon/core/io/row_to_arrow_array_converter.h"
+#include "paimon/core/key_value.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/result.h"
+#include "paimon/utils/special_field_ids.h"
+
+namespace arrow {
+class MemoryPool;
+class Schema;
+class StructBuilder;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+struct KeyValue;
+
+// project KeyValue.value according to target_schema, output is BatchReader::ReadBatch
+class KeyValueProjectionConsumer
+    : public RowToArrowArrayConverter<KeyValue, BatchReader::ReadBatch> {
+ public:
+    static constexpr int32_t kSequenceNumberProjection = SpecialFieldIds::SEQUENCE_NUMBER;
+    static constexpr int32_t kValueKindProjection = SpecialFieldIds::VALUE_KIND;
+
+    static Result<std::unique_ptr<KeyValueProjectionConsumer>> Create(
+        const std::shared_ptr<arrow::Schema>& target_schema,
+        const std::vector<int32_t>& target_to_src_mapping, const std::shared_ptr<MemoryPool>& pool);
+
+    Result<BatchReader::ReadBatch> NextBatch(const std::vector<KeyValue>& key_value_vec) override;
+
+    ~KeyValueProjectionConsumer() override = default;
+
+ private:
+    KeyValueProjectionConsumer(int32_t reserve_count, std::vector<AppendValueFunc>&& appenders,
+                               std::unique_ptr<arrow::StructBuilder>&& array_builder,
+                               std::unique_ptr<arrow::MemoryPool>&& arrow_pool,
+                               const std::vector<int32_t>& target_to_src_mapping)
+        : RowToArrowArrayConverter(reserve_count, std::move(appenders), std::move(array_builder),
+                                   std::move(arrow_pool)),
+          target_to_src_mapping_(target_to_src_mapping) {}
+
+    std::vector<int32_t> target_to_src_mapping_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_projection_reader.cpp
+++ b/src/paimon/core/io/key_value_projection_reader.cpp
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/key_value_projection_reader.h"
+
+#include <cassert>
+#include <utility>
+
+#include "arrow/c/abi.h"
+#include "paimon/core/io/key_value_projection_consumer.h"
+#include "paimon/core/key_value.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+
+Result<std::unique_ptr<KeyValueProjectionReader>> KeyValueProjectionReader::Create(
+    std::unique_ptr<SortMergeReader>&& sort_merge_reader,
+    const std::shared_ptr<arrow::Schema>& target_schema,
+    const std::vector<int32_t>& target_to_src_mapping, int32_t batch_size,
+    const std::shared_ptr<MemoryPool>& pool) {
+    std::unique_ptr<RowToArrowArrayConverter<KeyValue, BatchReader::ReadBatch>> projection_consumer;
+    PAIMON_ASSIGN_OR_RAISE(projection_consumer, KeyValueProjectionConsumer::Create(
+                                                    target_schema, target_to_src_mapping, pool));
+    return std::unique_ptr<KeyValueProjectionReader>(new KeyValueProjectionReader(
+        batch_size, std::move(sort_merge_reader), std::move(projection_consumer)));
+}
+
+KeyValueProjectionReader::KeyValueProjectionReader(
+    int32_t batch_size, std::unique_ptr<SortMergeReader>&& sort_merge_reader,
+    std::unique_ptr<RowToArrowArrayConverter<KeyValue, BatchReader::ReadBatch>>&&
+        projection_consumer)
+    : batch_size_(batch_size),
+      sort_merge_reader_(std::move(sort_merge_reader)),
+      key_value_consumer_(std::move(projection_consumer)) {}
+
+Result<BatchReader::ReadBatch> KeyValueProjectionReader::NextBatch() {
+    int32_t cur_batch_size = 0;
+    std::vector<KeyValue> key_value_vec;
+    key_value_vec.reserve(batch_size_);
+    while (!read_finished_ && cur_batch_size < batch_size_) {
+        if (iterator_ == nullptr) {
+            PAIMON_ASSIGN_OR_RAISE(iterator_, sort_merge_reader_->NextBatch());
+            if (iterator_ == nullptr) {
+                // read eof
+                read_finished_ = true;
+                break;
+            }
+        }
+        PAIMON_ASSIGN_OR_RAISE(bool has_next, iterator_->HasNext());
+        if (!has_next) {
+            // current iterator is all visited
+            iterator_ = nullptr;
+            continue;
+        }
+        key_value_vec.push_back(std::move(iterator_->Next()));
+        cur_batch_size++;
+    }
+    if (cur_batch_size > 0) {
+        return key_value_consumer_->NextBatch(key_value_vec);
+    } else {
+        assert(read_finished_);
+        return BatchReader::MakeEofBatch();
+    }
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_projection_reader.h
+++ b/src/paimon/core/io/key_value_projection_reader.h
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "arrow/api.h"
+#include "paimon/core/io/row_to_arrow_array_converter.h"
+#include "paimon/core/mergetree/compact/sort_merge_reader.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+class Metrics;
+struct KeyValue;
+
+// Serial iterate KeyValue from SortMergeReader and convert KeyValue to arrow array
+class KeyValueProjectionReader : public BatchReader {
+ public:
+    static Result<std::unique_ptr<KeyValueProjectionReader>> Create(
+        std::unique_ptr<SortMergeReader>&& sort_merge_reader,
+        const std::shared_ptr<arrow::Schema>& target_schema,
+        const std::vector<int32_t>& target_to_src_mapping, int32_t batch_size,
+        const std::shared_ptr<MemoryPool>& pool);
+
+    Result<ReadBatch> NextBatch() override;
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return sort_merge_reader_->GetReaderMetrics();
+    }
+
+    void Close() override {
+        iterator_.reset();
+        key_value_consumer_->CleanUp();
+        sort_merge_reader_->Close();
+    }
+
+ private:
+    KeyValueProjectionReader(
+        int32_t batch_size, std::unique_ptr<SortMergeReader>&& sort_merge_reader,
+        std::unique_ptr<RowToArrowArrayConverter<KeyValue, BatchReader::ReadBatch>>&&
+            projection_consumer);
+
+ private:
+    int32_t batch_size_;
+    bool read_finished_ = false;
+    std::unique_ptr<SortMergeReader> sort_merge_reader_;
+    std::unique_ptr<SortMergeReader::Iterator> iterator_;
+    std::unique_ptr<RowToArrowArrayConverter<KeyValue, BatchReader::ReadBatch>> key_value_consumer_;
+};
+}  // namespace paimon

--- a/src/paimon/core/io/key_value_projection_reader_test.cpp
+++ b/src/paimon/core/io/key_value_projection_reader_test.cpp
@@ -1,0 +1,556 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/key_value_projection_reader.h"
+
+#include <cassert>
+#include <ostream>
+#include <string>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_dict.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/array/builder_binary.h"
+#include "arrow/array/builder_dict.h"
+#include "arrow/array/builder_nested.h"
+#include "arrow/c/abi.h"
+#include "arrow/ipc/json_simple.h"
+#include "arrow/util/checked_cast.h"
+#include "gtest/gtest.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/io/async_key_value_projection_reader.h"
+#include "paimon/core/io/concat_key_value_record_reader.h"
+#include "paimon/core/io/key_value_data_file_record_reader.h"
+#include "paimon/core/io/key_value_projection_consumer.h"
+#include "paimon/core/io/key_value_record_reader.h"
+#include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
+#include "paimon/core/mergetree/compact/reducer_merge_function_wrapper.h"
+#include "paimon/core/mergetree/compact/sort_merge_reader_with_min_heap.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/mock/mock_file_batch_reader.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class KeyValueProjectionReaderTest : public testing::Test,
+                                     public ::testing::WithParamInterface<bool> {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+    }
+
+    std::unique_ptr<BatchReader> GenerateProjectionReader(
+        const std::shared_ptr<arrow::Array>& src_array,
+        const std::shared_ptr<arrow::Schema>& target_schema,
+        const std::vector<int32_t>& target_to_src_mapping,
+        const std::shared_ptr<arrow::Schema>& key_schema,
+        const std::shared_ptr<arrow::Schema>& value_schema, int32_t batch_size,
+        bool multi_thread_row_to_batch) const {
+        std::vector<int32_t> key_sort_fields(key_schema->num_fields());
+        std::iota(key_sort_fields.begin(), key_sort_fields.end(), 0);
+        std::vector<DataField> key_fields;
+        for (int32_t i = 0; i < key_schema->num_fields(); i++) {
+            const auto& key_field = key_schema->field(i);
+            key_fields.emplace_back(i, key_field);
+        }
+        EXPECT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> user_key_comparator,
+                             FieldsComparator::Create(key_fields, key_sort_fields,
+                                                      /*is_ascending_order=*/true));
+
+        auto mfunc = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/false);
+        auto merge_function_wrapper =
+            std::make_shared<ReducerMergeFunctionWrapper>(std::move(mfunc));
+        auto file_batch_reader = std::make_unique<MockFileBatchReader>(src_array, src_array->type(),
+                                                                       /*batch_size=*/batch_size);
+        auto record_reader = std::make_unique<KeyValueDataFileRecordReader>(
+            std::move(file_batch_reader), key_schema, value_schema, /*level=*/0, pool_);
+        std::vector<std::unique_ptr<KeyValueRecordReader>> readers;
+        readers.push_back(std::move(record_reader));
+        std::vector<std::unique_ptr<KeyValueRecordReader>> concat_readers;
+        concat_readers.push_back(std::make_unique<ConcatKeyValueRecordReader>(std::move(readers)));
+
+        auto sort_merge_reader = std::make_unique<SortMergeReaderWithMinHeap>(
+            std::move(concat_readers), user_key_comparator,
+            /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper);
+        if (!multi_thread_row_to_batch) {
+            EXPECT_OK_AND_ASSIGN(auto projection_reader, KeyValueProjectionReader::Create(
+                                                             std::move(sort_merge_reader),
+                                                             target_schema, target_to_src_mapping,
+                                                             /*batch_size=*/batch_size, pool_));
+            return std::move(projection_reader);
+        } else {
+            return std::make_unique<AsyncKeyValueProjectionReader>(
+                std::move(sort_merge_reader), target_schema, target_to_src_mapping, batch_size,
+                /*projection_thread_num=*/3, pool_);
+        }
+    }
+
+    void CheckResult(const std::shared_ptr<arrow::Array>& src_array,
+                     const std::shared_ptr<arrow::StructType>& target_type,
+                     const std::vector<int32_t>& target_to_src_mapping,
+                     const std::shared_ptr<arrow::Schema>& key_schema,
+                     const std::shared_ptr<arrow::Schema>& value_schema,
+                     const std::shared_ptr<arrow::ChunkedArray>& expected_array,
+                     const std::shared_ptr<arrow::Schema>& expected_sort_schema,
+                     int32_t expected_reserve_count) const {
+        bool multi_thread_row_to_batch = GetParam();
+        auto target_schema = arrow::schema(target_type->fields());
+        for (const auto& batch_size : {1, 2, 3, 4, 100}) {
+            auto projection_reader = GenerateProjectionReader(
+                src_array, target_schema, target_to_src_mapping, key_schema, value_schema,
+                batch_size, multi_thread_row_to_batch);
+            ASSERT_OK_AND_ASSIGN(auto result, paimon::test::ReadResultCollector::CollectResult(
+                                                  projection_reader.get()));
+            // after read eof, always return nullptr
+            ASSERT_OK_AND_ASSIGN(auto eof_result, projection_reader->NextBatch());
+            ASSERT_FALSE(eof_result.first);
+
+            if (!multi_thread_row_to_batch) {
+                ASSERT_TRUE(result);
+                ASSERT_TRUE(expected_array->Equals(result));
+            } else {
+                ASSERT_TRUE(result);
+                ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::ChunkedArray> sorted_result,
+                                     ReadResultCollector::SortArray(result, expected_sort_schema));
+                ASSERT_OK_AND_ASSIGN(
+                    std::shared_ptr<arrow::ChunkedArray> sorted_expected,
+                    ReadResultCollector::SortArray(expected_array, expected_sort_schema));
+                ASSERT_TRUE(sorted_result->Equals(*sorted_expected))
+                    << sorted_result->ToString() << std::endl
+                    << sorted_expected->ToString();
+            }
+            projection_reader->Close();
+            // test reserve and accumulate
+            if (!multi_thread_row_to_batch) {
+                auto* typed_projection_reader =
+                    dynamic_cast<KeyValueProjectionReader*>(projection_reader.get());
+                ASSERT_TRUE(typed_projection_reader);
+                auto& consumer = typed_projection_reader->key_value_consumer_;
+                ASSERT_EQ(consumer->reserved_sizes_.size(), expected_reserve_count);
+                for (const auto& reserved_size : consumer->reserved_sizes_) {
+                    ASSERT_GT(reserved_size, 0);
+                }
+            }
+        }
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+TEST_P(KeyValueProjectionReaderTest, TestBulkData) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("v0", arrow::int16()),
+                                 arrow::field("v1", arrow::float32()),
+                                 arrow::field("v2", arrow::utf8())};
+    std::shared_ptr<arrow::Schema> key_schema = arrow::schema(arrow::FieldVector({fields[2]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+
+    auto arrow_pool = GetArrowPool(pool_);
+    std::unique_ptr<arrow::ArrayBuilder> array_builder;
+    ASSERT_TRUE(arrow::MakeBuilder(arrow_pool.get(), src_type, &array_builder).ok());
+
+    auto struct_builder =
+        arrow::internal::checked_pointer_cast<arrow::StructBuilder>(std::move(array_builder));
+    auto seq_builder = static_cast<arrow::Int64Builder*>(struct_builder->field_builder(0));
+    auto kind_builder = static_cast<arrow::Int8Builder*>(struct_builder->field_builder(1));
+    auto int_builder = static_cast<arrow::Int32Builder*>(struct_builder->field_builder(2));
+    auto short_builder = static_cast<arrow::Int16Builder*>(struct_builder->field_builder(3));
+    auto float_builder = static_cast<arrow::FloatBuilder*>(struct_builder->field_builder(4));
+    auto string_builder = static_cast<arrow::StringBuilder*>(struct_builder->field_builder(5));
+    for (int32_t i = 0; i < 2000; ++i) {
+        ASSERT_TRUE(struct_builder->Append().ok());
+        ASSERT_TRUE(int_builder->Append(i).ok());
+        ASSERT_TRUE(seq_builder->Append(0).ok());
+        ASSERT_TRUE(kind_builder->Append(0).ok());
+
+        if (i % 2 == 0) {
+            // test null value
+            ASSERT_TRUE(short_builder->AppendNull().ok());
+            ASSERT_TRUE(float_builder->AppendNull().ok());
+            ASSERT_TRUE(string_builder->AppendNull().ok());
+        } else {
+            ASSERT_TRUE(short_builder->Append(i * 2).ok());
+            ASSERT_TRUE(float_builder->Append(i + 0.1).ok());
+            ASSERT_TRUE(string_builder->Append("str_" + std::to_string(i)).ok());
+        }
+    }
+    std::shared_ptr<arrow::Array> src_array;
+    ASSERT_TRUE(struct_builder->Finish(&src_array).ok());
+    auto typed_array = arrow::internal::checked_pointer_cast<arrow::StructArray>(src_array);
+
+    auto target_type = std::dynamic_pointer_cast<arrow::StructType>(
+        arrow::struct_({fields[2], fields[3], fields[4], fields[5]}));
+    ASSERT_TRUE(target_type);
+    std::vector<int32_t> target_to_src_mapping = {0, 1, 2, 3};
+
+    auto expected_array = arrow::StructArray::Make({typed_array->field(2), typed_array->field(3),
+                                                    typed_array->field(4), typed_array->field(5)},
+                                                   value_schema->fields())
+                              .ValueOrDie();
+    auto expected = arrow::ChunkedArray::Make({expected_array}).ValueOrDie();
+
+    std::shared_ptr<arrow::Schema> expected_sort_schema =
+        arrow::schema(arrow::FieldVector({fields[2]}));
+    CheckResult(src_array, target_type, target_to_src_mapping, key_schema, value_schema, expected,
+                expected_sort_schema, /*expected_reserve_count=*/6);
+}
+
+TEST_P(KeyValueProjectionReaderTest, TestProjectKeyValueMetadata) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int32()),
+                                 arrow::field("v0", arrow::int16())};
+    std::shared_ptr<arrow::Schema> key_schema = arrow::schema(arrow::FieldVector({fields[2]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+
+    auto src_array = arrow::ipc::internal::json::ArrayFromJSON(
+                         src_type, R"([[0, 0, 1, 10], [1, 1, 2, 20], [2, 2, 3, 30]])")
+                         .ValueOrDie();
+    auto target_type = std::dynamic_pointer_cast<arrow::StructType>(
+        arrow::struct_({fields[0], fields[1], fields[2], fields[3]}));
+    ASSERT_TRUE(target_type);
+    std::vector<int32_t> target_to_src_mapping = {
+        KeyValueProjectionConsumer::kSequenceNumberProjection,
+        KeyValueProjectionConsumer::kValueKindProjection, 0, 1};
+
+    auto expected_array = arrow::ChunkedArray::Make({src_array}).ValueOrDie();
+    std::shared_ptr<arrow::Schema> expected_sort_schema =
+        arrow::schema(arrow::FieldVector({fields[2]}));
+    CheckResult(src_array, target_type, target_to_src_mapping, key_schema, value_schema,
+                expected_array, expected_sort_schema, /*expected_reserve_count=*/5);
+}
+
+TEST_P(KeyValueProjectionReaderTest, TestSimple) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::int8()),
+                                 arrow::field("k1", arrow::int16()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int64()),
+                                 arrow::field("v2", arrow::float32()),
+                                 arrow::field("v3", arrow::float64())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema = arrow::schema(
+        arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6], fields[7]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, null, 30.01],
+        [0, 0, 1, 3, 11, 21, 31.0, 31.01],
+        [1, 0, 2, 2, 12, 22, 32.0, null],
+        [2, 0, 2, 3, 13, 23, 33.0, 32.01]
+    ])")
+            .ValueOrDie());
+
+    auto target_type = std::dynamic_pointer_cast<arrow::StructType>(
+        arrow::struct_({fields[7], fields[6], fields[4], fields[2]}));
+    ASSERT_TRUE(target_type);
+    std::vector<int32_t> target_to_src_mapping = {5, 4, 2, 0};
+    std::shared_ptr<arrow::ChunkedArray> expected;
+    auto array_status = arrow::ipc::internal::json::ChunkedArrayFromJSON(target_type, {R"([
+        [30.01, null, 10, 1],
+        [31.01, 31.0, 11, 1],
+        [null, 32.0, 12, 2],
+        [32.01, 33.0, 13, 2]
+    ])"},
+                                                                         &expected);
+    ASSERT_TRUE(array_status.ok());
+    std::shared_ptr<arrow::Schema> expected_sort_schema = arrow::schema(target_type->fields());
+    CheckResult(src_array, target_type, target_to_src_mapping, key_schema, value_schema, expected,
+                expected_sort_schema, /*expected_reserve_count=*/5);
+}
+
+TEST_P(KeyValueProjectionReaderTest, TestTimestampType) {
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    arrow::FieldVector fields = {
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+        arrow::field("_VALUE_KIND", arrow::int8()),
+        arrow::field("ts_sec", arrow::timestamp(arrow::TimeUnit::SECOND)),
+        arrow::field("ts_milli", arrow::timestamp(arrow::TimeUnit::MILLI)),
+        arrow::field("ts_micro", arrow::timestamp(arrow::TimeUnit::MICRO)),
+        arrow::field("ts_nano", arrow::timestamp(arrow::TimeUnit::NANO)),
+        arrow::field("ts_tz_sec", arrow::timestamp(arrow::TimeUnit::SECOND, timezone)),
+        arrow::field("ts_tz_milli", arrow::timestamp(arrow::TimeUnit::MILLI, timezone)),
+        arrow::field("ts_tz_micro", arrow::timestamp(arrow::TimeUnit::MICRO, timezone)),
+        arrow::field("ts_tz_nano", arrow::timestamp(arrow::TimeUnit::NANO, timezone))};
+    std::shared_ptr<arrow::Schema> key_schema = arrow::schema(arrow::FieldVector({fields[2]}));
+    std::shared_ptr<arrow::Schema> value_schema = arrow::schema(arrow::FieldVector(
+        {fields[2], fields[3], fields[4], fields[5], fields[6], fields[7], fields[8], fields[9]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+[0, 0, "1970-01-01 00:00:01", "1970-01-01 00:00:00.001", "1970-01-01 00:00:00.000001", "1970-01-01 00:00:00.000000001", "1970-01-01 00:00:02", "1970-01-01 00:00:00.002", "1970-01-01 00:00:00.000002", "1970-01-01 00:00:00.000000002"],
+[1, 0, "1970-01-01 00:00:03", "1970-01-01 00:00:00.003", null, "1970-01-01 00:00:00.000000003", "1970-01-01 00:00:04", "1970-01-01 00:00:00.004", "1970-01-01 00:00:00.000004", "1970-01-01 00:00:00.000000004"],
+[2, 0, "1970-01-01 00:00:05", "1970-01-01 00:00:00.005", null, null, "1970-01-01 00:00:06", null, "1970-01-01 00:00:00.000006", null]
+    ])")
+            .ValueOrDie());
+
+    auto target_type = std::dynamic_pointer_cast<arrow::StructType>(arrow::struct_(
+        {fields[2], fields[3], fields[4], fields[5], fields[6], fields[7], fields[8], fields[9]}));
+    ASSERT_TRUE(target_type);
+    std::vector<int32_t> target_to_src_mapping = {0, 1, 2, 3, 4, 5, 6, 7};
+    std::shared_ptr<arrow::ChunkedArray> expected;
+    auto array_status = arrow::ipc::internal::json::ChunkedArrayFromJSON(target_type, {R"([
+["1970-01-01 00:00:01", "1970-01-01 00:00:00.001", "1970-01-01 00:00:00.000001", "1970-01-01 00:00:00.000000001", "1970-01-01 00:00:02", "1970-01-01 00:00:00.002", "1970-01-01 00:00:00.000002", "1970-01-01 00:00:00.000000002"],
+["1970-01-01 00:00:03", "1970-01-01 00:00:00.003", null, "1970-01-01 00:00:00.000000003", "1970-01-01 00:00:04", "1970-01-01 00:00:00.004", "1970-01-01 00:00:00.000004", "1970-01-01 00:00:00.000000004"],
+["1970-01-01 00:00:05", "1970-01-01 00:00:00.005", null, null, "1970-01-01 00:00:06", null, "1970-01-01 00:00:00.000006", null]
+    ])"},
+                                                                         &expected);
+    ASSERT_TRUE(array_status.ok());
+    std::shared_ptr<arrow::Schema> expected_sort_schema =
+        arrow::schema(arrow::FieldVector({fields[2]}));
+    CheckResult(src_array, target_type, target_to_src_mapping, key_schema, value_schema, expected,
+                expected_sort_schema, /*expected_reserve_count=*/9);
+}
+
+TEST_P(KeyValueProjectionReaderTest, TestComplexType) {
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int8()),
+                                 arrow::field("k0", arrow::boolean()),
+                                 arrow::field("k1", arrow::utf8()),
+                                 arrow::field("v0", arrow::binary()),
+                                 arrow::field("v1", arrow::date32()),
+                                 arrow::field("v2", arrow::timestamp(arrow::TimeUnit::NANO)),
+                                 arrow::field("v3", arrow::decimal128(5, 2))};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema = arrow::schema(
+        arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6], fields[7]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, false, "apple",  null,   20, "1970-01-01 00:00:00.000000500", "123.23"],
+        [0, 0, false, "banana", "中国", 21, "2025-01-01 23:59:59.000000500", "213.59"],
+        [1, 0, true, "apple",   "北京", 22, "2000-01-01 00:00:00.000000500", null],
+        [2, 0, true, "papaya",  "你好",   23, "1970-01-02 00:00:00.000000500", "-12.21"]
+    ])")
+            .ValueOrDie());
+
+    auto target_type = std::dynamic_pointer_cast<arrow::StructType>(
+        arrow::struct_({fields[2], fields[3], fields[4], fields[5], fields[6], fields[7]}));
+    ASSERT_TRUE(target_type);
+    std::vector<int32_t> target_to_src_mapping = {0, 1, 2, 3, 4, 5};
+    std::shared_ptr<arrow::ChunkedArray> expected;
+    auto array_status = arrow::ipc::internal::json::ChunkedArrayFromJSON(target_type, {R"([
+        [false, "apple",  null,   20, "1970-01-01 00:00:00.000000500", "123.23"],
+        [false, "banana", "中国", 21, "2025-01-01 23:59:59.000000500", "213.59"],
+        [true, "apple",   "北京", 22, "2000-01-01 00:00:00.000000500", null],
+        [true, "papaya",  "你好",   23, "1970-01-02 00:00:00.000000500", "-12.21"]
+    ])"},
+                                                                         &expected);
+    ASSERT_TRUE(array_status.ok());
+    std::shared_ptr<arrow::Schema> expected_sort_schema = arrow::schema(target_type->fields());
+    CheckResult(src_array, target_type, target_to_src_mapping, key_schema, value_schema, expected,
+                expected_sort_schema, /*expected_reserve_count=*/9);
+}
+
+TEST_P(KeyValueProjectionReaderTest, TestNestedType) {
+    arrow::FieldVector fields = {
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+        arrow::field("_VALUE_KIND", arrow::int8()),
+        arrow::field("key", arrow::utf8()),
+        arrow::field("f0", arrow::list(arrow::int32())),
+        arrow::field("f1", arrow::map(arrow::utf8(), arrow::int64())),
+        arrow::field("f2",
+                     arrow::struct_({field("sub1", arrow::int64()), field("sub2", arrow::float64()),
+                                     field("sub3", arrow::boolean())}))};
+    std::shared_ptr<arrow::Schema> key_schema = arrow::schema(arrow::FieldVector({fields[2]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, "apple",  [1, 2, 3],    [["apple", 3], ["banana", 4]],          [10, 10.1, false]],
+        [0, 0, "banana", [4, 5],       [["cat", 5], ["dog", 6], ["mouse", 7]], [20, 20.1, true]],
+        [0, 0, "cat",    [6],          [["elephant", 7], ["fox", 8]],          [null, 30.1, true]],
+        [0, 0, "dog",    [7],          [["giraffe", 9]],                       [null, 40.1, true]],
+        [0, 0, "eagle",  null,         [["horse", 10], ["Panda", 11]],        [50, 50.1, null]],
+        [0, 0, "fox",    [9],          null,                                   [60, 60.1, false]],
+        [0, 0, "giraffe",[10, 11, 12], [["rabbit", null], ["tiger", 13]],      null]
+    ])")
+            .ValueOrDie());
+
+    auto target_type = std::dynamic_pointer_cast<arrow::StructType>(
+        arrow::struct_({fields[2], fields[3], fields[4], fields[5]}));
+    ASSERT_TRUE(target_type);
+    std::vector<int32_t> target_to_src_mapping = {0, 1, 2, 3};
+    std::shared_ptr<arrow::ChunkedArray> expected;
+    auto array_status = arrow::ipc::internal::json::ChunkedArrayFromJSON(target_type, {R"([
+        ["apple",   [1, 2, 3],    [["apple", 3], ["banana", 4]],          [10, 10.1, false]],
+        ["banana",  [4, 5],       [["cat", 5], ["dog", 6], ["mouse", 7]], [20, 20.1, true]],
+        ["cat",     [6],          [["elephant", 7], ["fox", 8]],          [null, 30.1, true]],
+        ["dog",     [7],          [["giraffe", 9]],                       [null, 40.1, true]],
+        ["eagle",   null,         [["horse", 10], ["Panda", 11]],         [50, 50.1, null]],
+        ["fox",     [9],          null,                                   [60, 60.1, false]],
+        ["giraffe", [10, 11, 12], [["rabbit", null], ["tiger", 13]],      null]
+    ])"},
+                                                                         &expected);
+    ASSERT_TRUE(array_status.ok());
+    std::shared_ptr<arrow::Schema> expected_sort_schema =
+        arrow::schema(arrow::FieldVector({fields[2]}));
+    CheckResult(src_array, target_type, target_to_src_mapping, key_schema, value_schema, expected,
+                expected_sort_schema, /*expected_reserve_count=*/13);
+}
+
+TEST_P(KeyValueProjectionReaderTest, TestNestedType2) {
+    arrow::FieldVector fields = {
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+        arrow::field("_VALUE_KIND", arrow::int8()),
+        arrow::field("key", arrow::utf8()),
+        arrow::field("f0", arrow::list(arrow::struct_(
+                               {field("a", arrow::int64()), field("b", arrow::boolean())}))),
+        arrow::field("f1", arrow::map(arrow::struct_({field("a", arrow::int64()),
+                                                      field("b", arrow::boolean())}),
+                                      arrow::boolean())),
+        arrow::field("f2", arrow::struct_({field("a", arrow::list(arrow::int32())),
+                                           field("b", arrow::boolean())})),
+    };
+    std::shared_ptr<arrow::Schema> key_schema = arrow::schema(arrow::FieldVector({fields[2]}));
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3], fields[4], fields[5]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, "apple",  [null, [1, true], null], [[[1, true], true]], null],
+        [0, 0, "banana", [[2, false], null], null, [[1, 2], true]],
+        [0, 0, "cat",    [[2, false], [3, true], [4, null]], [[[1, true], true], [[5, false], true]], [[5, 6, 7], true]]
+    ])")
+            .ValueOrDie());
+    assert(src_array);
+    auto target_type = std::dynamic_pointer_cast<arrow::StructType>(
+        arrow::struct_({fields[4], fields[3], fields[5], fields[2]}));
+    ASSERT_TRUE(target_type);
+    std::vector<int32_t> target_to_src_mapping = {2, 1, 3, 0};
+    std::shared_ptr<arrow::ChunkedArray> expected;
+    auto array_status = arrow::ipc::internal::json::ChunkedArrayFromJSON(target_type, {R"([
+        [[[[1, true], true]], [null, [1, true], null], null, "apple"],
+        [null, [[2, false], null], [[1, 2], true], "banana"],
+        [[[[1, true], true], [[5, false], true]], [[2, false], [3, true], [4, null]], [[5, 6, 7], true], "cat"]
+    ])"},
+                                                                         &expected);
+    ASSERT_TRUE(array_status.ok());
+    std::shared_ptr<arrow::Schema> expected_sort_schema =
+        arrow::schema(arrow::FieldVector({fields[2]}));
+
+    CheckResult(src_array, target_type, target_to_src_mapping, key_schema, value_schema, expected,
+                expected_sort_schema, /*expected_reserve_count=*/16);
+}
+
+TEST_P(KeyValueProjectionReaderTest, TestDictionary) {
+    auto dict_type = arrow::dictionary(arrow::int32(), arrow::utf8());
+    arrow::FieldVector fields = {
+        arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+        arrow::field("_VALUE_KIND", arrow::int8()),
+        arrow::field("key", arrow::utf8()),
+        arrow::field("f0", dict_type),
+    };
+    std::shared_ptr<arrow::Schema> key_schema = arrow::schema(arrow::FieldVector({fields[2]}));
+
+    std::shared_ptr<arrow::Schema> value_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    auto indices =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::int32(), "[1, 2, 0, 2, 0]").ValueOrDie();
+    auto dict = arrow::ipc::internal::json::ArrayFromJSON(arrow::utf8(), R"(["foo", "bar", "baz"])")
+                    .ValueOrDie();
+    std::shared_ptr<arrow::DictionaryArray> f0_array =
+        std::make_shared<arrow::DictionaryArray>(dict_type, indices, dict);
+    auto key_array = arrow::ipc::internal::json::ArrayFromJSON(
+                         arrow::utf8(), R"(["apple", "banana", "cat", "dog", "mouse"])")
+                         .ValueOrDie();
+    auto seq_array = arrow::ipc::internal::json::ArrayFromJSON(arrow::int64(), R"([1, 2, 3, 4, 5])")
+                         .ValueOrDie();
+    auto kind_array =
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::int8(), R"([0, 0, 0, 0, 0])").ValueOrDie();
+
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::make_shared<arrow::StructArray>(
+        src_type, /*length=*/5, arrow::ArrayVector({seq_array, kind_array, key_array, f0_array}));
+
+    auto target_type = std::dynamic_pointer_cast<arrow::StructType>(
+        arrow::struct_({arrow::field("f0", arrow::utf8()), fields[2]}));
+    ASSERT_TRUE(target_type);
+    std::vector<int32_t> target_to_src_mapping = {1, 0};
+
+    auto f0_string_array = arrow::ipc::internal::json::ArrayFromJSON(
+                               arrow::utf8(), R"(["bar", "baz", "foo", "baz", "foo"])")
+                               .ValueOrDie();
+
+    auto expected = std::make_shared<arrow::ChunkedArray>(std::make_shared<arrow::StructArray>(
+        target_type, /*length=*/5, arrow::ArrayVector({f0_string_array, key_array})));
+
+    std::shared_ptr<arrow::Schema> expected_sort_schema = arrow::schema(target_type->fields());
+    CheckResult(src_array, target_type, target_to_src_mapping, key_schema, value_schema, expected,
+                expected_sort_schema, /*expected_reserve_count=*/5);
+}
+
+TEST_P(KeyValueProjectionReaderTest, TestInvalidProducer) {
+    // VALUE_KIND is int16 rather than int8
+    arrow::FieldVector fields = {arrow::field("_SEQUENCE_NUMBER", arrow::int64()),
+                                 arrow::field("_VALUE_KIND", arrow::int16()),
+                                 arrow::field("k0", arrow::int8()),
+                                 arrow::field("k1", arrow::int16()),
+                                 arrow::field("v0", arrow::int32()),
+                                 arrow::field("v1", arrow::int64()),
+                                 arrow::field("v2", arrow::float32()),
+                                 arrow::field("v3", arrow::float64())};
+    std::shared_ptr<arrow::Schema> key_schema =
+        arrow::schema(arrow::FieldVector({fields[2], fields[3]}));
+    std::shared_ptr<arrow::Schema> value_schema = arrow::schema(
+        arrow::FieldVector({fields[2], fields[3], fields[4], fields[5], fields[6], fields[7]}));
+    std::shared_ptr<arrow::DataType> src_type = arrow::struct_(fields);
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(src_type, R"([
+        [0, 0, 1, 1, 10, 20, null, 30.01],
+        [0, 0, 1, 3, 11, 21, 31.0, 31.01],
+        [1, 0, 2, 2, 12, 22, 32.0, null],
+        [2, 0, 2, 3, 13, 23, 33.0, 32.01]
+    ])")
+            .ValueOrDie());
+
+    auto target_type = std::dynamic_pointer_cast<arrow::StructType>(
+        arrow::struct_({fields[7], fields[6], fields[4], fields[2]}));
+    ASSERT_TRUE(target_type);
+    std::vector<int32_t> target_to_src_mapping = {5, 4, 2, 0};
+
+    bool multi_thread_row_to_batch = GetParam();
+    auto target_schema = arrow::schema(target_type->fields());
+    auto projection_reader =
+        GenerateProjectionReader(src_array, target_schema, target_to_src_mapping, key_schema,
+                                 value_schema, /*batch_size=*/1, multi_thread_row_to_batch);
+    ASSERT_NOK_WITH_MSG(paimon::test::ReadResultCollector::CollectResult(projection_reader.get()),
+                        "cannot cast VALUE_KIND column to int8 arrow array");
+}
+
+INSTANTIATE_TEST_SUITE_P(EnableMultiThreadRowToBatch, KeyValueProjectionReaderTest,
+                         ::testing::Values(false, true));
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/row_to_arrow_array_converter.h
+++ b/src/paimon/core/io/row_to_arrow_array_converter.h
@@ -1,0 +1,503 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "paimon/common/data/internal_array.h"
+#include "paimon/common/data/internal_map.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/core/key_value.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/reader/batch_reader.h"
+namespace paimon {
+// convert row T to output R (R maybe BatchReader::ReadBatch or KeyValueBatch)
+template <typename T, typename R>
+class RowToArrowArrayConverter {
+ public:
+    virtual ~RowToArrowArrayConverter() = default;
+
+    virtual Result<R> NextBatch(const std::vector<T>& rows) = 0;
+
+    void CleanUp() {
+        appenders_.clear();
+        array_builder_.reset();
+    }
+
+ protected:
+    using AppendValueFunc =
+        std::function<arrow::Status(const DataGetters& data_getter, int32_t pos)>;
+    RowToArrowArrayConverter(int32_t reserve_count, std::vector<AppendValueFunc>&& appenders,
+                             std::unique_ptr<arrow::StructBuilder>&& array_builder,
+                             std::unique_ptr<arrow::MemoryPool>&& arrow_pool);
+
+    static Result<AppendValueFunc> AppendField(bool use_view, arrow::ArrayBuilder* array_builder,
+                                               int32_t* reserve_count);
+
+ protected:
+    Status ResetAndReserve();
+    Result<BatchReader::ReadBatch> FinishAndAccumulate();
+    Status Accumulate(const arrow::Array* array, int32_t* idx);
+    Status Reserve(arrow::ArrayBuilder* array_builder, int32_t* idx);
+
+ private:
+    template <typename BuilderType>
+    static Result<BuilderType*> CastToTypedBuilder(arrow::ArrayBuilder* array_builder);
+
+    static inline const double INFLATION_FACTOR = 1.2;
+    void UpdateAccumulatedVec(int32_t value, int32_t* idx);
+
+ protected:
+    std::vector<int32_t> reserved_sizes_;
+    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::vector<AppendValueFunc> appenders_;
+    std::unique_ptr<arrow::StructBuilder> array_builder_;
+};
+
+#define CHECK_AND_APPEND_NULL(getter, builder, pos) \
+    if (getter.IsNullAt(pos)) {                     \
+        return builder->AppendNull();               \
+    }
+
+template <typename T, typename R>
+RowToArrowArrayConverter<T, R>::RowToArrowArrayConverter(
+    int32_t reserve_count, std::vector<RowToArrowArrayConverter<T, R>::AppendValueFunc>&& appenders,
+    std::unique_ptr<arrow::StructBuilder>&& array_builder,
+    std::unique_ptr<arrow::MemoryPool>&& arrow_pool)
+    : reserved_sizes_(reserve_count, -1),
+      arrow_pool_(std::move(arrow_pool)),
+      appenders_(std::move(appenders)),
+      array_builder_(std::move(array_builder)) {}
+
+template <typename T, typename R>
+Status RowToArrowArrayConverter<T, R>::ResetAndReserve() {
+    array_builder_->Reset();
+    int32_t reserve_idx = 0;
+    return Reserve(array_builder_.get(), &reserve_idx);
+}
+
+template <typename T, typename R>
+Result<BatchReader::ReadBatch> RowToArrowArrayConverter<T, R>::FinishAndAccumulate() {
+    std::shared_ptr<arrow::Array> array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(array_builder_->Finish(&array));
+
+    int32_t reserve_idx = 0;
+    PAIMON_RETURN_NOT_OK(Accumulate(array.get(), &reserve_idx));
+
+    std::unique_ptr<ArrowArray> c_array = std::make_unique<ArrowArray>();
+    std::unique_ptr<ArrowSchema> c_schema = std::make_unique<ArrowSchema>();
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*array, c_array.get(), c_schema.get()));
+    return make_pair(std::move(c_array), std::move(c_schema));
+}
+
+template <typename T, typename R>
+Status RowToArrowArrayConverter<T, R>::Reserve(arrow::ArrayBuilder* array_builder, int32_t* idx) {
+    if (reserved_sizes_[*idx] == -1) {
+        // first batch, reserved_sizes_ is not initialized
+        return Status::OK();
+    }
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        array_builder->Reserve(INFLATION_FACTOR * reserved_sizes_[(*idx)++]));
+    arrow::Type::type type = array_builder->type()->id();
+    switch (type) {
+        case arrow::Type::type::BOOL:
+        case arrow::Type::type::INT8:
+        case arrow::Type::type::INT16:
+        case arrow::Type::type::INT32:
+        case arrow::Type::type::DATE32:
+        case arrow::Type::type::INT64:
+        case arrow::Type::type::FLOAT:
+        case arrow::Type::type::DOUBLE:
+        case arrow::Type::type::TIMESTAMP:
+        case arrow::Type::type::DECIMAL:
+            break;
+        case arrow::Type::type::STRING: {
+            // reserve string data buffer
+            PAIMON_ASSIGN_OR_RAISE(auto* string_builder,
+                                   CastToTypedBuilder<arrow::StringBuilder>(array_builder));
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                string_builder->ReserveData(INFLATION_FACTOR * reserved_sizes_[(*idx)++]));
+            break;
+        }
+        case arrow::Type::type::BINARY: {
+            // reserve binary data buffer
+            PAIMON_ASSIGN_OR_RAISE(auto* binary_builder,
+                                   CastToTypedBuilder<arrow::BinaryBuilder>(array_builder));
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                binary_builder->ReserveData(INFLATION_FACTOR * reserved_sizes_[(*idx)++]));
+            break;
+        }
+        case arrow::Type::type::LIST: {
+            PAIMON_ASSIGN_OR_RAISE(auto* list_builder,
+                                   CastToTypedBuilder<arrow::ListBuilder>(array_builder));
+            // reserve value builder in list
+            PAIMON_RETURN_NOT_OK(Reserve(list_builder->value_builder(), idx));
+            break;
+        }
+        case arrow::Type::type::MAP: {
+            PAIMON_ASSIGN_OR_RAISE(auto* map_builder,
+                                   CastToTypedBuilder<arrow::MapBuilder>(array_builder));
+            // reserve key builder in map
+            PAIMON_RETURN_NOT_OK(Reserve(map_builder->key_builder(), idx));
+            // reserve item builder in map
+            PAIMON_RETURN_NOT_OK(Reserve(map_builder->item_builder(), idx));
+            break;
+        }
+        case arrow::Type::type::STRUCT: {
+            PAIMON_ASSIGN_OR_RAISE(auto* struct_builder,
+                                   CastToTypedBuilder<arrow::StructBuilder>(array_builder));
+            for (int32_t i = 0; i < struct_builder->num_fields(); i++) {
+                // reserve item builder in struct
+                PAIMON_RETURN_NOT_OK(Reserve(struct_builder->field_builder(i), idx));
+            }
+            break;
+        }
+        default:
+            assert(false);
+            return Status::Invalid(fmt::format("Do not support type {} in RowToArrowArrayConverter",
+                                               array_builder->type()->ToString()));
+    }
+    return Status::OK();
+}
+
+template <typename T, typename R>
+void RowToArrowArrayConverter<T, R>::UpdateAccumulatedVec(int32_t value, int32_t* idx) {
+    reserved_sizes_[*idx] =
+        (reserved_sizes_[*idx] == -1 ? value : (reserved_sizes_[*idx] + value) / 2);
+    (*idx)++;
+}
+
+template <typename T, typename R>
+Status RowToArrowArrayConverter<T, R>::Accumulate(const arrow::Array* array, int32_t* idx) {
+    UpdateAccumulatedVec(array->length(), idx);
+    arrow::Type::type type = array->type()->id();
+    switch (type) {
+        case arrow::Type::type::BOOL:
+        case arrow::Type::type::INT8:
+        case arrow::Type::type::INT16:
+        case arrow::Type::type::INT32:
+        case arrow::Type::type::DATE32:
+        case arrow::Type::type::INT64:
+        case arrow::Type::type::FLOAT:
+        case arrow::Type::type::DOUBLE:
+        case arrow::Type::type::TIMESTAMP:
+        case arrow::Type::type::DECIMAL:
+            break;
+        case arrow::Type::type::STRING: {
+            auto string_array = arrow::internal::checked_cast<const arrow::StringArray*>(array);
+            assert(string_array);
+            // accumulate the bytes buffer size of binary
+            UpdateAccumulatedVec(string_array->value_data()->size(), idx);
+            break;
+        }
+        case arrow::Type::type::BINARY: {
+            auto binary_array = arrow::internal::checked_cast<const arrow::BinaryArray*>(array);
+            assert(binary_array);
+            // accumulate the bytes buffer size of binary
+            UpdateAccumulatedVec(binary_array->value_data()->size(), idx);
+            break;
+        }
+        case arrow::Type::type::LIST: {
+            auto list_array = arrow::internal::checked_cast<const arrow::ListArray*>(array);
+            assert(list_array);
+            PAIMON_RETURN_NOT_OK(Accumulate(list_array->values().get(), idx));
+            break;
+        }
+        case arrow::Type::type::MAP: {
+            auto map_array = arrow::internal::checked_cast<const arrow::MapArray*>(array);
+            assert(map_array);
+            PAIMON_RETURN_NOT_OK(Accumulate(map_array->keys().get(), idx));
+            PAIMON_RETURN_NOT_OK(Accumulate(map_array->items().get(), idx));
+            break;
+        }
+        case arrow::Type::type::STRUCT: {
+            auto struct_array = arrow::internal::checked_cast<const arrow::StructArray*>(array);
+            assert(struct_array);
+            for (const auto& field : struct_array->fields()) {
+                PAIMON_RETURN_NOT_OK(Accumulate(field.get(), idx));
+            }
+            break;
+        }
+        default:
+            assert(false);
+            return Status::Invalid(fmt::format("Do not support type {} in RowToArrowArrayConverter",
+                                               array->type()->ToString()));
+    }
+    return Status::OK();
+}
+
+template <typename T, typename R>
+template <typename BuilderType>
+Result<BuilderType*> RowToArrowArrayConverter<T, R>::CastToTypedBuilder(
+    arrow::ArrayBuilder* array_builder) {
+    auto field_builder = arrow::internal::checked_cast<BuilderType*>(array_builder);
+    if (field_builder == nullptr) {
+        return Status::Invalid("field builder is nullptr");
+    }
+    return field_builder;
+}
+
+template <typename T, typename R>
+Result<typename RowToArrowArrayConverter<T, R>::AppendValueFunc>
+RowToArrowArrayConverter<T, R>::AppendField(bool use_view, arrow::ArrayBuilder* array_builder,
+                                            int32_t* reserve_count) {
+    arrow::Type::type type = array_builder->type()->id();
+    (*reserve_count)++;
+    switch (type) {
+        case arrow::Type::type::BOOL: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::BooleanBuilder>(array_builder));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    bool value = data_getter.GetBoolean(pos);
+                    return field_builder->Append(value);
+                });
+        }
+        case arrow::Type::type::INT8: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::Int8Builder>(array_builder));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    int8_t value = data_getter.GetByte(pos);
+                    return field_builder->Append(value);
+                });
+        }
+        case arrow::Type::type::INT16: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::Int16Builder>(array_builder));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    int16_t value = data_getter.GetShort(pos);
+                    return field_builder->Append(value);
+                });
+        }
+        case arrow::Type::type::INT32: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::Int32Builder>(array_builder));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    int32_t value = data_getter.GetInt(pos);
+                    return field_builder->Append(value);
+                });
+        }
+        case arrow::Type::type::DATE32: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::Date32Builder>(array_builder));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    int32_t value = data_getter.GetDate(pos);
+                    return field_builder->Append(value);
+                });
+        }
+        case arrow::Type::type::INT64: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::Int64Builder>(array_builder));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    int64_t value = data_getter.GetLong(pos);
+                    return field_builder->Append(value);
+                });
+        }
+        case arrow::Type::type::FLOAT: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::FloatBuilder>(array_builder));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    float value = data_getter.GetFloat(pos);
+                    return field_builder->Append(value);
+                });
+        }
+
+        case arrow::Type::type::DOUBLE: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::DoubleBuilder>(array_builder));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    double value = data_getter.GetDouble(pos);
+                    return field_builder->Append(value);
+                });
+        }
+        case arrow::Type::type::STRING: {
+            (*reserve_count)++;
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::BinaryBuilder>(array_builder));
+            if (use_view) {
+                return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                    [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                        CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                        auto view = data_getter.GetStringView(pos);
+                        return field_builder->Append(view.data(), view.size());
+                    });
+            }
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    auto str = data_getter.GetString(pos).ToString();
+                    return field_builder->Append(str.data(), str.size());
+                });
+        }
+        case arrow::Type::type::BINARY: {
+            (*reserve_count)++;
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::BinaryBuilder>(array_builder));
+            if (use_view) {
+                return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                    [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                        CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                        auto view = data_getter.GetStringView(pos);
+                        return field_builder->Append(view.data(), view.size());
+                    });
+            }
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    auto bytes = data_getter.GetBinary(pos);
+                    assert(bytes);
+                    return field_builder->Append(bytes->data(), bytes->size());
+                });
+        }
+        case arrow::Type::type::TIMESTAMP: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::TimestampBuilder>(array_builder));
+            auto ts_type =
+                arrow::internal::checked_pointer_cast<arrow::TimestampType>(field_builder->type());
+            if (!ts_type) {
+                return Status::Invalid("cannot cast to timestamp type");
+            }
+            DateTimeUtils::TimeType time_type = DateTimeUtils::GetTimeTypeFromArrowType(ts_type);
+            int32_t precision = DateTimeUtils::GetPrecisionFromType(ts_type);
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder, precision, time_type](const DataGetters& data_getter,
+                                                      int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    Timestamp timestamp = data_getter.GetTimestamp(pos, precision);
+                    return field_builder->Append(
+                        DateTimeUtils::TimestampToInteger(timestamp, time_type));
+                });
+        }
+        case arrow::Type::type::DECIMAL: {
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::Decimal128Builder>(array_builder));
+            auto decimal_type =
+                arrow::internal::checked_cast<arrow::Decimal128Type*>(field_builder->type().get());
+            if (!decimal_type) {
+                return Status::Invalid("cannot cast to decimal type");
+            }
+            auto precision = decimal_type->precision();
+            auto scale = decimal_type->scale();
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder, precision, scale](const DataGetters& data_getter,
+                                                  int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    Decimal value = data_getter.GetDecimal(pos, precision, scale);
+                    return field_builder->Append(
+                        arrow::Decimal128(value.HighBits(), value.LowBits()));
+                });
+        }
+        case arrow::Type::type::LIST: {
+            PAIMON_ASSIGN_OR_RAISE(auto* list_builder,
+                                   CastToTypedBuilder<arrow::ListBuilder>(array_builder));
+            PAIMON_ASSIGN_OR_RAISE(AppendValueFunc value_func,
+                                   (RowToArrowArrayConverter<T, R>::AppendField(
+                                       use_view, list_builder->value_builder(), reserve_count)));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [list_builder, value_func](const DataGetters& data_getter,
+                                           int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, list_builder, pos);
+                    ARROW_RETURN_NOT_OK(list_builder->Append());
+                    auto sub_array = data_getter.GetArray(pos);
+                    assert(sub_array);
+                    for (int32_t i = 0; i < sub_array->Size(); i++) {
+                        ARROW_RETURN_NOT_OK(value_func(*sub_array, i));
+                    }
+                    return arrow::Status::OK();
+                });
+        }
+        case arrow::Type::type::MAP: {
+            PAIMON_ASSIGN_OR_RAISE(auto* map_builder,
+                                   CastToTypedBuilder<arrow::MapBuilder>(array_builder));
+            PAIMON_ASSIGN_OR_RAISE(AppendValueFunc key_func,
+                                   (RowToArrowArrayConverter<T, R>::AppendField(
+                                       use_view, map_builder->key_builder(), reserve_count)));
+            PAIMON_ASSIGN_OR_RAISE(AppendValueFunc item_func,
+                                   (RowToArrowArrayConverter<T, R>::AppendField(
+                                       use_view, map_builder->item_builder(), reserve_count)));
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [map_builder, key_func, item_func](const DataGetters& data_getter,
+                                                   int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, map_builder, pos);
+                    ARROW_RETURN_NOT_OK(map_builder->Append());
+                    auto sub_map = data_getter.GetMap(pos);
+                    assert(sub_map);
+                    auto key_array = sub_map->KeyArray();
+                    auto item_array = sub_map->ValueArray();
+                    for (int32_t i = 0; i < sub_map->Size(); i++) {
+                        ARROW_RETURN_NOT_OK(key_func(*key_array, i));
+                        ARROW_RETURN_NOT_OK(item_func(*item_array, i));
+                    }
+                    return arrow::Status::OK();
+                });
+        }
+        case arrow::Type::type::STRUCT: {
+            PAIMON_ASSIGN_OR_RAISE(auto* struct_builder,
+                                   CastToTypedBuilder<arrow::StructBuilder>(array_builder));
+            std::vector<RowToArrowArrayConverter<T, R>::AppendValueFunc> sub_funcs;
+            sub_funcs.reserve(struct_builder->num_fields());
+            for (int32_t i = 0; i < struct_builder->num_fields(); i++) {
+                PAIMON_ASSIGN_OR_RAISE(
+                    AppendValueFunc sub_func,
+                    (RowToArrowArrayConverter<T, R>::AppendField(
+                        use_view, struct_builder->field_builder(i), reserve_count)));
+                sub_funcs.push_back(std::move(sub_func));
+            }
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [struct_builder, sub_funcs](const DataGetters& data_getter,
+                                            int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, struct_builder, pos);
+                    ARROW_RETURN_NOT_OK(struct_builder->Append());
+                    auto sub_row = data_getter.GetRow(pos, sub_funcs.size());
+                    assert(sub_row);
+                    assert(sub_funcs.size() == static_cast<size_t>(struct_builder->num_fields()));
+                    for (size_t i = 0; i < sub_funcs.size(); i++) {
+                        ARROW_RETURN_NOT_OK(sub_funcs[i](*sub_row, i));
+                    }
+                    return arrow::Status::OK();
+                });
+        }
+        default:
+            return Status::Invalid(fmt::format("Do not support type {} in RowToArrowArrayConverter",
+                                               array_builder->type()->ToString()));
+    }
+}
+
+}  // namespace paimon


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

Migrate record reader interface, implementations, and IO utility modules:

Record readers (`src/paimon/core/io/`):
- `KeyValueRecordReader` — abstract record reader interface (`key_value_record_reader.h`)
- `KeyValueDataFileRecordReader` — data file backed key-value reader (`key_value_data_file_record_reader.h/cpp`)
- `KeyValueInMemoryRecordReader` — in-memory key-value reader (`key_value_in_memory_record_reader.h/cpp`)
- `ConcatKeyValueRecordReader` — concatenating multiple readers sequentially (`concat_key_value_record_reader.h`)
- `MergedKeyValueRecordReader` — merge-sorted reader over multiple inputs (`merged_key_value_record_reader.h/cpp`)

IO utilities (`src/paimon/core/io/`):
- `FileIndexEvaluator` — file index predicate evaluation for data file pruning (`file_index_evaluator.h/cpp`)
- `CompleteRowTrackingFieldsReader` — completes row tracking fields during read (`complete_row_tracking_fields_reader.h/cpp`)
- `MetaToArrowArrayConverter` — converts file metadata to Arrow arrays (`meta_to_arrow_array_converter.h/cpp`)

Projection and field mapping (`src/paimon/core/io/`):
- `KeyValueProjectionReader` — applies schema projection to key-value reads (`key_value_projection_reader.h/cpp`)
- `KeyValueProjectionConsumer` — consumer with projection capability (`key_value_projection_consumer.h/cpp`)
- `KeyValueMetaProjectionConsumer` — meta-level projection consumer (`key_value_meta_projection_consumer.h/cpp`)
- `AsyncKeyValueProjectionReader` — async wrapper for projection reader (`async_key_value_projection_reader.h`)
- `FieldMappingReader` — maps fields between schemas during read (`field_mapping_reader.h/cpp`)
- `AsyncKeyValueProducerAndConsumer` — async producer-consumer pipeline for key-value data (`async_key_value_producer_and_consumer.h/cpp`)


<!-- What is the purpose of the change -->

### Tests

- `key_value_data_file_record_reader_test.cpp` — data file reader round-trip, schema projection
- `key_value_in_memory_record_reader_test.cpp` — in-memory reader iteration, key-value ordering
- `concat_key_value_record_reader_test.cpp` — concatenation across multiple readers
- `merged_key_value_record_reader_test.cpp` — merge-sort correctness
- `file_index_evaluator_test.cpp` — predicate evaluation against file indexes
- `complete_row_tracking_fields_reader_test.cpp` — row tracking field completion
- `key_value_projection_reader_test.cpp` — projection reader correctness
- `field_mapping_reader_test.cpp` — field mapping and schema evolution
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Migrate-by: Aone Copilot (Claude)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
