### PR TITLE
feat: Migrate file store scan modules

### DIFF
--- a/include/paimon/scan_context.h
+++ b/include/paimon/scan_context.h
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "paimon/global_index/global_index_result.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/result.h"
+#include "paimon/type_fwd.h"
+#include "paimon/visibility.h"
+namespace paimon {
+class ScanContextBuilder;
+class ScanFilter;
+class Executor;
+class MemoryPool;
+class Predicate;
+
+/// `ScanContext` is some configuration for table scan operations.
+///
+/// Please do not use this class directly, use `ScanContextBuilder` to build a `ScanContext` which
+/// has input validation.
+/// @see ScanContextBuilder
+class PAIMON_EXPORT ScanContext {
+ public:
+    ScanContext(const std::string& path, bool is_streaming_mode, std::optional<int32_t> limit,
+                const std::shared_ptr<ScanFilter>& scan_filter,
+                const std::shared_ptr<GlobalIndexResult>& global_index_result,
+                const std::shared_ptr<MemoryPool>& memory_pool,
+                const std::shared_ptr<Executor>& executor,
+                const std::shared_ptr<FileSystem>& specific_file_system,
+                const std::map<std::string, std::string>& options);
+
+    ~ScanContext();
+
+    const std::string& GetPath() const {
+        return path_;
+    }
+
+    bool IsStreamingMode() const {
+        return is_streaming_mode_;
+    }
+
+    std::optional<int32_t> GetLimit() const {
+        return limit_;
+    }
+
+    std::shared_ptr<ScanFilter> GetScanFilters() const {
+        return scan_filters_;
+    }
+    const std::map<std::string, std::string>& GetOptions() const {
+        return options_;
+    }
+
+    std::shared_ptr<MemoryPool> GetMemoryPool() const {
+        return memory_pool_;
+    }
+
+    std::shared_ptr<Executor> GetExecutor() const {
+        return executor_;
+    }
+    std::shared_ptr<GlobalIndexResult> GetGlobalIndexResult() const {
+        return global_index_result_;
+    }
+
+    std::shared_ptr<FileSystem> GetSpecificFileSystem() const {
+        return specific_file_system_;
+    }
+
+ private:
+    std::string path_;
+    bool is_streaming_mode_;
+    std::optional<int32_t> limit_;
+    std::shared_ptr<ScanFilter> scan_filters_;
+    std::shared_ptr<GlobalIndexResult> global_index_result_;
+    std::shared_ptr<MemoryPool> memory_pool_;
+    std::shared_ptr<Executor> executor_;
+    std::shared_ptr<FileSystem> specific_file_system_;
+    std::map<std::string, std::string> options_;
+};
+
+/// Filter configuration for table scan operations
+class PAIMON_EXPORT ScanFilter {
+ public:
+    ScanFilter(const std::shared_ptr<Predicate>& predicate,
+               const std::vector<std::map<std::string, std::string>>& partition_filters,
+               const std::optional<int32_t>& bucket_filter)
+        : predicates_(predicate),
+          bucket_filter_(bucket_filter),
+          partition_filters_(partition_filters) {}
+
+    std::shared_ptr<Predicate> GetPredicate() const {
+        return predicates_;
+    }
+    std::optional<int32_t> GetBucketFilter() const {
+        return bucket_filter_;
+    }
+    const std::vector<std::map<std::string, std::string>>& GetPartitionFilters() const {
+        return partition_filters_;
+    }
+
+ private:
+    std::shared_ptr<Predicate> predicates_;
+    std::optional<int32_t> bucket_filter_;
+    std::vector<std::map<std::string, std::string>> partition_filters_;
+};
+
+/// `ScanContextBuilder` used to build a `ScanContext`, has input validation.
+class PAIMON_EXPORT ScanContextBuilder {
+ public:
+    /// Constructs a `ScanContextBuilder` with required parameters.
+    /// @param path The root path of the table.
+    explicit ScanContextBuilder(const std::string& path);
+    ~ScanContextBuilder();
+    /// If limit is not set, it defaults to unlimited.
+    ScanContextBuilder& SetLimit(int32_t limit);
+    /// Set a bucket filter to scan only specific bucket.
+    ScanContextBuilder& SetBucketFilter(int32_t bucket_filter);
+    /// partition_filters in vector is supposed to be OR, filter in map is supposed to be AND, e.g.,
+    /// partition_filters is {{k1=1,k2=10}, {k1=2,k2=20}} => OR(AND(k1=1,k2=10), AND(k1=2,k2=20))
+    ScanContextBuilder& SetPartitionFilter(
+        const std::vector<std::map<std::string, std::string>>& partition_filters);
+    /// Set a predicate for filtering data.
+    ScanContextBuilder& SetPredicate(const std::shared_ptr<Predicate>& predicate);
+
+    /// Sets the result of a global index search (e.g., row ids (may with scores) from a distributed
+    /// index lookup). This is used to push down index-filtered row ids into the scan for efficient
+    /// data retrieval.
+    ScanContextBuilder& SetGlobalIndexResult(
+        const std::shared_ptr<GlobalIndexResult>& global_index_result);
+
+    /// The options added or set in `ScanContextBuilder` have high priority and will be merged with
+    /// the options in table schema.
+    ScanContextBuilder& AddOption(const std::string& key, const std::string& value);
+    /// Set a configuration options map to set some option entries which are not defined in the
+    /// table schema or whose values you want to overwrite.
+    /// @note The options map will clear the options added by `AddOption()` before.
+    /// @param options The configuration options map.
+    /// @return Reference to this builder for method chaining.
+    ScanContextBuilder& SetOptions(const std::map<std::string, std::string>& options);
+
+    /// Set whether the scan is in streaming mode.
+    /// @note if not set, is_streaming_mode = false
+    ScanContextBuilder& WithStreamingMode(bool is_streaming_mode);
+    /// Set custom memory pool for memory management.
+    /// @param memory_pool The memory pool to use.
+    /// @return Reference to this builder for method chaining.
+    /// @note if not set, memory_pool is default pool
+    ScanContextBuilder& WithMemoryPool(const std::shared_ptr<MemoryPool>& memory_pool);
+    /// Set custom executor for task execution.
+    /// @param executor The executor to use.
+    /// @return Reference to this builder for method chaining.
+    /// @note if not set, executor is default executor
+    ScanContextBuilder& WithExecutor(const std::shared_ptr<Executor>& executor);
+    /// Sets a custom file system instance to be used for all file operations in this scan context.
+    /// This bypasses the global file system registry and uses the provided implementation directly.
+    /// @param file_system The file system to use.
+    /// @return Reference to this builder for method chaining.
+    /// @note If not set, use default file system (configured in `Options::FILE_SYSTEM`)
+    ScanContextBuilder& WithFileSystem(const std::shared_ptr<FileSystem>& file_system);
+
+    /// Build and return a `ScanContext` instance with input validation.
+    /// @return Result containing the constructed `ScanContext` or an error status.
+    Result<std::unique_ptr<ScanContext>> Finish();
+
+ private:
+    class Impl;
+
+    std::unique_ptr<Impl> impl_;
+};
+}  // namespace paimon

--- a/src/paimon/core/operation/append_only_file_store_scan.cpp
+++ b/src/paimon/core/operation/append_only_file_store_scan.cpp
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/append_only_file_store_scan.h"
+
+#include <cassert>
+#include <cstdint>
+#include <exception>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "arrow/type.h"
+#include "fmt/format.h"
+#include "paimon/common/predicate/predicate_filter.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/file_index_evaluator.h"
+#include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/stats/simple_stats_evolution.h"
+#include "paimon/core/stats/simple_stats_evolutions.h"
+#include "paimon/core/utils/field_mapping.h"
+#include "paimon/file_index/file_index_result.h"
+#include "paimon/predicate/predicate_utils.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class Executor;
+class ManifestFile;
+class ManifestList;
+class MemoryPool;
+class ScanFilter;
+class SnapshotManager;
+
+Result<std::unique_ptr<AppendOnlyFileStoreScan>> AppendOnlyFileStoreScan::Create(
+    const std::shared_ptr<SnapshotManager>& snapshot_manager,
+    const std::shared_ptr<SchemaManager>& schema_manager,
+    const std::shared_ptr<ManifestList>& manifest_list,
+    const std::shared_ptr<ManifestFile>& manifest_file,
+    const std::shared_ptr<TableSchema>& table_schema,
+    const std::shared_ptr<arrow::Schema>& arrow_schema,
+    const std::shared_ptr<ScanFilter>& scan_filters, const CoreOptions& core_options,
+    const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool) {
+    auto scan = std::unique_ptr<AppendOnlyFileStoreScan>(
+        new AppendOnlyFileStoreScan(snapshot_manager, schema_manager, manifest_list, manifest_file,
+                                    table_schema, arrow_schema, core_options, executor, pool));
+    PAIMON_RETURN_NOT_OK(
+        scan->SplitAndSetFilter(table_schema->PartitionKeys(), arrow_schema, scan_filters));
+    return scan;
+}
+
+AppendOnlyFileStoreScan::AppendOnlyFileStoreScan(
+    const std::shared_ptr<SnapshotManager>& snapshot_manager,
+    const std::shared_ptr<SchemaManager>& schema_manager,
+    const std::shared_ptr<ManifestList>& manifest_list,
+    const std::shared_ptr<ManifestFile>& manifest_file,
+    const std::shared_ptr<TableSchema>& table_schema, const std::shared_ptr<arrow::Schema>& schema,
+    const CoreOptions& core_options, const std::shared_ptr<Executor>& executor,
+    const std::shared_ptr<MemoryPool>& pool)
+    : FileStoreScan(snapshot_manager, schema_manager, manifest_list, manifest_file, table_schema,
+                    schema, core_options, executor, pool) {
+    evolutions_ = std::make_shared<SimpleStatsEvolutions>(table_schema, pool);
+}
+
+Result<bool> AppendOnlyFileStoreScan::FilterByStats(const ManifestEntry& entry) const {
+    if (!predicates_) {
+        return true;
+    }
+    const auto& meta = entry.File();
+    std::shared_ptr<TableSchema> data_schema = table_schema_;
+    std::shared_ptr<Predicate> trimmed_predicates = predicates_;
+    int64_t data_schema_id = meta->schema_id;
+    if (data_schema_id != table_schema_->Id()) {
+        PAIMON_ASSIGN_OR_RAISE(data_schema, schema_manager_->ReadSchema(data_schema_id));
+    }
+    auto evolution = evolutions_->GetOrCreate(data_schema);
+    if (data_schema_id != table_schema_->Id()) {
+        // remove fields with casting in predicate
+        PAIMON_ASSIGN_OR_RAISE(trimmed_predicates,
+                               ReconstructPredicateWithNonCastedFields(predicates_, evolution));
+    }
+    if (!trimmed_predicates) {
+        return true;
+    }
+    // evolution stats, from data schema to table schema, also deal with dense fields
+    PAIMON_ASSIGN_OR_RAISE(
+        SimpleStatsEvolution::EvolutionStats new_stats,
+        evolution->Evolution(meta->value_stats, meta->row_count, meta->value_stats_cols));
+
+    // predicate tests evolution stats
+    auto predicate_filter = std::dynamic_pointer_cast<PredicateFilter>(trimmed_predicates);
+    if (!predicate_filter) {
+        return Status::Invalid("cannot cast to predicate filter");
+    }
+    try {
+        PAIMON_ASSIGN_OR_RAISE(
+            bool predicate_result,
+            predicate_filter->Test(schema_, meta->row_count, *(new_stats.min_values),
+                                   *(new_stats.max_values), *(new_stats.null_counts)));
+        if (!predicate_result) {
+            return false;
+        }
+    } catch (const std::exception& e) {
+        return Status::Invalid(fmt::format("FilterByStats failed for file {}, with {} error",
+                                           meta->file_name, e.what()));
+    } catch (...) {
+        return Status::Invalid(
+            fmt::format("FilterByStats failed for file {}, with unknown error", meta->file_name));
+    }
+
+    if (!core_options_.FileIndexReadEnabled()) {
+        return true;
+    }
+
+    return TestFileIndex(meta, evolution, data_schema);
+}
+
+Result<bool> AppendOnlyFileStoreScan::TestFileIndex(
+    const std::shared_ptr<DataFileMeta>& meta,
+    const std::shared_ptr<SimpleStatsEvolution>& evolution,
+    const std::shared_ptr<TableSchema>& data_schema) const {
+    std::shared_ptr<Predicate> data_predicate = predicates_;
+    if (data_schema->Id() != table_schema_->Id()) {
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::shared_ptr<Predicate>> reconstruct_predicate,
+                               FieldMappingBuilder::ReconstructPredicateWithDataFields(
+                                   predicates_, evolution->GetFieldNameToTableField(),
+                                   evolution->GetFieldIdToDataField()));
+
+        if (reconstruct_predicate == std::nullopt) {
+            return true;
+        }
+        data_predicate = reconstruct_predicate.value();
+    }
+    assert(data_predicate);
+    auto data_arrow_schema = DataField::ConvertDataFieldsToArrowSchema(data_schema->Fields());
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<FileIndexResult> index_result,
+        FileIndexEvaluator::Evaluate(data_arrow_schema, data_predicate, meta, pool_));
+    return index_result->IsRemain();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/operation/append_only_file_store_scan.h
+++ b/src/paimon/core/operation/append_only_file_store_scan.h
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "paimon/core/operation/file_store_scan.h"
+#include "paimon/core/stats/simple_stats_evolutions.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class CoreOptions;
+class Executor;
+class ManifestEntry;
+class ManifestFile;
+class ManifestList;
+class MemoryPool;
+class ScanFilter;
+class SchemaManager;
+class SimpleStatsEvolution;
+class SimpleStatsEvolutions;
+class SnapshotManager;
+class TableSchema;
+struct DataFileMeta;
+
+/// `FileStoreScan` for `AppendOnlyFileStore`.
+class AppendOnlyFileStoreScan : public FileStoreScan {
+ public:
+    static Result<std::unique_ptr<AppendOnlyFileStoreScan>> Create(
+        const std::shared_ptr<SnapshotManager>& snapshot_manager,
+        const std::shared_ptr<SchemaManager>& schema_manager,
+        const std::shared_ptr<ManifestList>& manifest_list,
+        const std::shared_ptr<ManifestFile>& manifest_file,
+        const std::shared_ptr<TableSchema>& table_schema,
+        const std::shared_ptr<arrow::Schema>& arrow_schema,
+        const std::shared_ptr<ScanFilter>& scan_filters, const CoreOptions& core_options,
+        const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool);
+
+    /// @note Keep this thread-safe.
+    Result<bool> FilterByStats(const ManifestEntry& entry) const override;
+
+ private:
+    Result<bool> TestFileIndex(const std::shared_ptr<DataFileMeta>& meta,
+                               const std::shared_ptr<SimpleStatsEvolution>& evolution,
+                               const std::shared_ptr<TableSchema>& data_schema) const;
+
+    AppendOnlyFileStoreScan(const std::shared_ptr<SnapshotManager>& snapshot_manager,
+                            const std::shared_ptr<SchemaManager>& schema_manager,
+                            const std::shared_ptr<ManifestList>& manifest_list,
+                            const std::shared_ptr<ManifestFile>& manifest_file,
+                            const std::shared_ptr<TableSchema>& table_schema,
+                            const std::shared_ptr<arrow::Schema>& schema,
+                            const CoreOptions& core_options,
+                            const std::shared_ptr<Executor>& executor,
+                            const std::shared_ptr<MemoryPool>& pool);
+
+ private:
+    std::shared_ptr<SimpleStatsEvolutions> evolutions_;
+};
+}  // namespace paimon

--- a/src/paimon/core/operation/append_only_file_store_scan_test.cpp
+++ b/src/paimon/core/operation/append_only_file_store_scan_test.cpp
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/append_only_file_store_scan.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/core/manifest/partition_entry.h"
+#include "paimon/core/operation/metrics/scan_metrics.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/stats/simple_stats_evolution.h"
+#include "paimon/core/table/source/abstract_table_scan.h"
+#include "paimon/core/table/source/snapshot/snapshot_reader.h"
+#include "paimon/defs.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/metrics.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/scan_context.h"
+#include "paimon/status.h"
+#include "paimon/table/source/table_scan.h"
+#include "paimon/testing/utils/testharness.h"
+#include "paimon/testing/utils/timezone_guard.h"
+namespace paimon::test {
+
+TEST(AppendOnlyFileStoreScanTest, TestReconstructPredicateWithNonCastedFields) {
+    std::string table_root =
+        paimon::test::GetDataDir() +
+        "/orc/append_table_alter_table_with_cast.db/append_table_alter_table_with_cast";
+    auto fs = std::make_shared<LocalFileSystem>();
+    auto pool = GetDefaultPool();
+    SchemaManager manager(fs, table_root);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> schema, manager.ReadSchema(/*schema_id=*/0));
+    ASSERT_TRUE(schema);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> schema1, manager.ReadSchema(/*schema_id=*/1));
+    ASSERT_TRUE(schema1);
+    auto evo = std::make_shared<SimpleStatsEvolution>(schema->Fields(), schema1->Fields(),
+                                                      /*need_mapping=*/true, pool);
+    ASSERT_OK_AND_ASSIGN(
+        auto child1,
+        PredicateBuilder::Or(
+            {PredicateBuilder::IsNull(/*field_index=*/0, /*field_name=*/"f4", FieldType::TIMESTAMP),
+             PredicateBuilder::IsNull(/*field_index=*/1, /*field_name=*/"key0", FieldType::INT),
+             PredicateBuilder::IsNull(/*field_index=*/2, /*field_name=*/"key1", FieldType::INT)}));
+
+    auto sub_child1 =
+        PredicateBuilder::IsNull(/*field_index=*/3, /*field_name=*/"f3", FieldType::INT);
+    auto sub_child2 =
+        PredicateBuilder::IsNull(/*field_index=*/4, /*field_name=*/"f1", FieldType::STRING);
+    auto sub_child3 =
+        PredicateBuilder::IsNull(/*field_index=*/5, /*field_name=*/"f2", FieldType::DECIMAL);
+    ASSERT_OK_AND_ASSIGN(auto child2, PredicateBuilder::And({sub_child1, sub_child2, sub_child3}));
+
+    auto child3 =
+        PredicateBuilder::IsNull(/*field_index=*/6, /*field_name=*/"f0", FieldType::BOOLEAN);
+    auto child4 = PredicateBuilder::IsNull(/*field_index=*/7, /*field_name=*/"f6", FieldType::INT);
+
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({child1, child2, child3, child4}));
+
+    ASSERT_OK_AND_ASSIGN(
+        auto result,
+        AppendOnlyFileStoreScan::ReconstructPredicateWithNonCastedFields(predicate, evo));
+    ASSERT_EQ(*result, *child4);
+}
+
+TEST(AppendOnlyFileStoreScanTest, TestReadPartitionEntries) {
+    TimezoneGuard guard("Asia/Shanghai");
+    std::string table_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09/";
+    ScanContextBuilder context_builder(table_path);
+    context_builder.AddOption(Options::FILE_FORMAT, "orc")
+        .AddOption(Options::MANIFEST_FORMAT, "orc")
+        .AddOption(Options::SCAN_SNAPSHOT_ID, "5");
+    ASSERT_OK_AND_ASSIGN(auto scan_context, context_builder.Finish());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(auto table_scan, TableScan::Create(std::move(scan_context)));
+    auto typed_table_scan = dynamic_cast<AbstractTableScan*>(table_scan.get());
+    ASSERT_TRUE(typed_table_scan);
+
+    auto file_store_scan = typed_table_scan->snapshot_reader_->scan_;
+    ASSERT_TRUE(file_store_scan);
+    ASSERT_OK_AND_ASSIGN(std::vector<PartitionEntry> result_partition_entries,
+                         file_store_scan->ReadPartitionEntries());
+
+    auto GenerateRow = [&](int32_t value) {
+        BinaryRow row(1);
+        BinaryRowWriter writer(&row, 0, pool.get());
+        writer.WriteInt(0, value);
+        writer.Complete();
+        return row;
+    };
+
+    std::vector<PartitionEntry> expected_partition_entries = {
+        PartitionEntry(GenerateRow(10), /*record_count=*/9, /*file_size_in_bytes=*/1183,
+                       /*file_count=*/2, /*last_file_creation_time=*/1721643834472l - 28800000l,
+                       /*total_buckets=*/2),
+        PartitionEntry(GenerateRow(20), /*record_count=*/2, /*file_size_in_bytes=*/1047,
+                       /*file_count=*/2, /*last_file_creation_time=*/1721643267404l - 28800000l,
+                       /*total_buckets=*/2)};
+    auto ComparePartitionEntryByPartition = [](const PartitionEntry& lhs,
+                                               const PartitionEntry& rhs) -> bool {
+        return lhs.Partition().GetInt(0) < rhs.Partition().GetInt(0);
+    };
+
+    std::stable_sort(result_partition_entries.begin(), result_partition_entries.end(),
+                     ComparePartitionEntryByPartition);
+    std::stable_sort(expected_partition_entries.begin(), expected_partition_entries.end(),
+                     ComparePartitionEntryByPartition);
+
+    ASSERT_EQ(result_partition_entries, expected_partition_entries);
+}
+
+TEST(AppendOnlyFileStoreScanTest, TestScanDurationMetric) {
+    TimezoneGuard guard("Asia/Shanghai");
+    std::string table_path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09/";
+    ScanContextBuilder context_builder(table_path);
+    context_builder.AddOption(Options::FILE_FORMAT, "orc")
+        .AddOption(Options::MANIFEST_FORMAT, "orc")
+        .AddOption(Options::SCAN_SNAPSHOT_ID, "5");
+    ASSERT_OK_AND_ASSIGN(auto scan_context, context_builder.Finish());
+
+    ASSERT_OK_AND_ASSIGN(auto table_scan, TableScan::Create(std::move(scan_context)));
+    auto typed_table_scan = dynamic_cast<AbstractTableScan*>(table_scan.get());
+    ASSERT_TRUE(typed_table_scan);
+
+    auto file_store_scan = typed_table_scan->snapshot_reader_->scan_;
+    ASSERT_TRUE(file_store_scan);
+
+    constexpr uint64_t kPlanCount = 5;
+    for (uint64_t i = 0; i < kPlanCount; ++i) {
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStoreScan::RawPlan> raw_plan,
+                             file_store_scan->CreatePlan());
+        (void)raw_plan;
+    }
+
+    std::shared_ptr<Metrics> metrics = file_store_scan->GetScanMetrics();
+    ASSERT_TRUE(metrics);
+
+    ASSERT_OK_AND_ASSIGN(uint64_t last_scan_duration,
+                         metrics->GetCounter(ScanMetrics::LAST_SCAN_DURATION));
+    ASSERT_OK_AND_ASSIGN(HistogramStats stats,
+                         metrics->GetHistogramStats(ScanMetrics::SCAN_DURATION));
+    ASSERT_EQ(stats.count, kPlanCount);
+    ASSERT_LE(stats.min, stats.max);
+    ASSERT_LE(stats.min, static_cast<double>(last_scan_duration));
+    ASSERT_LE(static_cast<double>(last_scan_duration), stats.max);
+    ASSERT_LE(stats.min, stats.p99);
+    ASSERT_LE(stats.p50, stats.p99);
+    ASSERT_LE(stats.p99, stats.max);
+}
+}  // namespace paimon::test

--- a/src/paimon/core/operation/data_evolution_file_store_scan.cpp
+++ b/src/paimon/core/operation/data_evolution_file_store_scan.cpp
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/data_evolution_file_store_scan.h"
+
+#include <map>
+#include <string>
+
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/reader/data_evolution_array.h"
+#include "paimon/common/reader/data_evolution_row.h"
+#include "paimon/common/utils/object_utils.h"
+#include "paimon/common/utils/range_helper.h"
+namespace paimon {
+Result<bool> DataEvolutionFileStoreScan::FilterEntryByRowRanges(
+    const ManifestEntry& entry, const std::optional<RowRangeIndex>& row_range_index) {
+    // If row range index is null, all entries should be kept
+    if (!row_range_index) {
+        return true;
+    }
+    // If firstRowId does not exist, keep the entry
+    std::optional<int64_t> first_row_id = entry.File()->first_row_id;
+    if (first_row_id == std::nullopt) {
+        return true;
+    }
+
+    // Check if any value in indices is in the range [firstRowId, firstRowId + rowCount - 1]
+    int64_t end_row_id = first_row_id.value() + entry.File()->row_count - 1;
+
+    return row_range_index->Intersects(first_row_id.value(), end_row_id);
+}
+
+Result<bool> DataEvolutionFileStoreScan::FilterByStats(const ManifestEntry& entry) const {
+    return FilterEntryByRowRanges(entry, row_range_index_);
+}
+
+Result<std::vector<ManifestEntry>> DataEvolutionFileStoreScan::PostFilterManifestEntries(
+    std::vector<ManifestEntry>&& entries) const {
+    if (!predicates_) {
+        return std::move(entries);
+    }
+    // group by row id range
+    RangeHelper<ManifestEntry> range_helper(
+        [](const ManifestEntry& entry) -> Result<int64_t> {
+            return entry.File()->NonNullFirstRowId();
+        },
+        [](const ManifestEntry& entry) -> Result<int64_t> {
+            const auto& file_meta = entry.File();
+            PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file_meta->NonNullFirstRowId());
+            return first_row_id + file_meta->row_count - 1;
+        });
+
+    std::vector<ManifestEntry> result_entries;
+    result_entries.reserve(entries.size());
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<ManifestEntry>> split_by_row_id,
+                           range_helper.MergeOverlappingRanges(std::move(entries)));
+
+    for (auto& with_same_row_id : split_by_row_id) {
+        PAIMON_ASSIGN_OR_RAISE(bool saved, FilterByStatsWithSameRowId(with_same_row_id));
+        if (saved) {
+            for (auto& entry : with_same_row_id) {
+                result_entries.push_back(std::move(entry));
+            }
+        }
+    }
+    return result_entries;
+}
+
+Result<bool> DataEvolutionFileStoreScan::FilterByStatsWithSameRowId(
+    const std::vector<ManifestEntry>& entries) const {
+    if (entries.empty()) {
+        return Status::Invalid(
+            "DataEvolutionFileStoreScan FilterByStats must have at least one ManifestEntry");
+    }
+    // evolution stats from multiple entries with the same first row id, from data schema to
+    // table schema, also deal with dense fields
+    std::function<Result<std::shared_ptr<TableSchema>>(int64_t)> schema_fetcher =
+        [this](int64_t schema_id) -> Result<std::shared_ptr<TableSchema>> {
+        if (schema_id == table_schema_->Id()) {
+            return table_schema_;
+        }
+        return schema_manager_->ReadSchema(schema_id);
+    };
+    std::pair<int64_t, SimpleStatsEvolution::EvolutionStats> row_count_new_stats;
+    PAIMON_ASSIGN_OR_RAISE(row_count_new_stats,
+                           EvolutionStats(entries, table_schema_, schema_fetcher));
+    const auto& [row_count, new_stats] = row_count_new_stats;
+
+    // predicate tests evolution stats
+    auto predicate_filter = std::dynamic_pointer_cast<PredicateFilter>(predicates_);
+    if (!predicate_filter) {
+        return Status::Invalid("cannot cast to predicate filter");
+    }
+    return predicate_filter->Test(schema_, row_count, *(new_stats.min_values),
+                                  *(new_stats.max_values), *(new_stats.null_counts));
+}
+
+Result<std::pair<int64_t, SimpleStatsEvolution::EvolutionStats>>
+DataEvolutionFileStoreScan::EvolutionStats(
+    const std::vector<ManifestEntry>& old_entries, const std::shared_ptr<TableSchema>& table_schema,
+    const std::function<Result<std::shared_ptr<TableSchema>>(int64_t)>& schema_fetcher) {
+    // exclude blob files, useless for predicate eval
+    std::vector<ManifestEntry> entries;
+    entries.reserve(old_entries.size());
+    for (const auto& entry : old_entries) {
+        if (!BlobUtils::IsBlobFile(entry.File()->file_name)) {
+            entries.push_back(entry);
+        }
+    }
+    if (entries.empty()) {
+        return Status::Invalid(
+            "DataEvolutionFileStoreScan EvolutionStats: after exclude blob files, entries cannot "
+            "be empty");
+    }
+    std::stable_sort(entries.begin(), entries.end(),
+                     [](const ManifestEntry& e1, const ManifestEntry& e2) {
+                         return e1.File()->max_sequence_number > e2.File()->max_sequence_number;
+                     });
+
+    // Init all we need to create a compound stats
+    const auto& table_fields = table_schema->Fields();
+    //  which row the read field index belongs to
+    std::vector<int32_t> row_offsets(table_fields.size(), -1);
+    // which field index in the reading row
+    std::vector<int32_t> field_offsets(table_fields.size(), -1);
+
+    for (int32_t entry_idx = 0; entry_idx < static_cast<int32_t>(entries.size()); entry_idx++) {
+        const auto& file_meta = entries[entry_idx].File();
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<TableSchema> data_schema,
+                               schema_fetcher(file_meta->schema_id));
+
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<DataField> write_fields,
+            DataField::ProjectFields(data_schema->Fields(), file_meta->write_cols));
+        PAIMON_ASSIGN_OR_RAISE(std::vector<DataField> stats_fields,
+                               DataField::ProjectFields(write_fields, file_meta->value_stats_cols));
+        // field name to stats idx
+        std::map<std::string, int32_t> stats_field_map = ObjectUtils::CreateIdentifierToIndexMap(
+            stats_fields, [](const DataField& field) -> std::string { return field.Name(); });
+
+        for (int32_t table_field_idx = 0;
+             table_field_idx < static_cast<int32_t>(table_fields.size()); table_field_idx++) {
+            // -1 indicates that the table fields are not matched
+            if (row_offsets[table_field_idx] != -1) {
+                continue;
+            }
+            for (const auto& write_field : write_fields) {
+                const auto& table_field = table_fields[table_field_idx];
+                if (write_field.Id() == table_field.Id()) {
+                    // indicates write field matches table field
+                    // -2 indicates that the table fields will be matched to the current file.
+                    row_offsets[table_field_idx] = -2;
+                    auto stats_iter = stats_field_map.find(write_field.Name());
+                    // if the fields are of the same type and contain statistics, then update
+                    // row_offsets, otherwise evolved stats of current field is null
+                    if (table_field.Type()->Equals(write_field.Type()) &&
+                        stats_iter != stats_field_map.end()) {
+                        row_offsets[table_field_idx] = entry_idx;
+                        field_offsets[table_field_idx] = stats_iter->second;
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    std::vector<BinaryRow> min_rows;
+    std::vector<BinaryRow> max_rows;
+    std::vector<BinaryArray> null_counts;
+    min_rows.reserve(entries.size());
+    max_rows.reserve(entries.size());
+    null_counts.reserve(entries.size());
+    for (const auto& entry : entries) {
+        const auto& stats = entry.File()->value_stats;
+        min_rows.push_back(stats.MinValues());
+        max_rows.push_back(stats.MaxValues());
+        null_counts.push_back(stats.NullCounts());
+    }
+
+    auto final_min = std::make_shared<DataEvolutionRow>(min_rows, row_offsets, field_offsets);
+    auto final_max = std::make_shared<DataEvolutionRow>(max_rows, row_offsets, field_offsets);
+    auto final_null_counts =
+        std::make_shared<DataEvolutionArray>(null_counts, row_offsets, field_offsets);
+    return std::make_pair(
+        entries[0].File()->row_count,
+        SimpleStatsEvolution::EvolutionStats(final_min, final_max, final_null_counts));
+}
+
+}  // namespace paimon

--- a/src/paimon/core/operation/data_evolution_file_store_scan.h
+++ b/src/paimon/core/operation/data_evolution_file_store_scan.h
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "paimon/core/operation/file_store_scan.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/stats/simple_stats_evolution.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class CoreOptions;
+class Executor;
+class ManifestEntry;
+class ManifestFile;
+class ManifestList;
+class MemoryPool;
+class ScanFilter;
+class SchemaManager;
+class SnapshotManager;
+
+/// `FileStoreScan` for data-evolution enabled table.
+class DataEvolutionFileStoreScan : public FileStoreScan {
+ public:
+    static Result<std::unique_ptr<DataEvolutionFileStoreScan>> Create(
+        const std::shared_ptr<SnapshotManager>& snapshot_manager,
+        const std::shared_ptr<SchemaManager>& schema_manager,
+        const std::shared_ptr<ManifestList>& manifest_list,
+        const std::shared_ptr<ManifestFile>& manifest_file,
+        const std::shared_ptr<TableSchema>& table_schema,
+        const std::shared_ptr<arrow::Schema>& arrow_schema,
+        const std::shared_ptr<ScanFilter>& scan_filters, const CoreOptions& core_options,
+        const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool) {
+        auto scan = std::unique_ptr<DataEvolutionFileStoreScan>(new DataEvolutionFileStoreScan(
+            snapshot_manager, schema_manager, manifest_list, manifest_file, table_schema,
+            arrow_schema, core_options, executor, pool));
+        PAIMON_RETURN_NOT_OK(
+            scan->SplitAndSetFilter(table_schema->PartitionKeys(), arrow_schema, scan_filters));
+        return scan;
+    }
+
+    Result<std::vector<ManifestEntry>> PostFilterManifestEntries(
+        std::vector<ManifestEntry>&& entries) const override;
+
+    /// @note Keep this thread-safe.
+    Result<bool> FilterByStats(const ManifestEntry& entry) const override;
+
+ private:
+    DataEvolutionFileStoreScan(const std::shared_ptr<SnapshotManager>& snapshot_manager,
+                               const std::shared_ptr<SchemaManager>& schema_manager,
+                               const std::shared_ptr<ManifestList>& manifest_list,
+                               const std::shared_ptr<ManifestFile>& manifest_file,
+                               const std::shared_ptr<TableSchema>& table_schema,
+                               const std::shared_ptr<arrow::Schema>& schema,
+                               const CoreOptions& core_options,
+                               const std::shared_ptr<Executor>& executor,
+                               const std::shared_ptr<MemoryPool>& pool)
+        : FileStoreScan(snapshot_manager, schema_manager, manifest_list, manifest_file,
+                        table_schema, schema, core_options, executor, pool) {}
+
+    Result<bool> FilterByStatsWithSameRowId(const std::vector<ManifestEntry>& entries) const;
+
+    static Result<bool> FilterEntryByRowRanges(const ManifestEntry& entry,
+                                               const std::optional<RowRangeIndex>& row_range_index);
+
+    static Result<std::pair<int64_t, SimpleStatsEvolution::EvolutionStats>> EvolutionStats(
+        const std::vector<ManifestEntry>& entries, const std::shared_ptr<TableSchema>& table_schema,
+        const std::function<Result<std::shared_ptr<TableSchema>>(int64_t)>& schema_fetcher);
+};
+}  // namespace paimon

--- a/src/paimon/core/operation/data_evolution_file_store_scan_test.cpp
+++ b/src/paimon/core/operation/data_evolution_file_store_scan_test.cpp
@@ -1,0 +1,614 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/data_evolution_file_store_scan.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/reader/data_evolution_array.h"
+#include "paimon/common/reader/data_evolution_row.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/stats/simple_stats_evolution.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class DataEvolutionFileStoreScanTest : public ::testing::Test {
+ public:
+    void SetUp() override {}
+    void TearDown() override {}
+
+    std::shared_ptr<TableSchema> CreateTableSchema(int64_t schema_id,
+                                                   const std::vector<DataField>& fields) const {
+        EXPECT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::InitSchema(schema_id, fields, /*highest_field_id=*/fields.size(),
+                                    /*partition_keys=*/{},
+                                    /*primary_keys=*/{}, /*options=*/{}, /*comment=*/std::nullopt,
+                                    /*time_millis=*/0));
+        return table_schema;
+    }
+    ManifestEntry CreateManifestEntry(
+        int64_t schema_id, const SimpleStats& stats,
+        const std::optional<std::vector<std::string>>& value_stats_cols,
+        const std::optional<std::vector<std::string>>& write_cols,
+        int64_t sequence_number = 0) const {
+        EXPECT_OK_AND_ASSIGN(
+            auto meta,
+            DataFileMeta::ForAppend(
+                /*file_name=*/"test-file.parquet", /*file_size=*/100l, /*row_count=*/100l, stats,
+                /*min_sequence_number=*/sequence_number,
+                /*max_sequence_number=*/sequence_number, schema_id,
+                /*file_source=*/FileSource::Append(), value_stats_cols,
+                /*external_path=*/std::nullopt, /*first_row_id=*/0, write_cols));
+        return ManifestEntry(FileKind::Add(), /*partition=*/BinaryRow::EmptyRow(), /*bucket=*/0,
+                             /*total_buckets=*/1, meta);
+    }
+
+    ManifestEntry CreateBlobManifestEntry(
+        int64_t schema_id, const SimpleStats& stats,
+        const std::optional<std::vector<std::string>>& value_stats_cols,
+        const std::optional<std::vector<std::string>>& write_cols, int64_t first_row_id,
+        int64_t row_count) const {
+        EXPECT_OK_AND_ASSIGN(
+            auto meta,
+            DataFileMeta::ForAppend(
+                /*file_name=*/"test-file.blob", /*file_size=*/100l, /*row_count=*/100l, stats,
+                /*min_sequence_number=*/0l,
+                /*max_sequence_number=*/0l, schema_id,
+                /*file_source=*/FileSource::Append(), value_stats_cols,
+                /*external_path=*/std::nullopt, /*first_row_id=*/0, write_cols));
+        return ManifestEntry(FileKind::Add(), /*partition=*/BinaryRow::EmptyRow(), /*bucket=*/0,
+                             /*total_buckets=*/1, meta);
+    }
+
+    void CheckFieldCountAndArraySize(const std::shared_ptr<DataEvolutionRow>& min_row,
+                                     const std::shared_ptr<DataEvolutionRow>& max_row,
+                                     const std::shared_ptr<DataEvolutionArray>& null_counts,
+                                     int32_t expected) const {
+        ASSERT_EQ(min_row->GetFieldCount(), expected);
+        ASSERT_EQ(max_row->GetFieldCount(), expected);
+        ASSERT_EQ(null_counts->Size(), expected);
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+};
+
+TEST_F(DataEvolutionFileStoreScanTest, TestEvolutionStatsSingleFile) {
+    std::vector<DataField> fields = {DataField(0, arrow::field("f0", arrow::int32())),
+                                     DataField(1, arrow::field("f1", arrow::utf8()))};
+    auto table_schema = CreateTableSchema(/*schema_id=*/0, fields);
+
+    std::function<Result<std::shared_ptr<TableSchema>>(int64_t)> schema_fetcher =
+        [&](int64_t schema_id) -> Result<std::shared_ptr<TableSchema>> {
+        assert(schema_id == 0);
+        return table_schema;
+    };
+
+    auto entry = CreateManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({1, std::string("a")}, {5, std::string("z")}, {0, 1},
+                                          pool_.get()),
+        /*value_stats_cols=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    ASSERT_OK_AND_ASSIGN(auto result_stats, DataEvolutionFileStoreScan::EvolutionStats(
+                                                {entry}, table_schema, schema_fetcher));
+    auto result_row_count = result_stats.first;
+    ASSERT_EQ(result_row_count, 100);
+    auto min_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.min_values);
+    ASSERT_TRUE(min_row);
+    auto max_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.max_values);
+    ASSERT_TRUE(max_row);
+    auto null_counts =
+        std::dynamic_pointer_cast<DataEvolutionArray>(result_stats.second.null_counts);
+    ASSERT_TRUE(null_counts);
+
+    // check field count and array size
+    CheckFieldCountAndArraySize(min_row, max_row, null_counts, 2);
+
+    // check min/max row
+    ASSERT_EQ(min_row->GetInt(0), 1);
+    ASSERT_EQ(max_row->GetInt(0), 5);
+    ASSERT_EQ(min_row->GetString(1).ToString(), "a");
+    ASSERT_EQ(max_row->GetString(1).ToString(), "z");
+
+    // check null count array
+    ASSERT_EQ(null_counts->GetLong(0), 0);
+    ASSERT_EQ(null_counts->GetLong(1), 1);
+}
+
+TEST_F(DataEvolutionFileStoreScanTest, TestEvolutionStatsMultipleFiles) {
+    std::vector<DataField> fields = {
+        DataField(0, arrow::field("f0", arrow::int32())),
+        DataField(1, arrow::field("f1", arrow::utf8())),
+        DataField(2, arrow::field("f2", arrow::int32())),
+    };
+
+    auto table_schema0 = CreateTableSchema(/*schema_id=*/0, fields);
+    auto table_schema1 = CreateTableSchema(/*schema_id=*/1, {fields[0], fields[2]});
+
+    std::function<Result<std::shared_ptr<TableSchema>>(int64_t)> schema_fetcher =
+        [&](int64_t schema_id) -> Result<std::shared_ptr<TableSchema>> {
+        if (schema_id == 0) {
+            return table_schema0;
+        } else if (schema_id == 1) {
+            return table_schema1;
+        }
+        return std::shared_ptr<TableSchema>();
+    };
+
+    auto entry0 = CreateManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({1, std::string("a"), 10}, {3, std::string("c"), 30},
+                                          {0, 1, 0}, pool_.get()),
+        /*value_stats_cols=*/std::nullopt, /*write_cols=*/std::nullopt);
+    auto entry1 = CreateManifestEntry(
+        /*schema_id=*/1, /*stats=*/
+        BinaryRowGenerator::GenerateStats({2, 20}, {4, 40}, {1, 2}, pool_.get()),
+        /*value_stats_cols=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    ASSERT_OK_AND_ASSIGN(auto result_stats, DataEvolutionFileStoreScan::EvolutionStats(
+                                                {entry1, entry0}, table_schema0, schema_fetcher));
+
+    auto min_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.min_values);
+    ASSERT_TRUE(min_row);
+    auto max_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.max_values);
+    ASSERT_TRUE(max_row);
+    auto null_counts =
+        std::dynamic_pointer_cast<DataEvolutionArray>(result_stats.second.null_counts);
+    ASSERT_TRUE(null_counts);
+
+    // check field count and array size
+    CheckFieldCountAndArraySize(min_row, max_row, null_counts, 3);
+
+    // check min/max row
+    ASSERT_EQ(min_row->GetInt(0), 2);
+    ASSERT_EQ(max_row->GetInt(0), 4);
+    ASSERT_EQ(min_row->GetString(1).ToString(), "a");
+    ASSERT_EQ(max_row->GetString(1).ToString(), "c");
+    ASSERT_EQ(min_row->GetInt(2), 20);
+    ASSERT_EQ(max_row->GetInt(2), 40);
+
+    // check null count array
+    ASSERT_EQ(null_counts->GetLong(0), 1);
+    ASSERT_EQ(null_counts->GetLong(1), 1);
+    ASSERT_EQ(null_counts->GetLong(2), 2);
+}
+
+TEST_F(DataEvolutionFileStoreScanTest, TestEvolutionStatsWithSchemaEvolution) {
+    std::vector<DataField> fields = {
+        DataField(0, arrow::field("f0", arrow::int32())),
+        DataField(1, arrow::field("f1", arrow::utf8())),
+        DataField(2, arrow::field("f2", arrow::int32())),
+    };
+
+    auto table_schema0 = CreateTableSchema(/*schema_id=*/0, {fields[0], fields[1]});
+    auto table_schema1 = CreateTableSchema(/*schema_id=*/1, fields);
+
+    std::function<Result<std::shared_ptr<TableSchema>>(int64_t)> schema_fetcher =
+        [&](int64_t schema_id) -> Result<std::shared_ptr<TableSchema>> {
+        if (schema_id == 0) {
+            return table_schema0;
+        } else if (schema_id == 1) {
+            return table_schema1;
+        }
+        return std::shared_ptr<TableSchema>();
+    };
+
+    auto entry0 = CreateManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({1, std::string("a")}, {3, std::string("c")}, {0, 1},
+                                          pool_.get()),
+        /*value_stats_cols=*/std::nullopt, /*write_cols=*/std::nullopt);
+    auto entry1 = CreateManifestEntry(
+        /*schema_id=*/1, /*stats=*/
+        BinaryRowGenerator::GenerateStats({2, std::string("b"), 20}, {4, std::string("d"), 40},
+                                          {1, 0, 1}, pool_.get()),
+        /*value_stats_cols=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    ASSERT_OK_AND_ASSIGN(auto result_stats, DataEvolutionFileStoreScan::EvolutionStats(
+                                                {entry0, entry1}, table_schema1, schema_fetcher));
+
+    auto min_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.min_values);
+    ASSERT_TRUE(min_row);
+    auto max_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.max_values);
+    ASSERT_TRUE(max_row);
+    auto null_counts =
+        std::dynamic_pointer_cast<DataEvolutionArray>(result_stats.second.null_counts);
+    ASSERT_TRUE(null_counts);
+
+    // check field count and array size
+    CheckFieldCountAndArraySize(min_row, max_row, null_counts, 3);
+
+    // check min/max row
+    ASSERT_EQ(min_row->GetInt(0), 1);
+    ASSERT_EQ(max_row->GetInt(0), 3);
+    ASSERT_EQ(min_row->GetString(1).ToString(), "a");
+    ASSERT_EQ(max_row->GetString(1).ToString(), "c");
+    ASSERT_EQ(min_row->GetInt(2), 20);
+    ASSERT_EQ(max_row->GetInt(2), 40);
+
+    // check null count array
+    ASSERT_EQ(null_counts->GetLong(0), 0);
+    ASSERT_EQ(null_counts->GetLong(1), 1);
+    ASSERT_EQ(null_counts->GetLong(2), 1);
+}
+
+TEST_F(DataEvolutionFileStoreScanTest, TestEvolutionStatsWithWriteColsNotEqualToValueStatsCols) {
+    std::vector<DataField> fields = {
+        DataField(0, arrow::field("f0", arrow::int32())),
+        DataField(1, arrow::field("f1", arrow::utf8())),
+        DataField(2, arrow::field("f2", arrow::int32())),
+    };
+
+    auto table_schema0 = CreateTableSchema(/*schema_id=*/0, fields);
+    auto table_schema1 = CreateTableSchema(/*schema_id=*/1, fields);
+
+    std::function<Result<std::shared_ptr<TableSchema>>(int64_t)> schema_fetcher =
+        [&](int64_t schema_id) -> Result<std::shared_ptr<TableSchema>> {
+        if (schema_id == 0) {
+            return table_schema0;
+        } else if (schema_id == 1) {
+            return table_schema1;
+        }
+        return std::shared_ptr<TableSchema>();
+    };
+
+    auto entry0 = CreateManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({1, std::string("a")}, {3, std::string("c")}, {0, 1},
+                                          pool_.get()),
+        /*value_stats_cols=*/std::vector<std::string>({"f0", "f1"}),
+        /*write_cols=*/std::vector<std::string>({"f0", "f1", "f2"}));
+    auto entry1 = CreateManifestEntry(
+        /*schema_id=*/1, /*stats=*/
+        BinaryRowGenerator::GenerateStats({2, 20}, {4, 40}, {1, 0}, pool_.get()),
+        /*value_stats_cols=*/std::vector<std::string>({"f0", "f2"}),
+        /*write_cols=*/std::vector<std::string>({"f0", "f2"}));
+
+    ASSERT_OK_AND_ASSIGN(auto result_stats, DataEvolutionFileStoreScan::EvolutionStats(
+                                                {entry0, entry1}, table_schema1, schema_fetcher));
+
+    auto min_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.min_values);
+    ASSERT_TRUE(min_row);
+    auto max_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.max_values);
+    ASSERT_TRUE(max_row);
+    auto null_counts =
+        std::dynamic_pointer_cast<DataEvolutionArray>(result_stats.second.null_counts);
+    ASSERT_TRUE(null_counts);
+
+    // check field count and array size
+    CheckFieldCountAndArraySize(min_row, max_row, null_counts, 3);
+
+    // check min/max row
+    ASSERT_EQ(min_row->GetInt(0), 1);
+    ASSERT_EQ(max_row->GetInt(0), 3);
+    ASSERT_EQ(min_row->GetString(1).ToString(), "a");
+    ASSERT_EQ(max_row->GetString(1).ToString(), "c");
+    ASSERT_TRUE(min_row->IsNullAt(2));
+    ASSERT_TRUE(max_row->IsNullAt(2));
+
+    // check null count array
+    ASSERT_EQ(null_counts->GetLong(0), 0);
+    ASSERT_EQ(null_counts->GetLong(1), 1);
+    ASSERT_TRUE(null_counts->IsNullAt(2));
+}
+
+TEST_F(DataEvolutionFileStoreScanTest, TestEvolutionStatsWithSchemaEvolutionRenameFields) {
+    std::vector<DataField> fields0 = {
+        DataField(0, arrow::field("f0", arrow::int32())),
+        DataField(1, arrow::field("f1", arrow::utf8())),
+        DataField(2, arrow::field("f2", arrow::int32())),
+        DataField(3, arrow::field("f3", arrow::utf8())),
+    };
+    auto table_schema0 = CreateTableSchema(/*schema_id=*/0, fields0);
+    std::vector<DataField> fields1 = {
+        DataField(0, arrow::field("f3", arrow::int32())),
+        DataField(1, arrow::field("f1", arrow::utf8())),
+        DataField(2, arrow::field("f0", arrow::int32())),
+        DataField(4, arrow::field("f5", arrow::utf8())),
+    };
+    auto table_schema1 = CreateTableSchema(/*schema_id=*/1, fields1);
+
+    std::function<Result<std::shared_ptr<TableSchema>>(int64_t)> schema_fetcher =
+        [&](int64_t schema_id) -> Result<std::shared_ptr<TableSchema>> {
+        if (schema_id == 0) {
+            return table_schema0;
+        } else if (schema_id == 1) {
+            return table_schema1;
+        }
+        return std::shared_ptr<TableSchema>();
+    };
+
+    auto entry0 = CreateManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("a"), 10}, {std::string("c"), 15}, {0, 1},
+                                          pool_.get()),
+        /*value_stats_cols=*/std::vector<std::string>({"f1", "f2"}),
+        /*write_cols=*/std::vector<std::string>({"f1", "f2"}));
+    auto entry1 = CreateManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({20, 2}, {25, 5}, {1, 0}, pool_.get()),
+        /*value_stats_cols=*/std::vector<std::string>({"f2", "f0"}),
+        /*write_cols=*/std::vector<std::string>({"f2", "f0"}));
+    auto entry2 = CreateManifestEntry(
+        /*schema_id=*/1, /*stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("bb"), std::string("cd")},
+                                          {std::string("dd"), std::string("xy")}, {1, 3},
+                                          pool_.get()),
+        /*value_stats_cols=*/std::vector<std::string>({"f5", "f1"}),
+        /*write_cols=*/std::vector<std::string>({"f3", "f1", "f5"}));
+
+    ASSERT_OK_AND_ASSIGN(auto result_stats,
+                         DataEvolutionFileStoreScan::EvolutionStats({entry2, entry1, entry0},
+                                                                    table_schema1, schema_fetcher));
+
+    auto min_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.min_values);
+    ASSERT_TRUE(min_row);
+    auto max_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.max_values);
+    ASSERT_TRUE(max_row);
+    auto null_counts =
+        std::dynamic_pointer_cast<DataEvolutionArray>(result_stats.second.null_counts);
+    ASSERT_TRUE(null_counts);
+
+    // check field count and array size
+    CheckFieldCountAndArraySize(min_row, max_row, null_counts, 4);
+
+    // check min/max row
+    ASSERT_TRUE(min_row->IsNullAt(0));
+    ASSERT_TRUE(max_row->IsNullAt(0));
+    ASSERT_EQ(min_row->GetString(1).ToString(), "cd");
+    ASSERT_EQ(max_row->GetString(1).ToString(), "xy");
+    ASSERT_EQ(min_row->GetInt(2), 20);
+    ASSERT_EQ(max_row->GetInt(2), 25);
+    ASSERT_EQ(min_row->GetString(3).ToString(), "bb");
+    ASSERT_EQ(max_row->GetString(3).ToString(), "dd");
+
+    // check null count array
+    ASSERT_TRUE(null_counts->IsNullAt(0));
+    ASSERT_EQ(null_counts->GetLong(1), 3);
+    ASSERT_EQ(null_counts->GetLong(2), 1);
+    ASSERT_EQ(null_counts->GetLong(3), 1);
+}
+
+TEST_F(DataEvolutionFileStoreScanTest, TestEvolutionStatsWithSchemaEvolutionUpdateType) {
+    std::vector<DataField> fields0 = {
+        DataField(0, arrow::field("f0", arrow::int32())),
+        DataField(1, arrow::field("f1", arrow::utf8())),
+        DataField(2, arrow::field("f2", arrow::int32())),
+        DataField(3, arrow::field("f3", arrow::utf8())),
+    };
+    auto table_schema0 = CreateTableSchema(/*schema_id=*/0, fields0);
+    std::vector<DataField> fields1 = {
+        DataField(4, arrow::field("f4", arrow::int32())),
+        DataField(1, arrow::field("f1", arrow::int32())),
+        DataField(2, arrow::field("f2", arrow::int32())),
+        DataField(3, arrow::field("f3", arrow::int32())),
+    };
+
+    auto table_schema1 = CreateTableSchema(/*schema_id=*/1, fields1);
+
+    std::function<Result<std::shared_ptr<TableSchema>>(int64_t)> schema_fetcher =
+        [&](int64_t schema_id) -> Result<std::shared_ptr<TableSchema>> {
+        if (schema_id == 0) {
+            return table_schema0;
+        } else if (schema_id == 1) {
+            return table_schema1;
+        }
+        return std::shared_ptr<TableSchema>();
+    };
+
+    auto entry0 = CreateManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({10, std::string("a"), 11, std::string("b")},
+                                          {20, std::string("c"), 22, std::string("d")},
+                                          {0, 1, 2, 3}, pool_.get()),
+        /*value_stats_cols=*/std::nullopt, /*write_cols=*/std::nullopt);
+    auto entry1 = CreateManifestEntry(
+        /*schema_id=*/1, /*stats=*/
+        BinaryRowGenerator::GenerateStats({2}, {5}, {0}, pool_.get()),
+        /*value_stats_cols=*/std::vector<std::string>({"f4"}),
+        /*write_cols=*/std::vector<std::string>({"f1", "f4"}));
+
+    ASSERT_OK_AND_ASSIGN(auto result_stats, DataEvolutionFileStoreScan::EvolutionStats(
+                                                {entry1, entry0}, table_schema1, schema_fetcher));
+
+    auto min_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.min_values);
+    ASSERT_TRUE(min_row);
+    auto max_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.max_values);
+    ASSERT_TRUE(max_row);
+    auto null_counts =
+        std::dynamic_pointer_cast<DataEvolutionArray>(result_stats.second.null_counts);
+    ASSERT_TRUE(null_counts);
+
+    // check field count and array size
+    CheckFieldCountAndArraySize(min_row, max_row, null_counts, 4);
+
+    // check min/max values and null_counts
+    ASSERT_EQ(min_row->GetInt(0), 2);
+    ASSERT_EQ(max_row->GetInt(0), 5);
+    ASSERT_EQ(null_counts->GetLong(0), 0);
+
+    ASSERT_TRUE(min_row->IsNullAt(1));
+    ASSERT_TRUE(max_row->IsNullAt(1));
+    ASSERT_TRUE(null_counts->IsNullAt(1));
+
+    ASSERT_EQ(min_row->GetInt(2), 11);
+    ASSERT_EQ(max_row->GetInt(2), 22);
+    ASSERT_EQ(null_counts->GetLong(2), 2);
+
+    // f1 in entry0 type mismatch schema1
+    ASSERT_TRUE(min_row->IsNullAt(3));
+    ASSERT_TRUE(max_row->IsNullAt(3));
+    ASSERT_TRUE(null_counts->IsNullAt(3));
+}
+
+TEST_F(DataEvolutionFileStoreScanTest, TestEvolutionStatsWithBlob) {
+    std::vector<DataField> fields = {
+        DataField(0, arrow::field("f0", arrow::int32())),
+        DataField(1, arrow::field("f1", arrow::utf8())),
+        DataField(2, BlobUtils::ToArrowField("blob")),
+    };
+    auto table_schema = CreateTableSchema(/*schema_id=*/0, fields);
+
+    std::function<Result<std::shared_ptr<TableSchema>>(int64_t)> schema_fetcher =
+        [&](int64_t schema_id) -> Result<std::shared_ptr<TableSchema>> {
+        assert(schema_id == 0);
+        return table_schema;
+    };
+
+    auto entry0 = CreateManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({10, std::string("aa")}, {55, std::string("zz")}, {2, 3},
+                                          pool_.get()),
+        /*value_stats_cols=*/std::nullopt,
+        /*write_cols=*/std::optional<std::vector<std::string>>({"f0", "f1"}),
+        /*sequence_number=*/1l);
+
+    auto blob_entry0 = CreateBlobManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({NullType()}, {NullType()}, {0}, pool_.get()),
+        /*value_stats_cols=*/std::nullopt,
+        /*write_cols=*/std::optional<std::vector<std::string>>({"f0"}),
+        /*first_row_id=*/0, /*row_count=*/10l);
+
+    auto blob_entry1 = CreateBlobManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({NullType()}, {NullType()}, {0}, pool_.get()),
+        /*value_stats_cols=*/std::nullopt,
+        /*write_cols=*/std::optional<std::vector<std::string>>({"f0"}),
+        /*first_row_id=*/10, /*row_count=*/90l);
+
+    auto entry1 = CreateManifestEntry(
+        /*schema_id=*/0, /*stats=*/
+        BinaryRowGenerator::GenerateStats({1, std::string("a")}, {5, std::string("z")}, {0, 1},
+                                          pool_.get()),
+        /*value_stats_cols=*/std::nullopt,
+        /*write_cols=*/std::optional<std::vector<std::string>>({"f0", "f1"}),
+        /*sequence_number=*/2l);
+
+    ASSERT_OK_AND_ASSIGN(auto result_stats, DataEvolutionFileStoreScan::EvolutionStats(
+                                                {blob_entry0, blob_entry1, entry0, entry1},
+                                                table_schema, schema_fetcher));
+
+    auto result_row_count = result_stats.first;
+    ASSERT_EQ(result_row_count, 100);
+    auto min_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.min_values);
+    ASSERT_TRUE(min_row);
+    auto max_row = std::dynamic_pointer_cast<DataEvolutionRow>(result_stats.second.max_values);
+    ASSERT_TRUE(max_row);
+    auto null_counts =
+        std::dynamic_pointer_cast<DataEvolutionArray>(result_stats.second.null_counts);
+    ASSERT_TRUE(null_counts);
+
+    // check field count and array size
+    CheckFieldCountAndArraySize(min_row, max_row, null_counts, 3);
+
+    // check min/max row
+    ASSERT_EQ(min_row->GetInt(0), 1);
+    ASSERT_EQ(max_row->GetInt(0), 5);
+    ASSERT_EQ(min_row->GetString(1).ToString(), "a");
+    ASSERT_EQ(max_row->GetString(1).ToString(), "z");
+    ASSERT_TRUE(min_row->IsNullAt(2));
+    ASSERT_TRUE(max_row->IsNullAt(2));
+
+    // check null count array
+    ASSERT_EQ(null_counts->GetLong(0), 0);
+    ASSERT_EQ(null_counts->GetLong(1), 1);
+    ASSERT_TRUE(null_counts->IsNullAt(2));
+}
+
+TEST_F(DataEvolutionFileStoreScanTest, TestFilterEntryByRowRanges) {
+    // row id range [100, 200)
+    auto file = std::make_shared<DataFileMeta>(
+        "data-0.orc", /*file_size=*/645,
+        /*row_count=*/100, BinaryRow::EmptyRow(), BinaryRow::EmptyRow(), SimpleStats::EmptyStats(),
+        SimpleStats::EmptyStats(),
+        /*min_sequence_number=*/100, /*max_sequence_number=*/199, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1737111915429ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/100, /*write_cols=*/std::nullopt);
+    ManifestEntry entry(FileKind::Add(), BinaryRow::EmptyRow(), /*bucket=*/0, /*total_buckets=*/1,
+                        file);
+    {
+        // row_ids is null
+        ASSERT_OK_AND_ASSIGN(bool exist, DataEvolutionFileStoreScan::FilterEntryByRowRanges(
+                                             entry, /*row_range_index=*/std::nullopt));
+        ASSERT_TRUE(exist);
+    }
+    {
+        auto file_without_first_row_id = std::make_shared<DataFileMeta>(
+            "data-0.orc", /*file_size=*/645,
+            /*row_count=*/100, BinaryRow::EmptyRow(), BinaryRow::EmptyRow(),
+            SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+            /*min_sequence_number=*/100, /*max_sequence_number=*/199, /*schema_id=*/0,
+            /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(1737111915429ll, 0),
+            /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+            /*value_stats_cols=*/std::nullopt,
+            /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt);
+        ManifestEntry entry_without_first_row_id(FileKind::Add(), BinaryRow::EmptyRow(),
+                                                 /*bucket=*/0, /*total_buckets=*/1,
+                                                 file_without_first_row_id);
+        ASSERT_OK_AND_ASSIGN(RowRangeIndex row_range_index,
+                             RowRangeIndex::Create(std::vector<Range>({Range(0l, 0l)})));
+        // first row id is null
+        ASSERT_OK_AND_ASSIGN(bool exist, DataEvolutionFileStoreScan::FilterEntryByRowRanges(
+                                             entry_without_first_row_id, row_range_index));
+        ASSERT_TRUE(exist);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            RowRangeIndex row_range_index,
+            RowRangeIndex::Create(std::vector<Range>({Range(0l, 0l), Range(10l, 10l)})));
+        ASSERT_OK_AND_ASSIGN(
+            bool exist, DataEvolutionFileStoreScan::FilterEntryByRowRanges(entry, row_range_index));
+        ASSERT_FALSE(exist);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            RowRangeIndex row_range_index,
+            RowRangeIndex::Create(std::vector<Range>({Range(0l, 0l), Range(101l, 101l)})));
+        ASSERT_OK_AND_ASSIGN(
+            bool exist, DataEvolutionFileStoreScan::FilterEntryByRowRanges(entry, row_range_index));
+        ASSERT_TRUE(exist);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            RowRangeIndex row_range_index,
+            RowRangeIndex::Create(std::vector<Range>({Range(100l, 100l), Range(189l, 189l)})));
+        ASSERT_OK_AND_ASSIGN(
+            bool exist, DataEvolutionFileStoreScan::FilterEntryByRowRanges(entry, row_range_index));
+        ASSERT_TRUE(exist);
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/operation/file_store_scan.cpp
+++ b/src/paimon/core/operation/file_store_scan.cpp
@@ -1,0 +1,456 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/file_store_scan.h"
+
+#include <cstddef>
+#include <future>
+#include <list>
+#include <numeric>
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+
+#include "arrow/type.h"
+#include "fmt/format.h"
+#include "paimon/common/data/binary_array.h"
+#include "paimon/common/executor/future.h"
+#include "paimon/common/predicate/literal_converter.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_entry.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/manifest_file.h"
+#include "paimon/core/manifest/manifest_file_meta.h"
+#include "paimon/core/manifest/manifest_list.h"
+#include "paimon/core/operation/metrics/scan_metrics.h"
+#include "paimon/core/partition/partition_info.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/stats/simple_stats_evolution.h"
+#include "paimon/core/utils/duration.h"
+#include "paimon/core/utils/field_mapping.h"
+#include "paimon/core/utils/snapshot_manager.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/predicate/predicate_utils.h"
+#include "paimon/scan_context.h"
+
+namespace paimon {
+enum class FieldType;
+
+Result<std::shared_ptr<Predicate>> FileStoreScan::ReconstructPredicateWithNonCastedFields(
+    const std::shared_ptr<Predicate>& predicate,
+    const std::shared_ptr<SimpleStatsEvolution>& evolution) {
+    const auto& id_to_data_fields = evolution->GetFieldIdToDataField();
+    const auto& name_to_table_fields = evolution->GetFieldNameToTableField();
+
+    std::set<std::string> field_names_in_predicate;
+    PAIMON_RETURN_NOT_OK(PredicateUtils::GetAllNames(predicate, &field_names_in_predicate));
+    std::set<std::string> excluded_field_names;
+    for (const auto& field_name : field_names_in_predicate) {
+        auto table_iter = name_to_table_fields.find(field_name);
+        if (table_iter == name_to_table_fields.end()) {
+            return Status::Invalid(
+                fmt::format("field {} in predicate is not included in table schema", field_name));
+        }
+        auto data_iter = id_to_data_fields.find(table_iter->second.Id());
+        if (data_iter != id_to_data_fields.end()) {
+            // Exclude fields requiring casting to avoid false negatives in stats filtering.
+            if (!data_iter->second.second.Type()->Equals(table_iter->second.Type())) {
+                excluded_field_names.insert(field_name);
+            }
+        }
+    }
+    return PredicateUtils::ExcludePredicateWithFields(predicate, excluded_field_names);
+}
+
+std::vector<ManifestEntry> FileStoreScan::RawPlan::Files(const FileKind& kind) {
+    std::vector<ManifestEntry> entries = Files();
+    std::vector<ManifestEntry> filtered_entries;
+    filtered_entries.reserve(entries.size());
+    for (auto& entry : entries) {
+        if (entry.Kind() == kind) {
+            filtered_entries.emplace_back(std::move(entry));
+        }
+    }
+    return filtered_entries;
+}
+
+FileStoreScan::RawPlan::GroupFiles FileStoreScan::RawPlan::GroupByPartFiles(
+    std::vector<ManifestEntry>&& files) {
+    LinkedHashMap<BinaryRow, LinkedHashMap<int32_t, std::vector<ManifestEntry>>> group_by;
+    for (auto& entry : files) {
+        auto& bucket_map = group_by[entry.Partition()];
+        auto& file_list = bucket_map[entry.Bucket()];
+        file_list.emplace_back(std::move(entry));
+    }
+    return group_by;
+}
+
+Result<std::vector<PartitionEntry>> FileStoreScan::ReadPartitionEntries() const {
+    std::optional<Snapshot> snapshot;
+    std::vector<ManifestFileMeta> all_manifest_file_metas;
+    std::vector<ManifestFileMeta> filtered_manifest_file_metas;
+    PAIMON_RETURN_NOT_OK(
+        ReadManifests(&snapshot, &all_manifest_file_metas, &filtered_manifest_file_metas));
+    std::vector<ManifestEntry> manifest_entries;
+    PAIMON_RETURN_NOT_OK(ReadFileEntries(filtered_manifest_file_metas, &manifest_entries));
+    std::unordered_map<BinaryRow, PartitionEntry> partitions;
+    PAIMON_RETURN_NOT_OK(PartitionEntry::Merge(manifest_entries, &partitions));
+
+    std::vector<PartitionEntry> partition_entries;
+    partition_entries.reserve(partitions.size());
+    for (const auto& [_, partition_entry] : partitions) {
+        if (partition_entry.FileCount() > 0) {
+            partition_entries.push_back(partition_entry);
+        }
+    }
+    return partition_entries;
+}
+
+Result<std::shared_ptr<FileStoreScan::RawPlan>> FileStoreScan::CreatePlan() const {
+    Duration duration;
+    std::optional<Snapshot> snapshot;
+    std::vector<ManifestFileMeta> all_manifest_file_metas;
+    std::vector<ManifestFileMeta> filtered_manifest_file_metas;
+    PAIMON_RETURN_NOT_OK(
+        ReadManifests(&snapshot, &all_manifest_file_metas, &filtered_manifest_file_metas));
+
+    std::vector<ManifestEntry> manifest_entries;
+    PAIMON_RETURN_NOT_OK(ReadManifestEntries(filtered_manifest_file_metas, &manifest_entries));
+    PAIMON_ASSIGN_OR_RAISE(manifest_entries,
+                           PostFilterManifestEntries(std::move(manifest_entries)));
+
+    if (WholeBucketFilterEnabled()) {
+        // We group files by bucket here, and filter them by the whole bucket filter.
+        // Why do this: because in primary key table, we can't just filter the value
+        // by the stat in files (see `PrimaryKeyFileStoreTable.nonPartitionFilterConsumer`),
+        // but we can do this by filter the whole bucket files
+        // we use LinkedHashMap to avoid disorder
+        LinkedHashMap<std::pair<BinaryRow, int32_t>, std::vector<ManifestEntry>> grouped_entries;
+        for (auto& entry : manifest_entries) {
+            auto key = std::make_pair(entry.Partition(), entry.Bucket());
+            grouped_entries[key].push_back(std::move(entry));
+        }
+        manifest_entries.clear();
+        for (const auto& [_, entries] : grouped_entries) {
+            auto tmp_entries = entries;
+            PAIMON_ASSIGN_OR_RAISE(std::vector<ManifestEntry> filtered_bucket_entries,
+                                   FilterWholeBucketByStats(std::move(tmp_entries)));
+            for (auto& entry : filtered_bucket_entries) {
+                manifest_entries.emplace_back(std::move(entry));
+            }
+        }
+    }
+    const int64_t all_data_files = std::accumulate(
+        all_manifest_file_metas.begin(), all_manifest_file_metas.end(), int64_t{0},
+        [](const int64_t sum, const ManifestFileMeta& manifest_file_meta) {
+            return sum + manifest_file_meta.NumAddedFiles() - manifest_file_meta.NumDeletedFiles();
+        });
+    const uint64_t scan_duration_ms = duration.Get();
+    metrics_->SetCounter(ScanMetrics::LAST_SCAN_DURATION, scan_duration_ms);
+    metrics_->ObserveHistogram(ScanMetrics::SCAN_DURATION, static_cast<double>(scan_duration_ms));
+    metrics_->SetCounter(ScanMetrics::LAST_SCANNED_SNAPSHOT_ID,
+                         snapshot.has_value() ? snapshot.value().Id() : int64_t{0});
+    metrics_->SetCounter(ScanMetrics::LAST_SCANNED_MANIFESTS, filtered_manifest_file_metas.size());
+    metrics_->SetCounter(ScanMetrics::LAST_SCAN_SKIPPED_TABLE_FILES,
+                         all_data_files - manifest_entries.size());
+    metrics_->SetCounter(ScanMetrics::LAST_SCAN_RESULTED_TABLE_FILES, manifest_entries.size());
+    return std::make_shared<FileStoreScan::RawPlan>(scan_mode_, snapshot,
+                                                    std::move(manifest_entries));
+}
+
+Status FileStoreScan::ReadManifests(std::optional<Snapshot>* snapshot_ptr,
+                                    std::vector<ManifestFileMeta>* all_manifests_ptr,
+                                    std::vector<ManifestFileMeta>* filter_manifests_ptr) const {
+    auto& snapshot = *snapshot_ptr;
+    auto& all_manifests = *all_manifests_ptr;
+    auto& filtered_manifests = *filter_manifests_ptr;
+    if (specified_snapshot_ != std::nullopt) {
+        snapshot = specified_snapshot_;
+    } else {
+        PAIMON_ASSIGN_OR_RAISE(snapshot, snapshot_manager_->LatestSnapshot());
+    }
+    if (snapshot == std::nullopt) {
+        all_manifests = std::vector<ManifestFileMeta>();
+        filtered_manifests = std::vector<ManifestFileMeta>();
+        return Status::OK();
+    }
+    PAIMON_RETURN_NOT_OK(ReadManifestsWithSnapshot(snapshot.value(), &all_manifests));
+    for (const auto& meta : all_manifests) {
+        PAIMON_ASSIGN_OR_RAISE(bool filter_meta_result, FilterManifestFileMeta(meta));
+        if (filter_meta_result) {
+            filtered_manifests.push_back(meta);
+        }
+    }
+    return Status::OK();
+}
+
+Status FileStoreScan::ReadManifestsWithSnapshot(const Snapshot& snapshot,
+                                                std::vector<ManifestFileMeta>* manifests) const {
+    switch (scan_mode_) {
+        case ScanMode::ALL:
+            return manifest_list_->ReadDataManifests(snapshot, manifests);
+        case ScanMode::DELTA:
+            return manifest_list_->ReadDeltaManifests(snapshot, manifests);
+        default:
+            return Status::NotImplemented("Unknown scan mode ",
+                                          std::to_string(static_cast<int32_t>(scan_mode_)));
+    }
+}
+
+Status FileStoreScan::ReadFileEntries(const std::vector<ManifestFileMeta>& manifest_metas,
+                                      std::vector<ManifestEntry>* manifest_entries) const {
+    std::vector<std::future<Result<std::vector<ManifestEntry>>>> futures;
+    for (const auto& meta : manifest_metas) {
+        auto read_meta_task = [this, &meta]() -> Result<std::vector<ManifestEntry>> {
+            std::vector<ManifestEntry> tmp_entries;
+            PAIMON_RETURN_NOT_OK(ReadManifestFileMeta(meta, &tmp_entries));
+            return tmp_entries;
+        };
+        futures.push_back(Via(executor_.get(), read_meta_task));
+    }
+
+    // sequential execute
+    auto unfiltered_entries = CollectAll(futures);
+    for (auto& entry_list : unfiltered_entries) {
+        if (!entry_list.ok()) {
+            return entry_list.status();
+        }
+        manifest_entries->reserve(manifest_entries->size() + entry_list.value().size());
+        for (auto& entry : entry_list.value()) {
+            manifest_entries->emplace_back(std::move(entry));
+        }
+    }
+    return Status::OK();
+}
+
+Status FileStoreScan::ReadManifestEntries(const std::vector<ManifestFileMeta>& manifest_metas,
+                                          std::vector<ManifestEntry>* manifest_entries) const {
+    if (scan_mode_ == ScanMode::ALL) {
+        return ReadAndMergeFileEntries(manifest_metas, manifest_entries);
+    }
+    return ReadAndNoMergeFileEntries(manifest_metas, manifest_entries);
+}
+
+Status FileStoreScan::ReadAndMergeFileEntries(const std::vector<ManifestFileMeta>& manifest_metas,
+                                              std::vector<ManifestEntry>* merged_entries) const {
+    std::vector<ManifestEntry> unmerged_entries;
+    PAIMON_RETURN_NOT_OK(ReadFileEntries(manifest_metas, &unmerged_entries));
+    std::unordered_set<FileEntry::Identifier> deleted_entries;
+    for (const auto& entry : unmerged_entries) {
+        if (entry.Kind() == FileKind::Delete()) {
+            deleted_entries.insert(entry.CreateIdentifier());
+        }
+    }
+    for (auto& entry : unmerged_entries) {
+        if (entry.Kind() == FileKind::Add() &&
+            deleted_entries.find(entry.CreateIdentifier()) == deleted_entries.end()) {
+            merged_entries->push_back(std::move(entry));
+        }
+    }
+    return Status::OK();
+}
+
+Status FileStoreScan::ReadAndNoMergeFileEntries(
+    const std::vector<ManifestFileMeta>& manifest_metas,
+    std::vector<ManifestEntry>* manifest_entries) const {
+    return ReadFileEntries(manifest_metas, manifest_entries);
+}
+
+Result<bool> FileStoreScan::FilterManifestFileMeta(const ManifestFileMeta& manifest) const {
+    // filter by min max bucket
+    std::optional<int32_t> min_bucket = manifest.MinBucket();
+    std::optional<int32_t> max_bucket = manifest.MaxBucket();
+    if (min_bucket && max_bucket) {
+        if (only_read_real_buckets_ && max_bucket.value() < 0) {
+            return false;
+        }
+        if (bucket_filter_ && (bucket_filter_.value() < min_bucket.value() ||
+                               bucket_filter_.value() > max_bucket.value())) {
+            return false;
+        }
+    }
+    // filter by partition filter
+
+    if (partition_filter_) {
+        SimpleStats stats = manifest.PartitionStats();
+        PAIMON_ASSIGN_OR_RAISE(
+            bool saved, partition_filter_->Test(
+                            partition_schema_,
+                            /*row_count=*/manifest.NumAddedFiles() + manifest.NumDeletedFiles(),
+                            stats.MinValues(), stats.MaxValues(), stats.NullCounts()));
+        if (!saved) {
+            return false;
+        }
+    }
+    return FilterManifestByRowRanges(manifest);
+}
+
+bool FileStoreScan::FilterManifestByRowRanges(const ManifestFileMeta& manifest) const {
+    if (!row_range_index_) {
+        return true;
+    }
+    std::optional<int64_t> min = manifest.MinRowId();
+    std::optional<int64_t> max = manifest.MaxRowId();
+    if (!min || !max) {
+        return true;
+    }
+    return row_range_index_->Intersects(min.value(), max.value());
+}
+
+Status FileStoreScan::ReadManifestFileMeta(const ManifestFileMeta& manifest,
+                                           std::vector<ManifestEntry>* entries) const {
+    auto filter = [&](const ManifestEntry& entry) -> Result<bool> {
+        if (partition_filter_) {
+            PAIMON_ASSIGN_OR_RAISE(bool res,
+                                   partition_filter_->Test(partition_schema_, entry.Partition()));
+            if (!res) {
+                return false;
+            }
+        }
+        if (only_read_real_buckets_ && entry.Bucket() < 0) {
+            return false;
+        }
+        if (bucket_filter_ != std::nullopt && entry.Bucket() != bucket_filter_.value()) {
+            return false;
+        }
+        if (level_filter_ != nullptr && !level_filter_(entry.Level())) {
+            return false;
+        }
+        return true;
+    };
+    std::vector<ManifestEntry> unfiltered_entries;
+    PAIMON_RETURN_NOT_OK(manifest_file_->Read(manifest.FileName(), filter, &unfiltered_entries));
+    entries->reserve(entries->size() + unfiltered_entries.size());
+    for (auto& entry : unfiltered_entries) {
+        PAIMON_ASSIGN_OR_RAISE(bool res, FilterByStats(entry));
+        if (res) {
+            entries->emplace_back(std::move(entry));
+        }
+    }
+    return Status::OK();
+}
+
+Status FileStoreScan::SplitAndSetFilter(const std::vector<std::string>& partition_keys,
+                                        const std::shared_ptr<arrow::Schema>& arrow_schema,
+                                        const std::shared_ptr<ScanFilter>& scan_filters) {
+    if (scan_filters->GetPredicate()) {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FieldMappingBuilder> mapping_builder,
+                               FieldMappingBuilder::Create(arrow_schema, partition_keys,
+                                                           scan_filters->GetPredicate()));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FieldMapping> mapping,
+                               mapping_builder->CreateFieldMapping(arrow_schema));
+        if (mapping->partition_info != std::nullopt) {
+            const auto& partition_info = mapping->partition_info.value();
+            partition_schema_ =
+                DataField::ConvertDataFieldsToArrowSchema(partition_info.partition_read_schema);
+            if (partition_info.partition_filter) {
+                auto predicate_filter =
+                    std::dynamic_pointer_cast<PredicateFilter>(partition_info.partition_filter);
+                if (!predicate_filter) {
+                    return Status::Invalid(
+                        "invalid partition predicate, cannot cast to PredicateFilter");
+                }
+                partition_filter_ = predicate_filter;
+            }
+        }
+        const auto& non_partition_info = mapping->non_partition_info;
+        if (non_partition_info.non_partition_filter) {
+            auto predicate =
+                std::dynamic_pointer_cast<PredicateFilter>(non_partition_info.non_partition_filter);
+            if (!predicate) {
+                return Status::Invalid(
+                    "invalid non partition predicate, cannot cast to PredicateFilter");
+            }
+            predicates_ = predicate;
+        }
+    }
+    bucket_filter_ = scan_filters->GetBucketFilter();
+    if (!scan_filters->GetPartitionFilters().empty()) {
+        PAIMON_ASSIGN_OR_RAISE(
+            partition_filter_,
+            CreatePartitionPredicate(partition_keys, core_options_.GetPartitionDefaultName(),
+                                     arrow_schema, scan_filters->GetPartitionFilters()));
+    }
+    return Status::OK();
+}
+
+Result<std::shared_ptr<PredicateFilter>> FileStoreScan::CreatePartitionPredicate(
+    const std::vector<std::string>& partition_keys, const std::string& partition_default_name,
+    const std::shared_ptr<arrow::Schema>& arrow_schema,
+    const std::vector<std::map<std::string, std::string>>& partition_filters) {
+    if (partition_filters.empty()) {
+        return std::shared_ptr<PredicateFilter>();
+    }
+    std::map<std::string, std::pair<int32_t, arrow::Type::type>> partition_keys_to_id_and_type;
+    for (size_t i = 0; i < partition_keys.size(); i++) {
+        const auto& partition_key = partition_keys[i];
+        auto field = arrow_schema->GetFieldByName(partition_key);
+        if (field == nullptr) {
+            return Status::Invalid(fmt::format("field {} does not exist in schema", partition_key));
+        }
+        partition_keys_to_id_and_type[partition_key] = {i, field->type()->id()};
+    }
+    std::vector<std::shared_ptr<Predicate>> or_predicates;
+    or_predicates.reserve(partition_filters.size());
+    for (const auto& partition_filter : partition_filters) {
+        std::vector<std::shared_ptr<Predicate>> and_predicates;
+        and_predicates.reserve(partition_filter.size());
+        if (partition_filter.empty()) {
+            // partition_filter.empty() indicates all partition are included
+            // or_predicates have one all_true predicate, just return all true predicate (nullptr)
+            return std::shared_ptr<PredicateFilter>();
+        }
+        for (const auto& [key, value] : partition_filter) {
+            auto iter = partition_keys_to_id_and_type.find(key);
+            if (iter == partition_keys_to_id_and_type.end()) {
+                return Status::Invalid(
+                    fmt::format("field {} does not exist in partition keys", key));
+            }
+            PAIMON_ASSIGN_OR_RAISE(FieldType field_type,
+                                   FieldTypeUtils::ConvertToFieldType(iter->second.second));
+            // for null partition
+            if (value == partition_default_name) {
+                auto predicate = PredicateBuilder::IsNull(iter->second.first, key, field_type);
+                and_predicates.push_back(predicate);
+                continue;
+            }
+            PAIMON_ASSIGN_OR_RAISE(Literal literal,
+                                   LiteralConverter::ConvertLiteralsFromString(field_type, value));
+            auto predicate = PredicateBuilder::Equal(iter->second.first, key, field_type, literal);
+            and_predicates.push_back(predicate);
+        }
+        assert(!and_predicates.empty());
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Predicate> and_predicate,
+                               PredicateBuilder::And(and_predicates));
+        or_predicates.push_back(and_predicate);
+    }
+    assert(!or_predicates.empty());
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Predicate> or_predicate,
+                           PredicateBuilder::Or(or_predicates));
+    auto predicate_filter = std::dynamic_pointer_cast<PredicateFilter>(or_predicate);
+    if (!predicate_filter) {
+        return Status::Invalid("invalid partition predicate, cannot cast to predicate filter");
+    }
+    return predicate_filter;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/operation/file_store_scan.h
+++ b/src/paimon/core/operation/file_store_scan.h
@@ -1,0 +1,283 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/metrics/metrics_impl.h"
+#include "paimon/common/predicate/compound_predicate_impl.h"
+#include "paimon/common/predicate/leaf_predicate_impl.h"
+#include "paimon/common/predicate/literal_converter.h"
+#include "paimon/common/predicate/predicate_filter.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/common/utils/linked_hash_map.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/manifest/manifest_file.h"
+#include "paimon/core/manifest/manifest_file_meta.h"
+#include "paimon/core/manifest/manifest_list.h"
+#include "paimon/core/manifest/partition_entry.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/table/source/scan_mode.h"
+#include "paimon/core/utils/snapshot_manager.h"
+#include "paimon/executor.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/result.h"
+#include "paimon/scan_context.h"
+#include "paimon/status.h"
+#include "paimon/utils/row_range_index.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class Executor;
+class FileKind;
+class ManifestFile;
+class ManifestFileMeta;
+class ManifestList;
+class MemoryPool;
+class Predicate;
+class ScanFilter;
+class SchemaManager;
+class SimpleStatsEvolution;
+class SnapshotManager;
+class TableSchema;
+
+/// Scan operation which produces a plan.
+class FileStoreScan {
+ public:
+    virtual ~FileStoreScan() = default;
+    FileStoreScan(const std::shared_ptr<SnapshotManager>& snapshot_manager,
+                  const std::shared_ptr<SchemaManager>& schema_manager,
+                  const std::shared_ptr<ManifestList>& manifest_list,
+                  const std::shared_ptr<ManifestFile>& manifest_file,
+                  const std::shared_ptr<TableSchema>& table_schema,
+                  const std::shared_ptr<arrow::Schema>& schema, const CoreOptions& core_options,
+                  const std::shared_ptr<Executor>& executor,
+                  const std::shared_ptr<MemoryPool>& pool)
+        : pool_(pool),
+          schema_manager_(schema_manager),
+          schema_(schema),
+          table_schema_(table_schema),
+          core_options_(core_options),
+          snapshot_manager_(snapshot_manager),
+          manifest_list_(manifest_list),
+          manifest_file_(manifest_file),
+          executor_(executor),
+          metrics_(std::make_shared<MetricsImpl>()) {
+        assert(executor_);
+    }
+
+    FileStoreScan* WithKind(const ScanMode& scan_mode) {
+        scan_mode_ = scan_mode;
+        return this;
+    }
+
+    FileStoreScan* WithSnapshot(const Snapshot& snapshot) {
+        specified_snapshot_ = snapshot;
+        return this;
+    }
+
+    FileStoreScan* WithLevelFilter(const std::function<bool(int32_t)>& level_filter) {
+        level_filter_ = level_filter;
+        return this;
+    }
+
+    FileStoreScan* OnlyReadRealBuckets() {
+        only_read_real_buckets_ = true;
+        return this;
+    }
+
+    FileStoreScan* WithRowRangeIndex(const RowRangeIndex& row_range_index) {
+        row_range_index_ = row_range_index;
+        return this;
+    }
+
+    virtual FileStoreScan* EnableValueFilter() {
+        return this;
+    }
+
+    const std::shared_ptr<SnapshotManager>& GetSnapshotManager() const {
+        return snapshot_manager_;
+    }
+
+    const CoreOptions& GetCoreOptions() const {
+        return core_options_;
+    }
+
+    std::shared_ptr<PredicateFilter> GetNonPartitionPredicate() const {
+        return predicates_;
+    }
+
+    std::shared_ptr<PredicateFilter> GetPartitionPredicate() const {
+        return partition_filter_;
+    }
+
+    std::shared_ptr<Metrics> GetScanMetrics() const {
+        return metrics_;
+    }
+
+    static Result<std::shared_ptr<PredicateFilter>> CreatePartitionPredicate(
+        const std::vector<std::string>& partition_keys, const std::string& partition_default_name,
+        const std::shared_ptr<arrow::Schema>& arrow_schema,
+        const std::vector<std::map<std::string, std::string>>& partition_filters);
+
+    class RawPlan {
+     public:
+        RawPlan(const ScanMode& scan_mode, const std::optional<Snapshot>& snapshot,
+                std::vector<ManifestEntry>&& entries)
+            : snapshot_(snapshot), manifest_entries_(std::move(entries)), scan_mode_(scan_mode) {}
+
+        const std::optional<Snapshot>& GetSnapshot() const {
+            return snapshot_;
+        }
+
+        std::optional<int64_t> SnapshotId() const {
+            return snapshot_ == std::nullopt ? std::optional<int64_t>() : snapshot_.value().Id();
+        }
+        ScanMode GetScanMode() const {
+            return scan_mode_;
+        }
+
+        // will move the manifest_entries_
+        std::vector<ManifestEntry>&& Files() {
+            return std::move(manifest_entries_);
+        }
+
+        /// Result `ManifestEntry` files with specific file kind.
+        // will move the manifest_entries_
+        std::vector<ManifestEntry> Files(const FileKind& kind);
+
+        using GroupFiles =
+            LinkedHashMap<BinaryRow, LinkedHashMap<int32_t, std::vector<ManifestEntry>>>;
+        /// Return a map group by partition and bucket.
+        static GroupFiles GroupByPartFiles(std::vector<ManifestEntry>&& files);
+
+     private:
+        std::optional<Snapshot> snapshot_;
+        std::vector<ManifestEntry> manifest_entries_;
+        ScanMode scan_mode_;
+    };
+
+    /// Produce a `Plan` of FileStoreScan.
+    Result<std::shared_ptr<RawPlan>> CreatePlan() const;
+
+    Result<std::vector<PartitionEntry>> ReadPartitionEntries() const;
+
+ protected:
+    /// @note Keep this thread-safe.
+    virtual Result<bool> FilterByStats(const ManifestEntry& entry) const = 0;
+
+    virtual Result<std::vector<ManifestEntry>> PostFilterManifestEntries(
+        std::vector<ManifestEntry>&& entries) const {
+        return std::move(entries);
+    }
+
+    virtual Result<std::vector<ManifestEntry>> FilterWholeBucketByStats(
+        std::vector<ManifestEntry>&& entries) const {
+        return std::move(entries);
+    }
+
+    virtual bool WholeBucketFilterEnabled() const {
+        return false;
+    }
+    Status SplitAndSetFilter(const std::vector<std::string>& partition_keys,
+                             const std::shared_ptr<arrow::Schema>& arrow_schema,
+                             const std::shared_ptr<ScanFilter>& scan_filters);
+
+    /// Set the bucket filter derived from predicate analysis (e.g., BucketSelectConverter).
+    /// Only sets the filter if no explicit bucket filter was already set.
+    void SetBucketFilterIfAbsent(int32_t bucket) {
+        if (!bucket_filter_.has_value()) {
+            bucket_filter_ = bucket;
+        }
+    }
+
+    // When schema evolves, predicates might contain fields requiring casting. To avoid false
+    // negatives when filtering by stats, we exclude those fields from predicate.
+    static Result<std::shared_ptr<Predicate>> ReconstructPredicateWithNonCastedFields(
+        const std::shared_ptr<Predicate>& predicate,
+        const std::shared_ptr<SimpleStatsEvolution>& evolution);
+
+ private:
+    Status ReadManifests(std::optional<Snapshot>* snapshot_ptr,
+                         std::vector<ManifestFileMeta>* all_manifests_ptr,
+                         std::vector<ManifestFileMeta>* filtered_manifests_ptr) const;
+
+    Status ReadManifestsWithSnapshot(const Snapshot& snapshot,
+                                     std::vector<ManifestFileMeta>* manifests) const;
+
+    Status ReadManifestEntries(const std::vector<ManifestFileMeta>& manifest_metas,
+                               std::vector<ManifestEntry>* manifest_entries) const;
+
+    Status ReadAndMergeFileEntries(const std::vector<ManifestFileMeta>& manifest_metas,
+                                   std::vector<ManifestEntry>* merged_entries) const;
+
+    Status ReadAndNoMergeFileEntries(const std::vector<ManifestFileMeta>& manifest_metas,
+                                     std::vector<ManifestEntry>* manifest_entries) const;
+
+    Status ReadFileEntries(const std::vector<ManifestFileMeta>& manifest_metas,
+                           std::vector<ManifestEntry>* manifest_entries) const;
+
+    Result<bool> FilterManifestFileMeta(const ManifestFileMeta& manifest) const;
+
+    bool FilterManifestByRowRanges(const ManifestFileMeta& manifest) const;
+
+    Status ReadManifestFileMeta(const ManifestFileMeta& manifest,
+                                std::vector<ManifestEntry>* entries) const;
+
+ protected:
+    std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<SchemaManager> schema_manager_;
+    std::shared_ptr<PredicateFilter> predicates_;
+    std::shared_ptr<arrow::Schema> schema_;
+    std::shared_ptr<TableSchema> table_schema_;
+    std::optional<RowRangeIndex> row_range_index_;
+
+    ScanMode scan_mode_ = ScanMode::ALL;
+    CoreOptions core_options_;
+
+ private:
+    mutable std::mutex lock_;
+    bool only_read_real_buckets_ = false;
+    std::shared_ptr<SnapshotManager> snapshot_manager_;
+    std::shared_ptr<ManifestList> manifest_list_;
+    std::shared_ptr<ManifestFile> manifest_file_;
+    std::shared_ptr<arrow::Schema> partition_schema_;
+    std::shared_ptr<PredicateFilter> partition_filter_;
+    std::shared_ptr<Executor> executor_;
+    std::optional<int32_t> bucket_filter_;
+    std::function<bool(int32_t)> level_filter_;
+    std::optional<Snapshot> specified_snapshot_;
+    std::shared_ptr<Metrics> metrics_;
+};
+}  // namespace paimon

--- a/src/paimon/core/operation/file_store_scan_test.cpp
+++ b/src/paimon/core/operation/file_store_scan_test.cpp
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/file_store_scan.h"
+
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class FileStoreScanTest : public ::testing::Test {
+ public:
+    void SetUp() override {}
+    void TearDown() override {}
+
+ private:
+    std::shared_ptr<arrow::Schema> schema_ = arrow::schema(arrow::FieldVector(
+        {arrow::field("f0", arrow::utf8()), arrow::field("f1", arrow::int32()),
+         arrow::field("f2", arrow::int32()), arrow::field("f3", arrow::float64())}));
+};
+
+TEST_F(FileStoreScanTest, TestCreatePartitionPredicate) {
+    std::vector<std::string> partition_keys = {"f1"};
+    std::string partition_default_name = "__DEFAULT_PARTITION__";
+    std::map<std::string, std::string> partition_filters;
+    partition_filters["f1"] = "1";
+    ASSERT_OK_AND_ASSIGN(auto partition_predicate,
+                         FileStoreScan::CreatePartitionPredicate(
+                             partition_keys, partition_default_name, schema_, {partition_filters}));
+    ASSERT_EQ(partition_predicate->ToString(), "Equal(f1, 1)");
+}
+
+TEST_F(FileStoreScanTest, TestCreatePartitionPredicateWithMultiPartitionKeys) {
+    std::vector<std::string> partition_keys = {"f1", "f0"};
+
+    std::string partition_default_name = "__DEFAULT_PARTITION__";
+    std::map<std::string, std::string> partition_filters;
+    partition_filters["f1"] = "1";
+    partition_filters["f0"] = "hello";
+    ASSERT_OK_AND_ASSIGN(auto partition_predicate,
+                         FileStoreScan::CreatePartitionPredicate(
+                             partition_keys, partition_default_name, schema_, {partition_filters}));
+    ASSERT_EQ(partition_predicate->ToString(), "And([Equal(f0, hello), Equal(f1, 1)])");
+}
+
+TEST_F(FileStoreScanTest, TestCreatePartitionPredicateWithDefaultPartitionName) {
+    std::vector<std::string> partition_keys = {"f1", "f0"};
+
+    std::string partition_default_name = "__DEFAULT_PARTITION__";
+    std::map<std::string, std::string> partition_filters;
+    partition_filters["f1"] = "1";
+    partition_filters["f0"] = partition_default_name;
+    ASSERT_OK_AND_ASSIGN(auto partition_predicate,
+                         FileStoreScan::CreatePartitionPredicate(
+                             partition_keys, partition_default_name, schema_, {partition_filters}));
+    ASSERT_EQ(partition_predicate->ToString(), "And([IsNull(f0), Equal(f1, 1)])");
+}
+
+TEST_F(FileStoreScanTest, TestCreatePartitionPredicateWithMultiPartitionFilters) {
+    std::vector<std::string> partition_keys = {"f1", "f0"};
+    std::string partition_default_name = "__DEFAULT_PARTITION__";
+    std::vector<std::map<std::string, std::string>> partition_filters = {
+        {{"f1", "1"}, {"f0", "hello"}}, {{"f1", "2"}, {"f0", "world"}}};
+    ASSERT_OK_AND_ASSIGN(auto partition_predicate,
+                         FileStoreScan::CreatePartitionPredicate(
+                             partition_keys, partition_default_name, schema_, partition_filters));
+    ASSERT_EQ(partition_predicate->ToString(),
+              "Or([And([Equal(f0, hello), Equal(f1, 1)]), And([Equal(f0, world), Equal(f1, 2)])])");
+}
+
+TEST_F(FileStoreScanTest, TestCreatePartitionPredicateWithOneEmptyPartitionFilter) {
+    std::vector<std::string> partition_keys = {"f1", "f0"};
+    std::string partition_default_name = "__DEFAULT_PARTITION__";
+    // empty map in partition_filters indicates a all_true partition filter
+    std::vector<std::map<std::string, std::string>> partition_filters = {
+        {{"f1", "1"}, {"f0", "hello"}}, {}};
+    ASSERT_OK_AND_ASSIGN(auto partition_predicate,
+                         FileStoreScan::CreatePartitionPredicate(
+                             partition_keys, partition_default_name, schema_, partition_filters));
+    ASSERT_FALSE(partition_predicate);
+}
+
+TEST_F(FileStoreScanTest, TestCreatePartitionPredicateWithEmptyPartitionFilters) {
+    std::vector<std::string> partition_keys = {"f1", "f0"};
+    std::string partition_default_name = "__DEFAULT_PARTITION__";
+    std::vector<std::map<std::string, std::string>> partition_filters = {};
+    ASSERT_OK_AND_ASSIGN(auto partition_predicate,
+                         FileStoreScan::CreatePartitionPredicate(
+                             partition_keys, partition_default_name, schema_, partition_filters));
+    ASSERT_FALSE(partition_predicate);
+}
+
+TEST_F(FileStoreScanTest, TestCreatePartitionPredicateWithInvalidPartitionKeys) {
+    std::vector<std::string> partition_keys = {"invalid"};
+    std::string partition_default_name = "__DEFAULT_PARTITION__";
+    std::map<std::string, std::string> partition_filters;
+    partition_filters["f1"] = "1";
+    ASSERT_NOK_WITH_MSG(FileStoreScan::CreatePartitionPredicate(
+                            partition_keys, partition_default_name, schema_, {partition_filters}),
+                        "field invalid does not exist in schema");
+}
+
+TEST_F(FileStoreScanTest, TestCreatePartitionPredicateWithInvalidPartitionFilter) {
+    std::vector<std::string> partition_keys = {"f1"};
+    std::string partition_default_name = "__DEFAULT_PARTITION__";
+    std::map<std::string, std::string> partition_filters;
+    partition_filters["invalid"] = "1";
+    ASSERT_NOK_WITH_MSG(FileStoreScan::CreatePartitionPredicate(
+                            partition_keys, partition_default_name, schema_, {partition_filters}),
+                        "field invalid does not exist in partition keys");
+}
+
+TEST_F(FileStoreScanTest, TestFilterManifestByRowRanges) {
+    class FakeFileStoreScan : public FileStoreScan {
+     public:
+        FakeFileStoreScan(const std::shared_ptr<SnapshotManager>& snapshot_manager,
+                          const std::shared_ptr<SchemaManager>& schema_manager,
+                          const std::shared_ptr<ManifestList>& manifest_list,
+                          const std::shared_ptr<ManifestFile>& manifest_file,
+                          const std::shared_ptr<TableSchema>& table_schema,
+                          const std::shared_ptr<arrow::Schema>& schema,
+                          const CoreOptions& core_options,
+                          const std::shared_ptr<Executor>& executor,
+                          const std::shared_ptr<MemoryPool>& pool)
+            : FileStoreScan(snapshot_manager, schema_manager, manifest_list, manifest_file,
+                            table_schema, schema, core_options, executor, pool) {}
+        Result<bool> FilterByStats(const ManifestEntry& entry) const override {
+            return false;
+        }
+    };
+    // row id [10, 20]
+    auto manifest1 =
+        ManifestFileMeta("manifest-65b0d403-a1bc-4157-b242-bff73c46596d-0", /*file_size=*/2779,
+                         /*num_added_files=*/1, /*num_deleted_files=*/0, SimpleStats::EmptyStats(),
+                         /*schema_id=*/0, /*min_bucket=*/0, /*max_bucket=*/0,
+                         /*min_level=*/0, /*max_level=*/0,
+                         /*min_row_id=*/10, /*max_row_id=*/20);
+
+    ASSERT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap({{}}));
+    auto file_store_scan = std::make_shared<FakeFileStoreScan>(
+        /*snapshot_manager=*/nullptr, /*schema_manager=*/nullptr, /*manifest_list=*/nullptr,
+        /*manifest_file=*/nullptr, /*table_schema=*/nullptr, /*schema=*/nullptr, options,
+        /*executor=*/CreateDefaultExecutor(), GetDefaultPool());
+    ASSERT_TRUE(file_store_scan->FilterManifestByRowRanges(manifest1));
+
+    ASSERT_OK_AND_ASSIGN(
+        RowRangeIndex row_range_index,
+        RowRangeIndex::Create(std::vector<Range>({Range(0, 15), Range(100, 200)})));
+    file_store_scan->WithRowRangeIndex(row_range_index);
+    ASSERT_TRUE(file_store_scan->FilterManifestByRowRanges(manifest1));
+
+    ASSERT_OK_AND_ASSIGN(row_range_index,
+                         RowRangeIndex::Create(std::vector<Range>({Range(0, 5), Range(100, 200)})));
+    file_store_scan->WithRowRangeIndex(row_range_index);
+    ASSERT_FALSE(file_store_scan->FilterManifestByRowRanges(manifest1));
+
+    auto manifest2 =
+        ManifestFileMeta("manifest-65b0d403-a1bc-4157-b242-bff73c46596d-0", /*file_size=*/2779,
+                         /*num_added_files=*/1, /*num_deleted_files=*/0, SimpleStats::EmptyStats(),
+                         /*schema_id=*/0, /*min_bucket=*/0, /*max_bucket=*/0,
+                         /*min_level=*/0, /*max_level=*/0,
+                         /*min_row_id=*/std::nullopt, /*max_row_id=*/std::nullopt);
+    ASSERT_OK_AND_ASSIGN(row_range_index, RowRangeIndex::Create(std::vector<Range>({Range(0, 0)})));
+    file_store_scan->WithRowRangeIndex(row_range_index);
+    ASSERT_TRUE(file_store_scan->FilterManifestByRowRanges(manifest2));
+}
+}  // namespace paimon::test

--- a/src/paimon/core/operation/key_value_file_store_scan.cpp
+++ b/src/paimon/core/operation/key_value_file_store_scan.cpp
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/key_value_file_store_scan.h"
+
+#include <cstdint>
+#include <exception>
+#include <map>
+#include <optional>
+#include <set>
+#include <utility>
+
+#include "fmt/format.h"
+#include "paimon/common/data/binary_array.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/predicate/predicate_filter.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/object_utils.h"
+#include "paimon/core/bucket/bucket_select_converter.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/options/merge_engine.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/stats/simple_stats_evolution.h"
+#include "paimon/core/stats/simple_stats_evolutions.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/predicate/predicate_utils.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class Executor;
+class ManifestFile;
+class ManifestList;
+class MemoryPool;
+class ScanFilter;
+class SnapshotManager;
+
+Result<std::unique_ptr<KeyValueFileStoreScan>> KeyValueFileStoreScan::Create(
+    const std::shared_ptr<SnapshotManager>& snapshot_manager,
+    const std::shared_ptr<SchemaManager>& schema_manager,
+    const std::shared_ptr<ManifestList>& manifest_list,
+    const std::shared_ptr<ManifestFile>& manifest_file,
+    const std::shared_ptr<TableSchema>& table_schema,
+    const std::shared_ptr<arrow::Schema>& arrow_schema,
+    const std::shared_ptr<ScanFilter>& scan_filters, const CoreOptions& core_options,
+    const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool) {
+    auto scan = std::unique_ptr<KeyValueFileStoreScan>(
+        new KeyValueFileStoreScan(snapshot_manager, schema_manager, manifest_list, manifest_file,
+                                  table_schema, arrow_schema, core_options, executor, pool));
+    PAIMON_RETURN_NOT_OK(
+        scan->SplitAndSetFilter(table_schema->PartitionKeys(), arrow_schema, scan_filters));
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> trimmed_pk, table_schema->TrimmedPrimaryKeys());
+    PAIMON_RETURN_NOT_OK(scan->SplitAndSetKeyValueFilter(trimmed_pk));
+    return scan;
+}
+
+Result<bool> KeyValueFileStoreScan::FilterByStats(const ManifestEntry& entry) const {
+    PAIMON_ASSIGN_OR_RAISE(bool value_filter_enabled, IsValueFilterEnabled());
+    if (value_filter_enabled) {
+        PAIMON_ASSIGN_OR_RAISE(bool filtered, FilterByValueFilter(entry));
+        if (!filtered) {
+            return false;
+        }
+    }
+
+    if (key_filter_ != nullptr) {
+        const auto& stats = entry.File()->key_stats;
+        return key_filter_->Test(schema_, entry.File()->row_count, stats.MinValues(),
+                                 stats.MaxValues(), stats.NullCounts());
+    }
+    return true;
+}
+
+Result<std::vector<ManifestEntry>> KeyValueFileStoreScan::FilterWholeBucketByStats(
+    std::vector<ManifestEntry>&& entries) const {
+    return NoOverlapping(entries) ? FilterWholeBucketPerFile(std::move(entries))
+                                  : FilterWholeBucketAllFiles(std::move(entries));
+}
+
+Status KeyValueFileStoreScan::SplitAndSetKeyValueFilter(
+    const std::vector<std::string>& trimmed_pk) {
+    if (predicates_ == nullptr) {
+        return Status::OK();
+    }
+    // currently we can only perform filter push down on keys
+    // consider this case:
+    //   data file 1: insert key = a, value = 1
+    //   data file 2: update key = a, value = 2
+    //   filter: value = 1
+    // if we perform filter push down on values, data file 1 will be chosen, but data
+    // file 2 will be ignored, and the final result will be key = a, value = 1 while the
+    // correct result is an empty set
+    std::map<std::string, int32_t> trimmed_pk_to_idx =
+        ObjectUtils::CreateIdentifierToIndexMap(trimmed_pk);
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Predicate> key_predicate,
+                           PredicateUtils::CreatePickedFieldFilter(predicates_, trimmed_pk_to_idx));
+    if (key_predicate) {
+        auto key_filter = std::dynamic_pointer_cast<PredicateFilter>(key_predicate);
+        if (!key_filter) {
+            return Status::Invalid("invalid key predicate, cannot cast to PredicateFilter");
+        }
+        WithKeyFilter(key_filter);
+
+        // Bucket select conversion: derive target bucket from EQUAL predicates on bucket keys
+        const auto& bucket_keys = table_schema_->BucketKeys();
+        int32_t num_buckets = core_options_.GetBucket();
+        if (num_buckets > 0 && !bucket_keys.empty()) {
+            std::vector<std::shared_ptr<arrow::DataType>> bucket_key_arrow_types;
+            bucket_key_arrow_types.reserve(bucket_keys.size());
+            for (const auto& key : bucket_keys) {
+                PAIMON_ASSIGN_OR_RAISE(DataField field, table_schema_->GetField(key));
+                bucket_key_arrow_types.push_back(field.Type());
+            }
+            PAIMON_ASSIGN_OR_RAISE(
+                std::optional<int32_t> selected_bucket,
+                BucketSelectConverter::Convert(key_predicate, bucket_keys, bucket_key_arrow_types,
+                                               core_options_.GetBucketFunctionType(), num_buckets,
+                                               pool_.get()));
+            if (selected_bucket.has_value()) {
+                SetBucketFilterIfAbsent(selected_bucket.value());
+            }
+        }
+    }
+
+    // Only set value filtering when there are predicates on non-primary-key fields.
+    //
+    // For primary key tables, we cannot safely push down arbitrary value predicates to each
+    // individual file (see the comment above). When value filtering is enabled, we will filter
+    // by stats either per file (when no overlapping) or by whole bucket (when overlapping).
+    //
+    // For key-only predicates, key_stats based filtering is enough and enabling value filtering
+    // may trigger unsupported paths (e.g. DataFileMeta::value_stats_cols).
+    std::set<std::string> field_names;
+    PAIMON_RETURN_NOT_OK(PredicateUtils::GetAllNames(predicates_, &field_names));
+    std::set<std::string> pk_names(trimmed_pk.begin(), trimmed_pk.end());
+    bool has_non_pk_predicate = false;
+    for (const auto& name : field_names) {
+        if (pk_names.find(name) == pk_names.end()) {
+            has_non_pk_predicate = true;
+            break;
+        }
+    }
+    if (has_non_pk_predicate) {
+        // support value filter in bucket level
+        WithValueFilter(predicates_);
+    }
+    return Status::OK();
+}
+
+Result<bool> KeyValueFileStoreScan::IsValueFilterEnabled() const {
+    if (value_filter_ == nullptr) {
+        return false;
+    }
+    switch (scan_mode_) {
+        case ScanMode::ALL:
+            return value_filter_force_enabled_;
+        case ScanMode::DELTA:
+            return false;
+        default:
+            return Status::NotImplemented("only support ALL and DELTA scan mode");
+    }
+}
+
+Result<bool> KeyValueFileStoreScan::FilterByValueFilter(const ManifestEntry& entry) const {
+    if (!value_filter_) {
+        return true;
+    }
+    if (entry.File()->embedded_index != nullptr) {
+        return Status::NotImplemented("do not support embedded index in DataFileMeta");
+    }
+
+    const auto& meta = entry.File();
+
+    // Primary key table currently does not support schema evolution for value filtering.
+    // Here we only handle `value_stats_cols` (dense stats) projection.
+    if (meta->schema_id != table_schema_->Id()) {
+        return Status::NotImplemented(
+            "Primary key table does not support schema evolution in FilterByValueFilter");
+    }
+
+    auto evolution = evolutions_->GetOrCreate(table_schema_);
+
+    PAIMON_ASSIGN_OR_RAISE(
+        SimpleStatsEvolution::EvolutionStats new_stats,
+        evolution->Evolution(meta->value_stats, meta->row_count, meta->value_stats_cols));
+
+    try {
+        PAIMON_ASSIGN_OR_RAISE(
+            bool predicate_result,
+            value_filter_->Test(schema_, meta->row_count, *(new_stats.min_values),
+                                *(new_stats.max_values), *(new_stats.null_counts)));
+        return predicate_result;
+    } catch (const std::exception& e) {
+        return Status::Invalid(fmt::format("FilterByValueFilter failed for file {}, with {} error",
+                                           meta->file_name, e.what()));
+    } catch (...) {
+        return Status::Invalid(fmt::format(
+            "FilterByValueFilter failed for file {}, with unknown error", meta->file_name));
+    }
+}
+
+bool KeyValueFileStoreScan::NoOverlapping(const std::vector<ManifestEntry>& entries) {
+    if (entries.size() <= 1) {
+        return true;
+    }
+    std::set<int32_t> level_set;
+    for (const auto& entry : entries) {
+        level_set.insert(entry.File()->level);
+    }
+    if (level_set.find(0) != level_set.end()) {
+        // level 0 files have overlapping
+        return false;
+    }
+    // have different level, have overlapping
+    return level_set.size() == 1;
+}
+
+Result<std::vector<ManifestEntry>> KeyValueFileStoreScan::FilterWholeBucketPerFile(
+    std::vector<ManifestEntry>&& entries) const {
+    std::vector<ManifestEntry> filtered_entries;
+    filtered_entries.reserve(entries.size());
+    for (auto& entry : entries) {
+        PAIMON_ASSIGN_OR_RAISE(bool filtered, FilterByValueFilter(entry));
+        if (filtered) {
+            filtered_entries.emplace_back(std::move(entry));
+        }
+    }
+    return filtered_entries;
+}
+
+Result<std::vector<ManifestEntry>> KeyValueFileStoreScan::FilterWholeBucketAllFiles(
+    std::vector<ManifestEntry>&& entries) const {
+    if (!core_options_.DeletionVectorsEnabled() &&
+        (core_options_.GetMergeEngine() == MergeEngine::AGGREGATE ||
+         core_options_.GetMergeEngine() == MergeEngine::PARTIAL_UPDATE)) {
+        return entries;
+    }
+    // entries come from the same bucket, if any of it doesn't meet the request, we could
+    // filter the bucket.
+    for (auto& entry : entries) {
+        PAIMON_ASSIGN_OR_RAISE(bool filtered, FilterByValueFilter(entry));
+        if (filtered) {
+            return std::move(entries);
+        }
+    }
+    return std::vector<ManifestEntry>();
+}
+
+KeyValueFileStoreScan::KeyValueFileStoreScan(
+    const std::shared_ptr<SnapshotManager>& snapshot_manager,
+    const std::shared_ptr<SchemaManager>& schema_manager,
+    const std::shared_ptr<ManifestList>& manifest_list,
+    const std::shared_ptr<ManifestFile>& manifest_file,
+    const std::shared_ptr<TableSchema>& table_schema, const std::shared_ptr<arrow::Schema>& schema,
+    const CoreOptions& core_options, const std::shared_ptr<Executor>& executor,
+    const std::shared_ptr<MemoryPool>& pool)
+    : FileStoreScan(snapshot_manager, schema_manager, manifest_list, manifest_file, table_schema,
+                    schema, core_options, executor, pool) {
+    evolutions_ = std::make_shared<SimpleStatsEvolutions>(table_schema, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/operation/key_value_file_store_scan.h
+++ b/src/paimon/core/operation/key_value_file_store_scan.h
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/operation/file_store_scan.h"
+#include "paimon/core/table/source/scan_mode.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class CoreOptions;
+class Executor;
+class ManifestFile;
+class ManifestList;
+class MemoryPool;
+class PredicateFilter;
+class ScanFilter;
+class SchemaManager;
+class SimpleStatsEvolutions;
+class SnapshotManager;
+class TableSchema;
+
+/// `FileStoreScan` for `KeyValueFileStore`.
+class KeyValueFileStoreScan : public FileStoreScan {
+ public:
+    static Result<std::unique_ptr<KeyValueFileStoreScan>> Create(
+        const std::shared_ptr<SnapshotManager>& snapshot_manager,
+        const std::shared_ptr<SchemaManager>& schema_manager,
+        const std::shared_ptr<ManifestList>& manifest_list,
+        const std::shared_ptr<ManifestFile>& manifest_file,
+        const std::shared_ptr<TableSchema>& table_schema,
+        const std::shared_ptr<arrow::Schema>& arrow_schema,
+        const std::shared_ptr<ScanFilter>& scan_filters, const CoreOptions& core_options,
+        const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool);
+
+    FileStoreScan* EnableValueFilter() override {
+        value_filter_force_enabled_ = true;
+        return this;
+    }
+
+    /// @note Keep this thread-safe.
+    Result<bool> FilterByStats(const ManifestEntry& entry) const override;
+
+    bool WholeBucketFilterEnabled() const override {
+        return value_filter_ != nullptr && scan_mode_ == ScanMode::ALL;
+    }
+
+    Result<std::vector<ManifestEntry>> FilterWholeBucketByStats(
+        std::vector<ManifestEntry>&& entries) const override;
+
+ private:
+    KeyValueFileStoreScan* WithKeyFilter(const std::shared_ptr<PredicateFilter>& predicate) {
+        key_filter_ = predicate;
+        return this;
+    }
+
+    KeyValueFileStoreScan* WithValueFilter(const std::shared_ptr<PredicateFilter>& predicate) {
+        value_filter_ = predicate;
+        return this;
+    }
+
+    Status SplitAndSetKeyValueFilter(const std::vector<std::string>& trimmed_pk);
+
+    Result<bool> IsValueFilterEnabled() const;
+
+    Result<bool> FilterByValueFilter(const ManifestEntry& entry) const;
+
+    static bool NoOverlapping(const std::vector<ManifestEntry>& entries);
+
+    Result<std::vector<ManifestEntry>> FilterWholeBucketPerFile(
+        std::vector<ManifestEntry>&& entries) const;
+
+    Result<std::vector<ManifestEntry>> FilterWholeBucketAllFiles(
+        std::vector<ManifestEntry>&& entries) const;
+
+    KeyValueFileStoreScan(const std::shared_ptr<SnapshotManager>& snapshot_manager,
+                          const std::shared_ptr<SchemaManager>& schema_manager,
+                          const std::shared_ptr<ManifestList>& manifest_list,
+                          const std::shared_ptr<ManifestFile>& manifest_file,
+                          const std::shared_ptr<TableSchema>& table_schema,
+                          const std::shared_ptr<arrow::Schema>& schema,
+                          const CoreOptions& core_options,
+                          const std::shared_ptr<Executor>& executor,
+                          const std::shared_ptr<MemoryPool>& pool);
+
+ private:
+    bool value_filter_force_enabled_ = false;
+    std::shared_ptr<PredicateFilter> key_filter_;
+    std::shared_ptr<PredicateFilter> value_filter_;
+    std::shared_ptr<SimpleStatsEvolutions> evolutions_;
+};
+}  // namespace paimon

--- a/src/paimon/core/operation/key_value_file_store_scan_test.cpp
+++ b/src/paimon/core/operation/key_value_file_store_scan_test.cpp
@@ -1,0 +1,442 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/key_value_file_store_scan.h"
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/predicate/predicate_filter.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/manifest/manifest_file.h"
+#include "paimon/core/manifest/manifest_list.h"
+#include "paimon/core/operation/metrics/scan_metrics.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/utils/field_mapping.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/core/utils/snapshot_manager.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/executor.h"
+#include "paimon/format/file_format.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/metrics.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/scan_context.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon::test {
+class KeyValueFileStoreScanTest : public testing::Test {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+    }
+    void TearDown() override {
+        pool_.reset();
+    }
+
+    Result<std::unique_ptr<KeyValueFileStoreScan>> CreateFileStoreScan(
+        const std::string& table_path, const std::shared_ptr<ScanFilter>& scan_filter,
+        int32_t table_schema_id, int32_t snapshot_id) const {
+        std::map<std::string, std::string> options_map = {{Options::MANIFEST_FORMAT, "orc"}};
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions core_options, CoreOptions::FromMap(options_map));
+        auto fs = core_options.GetFileSystem();
+        auto schema_manager = std::make_shared<SchemaManager>(fs, table_path);
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<TableSchema> table_schema,
+                               schema_manager->ReadSchema(table_schema_id));
+
+        auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> external_paths,
+                               core_options.CreateExternalPaths());
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::string> global_index_external_path,
+                               core_options.CreateGlobalIndexExternalPath());
+
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<FileStorePathFactory> path_factory,
+            FileStorePathFactory::Create(
+                table_path, arrow_schema, table_schema->PartitionKeys(),
+                core_options.GetPartitionDefaultName(), core_options.GetFileFormat()->Identifier(),
+                core_options.DataFilePrefix(), core_options.LegacyPartitionNameEnabled(),
+                external_paths, global_index_external_path, core_options.IndexFileInDataFileDir(),
+                pool_));
+        auto manifest_file_format = core_options.GetManifestFormat();
+        auto snapshot_manager = std::make_shared<SnapshotManager>(fs, table_path);
+
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<ManifestList> manifest_list,
+            ManifestList::Create(fs, manifest_file_format, core_options.GetManifestCompression(),
+                                 path_factory, pool_));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<arrow::Schema> partition_schema,
+            FieldMapping::GetPartitionSchema(arrow_schema, table_schema->PartitionKeys()));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<ManifestFile> manifest_file,
+            ManifestFile::Create(fs, manifest_file_format, core_options.GetManifestCompression(),
+                                 path_factory, core_options.GetManifestTargetFileSize(), pool_,
+                                 core_options, partition_schema));
+        if (table_schema->PrimaryKeys().empty()) {
+            return Status::Invalid("not a pk table in KeyValueFileStoreScan");
+        }
+        PAIMON_ASSIGN_OR_RAISE(auto trimmed_pk, table_schema->TrimmedPrimaryKeys());
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<KeyValueFileStoreScan> scan,
+            KeyValueFileStoreScan::Create(snapshot_manager, schema_manager, manifest_list,
+                                          manifest_file, table_schema, arrow_schema, scan_filter,
+                                          core_options, CreateDefaultExecutor(), pool_));
+        PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, snapshot_manager->LoadSnapshot(snapshot_id));
+        scan->WithSnapshot(snapshot);
+        return scan;
+    }
+
+    static int64_t GetMaxSequenceNumberOfRawPlan(
+        const std::shared_ptr<FileStoreScan::RawPlan>& raw_plan) {
+        std::vector<std::shared_ptr<DataFileMeta>> metas;
+        const std::vector<ManifestEntry>& files = raw_plan->Files();
+        for (const auto& file : files) {
+            metas.push_back(file.File());
+        }
+        return DataFileMeta::GetMaxSequenceNumber(metas);
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+TEST_F(KeyValueFileStoreScanTest, TestMaxSequenceNumber) {
+    {
+        // test with single partition field, scan multiple times with snapshot2 and 4
+        std::string table_path = paimon::test::GetDataDir() +
+                                 "orc/pk_table_with_dv_cardinality.db/pk_table_with_dv_cardinality";
+        std::vector<std::map<std::string, std::string>> partition_filters = {{{"f1", "10"}}};
+        auto scan_filter = std::make_shared<ScanFilter>(/*predicate=*/nullptr,
+                                                        /*partition_filters=*/partition_filters,
+                                                        /*bucket_filter=*/0);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreScan> scan,
+                             CreateFileStoreScan(table_path, scan_filter,
+                                                 /*table_schema_id=*/0, /*snapshot_id=*/2));
+
+        const auto started = std::chrono::high_resolution_clock::now();
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStoreScan::RawPlan> raw_plan, scan->CreatePlan());
+        std::shared_ptr<Metrics> metrics = scan->GetScanMetrics();
+        ASSERT_TRUE(metrics);
+        ASSERT_OK_AND_ASSIGN(uint64_t last_scan_duration,
+                             metrics->GetCounter(ScanMetrics::LAST_SCAN_DURATION));
+        ASSERT_LE(last_scan_duration, std::chrono::duration_cast<std::chrono::milliseconds>(
+                                          std::chrono::high_resolution_clock::now() - started)
+                                          .count());
+        ASSERT_OK_AND_ASSIGN(uint64_t last_scanned_snapshot_id,
+                             metrics->GetCounter(ScanMetrics::LAST_SCANNED_SNAPSHOT_ID));
+        ASSERT_EQ(last_scanned_snapshot_id, 2u);
+        ASSERT_OK_AND_ASSIGN(uint64_t last_scanned_manifests,
+                             metrics->GetCounter(ScanMetrics::LAST_SCANNED_MANIFESTS));
+        ASSERT_EQ(last_scanned_manifests, 2u);
+        ASSERT_OK_AND_ASSIGN(uint64_t last_scan_skipped_table_files,
+                             metrics->GetCounter(ScanMetrics::LAST_SCAN_SKIPPED_TABLE_FILES));
+        ASSERT_EQ(last_scan_skipped_table_files, 1u);
+        ASSERT_OK_AND_ASSIGN(uint64_t last_scan_resulted_table_files,
+                             metrics->GetCounter(ScanMetrics::LAST_SCAN_RESULTED_TABLE_FILES));
+        ASSERT_EQ(last_scan_resulted_table_files, 1u);
+        int64_t max_sequence_num = GetMaxSequenceNumberOfRawPlan(raw_plan);
+        ASSERT_EQ(max_sequence_num, 1);
+        // test multiple scan
+        ASSERT_OK_AND_ASSIGN(Snapshot snapshot, scan->GetSnapshotManager()->LoadSnapshot(4));
+        scan->WithSnapshot(snapshot);
+        ASSERT_OK_AND_ASSIGN(raw_plan, scan->CreatePlan());
+        max_sequence_num = GetMaxSequenceNumberOfRawPlan(raw_plan);
+        ASSERT_EQ(max_sequence_num, 2);
+    }
+    {
+        // test with single partition field with bucket 1, latest snapshot is snapshot4
+        std::string table_path = paimon::test::GetDataDir() +
+                                 "orc/pk_table_with_dv_cardinality.db/"
+                                 "pk_table_with_dv_cardinality";
+        std::vector<std::map<std::string, std::string>> partition_filters = {{{"f1", "10"}}};
+        auto scan_filter = std::make_shared<ScanFilter>(/*predicate=*/nullptr,
+                                                        /*partition_filters=*/partition_filters,
+                                                        /*bucket_filter=*/1);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreScan> scan,
+                             CreateFileStoreScan(table_path, scan_filter,
+                                                 /*table_schema_id=*/0, /*snapshot_id=*/4));
+
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStoreScan::RawPlan> raw_plan, scan->CreatePlan());
+        int64_t max_sequence_num = GetMaxSequenceNumberOfRawPlan(raw_plan);
+        ASSERT_EQ(max_sequence_num, 6);
+    }
+    {
+        // test with multi partition field, latest snapshot is snapshot1
+        std::string table_path =
+            paimon::test::GetDataDir() + "orc/pk_table_with_mor.db/pk_table_with_mor";
+        std::vector<std::map<std::string, std::string>> partition_filters = {
+            {{"p0", "1"}, {"p1", "0"}}};
+        auto scan_filter = std::make_shared<ScanFilter>(/*predicate=*/nullptr,
+                                                        /*partition_filters=*/partition_filters,
+                                                        /*bucket_filter=*/0);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreScan> scan,
+                             CreateFileStoreScan(table_path, scan_filter,
+                                                 /*table_schema_id=*/0, /*snapshot_id=*/1));
+
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStoreScan::RawPlan> raw_plan, scan->CreatePlan());
+        int64_t max_sequence_num = GetMaxSequenceNumberOfRawPlan(raw_plan);
+        ASSERT_EQ(max_sequence_num, 0);
+    }
+    {
+        // test with multi partition field, latest snapshot is snapshot2
+        std::string table_path =
+            paimon::test::GetDataDir() + "orc/pk_table_with_mor.db/pk_table_with_mor";
+        std::vector<std::map<std::string, std::string>> partition_filters = {
+            {{"p0", "0"}, {"p1", "0"}}};
+        auto scan_filter = std::make_shared<ScanFilter>(/*predicate=*/nullptr,
+                                                        /*partition_filters=*/partition_filters,
+                                                        /*bucket_filter=*/0);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreScan> scan,
+                             CreateFileStoreScan(table_path, scan_filter,
+                                                 /*table_schema_id=*/0, /*snapshot_id=*/2));
+
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStoreScan::RawPlan> raw_plan, scan->CreatePlan());
+        int64_t max_sequence_num = GetMaxSequenceNumberOfRawPlan(raw_plan);
+        ASSERT_EQ(max_sequence_num, 7);
+    }
+    {
+        // test without partition field
+        std::string table_path =
+            paimon::test::GetDataDir() + "orc/pk_table_partial_update.db/pk_table_partial_update";
+        std::vector<std::map<std::string, std::string>> partition_filters = {};
+        auto scan_filter = std::make_shared<ScanFilter>(/*predicate=*/nullptr,
+                                                        /*partition_filters=*/partition_filters,
+                                                        /*bucket_filter=*/0);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreScan> scan,
+                             CreateFileStoreScan(table_path, scan_filter,
+                                                 /*table_schema_id=*/0, /*snapshot_id=*/2));
+
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStoreScan::RawPlan> raw_plan, scan->CreatePlan());
+        int64_t max_sequence_num = GetMaxSequenceNumberOfRawPlan(raw_plan);
+        ASSERT_EQ(max_sequence_num, 7);
+    }
+}
+
+TEST_F(KeyValueFileStoreScanTest, TestScanDurationMetric) {
+    std::string table_path = paimon::test::GetDataDir() +
+                             "orc/pk_table_with_dv_cardinality.db/pk_table_with_dv_cardinality";
+    std::vector<std::map<std::string, std::string>> partition_filters = {{{"f1", "10"}}};
+    auto scan_filter = std::make_shared<ScanFilter>(/*predicate=*/nullptr,
+                                                    /*partition_filters=*/partition_filters,
+                                                    /*bucket_filter=*/0);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreScan> scan,
+                         CreateFileStoreScan(table_path, scan_filter,
+                                             /*table_schema_id=*/0, /*snapshot_id=*/2));
+
+    constexpr uint64_t kPlanCountPerSnapshot = 3;
+    const uint64_t kPlanCount = kPlanCountPerSnapshot * 2;
+    for (uint64_t i = 0; i < kPlanCountPerSnapshot; ++i) {
+        ASSERT_OK_AND_ASSIGN(Snapshot snapshot2, scan->GetSnapshotManager()->LoadSnapshot(2));
+        scan->WithSnapshot(snapshot2);
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStoreScan::RawPlan> raw_plan, scan->CreatePlan());
+        (void)raw_plan;
+
+        ASSERT_OK_AND_ASSIGN(Snapshot snapshot4, scan->GetSnapshotManager()->LoadSnapshot(4));
+        scan->WithSnapshot(snapshot4);
+        ASSERT_OK_AND_ASSIGN(raw_plan, scan->CreatePlan());
+        (void)raw_plan;
+    }
+
+    std::shared_ptr<Metrics> metrics = scan->GetScanMetrics();
+    ASSERT_TRUE(metrics);
+
+    ASSERT_OK_AND_ASSIGN(uint64_t last_scan_duration,
+                         metrics->GetCounter(ScanMetrics::LAST_SCAN_DURATION));
+    ASSERT_OK_AND_ASSIGN(HistogramStats stats,
+                         metrics->GetHistogramStats(ScanMetrics::SCAN_DURATION));
+    ASSERT_EQ(stats.count, kPlanCount);
+    ASSERT_LE(stats.min, stats.max);
+    ASSERT_LE(stats.min, static_cast<double>(last_scan_duration));
+    ASSERT_LE(static_cast<double>(last_scan_duration), stats.max);
+    ASSERT_LE(stats.min, stats.p99);
+    ASSERT_LE(stats.p50, stats.p99);
+    ASSERT_LE(stats.p99, stats.max);
+}
+
+TEST_F(KeyValueFileStoreScanTest, TestSplitAndSetKeyValueFilter) {
+    std::string table_path =
+        paimon::test::GetDataDir() + "orc/pk_table_with_mor.db/pk_table_with_mor";
+    std::vector<std::map<std::string, std::string>> partition_filters = {
+        {{"p0", "1"}, {"p1", "0"}}};
+    auto not_equal = PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"k1",
+                                                FieldType::INT, Literal(20));
+    auto equal = PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"k0", FieldType::INT,
+                                         Literal(10));
+    auto greater_than = PredicateBuilder::GreaterThan(/*field_index=*/2, /*field_name=*/"v0",
+                                                      FieldType::DOUBLE, Literal(30.1));
+    auto less_than =
+        PredicateBuilder::LessThan(/*field_index=*/3, "p0", FieldType::INT, Literal(40));
+    ASSERT_OK_AND_ASSIGN(auto predicate,
+                         PredicateBuilder::And({not_equal, equal, greater_than, less_than}));
+    auto scan_filter = std::make_shared<ScanFilter>(/*predicate=*/predicate,
+                                                    /*partition_filters=*/partition_filters,
+                                                    /*bucket_filter=*/0);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<KeyValueFileStoreScan> scan,
+                         CreateFileStoreScan(table_path, scan_filter,
+                                             /*table_schema_id=*/0, /*snapshot_id=*/1));
+    // check key filter
+    auto key_not_equal = PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"k1",
+                                                    FieldType::INT, Literal(20));
+    auto key_equal = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"k0", FieldType::INT,
+                                             Literal(10));
+    ASSERT_OK_AND_ASSIGN(auto expected_key_filter,
+                         PredicateBuilder::And({key_not_equal, key_equal}));
+    ASSERT_EQ(*expected_key_filter, *(scan->key_filter_));
+
+    // check value filter
+    auto value_greater_than = PredicateBuilder::GreaterThan(/*field_index=*/6, /*field_name=*/"v0",
+                                                            FieldType::DOUBLE, Literal(30.1));
+    ASSERT_OK_AND_ASSIGN(auto expected_value_filter,
+                         PredicateBuilder::And({key_not_equal, key_equal, value_greater_than}));
+    ASSERT_EQ(*expected_value_filter, *(scan->value_filter_)) << scan->value_filter_->ToString();
+
+    // check partition filter, less_than is removed as partition_filters overlaps predicates
+    auto equal_p0 =
+        PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"p0", FieldType::INT, Literal(1));
+    auto equal_p1 =
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"p1", FieldType::INT, Literal(0));
+    ASSERT_OK_AND_ASSIGN(auto expected_partition_filter,
+                         PredicateBuilder::And({equal_p0, equal_p1}));
+    ASSERT_EQ(*expected_partition_filter, *(scan->partition_filter_));
+}
+
+TEST_F(KeyValueFileStoreScanTest, TestNoOverlapping) {
+    auto generate_manifest_entries = [](const std::vector<int32_t>& levels) {
+        std::vector<ManifestEntry> entries;
+        for (const auto& level : levels) {
+            entries.emplace_back(
+                /*kind=*/FileKind::Add(), /*partition=*/BinaryRow::EmptyRow(), /*bucket=*/0,
+                /*total_buckets=*/1,
+                std::make_shared<DataFileMeta>(
+                    /*file_name=*/"name", /*file_size=*/1024, /*row_count=*/10,
+                    /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+                    /*key_stats=*/SimpleStats::EmptyStats(),
+                    /*value_stats=*/SimpleStats::EmptyStats(), /*min_sequence_number=*/0,
+                    /*max_sequence_number=*/10, /*schema_id=*/0, level,
+                    /*extra_files=*/std::vector<std::optional<std::string>>(),
+                    /*creation_time=*/Timestamp(0, 0),
+                    /*delete_row_count */ std::nullopt,
+                    /*embedded_index=*/nullptr,
+                    /*file_source=*/FileSource::Append(), /*external_path=*/std::nullopt,
+                    /*value_stats_cols=*/std::nullopt,
+                    /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt));
+        }
+        return entries;
+    };
+    ASSERT_TRUE(KeyValueFileStoreScan::NoOverlapping(generate_manifest_entries({0})));
+    ASSERT_FALSE(KeyValueFileStoreScan::NoOverlapping(generate_manifest_entries({0, 0, 0})));
+    ASSERT_TRUE(KeyValueFileStoreScan::NoOverlapping(generate_manifest_entries({1, 1, 1})));
+    ASSERT_FALSE(KeyValueFileStoreScan::NoOverlapping(generate_manifest_entries({0, 1, 1})));
+    ASSERT_FALSE(KeyValueFileStoreScan::NoOverlapping(generate_manifest_entries({2, 1, 1})));
+}
+
+TEST_F(KeyValueFileStoreScanTest, TestFilterByValueFilterWithValueStatsCols) {
+    std::string table_path =
+        paimon::test::GetDataDir() + "orc/pk_table_with_mor.db/pk_table_with_mor";
+    std::vector<std::map<std::string, std::string>> partition_filters = {};
+
+    // `v0` is at index 6 in schema-0 of pk_table_with_mor.
+    auto greater_than = PredicateBuilder::GreaterThan(/*field_index=*/6, /*field_name=*/"v0",
+                                                      FieldType::DOUBLE, Literal(30.1));
+    auto scan_filter = std::make_shared<ScanFilter>(/*predicate=*/greater_than,
+                                                    /*partition_filters=*/partition_filters,
+                                                    /*bucket_filter=*/0);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<KeyValueFileStoreScan> scan,
+                         CreateFileStoreScan(table_path, scan_filter,
+                                             /*table_schema_id=*/0, /*snapshot_id=*/1));
+    scan->EnableValueFilter();
+
+    // Build dense stats for only one column `v0`.
+    auto pool = GetDefaultPool();
+    SimpleStats value_stats = BinaryRowGenerator::GenerateStats(
+        /*min=*/{10.0}, /*max=*/{20.0}, /*null=*/{0}, pool.get());
+    std::vector<std::string> value_stats_cols = {"v0"};
+    ManifestEntry entry(
+        /*kind=*/FileKind::Add(), /*partition=*/BinaryRow::EmptyRow(), /*bucket=*/0,
+        /*total_buckets=*/1,
+        std::make_shared<DataFileMeta>(
+            /*file_name=*/"name", /*file_size=*/1024, /*row_count=*/10,
+            /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+            /*key_stats=*/SimpleStats::EmptyStats(),
+            /*value_stats=*/value_stats,
+            /*min_sequence_number=*/0,
+            /*max_sequence_number=*/10,
+            /*schema_id=*/0,
+            /*level=*/1,
+            /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(0, 0),
+            /*delete_row_count=*/std::nullopt,
+            /*embedded_index=*/nullptr,
+            /*file_source=*/FileSource::Append(),
+            /*value_stats_cols=*/value_stats_cols,
+            /*external_path=*/std::nullopt,
+            /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt));
+
+    // max(v0)=50 > 30.1, should be kept.
+    SimpleStats value_stats_keep = BinaryRowGenerator::GenerateStats(
+        /*min=*/{40.0}, /*max=*/{50.0}, /*null=*/{0}, pool.get());
+    ManifestEntry entry_keep(
+        /*kind=*/FileKind::Add(), /*partition=*/BinaryRow::EmptyRow(), /*bucket=*/0,
+        /*total_buckets=*/1,
+        std::make_shared<DataFileMeta>(
+            /*file_name=*/"name_keep", /*file_size=*/1024, /*row_count=*/10,
+            /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+            /*key_stats=*/SimpleStats::EmptyStats(),
+            /*value_stats=*/value_stats_keep,
+            /*min_sequence_number=*/0,
+            /*max_sequence_number=*/10,
+            /*schema_id=*/0,
+            /*level=*/1,
+            /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(0, 0),
+            /*delete_row_count=*/std::nullopt,
+            /*embedded_index=*/nullptr,
+            /*file_source=*/FileSource::Append(),
+            /*value_stats_cols=*/value_stats_cols,
+            /*external_path=*/std::nullopt,
+            /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt));
+
+    // max(v0)=20 <= 30.1, should be filtered out.
+    ASSERT_OK_AND_ASSIGN(bool keep, scan->FilterByStats(entry));
+    ASSERT_FALSE(keep);
+
+    ASSERT_OK_AND_ASSIGN(keep, scan->FilterByStats(entry_keep));
+    ASSERT_TRUE(keep);
+}
+}  // namespace paimon::test

--- a/src/paimon/core/operation/metrics/scan_metrics.h
+++ b/src/paimon/core/operation/metrics/scan_metrics.h
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace paimon {
+
+/// Metrics to measure scan operation.
+class ScanMetrics {
+ public:
+    static constexpr char LAST_SCAN_DURATION[] = "lastScanDuration";
+    // Histogram metric for scan plan duration (milliseconds).
+    static constexpr char SCAN_DURATION[] = "scanDuration";
+    static constexpr char LAST_SCANNED_SNAPSHOT_ID[] = "lastScannedSnapshotId";
+    static constexpr char LAST_SCANNED_MANIFESTS[] = "lastScannedManifests";
+    static constexpr char LAST_SCAN_SKIPPED_TABLE_FILES[] = "lastScanSkippedTableFiles";
+    static constexpr char LAST_SCAN_RESULTED_TABLE_FILES[] = "lastScanResultedTableFiles";
+};
+
+}  // namespace paimon

--- a/src/paimon/core/operation/scan_context.cpp
+++ b/src/paimon/core/operation/scan_context.cpp
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/scan_context.h"
+
+#include <utility>
+
+#include "paimon/common/utils/path_util.h"
+#include "paimon/executor.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class Predicate;
+
+ScanContext::ScanContext(const std::string& path, bool is_streaming_mode,
+                         std::optional<int32_t> limit,
+                         const std::shared_ptr<ScanFilter>& scan_filter,
+                         const std::shared_ptr<GlobalIndexResult>& global_index_result,
+                         const std::shared_ptr<MemoryPool>& memory_pool,
+                         const std::shared_ptr<Executor>& executor,
+                         const std::shared_ptr<FileSystem>& specific_file_system,
+                         const std::map<std::string, std::string>& options)
+    : path_(path),
+      is_streaming_mode_(is_streaming_mode),
+      limit_(limit),
+      scan_filters_(scan_filter),
+      global_index_result_(global_index_result),
+      memory_pool_(memory_pool),
+      executor_(executor),
+      specific_file_system_(specific_file_system),
+      options_(options) {}
+
+ScanContext::~ScanContext() = default;
+
+class ScanContextBuilder::Impl {
+ public:
+    friend class ScanContextBuilder;
+
+    void Reset() {
+        is_streaming_mode_ = false;
+        limit_ = std::nullopt;
+        bucket_filter_ = std::nullopt;
+        partition_filters_.clear();
+        predicates_.reset();
+        global_index_result_.reset();
+        memory_pool_ = GetDefaultPool();
+        executor_ = CreateDefaultExecutor();
+        specific_file_system_.reset();
+        options_.clear();
+    }
+
+ private:
+    std::string path_;
+    bool is_streaming_mode_ = false;
+    std::optional<int32_t> limit_;
+    std::optional<int32_t> bucket_filter_;
+    std::vector<std::map<std::string, std::string>> partition_filters_;
+    std::shared_ptr<Predicate> predicates_;
+    std::shared_ptr<GlobalIndexResult> global_index_result_;
+    std::shared_ptr<MemoryPool> memory_pool_ = GetDefaultPool();
+    std::shared_ptr<Executor> executor_ = CreateDefaultExecutor();
+    std::shared_ptr<FileSystem> specific_file_system_;
+    std::map<std::string, std::string> options_;
+};
+
+ScanContextBuilder::ScanContextBuilder(const std::string& path)
+    : impl_(std::make_unique<ScanContextBuilder::Impl>()) {
+    impl_->path_ = path;
+}
+ScanContextBuilder::~ScanContextBuilder() = default;
+ScanContextBuilder& ScanContextBuilder::WithStreamingMode(bool is_streaming_mode) {
+    impl_->is_streaming_mode_ = is_streaming_mode;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::SetLimit(int32_t limit) {
+    impl_->limit_ = limit;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::SetBucketFilter(int32_t bucket_filter) {
+    impl_->bucket_filter_ = bucket_filter;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::SetPartitionFilter(
+    const std::vector<std::map<std::string, std::string>>& partition_filters) {
+    impl_->partition_filters_ = partition_filters;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::SetPredicate(const std::shared_ptr<Predicate>& predicate) {
+    impl_->predicates_ = predicate;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::SetGlobalIndexResult(
+    const std::shared_ptr<GlobalIndexResult>& global_index_result) {
+    impl_->global_index_result_ = global_index_result;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::SetOptions(
+    const std::map<std::string, std::string>& options) {
+    impl_->options_ = options;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::AddOption(const std::string& key,
+                                                  const std::string& value) {
+    impl_->options_[key] = value;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::WithMemoryPool(
+    const std::shared_ptr<MemoryPool>& memory_pool) {
+    impl_->memory_pool_ = memory_pool;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::WithExecutor(const std::shared_ptr<Executor>& executor) {
+    impl_->executor_ = executor;
+    return *this;
+}
+
+ScanContextBuilder& ScanContextBuilder::WithFileSystem(
+    const std::shared_ptr<FileSystem>& file_system) {
+    impl_->specific_file_system_ = file_system;
+    return *this;
+}
+
+Result<std::unique_ptr<ScanContext>> ScanContextBuilder::Finish() {
+    PAIMON_ASSIGN_OR_RAISE(impl_->path_, PathUtil::NormalizePath(impl_->path_));
+    if (impl_->path_.empty()) {
+        return Status::Invalid("cannot scan with empty table path");
+    }
+    auto ctx = std::make_unique<ScanContext>(
+        impl_->path_, impl_->is_streaming_mode_, impl_->limit_,
+        std::make_shared<ScanFilter>(impl_->predicates_, impl_->partition_filters_,
+                                     impl_->bucket_filter_),
+        impl_->global_index_result_, impl_->memory_pool_, impl_->executor_,
+        impl_->specific_file_system_, impl_->options_);
+    impl_->Reset();
+    return ctx;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/operation/scan_context_test.cpp
+++ b/src/paimon/core/operation/scan_context_test.cpp
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/scan_context.h"
+
+#include "gtest/gtest.h"
+#include "paimon/defs.h"
+#include "paimon/executor.h"
+#include "paimon/global_index/bitmap_global_index_result.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/status.h"
+#include "paimon/testing/mock/mock_file_system.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(ScanContextTest, TestDefaultValue) {
+    ScanContextBuilder builder("table_root_path");
+    ASSERT_OK_AND_ASSIGN(auto ctx, builder.Finish());
+    ASSERT_EQ(ctx->GetPath(), "table_root_path");
+    ASSERT_FALSE(ctx->IsStreamingMode());
+    ASSERT_FALSE(ctx->GetLimit());
+    ASSERT_TRUE(ctx->GetMemoryPool());
+    ASSERT_TRUE(ctx->GetExecutor());
+    ASSERT_TRUE(ctx->GetScanFilters());
+    ASSERT_FALSE(ctx->GetScanFilters()->GetBucketFilter());
+    ASSERT_FALSE(ctx->GetScanFilters()->GetPredicate());
+    ASSERT_TRUE(ctx->GetScanFilters()->GetPartitionFilters().empty());
+    ASSERT_TRUE(ctx->GetOptions().empty());
+    ASSERT_FALSE(ctx->GetGlobalIndexResult());
+    ASSERT_FALSE(ctx->GetSpecificFileSystem());
+}
+
+TEST(ScanContextTest, TestSetContent) {
+    ScanContextBuilder builder("table_root_path");
+    std::shared_ptr<MemoryPool> memory_pool = GetDefaultPool();
+    std::shared_ptr<Executor> executor = CreateDefaultExecutor();
+
+    builder.SetBucketFilter(10);
+    std::vector<std::map<std::string, std::string>> partition_filters = {{{"f1", "20"}}};
+    builder.SetPartitionFilter(partition_filters);
+    auto predicate =
+        PredicateBuilder::IsNull(/*field_index=*/2, /*field_name=*/"f2", FieldType::INT);
+    builder.SetPredicate(predicate);
+    std::vector<Range> row_ranges = {Range(1, 2), Range(4, 5)};
+    auto global_index_result = BitmapGlobalIndexResult::FromRanges(row_ranges);
+    builder.SetGlobalIndexResult(global_index_result);
+    builder.SetLimit(1000);
+    builder.AddOption("key", "value");
+    builder.WithStreamingMode(true);
+    builder.WithMemoryPool(memory_pool);
+    builder.WithExecutor(executor);
+    auto fs = std::make_shared<MockFileSystem>();
+    builder.WithFileSystem(fs);
+    ASSERT_OK_AND_ASSIGN(auto ctx, builder.Finish());
+    ASSERT_EQ(ctx->GetPath(), "table_root_path");
+    ASSERT_TRUE(ctx->IsStreamingMode());
+    ASSERT_EQ(1000, ctx->GetLimit());
+    ASSERT_TRUE(ctx->GetScanFilters());
+    ASSERT_EQ(10, ctx->GetScanFilters()->GetBucketFilter());
+    ASSERT_EQ(*predicate, *(ctx->GetScanFilters()->GetPredicate()));
+    ASSERT_EQ(partition_filters, ctx->GetScanFilters()->GetPartitionFilters());
+    ASSERT_EQ("{1,2,4,5}", ctx->GetGlobalIndexResult()->ToString());
+    ASSERT_EQ(memory_pool, ctx->GetMemoryPool());
+    ASSERT_EQ(executor, ctx->GetExecutor());
+    std::map<std::string, std::string> expected_options = {{"key", "value"}};
+    ASSERT_EQ(expected_options, ctx->GetOptions());
+    ASSERT_EQ(fs, ctx->GetSpecificFileSystem());
+}
+
+TEST(ScanContextTest, TestSetOptionsOverridesAddedOptions) {
+    ScanContextBuilder builder("table_root_path");
+    builder.AddOption("old", "value");
+    builder.SetOptions({{"key1", "value1"}, {"key2", "value2"}});
+
+    ASSERT_OK_AND_ASSIGN(auto ctx, builder.Finish());
+
+    std::map<std::string, std::string> expected_options = {{"key1", "value1"}, {"key2", "value2"}};
+    ASSERT_EQ(expected_options, ctx->GetOptions());
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

Migrate file store scan infrastructure and implementations:

Scan context (`include/paimon/` + `src/paimon/core/operation/`):
- `ScanContext` — scan configuration and context holding predicates, projections, and scan options (`scan_context.h/cpp`)

File store scan (`src/paimon/core/operation/`):
- `FileStoreScan` — base file store scan with partition/bucket filtering and file index evaluation (`file_store_scan.h/cpp`)
- `AppendOnlyFileStoreScan` — scan for append-only tables (`append_only_file_store_scan.h/cpp`)
- `KeyValueFileStoreScan` — scan for key-value tables with level filtering and merge support (`key_value_file_store_scan.h/cpp`)
- `DataEvolutionFileStoreScan` — scan with schema evolution and data field change support (`data_evolution_file_store_scan.h/cpp`)
- `ScanMetrics` — scan metrics collection (`metrics/scan_metrics.h`)

<!-- What is the purpose of the change -->

### Tests
- `file_store_scan_test.cpp` — base scan operations
- `scan_context_test.cpp` — scan context configuration
- `append_only_file_store_scan_test.cpp` — append-only scan
- `key_value_file_store_scan_test.cpp` — key-value scan with merge
- `data_evolution_file_store_scan_test.cpp` — schema evolution scan
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Migrate-by: Aone Copilot (Claude)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
