### PR TITLE
feat: add global index implementations

### DIFF
--- a/src/paimon/common/global_index/bitmap/bitmap_global_index.cpp
+++ b/src/paimon/common/global_index/bitmap/bitmap_global_index.cpp
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "paimon/common/global_index/bitmap/bitmap_global_index.h"
+
+#include "paimon/common/global_index/wrap/file_index_reader_wrapper.h"
+#include "paimon/common/global_index/wrap/file_index_writer_wrapper.h"
+
+namespace paimon {
+Result<std::shared_ptr<GlobalIndexWriter>> BitmapGlobalIndex::CreateWriter(
+    const std::string& field_name, ::ArrowSchema* arrow_schema,
+    const std::shared_ptr<GlobalIndexFileWriter>& file_writer,
+    const std::shared_ptr<MemoryPool>& pool) const {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileIndexWriter> writer,
+                           index_->CreateWriter(arrow_schema, pool));
+    return std::make_shared<FileIndexWriterWrapper>(
+        /*index_type=*/"bitmap", file_writer, writer);
+}
+
+Result<std::shared_ptr<GlobalIndexReader>> BitmapGlobalIndex::CreateReader(
+    ::ArrowSchema* arrow_schema, const std::shared_ptr<GlobalIndexFileReader>& file_reader,
+    const std::vector<GlobalIndexIOMeta>& files, const std::shared_ptr<MemoryPool>& pool) const {
+    if (files.size() != 1) {
+        return Status::Invalid(
+            "invalid GlobalIndexIOMeta for BitmapGlobalIndex, exist multiple metas");
+    }
+    const auto& meta = files[0];
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InputStream> in,
+                           file_reader->GetInputStream(meta.file_path));
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<FileIndexReader> reader,
+        index_->CreateReader(arrow_schema, /*start=*/0, meta.file_size, in, pool));
+    auto transform = [](const std::shared_ptr<FileIndexResult>& result)
+        -> Result<std::shared_ptr<GlobalIndexResult>> {
+        return FileIndexReaderWrapper::ToGlobalIndexResult(result);
+    };
+    return std::make_shared<BitmapGlobalIndexReader>(reader, transform);
+}
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/bitmap/bitmap_global_index.h
+++ b/src/paimon/common/global_index/bitmap/bitmap_global_index.h
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/common/file_index/bitmap/bitmap_file_index.h"
+#include "paimon/common/global_index/wrap/file_index_reader_wrapper.h"
+#include "paimon/global_index/global_indexer.h"
+
+namespace paimon {
+class BitmapGlobalIndex : public GlobalIndexer {
+ public:
+    explicit BitmapGlobalIndex(const std::shared_ptr<BitmapFileIndex>& index) : index_(index) {}
+
+    Result<std::shared_ptr<GlobalIndexWriter>> CreateWriter(
+        const std::string& field_name, ::ArrowSchema* arrow_schema,
+        const std::shared_ptr<GlobalIndexFileWriter>& file_writer,
+        const std::shared_ptr<MemoryPool>& pool) const override;
+
+    Result<std::shared_ptr<GlobalIndexReader>> CreateReader(
+        ::ArrowSchema* arrow_schema, const std::shared_ptr<GlobalIndexFileReader>& file_reader,
+        const std::vector<GlobalIndexIOMeta>& files,
+        const std::shared_ptr<MemoryPool>& pool) const override;
+
+ private:
+    std::shared_ptr<BitmapFileIndex> index_;
+};
+
+class BitmapGlobalIndexReader : public FileIndexReaderWrapper {
+ public:
+    BitmapGlobalIndexReader(const std::shared_ptr<FileIndexReader>& reader,
+                            const std::function<Result<std::shared_ptr<GlobalIndexResult>>(
+                                const std::shared_ptr<FileIndexResult>&)>& transform)
+        : FileIndexReaderWrapper(reader, transform) {}
+
+    static inline const char kIdentifier[] = "bitmap";
+
+    bool IsThreadSafe() const override {
+        return false;
+    }
+
+    std::string GetIndexType() const override {
+        return kIdentifier;
+    }
+};
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/bitmap/bitmap_global_index_factory.cpp
+++ b/src/paimon/common/global_index/bitmap/bitmap_global_index_factory.cpp
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/global_index/bitmap/bitmap_global_index_factory.h"
+
+#include <utility>
+
+#include "paimon/common/file_index/bitmap/bitmap_file_index.h"
+#include "paimon/common/global_index/bitmap/bitmap_global_index.h"
+namespace paimon {
+
+const char BitmapGlobalIndexFactory::IDENTIFIER[] = "bitmap-global";
+
+Result<std::unique_ptr<GlobalIndexer>> BitmapGlobalIndexFactory::Create(
+    const std::map<std::string, std::string>& options) const {
+    auto bitmap_file_index = std::make_shared<BitmapFileIndex>(options);
+    return std::make_unique<BitmapGlobalIndex>(bitmap_file_index);
+}
+
+REGISTER_PAIMON_FACTORY(BitmapGlobalIndexFactory);
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/bitmap/bitmap_global_index_factory.h
+++ b/src/paimon/common/global_index/bitmap/bitmap_global_index_factory.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "paimon/global_index/global_indexer_factory.h"
+
+namespace paimon {
+/// Factory for creating bitmap global indexers.
+class BitmapGlobalIndexFactory : public GlobalIndexerFactory {
+ public:
+    static const char IDENTIFIER[];
+
+    const char* Identifier() const override {
+        return IDENTIFIER;
+    }
+
+    Result<std::unique_ptr<GlobalIndexer>> Create(
+        const std::map<std::string, std::string>& options) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/bitmap/bitmap_global_index_test.cpp
+++ b/src/paimon/common/global_index/bitmap/bitmap_global_index_test.cpp
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "paimon/common/global_index/bitmap/bitmap_global_index.h"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/c/bridge.h"
+#include "arrow/ipc/api.h"
+#include "gtest/gtest.h"
+#include "paimon/common/file_index/bitmap/bitmap_file_index.h"
+#include "paimon/common/global_index/wrap/file_index_writer_wrapper.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/global_index/global_index_file_manager.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/file_index/bitmap_index_result.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/global_index/bitmap_global_index_result.h"
+#include "paimon/global_index/global_index_result.h"
+#include "paimon/testing/mock/mock_index_path_factory.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class BitmapGlobalIndexTest : public ::testing::Test {
+ public:
+    void SetUp() override {}
+    void TearDown() override {}
+
+    std::unique_ptr<::ArrowSchema> CreateArrowSchema(
+        const std::shared_ptr<arrow::DataType>& data_type) const {
+        auto schema = arrow::schema({arrow::field("f0", data_type)});
+        auto c_schema = std::make_unique<::ArrowSchema>();
+        EXPECT_TRUE(arrow::ExportSchema(*schema, c_schema.get()).ok());
+        return c_schema;
+    }
+
+    Result<GlobalIndexIOMeta> WriteGlobalIndex(const std::string& index_root,
+                                               const std::shared_ptr<arrow::DataType>& type,
+                                               int32_t version,
+                                               const std::shared_ptr<arrow::Array>& array,
+                                               const Range& expected_range) const {
+        std::map<std::string, std::string> options;
+        options["version"] = std::to_string(version);
+        auto file_index = std::make_shared<BitmapFileIndex>(options);
+        auto global_index = std::make_shared<BitmapGlobalIndex>(file_index);
+
+        auto path_factory = std::make_shared<MockIndexPathFactory>(index_root);
+        auto file_writer = std::make_shared<GlobalIndexFileManager>(fs_, path_factory);
+
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<GlobalIndexWriter> global_writer,
+            global_index->CreateWriter("f0", CreateArrowSchema(type).get(), file_writer, pool_));
+
+        auto wrapper = std::dynamic_pointer_cast<FileIndexWriterWrapper>(global_writer);
+        EXPECT_TRUE(wrapper);
+        wrapper->max_write_size_ = 128;
+
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*array, &c_array));
+        std::vector<int64_t> row_ids(array->length());
+        std::iota(row_ids.begin(), row_ids.end(), 0);
+        PAIMON_RETURN_NOT_OK(global_writer->AddBatch(&c_array, std::move(row_ids)));
+        PAIMON_ASSIGN_OR_RAISE(auto result_metas, global_writer->Finish());
+        // check meta
+        if (result_metas.empty()) {
+            return Status::Invalid("write global index no data");
+        }
+        EXPECT_EQ(result_metas.size(), 1);
+        auto file_name = PathUtil::GetName(result_metas[0].file_path);
+        EXPECT_TRUE(StringUtils::StartsWith(file_name, "bitmap-global-index-"));
+        EXPECT_TRUE(StringUtils::EndsWith(file_name, ".index"));
+        EXPECT_FALSE(result_metas[0].metadata);
+        return result_metas[0];
+    }
+
+    void CheckResult(const std::shared_ptr<GlobalIndexResult>& result,
+                     const std::vector<int64_t>& expected) const {
+        auto typed_result = std::dynamic_pointer_cast<BitmapGlobalIndexResult>(result);
+        ASSERT_TRUE(typed_result);
+        ASSERT_OK_AND_ASSIGN(const RoaringBitmap64* bitmap, typed_result->GetBitmap());
+        ASSERT_TRUE(bitmap);
+        ASSERT_EQ(*(typed_result->GetBitmap().value()), RoaringBitmap64::From(expected))
+            << "result=" << (typed_result->GetBitmap().value())->ToString()
+            << ", expected=" << RoaringBitmap64::From(expected).ToString();
+    }
+
+    std::shared_ptr<GlobalIndexReader> CreateGlobalIndexReader(
+        const std::string& index_root, const std::shared_ptr<arrow::DataType>& type,
+        const GlobalIndexIOMeta& meta) {
+        auto file_index = std::make_shared<BitmapFileIndex>(std::map<std::string, std::string>());
+        auto global_index = std::make_shared<BitmapGlobalIndex>(file_index);
+
+        auto path_factory = std::make_shared<MockIndexPathFactory>(index_root);
+        auto file_reader = std::make_shared<GlobalIndexFileManager>(fs_, path_factory);
+        EXPECT_OK_AND_ASSIGN(
+            auto global_index_reader,
+            global_index->CreateReader(CreateArrowSchema(type).get(), file_reader, {meta}, pool_));
+        EXPECT_TRUE(global_index_reader);
+        return global_index_reader;
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+    std::shared_ptr<FileSystem> fs_ = std::make_shared<LocalFileSystem>();
+};
+
+TEST_F(BitmapGlobalIndexTest, TestStringType) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+    // data: a, null, b, null, a
+    auto type = arrow::utf8();
+    auto write_index = [&](int32_t version) -> Result<GlobalIndexIOMeta> {
+        auto array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({arrow::field("f0", type)}),
+                                                      R"([
+        ["a"],
+        [null],
+        ["b"],
+        [null],
+        ["a"]
+    ])")
+                .ValueOrDie());
+
+        return WriteGlobalIndex(test_root, type, version, array, Range(0, 4));
+    };
+    auto check_index = [&](const GlobalIndexIOMeta& meta) {
+        auto reader = CreateGlobalIndexReader(test_root, type, meta);
+
+        Literal lit_a(FieldType::STRING, "a", 1);
+        CheckResult(reader->VisitEqual(lit_a).value(), {0, 4});
+
+        Literal lit_b(FieldType::STRING, "b", 1);
+        CheckResult(reader->VisitEqual(lit_b).value(), {2});
+
+        CheckResult(reader->VisitIsNull().value(), {1, 3});
+
+        CheckResult(reader->VisitIn({lit_a, lit_b}).value(), {0, 2, 4});
+        CheckResult(reader->VisitNotIn({lit_a, lit_b}).value(), {});
+
+        // non-exist
+        Literal lit_c(FieldType::STRING, "c", 1);
+        CheckResult(reader->VisitEqual(lit_c).value(), {});
+
+        // greater than return REMAIN file index result, will convert to all range global index
+        // result
+        ASSERT_FALSE(reader->VisitGreaterThan(lit_c).value());
+
+        // test visit vector search
+        ASSERT_NOK_WITH_MSG(reader->VisitVectorSearch(std::make_shared<VectorSearch>(
+                                "f0", 10, std::vector<float>({1.0f, 2.0f}), nullptr, nullptr,
+                                std::nullopt, std::map<std::string, std::string>())),
+                            "FileIndexReaderWrapper is not supposed to handle vector search query");
+        // test VisitStartsWith, VisitEndsWith, VisitContains, VisitLike, VisitFullTextSearch
+        ASSERT_FALSE(reader->VisitStartsWith(lit_c).value());
+        ASSERT_FALSE(reader->VisitEndsWith(lit_c).value());
+        ASSERT_FALSE(reader->VisitContains(lit_c).value());
+        ASSERT_FALSE(reader->VisitLike(lit_c).value());
+        ASSERT_FALSE(reader->VisitFullTextSearch(nullptr).value());
+    };
+
+    {
+        // test version 1
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/1));
+        check_index(meta);
+    }
+    {
+        // test version 2
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/2));
+        check_index(meta);
+    }
+}
+
+TEST_F(BitmapGlobalIndexTest, TestIntType) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+    // data:  0, 1, null
+    auto type = arrow::int32();
+    auto write_index = [&](int32_t version) -> Result<GlobalIndexIOMeta> {
+        auto array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({arrow::field("f0", type)}),
+                                                      R"([
+        [0],
+        [1],
+        [null]
+    ])")
+                .ValueOrDie());
+
+        return WriteGlobalIndex(test_root, type, version, array, Range(0, 2));
+    };
+    auto check_index = [&](const GlobalIndexIOMeta& meta) {
+        auto reader = CreateGlobalIndexReader(test_root, type, meta);
+
+        Literal lit_0(static_cast<int32_t>(0));
+        Literal lit_1(static_cast<int32_t>(1));
+        Literal lit_2(static_cast<int32_t>(2));
+        CheckResult(reader->VisitEqual(lit_0).value(), {0});
+        CheckResult(reader->VisitEqual(lit_1).value(), {1});
+        CheckResult(reader->VisitIsNull().value(), {2});
+        CheckResult(reader->VisitIn({lit_0, lit_1, lit_2}).value(), {0, 1});
+        CheckResult(reader->VisitNotIn({lit_0, lit_1, lit_2}).value(), {});
+    };
+
+    {
+        // test version 1
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/1));
+        check_index(meta);
+    }
+    {
+        // test version 2
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/2));
+        check_index(meta);
+    }
+}
+
+TEST_F(BitmapGlobalIndexTest, TestTimestampType) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+    // data:
+    // 1745542802000lms, 123000ns
+    // 1745542902000lms, 123000ns
+    // 1745542602000lms, 123000ns
+    // -1745lms, 123000ns
+    // -1765lms, 123000ns
+    // null
+    // 1745542802000lms, 123001ns
+    // -1725lms, 123000ns
+    auto type = arrow::timestamp(arrow::TimeUnit::NANO);
+    auto write_index = [&](int32_t version) -> Result<GlobalIndexIOMeta> {
+        auto array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({arrow::field("f0", type)}),
+                                                      R"([
+        [1745542802000123000],
+        [1745542902000123000],
+        [1745542602000123000],
+        [-1744877000],
+        [-1764877000],
+        [null],
+        [1745542802000123001],
+        [-1724877000]
+    ])")
+                .ValueOrDie());
+
+        return WriteGlobalIndex(test_root, type, version, array, Range(0, 7));
+    };
+    auto check_index = [&](const GlobalIndexIOMeta& meta) {
+        auto reader = CreateGlobalIndexReader(test_root, type, meta);
+
+        CheckResult(reader->VisitIsNull().value(), {5});
+        CheckResult(reader->VisitIsNotNull().value(), {0, 1, 2, 3, 4, 6, 7});
+        CheckResult(reader->VisitEqual(Literal(Timestamp(1745542502000l, 123000))).value(), {});
+        // as timestamp is normalized by micro seconds, there is a loss of precision in the
+        // nanosecond part
+        CheckResult(reader->VisitEqual(Literal(Timestamp(1745542802000l, 123000))).value(), {0, 6});
+        CheckResult(reader->VisitNotEqual(Literal(Timestamp(1745542802000l, 123000))).value(),
+                    {1, 2, 3, 4, 7});
+        CheckResult(reader
+                        ->VisitIn({Literal(Timestamp(1745542802000l, 123000)),
+                                   Literal(Timestamp(-1745, 123000)),
+                                   Literal(Timestamp(1745542602000, 123000))})
+                        .value(),
+                    {0, 2, 3, 6});
+        CheckResult(reader
+                        ->VisitNotIn({Literal(Timestamp(1745542802000l, 123000)),
+                                      Literal(Timestamp(-1745, 123000)),
+                                      Literal(Timestamp(1745542602000, 123000))})
+                        .value(),
+                    {1, 4, 7});
+    };
+
+    {
+        // test version 1
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/1));
+        check_index(meta);
+    }
+    {
+        // test version 2
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/2));
+        check_index(meta);
+    }
+}
+
+TEST_F(BitmapGlobalIndexTest, TestHighCardinality) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+
+    int64_t seed = DateTimeUtils::GetCurrentUTCTimeUs();
+    std::srand(seed);
+    auto type = arrow::utf8();
+    std::vector<std::string> unique_values = {
+        "asdfghjkl123_0", "asdfghjkl123_2500", "asdfghjkl123_300", "asdfghjkl123_20",
+        "asdfghjkl123_1", "asdfghjkl123_2",    "asdfghjkl123_3",   "asdfghjkl123_4",
+        "asdfghjkl123_5", "asdfghjkl123_6"};
+    std::vector<std::vector<int64_t>> expected_bitmaps(unique_values.size());
+
+    auto write_index = [&](int32_t version) -> Result<GlobalIndexIOMeta> {
+        // clear expected bitmaps
+        for (auto& bitmap : expected_bitmaps) {
+            bitmap.clear();
+        }
+
+        arrow::StructBuilder struct_builder(arrow::struct_({arrow::field("f0", type)}),
+                                            arrow::default_memory_pool(),
+                                            {std::make_shared<arrow::StringBuilder>()});
+        auto string_builder = static_cast<arrow::StringBuilder*>(struct_builder.field_builder(0));
+
+        for (int32_t i = 0; i < 100000; i++) {
+            EXPECT_TRUE(struct_builder.Append().ok());
+            int64_t idx = paimon::test::RandomNumber(0, unique_values.size() - 1);
+            EXPECT_TRUE(string_builder->Append(unique_values[idx].data()).ok());
+            expected_bitmaps[idx].push_back(i);
+        }
+        std::shared_ptr<arrow::Array> array;
+        EXPECT_TRUE(struct_builder.Finish(&array).ok());
+
+        return WriteGlobalIndex(test_root, type, version, array, Range(0, 99999));
+    };
+
+    auto check_index = [&](const GlobalIndexIOMeta& meta) {
+        auto reader = CreateGlobalIndexReader(test_root, type, meta);
+
+        for (size_t i = 0; i < unique_values.size(); i++) {
+            Literal lit(FieldType::STRING, unique_values[i].data(), unique_values[i].size());
+            CheckResult(reader->VisitEqual(lit).value(), expected_bitmaps[i]);
+        }
+        CheckResult(reader->VisitIsNull().value(), {});
+    };
+
+    {
+        // test version 1
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/1));
+        check_index(meta);
+    }
+    {
+        // test version 2
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/2));
+        check_index(meta);
+    }
+}
+
+TEST_F(BitmapGlobalIndexTest, TestAllNull) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+    // data: null, null, null, null
+    auto type = arrow::int32();
+    auto write_index = [&](int32_t version) -> Result<GlobalIndexIOMeta> {
+        auto array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({arrow::field("f0", type)}),
+                                                      R"([
+        [null],
+        [null],
+        [null],
+        [null]
+    ])")
+                .ValueOrDie());
+
+        return WriteGlobalIndex(test_root, type, version, array, Range(0, 3));
+    };
+    auto check_index = [&](const GlobalIndexIOMeta& meta) {
+        auto reader = CreateGlobalIndexReader(test_root, type, meta);
+
+        Literal lit_0(static_cast<int32_t>(0));
+        CheckResult(reader->VisitEqual(lit_0).value(), {});
+        CheckResult(reader->VisitIsNull().value(), {0, 1, 2, 3});
+        CheckResult(reader->VisitIsNotNull().value(), {});
+    };
+
+    {
+        // test version 1
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/1));
+        check_index(meta);
+    }
+    {
+        // test version 2
+        ASSERT_OK_AND_ASSIGN(auto meta, write_index(/*version=*/2));
+        check_index(meta);
+    }
+}
+
+TEST_F(BitmapGlobalIndexTest, TestEmpty) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+    // no data
+    auto type = arrow::int32();
+    auto write_index = [&](int32_t version) -> Result<GlobalIndexIOMeta> {
+        auto array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({arrow::field("f0", type)}),
+                                                      R"([])")
+                .ValueOrDie());
+
+        return WriteGlobalIndex(test_root, type, version, array, Range(0, 2));
+    };
+    ASSERT_NOK_WITH_MSG(write_index(/*version=*/1), "write global index no data");
+    ASSERT_NOK_WITH_MSG(write_index(/*version=*/2), "write global index no data");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/global_index/offset_global_index_reader.cpp
+++ b/src/paimon/common/global_index/offset_global_index_reader.cpp
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/global_index/offset_global_index_reader.h"
+
+#include <utility>
+
+namespace paimon {
+
+OffsetGlobalIndexReader::OffsetGlobalIndexReader(std::shared_ptr<GlobalIndexReader>&& wrapped,
+                                                 int64_t offset)
+    : wrapped_(std::move(wrapped)), offset_(offset) {}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitIsNotNull() {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result, wrapped_->VisitIsNotNull());
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitIsNull() {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result, wrapped_->VisitIsNull());
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitEqual(
+    const Literal& literal) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitEqual(literal));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitNotEqual(
+    const Literal& literal) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitNotEqual(literal));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitLessThan(
+    const Literal& literal) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitLessThan(literal));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitLessOrEqual(
+    const Literal& literal) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitLessOrEqual(literal));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitGreaterThan(
+    const Literal& literal) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitGreaterThan(literal));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitGreaterOrEqual(
+    const Literal& literal) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitGreaterOrEqual(literal));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitIn(
+    const std::vector<Literal>& literals) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result, wrapped_->VisitIn(literals));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitNotIn(
+    const std::vector<Literal>& literals) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitNotIn(literals));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitStartsWith(
+    const Literal& prefix) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitStartsWith(prefix));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitEndsWith(
+    const Literal& suffix) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitEndsWith(suffix));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitContains(
+    const Literal& literal) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitContains(literal));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitLike(
+    const Literal& literal) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result, wrapped_->VisitLike(literal));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<ScoredGlobalIndexResult>> OffsetGlobalIndexReader::VisitVectorSearch(
+    const std::shared_ptr<VectorSearch>& vector_search) {
+    std::shared_ptr<VectorSearch> rewritten_search = vector_search;
+    if (vector_search && vector_search->pre_filter) {
+        auto original_filter = vector_search->pre_filter;
+        auto offset = offset_;
+        rewritten_search =
+            vector_search->ReplacePreFilter([original_filter, offset](int64_t local_id) -> bool {
+                return original_filter(local_id + offset);
+            });
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitVectorSearch(rewritten_search));
+    if (result == nullptr) {
+        return std::shared_ptr<ScoredGlobalIndexResult>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> offset_result,
+                           result->AddOffset(offset_));
+    auto scored_result = std::dynamic_pointer_cast<ScoredGlobalIndexResult>(offset_result);
+    if (!scored_result) {
+        return Status::Invalid(
+            "AddOffset on ScoredGlobalIndexResult did not return ScoredGlobalIndexResult");
+    }
+    return scored_result;
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::VisitFullTextSearch(
+    const std::shared_ptr<FullTextSearch>& full_text_search) {
+    // Rewrite pre_filter to convert global ids (used externally) to local ids (used by wrapped_).
+    // The original bitmap contains global ids; subtract offset_ to get local ids for the
+    // underlying reader.
+    std::shared_ptr<FullTextSearch> rewritten_search = full_text_search;
+    if (full_text_search && full_text_search->pre_filter.has_value()) {
+        RoaringBitmap64 local_bitmap;
+        const auto& global_bitmap = full_text_search->pre_filter.value();
+        for (auto iter = global_bitmap.Begin(); iter != global_bitmap.End(); ++iter) {
+            local_bitmap.Add(*iter - offset_);
+        }
+        rewritten_search = full_text_search->ReplacePreFilter(std::move(local_bitmap));
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                           wrapped_->VisitFullTextSearch(rewritten_search));
+    return ApplyOffset(result);
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> OffsetGlobalIndexReader::ApplyOffset(
+    const std::shared_ptr<GlobalIndexResult>& result) {
+    if (result == nullptr) {
+        return result;
+    }
+    return result->AddOffset(offset_);
+}
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/offset_global_index_reader.h
+++ b/src/paimon/common/global_index/offset_global_index_reader.h
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/global_index/global_index_reader.h"
+
+namespace paimon {
+
+/// A GlobalIndexReader that wraps another reader and applies an offset to all row ids in the
+/// results. This is used to convert local row IDs into global row IDs.
+class OffsetGlobalIndexReader : public GlobalIndexReader {
+ public:
+    /// Constructs an OffsetGlobalIndexReader.
+    /// @param wrapped The inner reader to delegate queries to. Its results are expected to
+    ///                contain local row ids.
+    /// @param offset  The offset to add to each row id in the results.
+    OffsetGlobalIndexReader(std::shared_ptr<GlobalIndexReader>&& wrapped, int64_t offset);
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIsNotNull() override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIsNull() override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitEqual(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitNotEqual(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLessThan(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLessOrEqual(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitGreaterThan(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitGreaterOrEqual(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIn(
+        const std::vector<Literal>& literals) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitNotIn(
+        const std::vector<Literal>& literals) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitStartsWith(const Literal& prefix) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitEndsWith(const Literal& suffix) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitContains(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLike(const Literal& literal) override;
+
+    Result<std::shared_ptr<ScoredGlobalIndexResult>> VisitVectorSearch(
+        const std::shared_ptr<VectorSearch>& vector_search) override;
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitFullTextSearch(
+        const std::shared_ptr<FullTextSearch>& full_text_search) override;
+
+    bool IsThreadSafe() const override {
+        return wrapped_->IsThreadSafe();
+    }
+
+    std::string GetIndexType() const override {
+        return wrapped_->GetIndexType();
+    }
+
+ private:
+    Result<std::shared_ptr<GlobalIndexResult>> ApplyOffset(
+        const std::shared_ptr<GlobalIndexResult>& result);
+
+ private:
+    std::shared_ptr<GlobalIndexReader> wrapped_;
+    int64_t offset_;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/offset_global_index_reader_test.cpp
+++ b/src/paimon/common/global_index/offset_global_index_reader_test.cpp
@@ -1,0 +1,404 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/global_index/offset_global_index_reader.h"
+
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/global_index/bitmap_global_index_result.h"
+#include "paimon/global_index/bitmap_scored_global_index_result.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/testing/utils/testharness.h"
+#include "paimon/utils/roaring_bitmap64.h"
+
+namespace paimon::test {
+class FakeGlobalIndexReader : public GlobalIndexReader {
+ public:
+    void SetDefaultResult(const std::vector<int64_t>& row_ids) {
+        default_result_ = row_ids;
+    }
+
+    void SetVectorSearchResult(const std::vector<int64_t>& row_ids,
+                               const std::vector<float>& scores) {
+        vector_search_row_ids_ = row_ids;
+        vector_search_scores_ = scores;
+        has_vector_search_result_ = true;
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIsNotNull() override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIsNull() override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitEqual(const Literal& literal) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitNotEqual(const Literal& literal) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLessThan(const Literal& literal) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLessOrEqual(const Literal& literal) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitGreaterThan(const Literal& literal) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitGreaterOrEqual(
+        const Literal& literal) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIn(
+        const std::vector<Literal>& literals) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitNotIn(
+        const std::vector<Literal>& literals) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitStartsWith(const Literal& prefix) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitEndsWith(const Literal& suffix) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitContains(const Literal& literal) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLike(const Literal& literal) override {
+        return MakeResult(default_result_);
+    }
+
+    Result<std::shared_ptr<ScoredGlobalIndexResult>> VisitVectorSearch(
+        const std::shared_ptr<VectorSearch>& vector_search) override {
+        if (!has_vector_search_result_) {
+            return Status::Invalid("FakeGlobalIndexReader does not support vector search");
+        }
+        auto bitmap = RoaringBitmap64::From(vector_search_row_ids_);
+        auto scores = vector_search_scores_;
+        return std::make_shared<BitmapScoredGlobalIndexResult>(std::move(bitmap),
+                                                               std::move(scores));
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitFullTextSearch(
+        const std::shared_ptr<FullTextSearch>& full_text_search) override {
+        return MakeResult(default_result_);
+    }
+
+    bool IsThreadSafe() const override {
+        return true;
+    }
+
+    std::string GetIndexType() const override {
+        return "fake";
+    }
+
+ private:
+    static Result<std::shared_ptr<GlobalIndexResult>> MakeResult(
+        const std::vector<int64_t>& row_ids) {
+        auto ids = row_ids;
+        return std::make_shared<BitmapGlobalIndexResult>(
+            [ids]() { return RoaringBitmap64::From(ids); });
+    }
+
+ private:
+    std::vector<int64_t> default_result_;
+    std::vector<int64_t> vector_search_row_ids_;
+    std::vector<float> vector_search_scores_;
+    bool has_vector_search_result_ = false;
+};
+
+class OffsetGlobalIndexReaderTest : public ::testing::Test {
+ public:
+    void CheckResult(const std::shared_ptr<GlobalIndexResult>& result,
+                     const std::vector<int64_t>& expected) const {
+        ASSERT_TRUE(result);
+        auto typed_result = std::dynamic_pointer_cast<BitmapGlobalIndexResult>(result);
+        ASSERT_TRUE(typed_result);
+        ASSERT_OK_AND_ASSIGN(const RoaringBitmap64* bitmap, typed_result->GetBitmap());
+        ASSERT_TRUE(bitmap);
+        ASSERT_EQ(*bitmap, RoaringBitmap64::From(expected))
+            << "result=" << bitmap->ToString()
+            << ", expected=" << RoaringBitmap64::From(expected).ToString();
+    }
+
+    static void CheckScoredResult(const std::shared_ptr<ScoredGlobalIndexResult>& result,
+                                  const std::vector<int64_t>& expected_row_ids,
+                                  const std::vector<float>& expected_scores) {
+        ASSERT_TRUE(result);
+        auto typed_result = std::dynamic_pointer_cast<BitmapScoredGlobalIndexResult>(result);
+        ASSERT_TRUE(typed_result);
+        ASSERT_OK_AND_ASSIGN(const RoaringBitmap64* bitmap, typed_result->GetBitmap());
+        ASSERT_TRUE(bitmap);
+        ASSERT_EQ(*bitmap, RoaringBitmap64::From(expected_row_ids))
+            << "result=" << bitmap->ToString()
+            << ", expected=" << RoaringBitmap64::From(expected_row_ids).ToString();
+        ASSERT_EQ(typed_result->GetScores(), expected_scores);
+    }
+};
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitEqualWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 1, 3});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 100);
+
+    Literal literal_5(5);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitEqual(literal_5));
+    // row ids {0, 1, 3} + offset 100 -> {100, 101, 103}
+    CheckResult(result, {100, 101, 103});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitIsNotNullWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 2, 4, 6});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 50);
+
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitIsNotNull());
+    // row ids {0, 2, 4, 6} + offset 50 -> {50, 52, 54, 56}
+    CheckResult(result, {50, 52, 54, 56});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitIsNullWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({1, 3});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 200);
+
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitIsNull());
+    // row ids {1, 3} + offset 200 -> {201, 203}
+    CheckResult(result, {201, 203});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitLessThanWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 1});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 10);
+
+    Literal literal_5(5);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitLessThan(literal_5));
+    // row ids {0, 1} + offset 10 -> {10, 11}
+    CheckResult(result, {10, 11});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitGreaterOrEqualWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({3, 4, 5});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 1000);
+
+    Literal literal_10(10);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitGreaterOrEqual(literal_10));
+    // row ids {3, 4, 5} + offset 1000 -> {1003, 1004, 1005}
+    CheckResult(result, {1003, 1004, 1005});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitInWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 2});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 5);
+
+    std::vector<Literal> literals = {Literal(1), Literal(3)};
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitIn(literals));
+    // row ids {0, 2} + offset 5 -> {5, 7}
+    CheckResult(result, {5, 7});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitNotInWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({1, 3, 5});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 20);
+
+    std::vector<Literal> literals = {Literal(2)};
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitNotIn(literals));
+    // row ids {1, 3, 5} + offset 20 -> {21, 23, 25}
+    CheckResult(result, {21, 23, 25});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitNotEqualWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 2, 4});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 7);
+
+    Literal literal_1(1);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitNotEqual(literal_1));
+    // row ids {0, 2, 4} + offset 7 -> {7, 9, 11}
+    CheckResult(result, {7, 9, 11});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitLessOrEqualWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 1, 2});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 30);
+
+    Literal literal_3(3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitLessOrEqual(literal_3));
+    // row ids {0, 1, 2} + offset 30 -> {30, 31, 32}
+    CheckResult(result, {30, 31, 32});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitGreaterThanWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({4, 5});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 15);
+
+    Literal literal_3(3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitGreaterThan(literal_3));
+    // row ids {4, 5} + offset 15 -> {19, 20}
+    CheckResult(result, {19, 20});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestZeroOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 1, 2});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 0);
+
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitIsNotNull());
+    // row ids {0, 1, 2} + offset 0 -> {0, 1, 2}
+    CheckResult(result, {0, 1, 2});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestEmptyResultWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 100);
+
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitIsNotNull());
+    // empty result + offset 100 -> still empty
+    CheckResult(result, {});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestIsThreadSafeDelegated) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 100);
+    // FakeGlobalIndexReader returns true for IsThreadSafe
+    ASSERT_TRUE(offset_reader->IsThreadSafe());
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestGetIndexTypeDelegated) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 100);
+    ASSERT_EQ(offset_reader->GetIndexType(), "fake");
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitFullTextSearchWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 3, 5});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 10);
+
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitFullTextSearch(nullptr));
+    // row ids {0, 3, 5} + offset 10 -> {10, 13, 15}
+    CheckResult(result, {10, 13, 15});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitVectorSearchWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetVectorSearchResult({0, 2, 5}, {0.9f, 0.7f, 0.3f});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 100);
+
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitVectorSearch(nullptr));
+    // row ids {0, 2, 5} + offset 100 -> {100, 102, 105}, scores unchanged
+    CheckScoredResult(result, {100, 102, 105}, {0.9f, 0.7f, 0.3f});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitVectorSearchNotSupported) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 10);
+    // FakeGlobalIndexReader without SetVectorSearchResult returns error for VectorSearch
+    ASSERT_NOK_WITH_MSG(offset_reader->VisitVectorSearch(nullptr),
+                        "FakeGlobalIndexReader does not support vector search");
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitStartsWithWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 1, 4});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 50);
+
+    Literal prefix(FieldType::STRING, "abc", 3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitStartsWith(prefix));
+    // row ids {0, 1, 4} + offset 50 -> {50, 51, 54}
+    CheckResult(result, {50, 51, 54});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitEndsWithWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({2, 3});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 25);
+
+    Literal suffix(FieldType::STRING, "xyz", 3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitEndsWith(suffix));
+    // row ids {2, 3} + offset 25 -> {27, 28}
+    CheckResult(result, {27, 28});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitContainsWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({1, 5, 6});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 300);
+
+    Literal literal(FieldType::STRING, "foo", 3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitContains(literal));
+    // row ids {1, 5, 6} + offset 300 -> {301, 305, 306}
+    CheckResult(result, {301, 305, 306});
+}
+
+TEST_F(OffsetGlobalIndexReaderTest, TestVisitLikeWithOffset) {
+    auto fake_reader = std::make_shared<FakeGlobalIndexReader>();
+    fake_reader->SetDefaultResult({0, 3, 7});
+
+    auto offset_reader = std::make_shared<OffsetGlobalIndexReader>(fake_reader, 40);
+
+    Literal pattern(FieldType::STRING, "ab%", 3);
+    ASSERT_OK_AND_ASSIGN(auto result, offset_reader->VisitLike(pattern));
+    // row ids {0, 3, 7} + offset 40 -> {40, 43, 47}
+    CheckResult(result, {40, 43, 47});
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index.cpp
+++ b/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index.cpp
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "paimon/common/global_index/rangebitmap/range_bitmap_global_index.h"
+
+#include "paimon/common/global_index/wrap/file_index_reader_wrapper.h"
+#include "paimon/common/global_index/wrap/file_index_writer_wrapper.h"
+
+namespace paimon {
+Result<std::shared_ptr<GlobalIndexWriter>> RangeBitmapGlobalIndex::CreateWriter(
+    const std::string& field_name, ::ArrowSchema* arrow_schema,
+    const std::shared_ptr<GlobalIndexFileWriter>& file_writer,
+    const std::shared_ptr<MemoryPool>& pool) const {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileIndexWriter> writer,
+                           index_->CreateWriter(arrow_schema, pool));
+    return std::make_shared<FileIndexWriterWrapper>(
+        /*index_type=*/"range-bitmap", file_writer, writer);
+}
+
+Result<std::shared_ptr<GlobalIndexReader>> RangeBitmapGlobalIndex::CreateReader(
+    ::ArrowSchema* arrow_schema, const std::shared_ptr<GlobalIndexFileReader>& file_reader,
+    const std::vector<GlobalIndexIOMeta>& files, const std::shared_ptr<MemoryPool>& pool) const {
+    if (files.size() != 1) {
+        return Status::Invalid(
+            "invalid GlobalIndexIOMeta for RangeBitmapGlobalIndex, exist multiple metas");
+    }
+    const auto& meta = files[0];
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InputStream> in,
+                           file_reader->GetInputStream(meta.file_path));
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<FileIndexReader> reader,
+        index_->CreateReader(arrow_schema, /*start=*/0, meta.file_size, in, pool));
+    auto transform = [](const std::shared_ptr<FileIndexResult>& result)
+        -> Result<std::shared_ptr<GlobalIndexResult>> {
+        return FileIndexReaderWrapper::ToGlobalIndexResult(result);
+    };
+    return std::make_shared<RangeBitmapGlobalIndexReader>(reader, transform);
+}
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index.h
+++ b/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index.h
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/common/file_index/rangebitmap/range_bitmap_file_index.h"
+#include "paimon/common/global_index/wrap/file_index_reader_wrapper.h"
+#include "paimon/global_index/global_indexer.h"
+
+namespace paimon {
+class RangeBitmapGlobalIndex : public GlobalIndexer {
+ public:
+    explicit RangeBitmapGlobalIndex(const std::shared_ptr<RangeBitmapFileIndex>& index)
+        : index_(index) {}
+
+    Result<std::shared_ptr<GlobalIndexWriter>> CreateWriter(
+        const std::string& field_name, ::ArrowSchema* arrow_schema,
+        const std::shared_ptr<GlobalIndexFileWriter>& file_writer,
+        const std::shared_ptr<MemoryPool>& pool) const override;
+
+    Result<std::shared_ptr<GlobalIndexReader>> CreateReader(
+        ::ArrowSchema* arrow_schema, const std::shared_ptr<GlobalIndexFileReader>& file_reader,
+        const std::vector<GlobalIndexIOMeta>& files,
+        const std::shared_ptr<MemoryPool>& pool) const override;
+
+ private:
+    std::shared_ptr<RangeBitmapFileIndex> index_;
+};
+
+class RangeBitmapGlobalIndexReader : public FileIndexReaderWrapper {
+ public:
+    RangeBitmapGlobalIndexReader(const std::shared_ptr<FileIndexReader>& reader,
+                                 const std::function<Result<std::shared_ptr<GlobalIndexResult>>(
+                                     const std::shared_ptr<FileIndexResult>&)>& transform)
+        : FileIndexReaderWrapper(reader, transform) {}
+
+    static inline const char kIdentifier[] = "range-bitmap";
+
+    bool IsThreadSafe() const override {
+        return false;
+    }
+
+    std::string GetIndexType() const override {
+        return kIdentifier;
+    }
+};
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index_factory.cpp
+++ b/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index_factory.cpp
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/global_index/rangebitmap/range_bitmap_global_index_factory.h"
+
+#include <utility>
+
+#include "paimon/common/file_index/rangebitmap/range_bitmap_file_index.h"
+#include "paimon/common/global_index/rangebitmap/range_bitmap_global_index.h"
+
+namespace paimon {
+
+const char RangeBitmapGlobalIndexFactory::IDENTIFIER[] = "range-bitmap-global";
+
+Result<std::unique_ptr<GlobalIndexer>> RangeBitmapGlobalIndexFactory::Create(
+    const std::map<std::string, std::string>& options) const {
+    auto range_bitmap_file_index = std::make_shared<RangeBitmapFileIndex>(options);
+    return std::make_unique<RangeBitmapGlobalIndex>(range_bitmap_file_index);
+}
+
+REGISTER_PAIMON_FACTORY(RangeBitmapGlobalIndexFactory);
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index_factory.h
+++ b/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index_factory.h
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "paimon/global_index/global_indexer_factory.h"
+
+namespace paimon {
+/// Factory for creating range-bitmap global indexers.
+class RangeBitmapGlobalIndexFactory : public GlobalIndexerFactory {
+ public:
+    static const char IDENTIFIER[];
+
+    const char* Identifier() const override {
+        return IDENTIFIER;
+    }
+
+    Result<std::unique_ptr<GlobalIndexer>> Create(
+        const std::map<std::string, std::string>& options) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index_test.cpp
+++ b/src/paimon/common/global_index/rangebitmap/range_bitmap_global_index_test.cpp
@@ -1,0 +1,340 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "paimon/common/global_index/rangebitmap/range_bitmap_global_index.h"
+
+#include <map>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "arrow/c/bridge.h"
+#include "arrow/ipc/api.h"
+#include "gtest/gtest.h"
+#include "paimon/common/file_index/rangebitmap/range_bitmap_file_index.h"
+#include "paimon/common/global_index/wrap/file_index_writer_wrapper.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/scope_guard.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/global_index/global_index_file_manager.h"
+#include "paimon/file_index/bitmap_index_result.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/global_index/bitmap_global_index_result.h"
+#include "paimon/global_index/global_index_result.h"
+#include "paimon/testing/mock/mock_index_path_factory.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class RangeBitmapGlobalIndexTest : public ::testing::Test {
+ public:
+    void SetUp() override {}
+    void TearDown() override {}
+
+    std::unique_ptr<::ArrowSchema> CreateArrowSchema(
+        const std::shared_ptr<arrow::DataType>& data_type) const {
+        auto schema = arrow::schema({arrow::field("f0", data_type)});
+        auto c_schema = std::make_unique<::ArrowSchema>();
+        EXPECT_TRUE(arrow::ExportSchema(*schema, c_schema.get()).ok());
+        return c_schema;
+    }
+
+    Result<GlobalIndexIOMeta> WriteGlobalIndex(const std::string& index_root,
+                                               const std::shared_ptr<arrow::DataType>& type,
+                                               const std::shared_ptr<arrow::Array>& array,
+                                               const Range& expected_range) const {
+        std::map<std::string, std::string> options;
+        auto file_index = std::make_shared<RangeBitmapFileIndex>(options);
+        auto global_index = std::make_shared<RangeBitmapGlobalIndex>(file_index);
+
+        auto path_factory = std::make_shared<MockIndexPathFactory>(index_root);
+        auto file_writer = std::make_shared<GlobalIndexFileManager>(fs_, path_factory);
+
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<GlobalIndexWriter> global_writer,
+            global_index->CreateWriter("f0", CreateArrowSchema(type).get(), file_writer, pool_));
+
+        auto wrapper = std::dynamic_pointer_cast<FileIndexWriterWrapper>(global_writer);
+        EXPECT_TRUE(wrapper);
+        wrapper->max_write_size_ = 128;
+
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*array, &c_array));
+        std::vector<int64_t> row_ids(array->length(), 0);
+        std::iota(row_ids.begin(), row_ids.end(), 0);
+        PAIMON_RETURN_NOT_OK(global_writer->AddBatch(&c_array, std::move(row_ids)));
+        PAIMON_ASSIGN_OR_RAISE(auto result_metas, global_writer->Finish());
+        // check meta
+        EXPECT_EQ(result_metas.size(), 1);
+        auto file_name = PathUtil::GetName(result_metas[0].file_path);
+        EXPECT_TRUE(StringUtils::StartsWith(file_name, "range-bitmap-global-index-"));
+        EXPECT_TRUE(StringUtils::EndsWith(file_name, ".index"));
+        EXPECT_FALSE(result_metas[0].metadata);
+        return result_metas[0];
+    }
+
+    void CheckResult(const std::shared_ptr<GlobalIndexResult>& result,
+                     const std::vector<int64_t>& expected) const {
+        auto typed_result = std::dynamic_pointer_cast<BitmapGlobalIndexResult>(result);
+        ASSERT_TRUE(typed_result);
+        ASSERT_OK_AND_ASSIGN(const RoaringBitmap64* bitmap, typed_result->GetBitmap());
+        ASSERT_TRUE(bitmap);
+        ASSERT_EQ(*(typed_result->GetBitmap().value()), RoaringBitmap64::From(expected))
+            << "result=" << (typed_result->GetBitmap().value())->ToString()
+            << ", expected=" << RoaringBitmap64::From(expected).ToString();
+    }
+
+    std::shared_ptr<GlobalIndexReader> CreateGlobalIndexReader(
+        const std::string& index_root, const std::shared_ptr<arrow::DataType>& type,
+        const GlobalIndexIOMeta& meta) const {
+        auto file_index =
+            std::make_shared<RangeBitmapFileIndex>(std::map<std::string, std::string>());
+        auto global_index = std::make_shared<RangeBitmapGlobalIndex>(file_index);
+
+        auto path_factory = std::make_shared<MockIndexPathFactory>(index_root);
+        auto file_reader = std::make_shared<GlobalIndexFileManager>(fs_, path_factory);
+        EXPECT_OK_AND_ASSIGN(
+            auto global_index_reader,
+            global_index->CreateReader(CreateArrowSchema(type).get(), file_reader, {meta}, pool_));
+        EXPECT_TRUE(global_index_reader);
+        return global_index_reader;
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+    std::shared_ptr<FileSystem> fs_ = std::make_shared<LocalFileSystem>();
+};
+
+TEST_F(RangeBitmapGlobalIndexTest, TestIntType) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+    // data:  0, 1, 2, 3, null
+    auto type = arrow::int32();
+
+    auto array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({arrow::field("f0", type)}),
+                                                  R"([
+        [0],
+        [1],
+        [2],
+        [3],
+        [null]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto meta, WriteGlobalIndex(test_root, type, array, Range(0, 4)));
+
+    auto reader = CreateGlobalIndexReader(test_root, type, meta);
+
+    Literal lit_0(static_cast<int32_t>(0));
+    Literal lit_1(static_cast<int32_t>(1));
+    Literal lit_2(static_cast<int32_t>(2));
+    Literal lit_3(static_cast<int32_t>(3));
+    Literal lit_5(static_cast<int32_t>(5));
+
+    // equal
+    CheckResult(reader->VisitEqual(lit_0).value(), {0});
+    CheckResult(reader->VisitEqual(lit_1).value(), {1});
+    CheckResult(reader->VisitEqual(lit_2).value(), {2});
+    CheckResult(reader->VisitEqual(lit_3).value(), {3});
+    CheckResult(reader->VisitEqual(lit_5).value(), {});
+
+    // not equal
+    CheckResult(reader->VisitNotEqual(lit_0).value(), {1, 2, 3});
+    CheckResult(reader->VisitNotEqual(lit_5).value(), {0, 1, 2, 3});
+
+    // null
+    CheckResult(reader->VisitIsNull().value(), {4});
+    CheckResult(reader->VisitIsNotNull().value(), {0, 1, 2, 3});
+
+    // in / not in
+    CheckResult(reader->VisitIn({lit_0, lit_1, lit_5}).value(), {0, 1});
+    CheckResult(reader->VisitNotIn({lit_0, lit_1, lit_5}).value(), {2, 3});
+
+    // range queries - the core advantage of range-bitmap
+    // greater than
+    CheckResult(reader->VisitGreaterThan(lit_1).value(), {2, 3});
+    CheckResult(reader->VisitGreaterThan(lit_3).value(), {});
+
+    // less than
+    CheckResult(reader->VisitLessThan(lit_2).value(), {0, 1});
+    CheckResult(reader->VisitLessThan(lit_0).value(), {});
+
+    // greater or equal
+    CheckResult(reader->VisitGreaterOrEqual(lit_2).value(), {2, 3});
+    CheckResult(reader->VisitGreaterOrEqual(lit_0).value(), {0, 1, 2, 3});
+
+    // less or equal
+    CheckResult(reader->VisitLessOrEqual(lit_1).value(), {0, 1});
+    CheckResult(reader->VisitLessOrEqual(lit_3).value(), {0, 1, 2, 3});
+
+    // test visit vector search
+    ASSERT_NOK_WITH_MSG(reader->VisitVectorSearch(std::make_shared<VectorSearch>(
+                            "f0", 10, std::vector<float>({1.0f, 2.0f}), nullptr, nullptr,
+                            std::nullopt, std::map<std::string, std::string>())),
+                        "FileIndexReaderWrapper is not supposed to handle vector search query");
+}
+
+TEST_F(RangeBitmapGlobalIndexTest, TestAllNull) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+    // data: null, null, null, null
+    auto type = arrow::int32();
+
+    auto array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({arrow::field("f0", type)}),
+                                                  R"([
+        [null],
+        [null],
+        [null],
+        [null]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto meta, WriteGlobalIndex(test_root, type, array, Range(0, 3)));
+
+    auto reader = CreateGlobalIndexReader(test_root, type, meta);
+
+    Literal lit_0(static_cast<int32_t>(0));
+    CheckResult(reader->VisitEqual(lit_0).value(), {});
+    CheckResult(reader->VisitIsNull().value(), {0, 1, 2, 3});
+    CheckResult(reader->VisitIsNotNull().value(), {});
+    CheckResult(reader->VisitGreaterThan(lit_0).value(), {});
+    CheckResult(reader->VisitLessThan(lit_0).value(), {});
+}
+
+TEST_F(RangeBitmapGlobalIndexTest, TestHighCardinality) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+
+    int64_t seed = DateTimeUtils::GetCurrentUTCTimeUs();
+    std::srand(seed);
+
+    ScopeGuard guard([seed]() { std::cout << "case failed with seed=" << seed << std::endl; });
+
+    auto type = arrow::int32();
+    // use 10 unique integer values
+    std::vector<int32_t> unique_values = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+    std::vector<std::vector<int64_t>> expected_bitmaps(unique_values.size());
+
+    arrow::StructBuilder struct_builder(arrow::struct_({arrow::field("f0", type)}),
+                                        arrow::default_memory_pool(),
+                                        {std::make_shared<arrow::Int32Builder>()});
+    auto int_builder = static_cast<arrow::Int32Builder*>(struct_builder.field_builder(0));
+
+    for (int32_t i = 0; i < 100000; i++) {
+        ASSERT_TRUE(struct_builder.Append().ok());
+        int64_t idx = paimon::test::RandomNumber(0, unique_values.size() - 1);
+        ASSERT_TRUE(int_builder->Append(unique_values[idx]).ok());
+        expected_bitmaps[idx].push_back(i);
+    }
+    std::shared_ptr<arrow::Array> array;
+    ASSERT_TRUE(struct_builder.Finish(&array).ok());
+
+    ASSERT_OK_AND_ASSIGN(auto meta, WriteGlobalIndex(test_root, type, array, Range(0, 99999)));
+
+    auto reader = CreateGlobalIndexReader(test_root, type, meta);
+
+    for (size_t i = 0; i < unique_values.size(); i++) {
+        Literal lit(unique_values[i]);
+        CheckResult(reader->VisitEqual(lit).value(), expected_bitmaps[i]);
+    }
+    CheckResult(reader->VisitIsNull().value(), {});
+
+    // range query on high cardinality data
+    // values >= 5
+    std::vector<int64_t> expected_gte_5;
+    for (size_t i = 5; i < unique_values.size(); i++) {
+        expected_gte_5.insert(expected_gte_5.end(), expected_bitmaps[i].begin(),
+                              expected_bitmaps[i].end());
+    }
+    std::sort(expected_gte_5.begin(), expected_gte_5.end());
+    CheckResult(reader->VisitGreaterOrEqual(Literal(static_cast<int32_t>(5))).value(),
+                expected_gte_5);
+    guard.Release();
+}
+
+TEST_F(RangeBitmapGlobalIndexTest, TestDoubleType) {
+    auto test_root_dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(test_root_dir);
+    std::string test_root = test_root_dir->Str();
+    // data: 1.1, 2.2, 3.3, 4.4, null, 2.2
+    auto type = arrow::float64();
+
+    auto array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({arrow::field("f0", type)}),
+                                                  R"([
+        [1.1],
+        [2.2],
+        [3.3],
+        [4.4],
+        [null],
+        [2.2]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto meta, WriteGlobalIndex(test_root, type, array, Range(0, 5)));
+
+    auto reader = CreateGlobalIndexReader(test_root, type, meta);
+
+    Literal lit_1_1(1.1);
+    Literal lit_2_2(2.2);
+    Literal lit_3_3(3.3);
+    Literal lit_4_4(4.4);
+    Literal lit_5_5(5.5);
+
+    // equal
+    CheckResult(reader->VisitEqual(lit_1_1).value(), {0});
+    CheckResult(reader->VisitEqual(lit_2_2).value(), {1, 5});
+    CheckResult(reader->VisitEqual(lit_3_3).value(), {2});
+    CheckResult(reader->VisitEqual(lit_4_4).value(), {3});
+    CheckResult(reader->VisitEqual(lit_5_5).value(), {});
+
+    // not equal
+    CheckResult(reader->VisitNotEqual(lit_2_2).value(), {0, 2, 3});
+    CheckResult(reader->VisitNotEqual(lit_5_5).value(), {0, 1, 2, 3, 5});
+
+    // null
+    CheckResult(reader->VisitIsNull().value(), {4});
+    CheckResult(reader->VisitIsNotNull().value(), {0, 1, 2, 3, 5});
+
+    // in / not in
+    CheckResult(reader->VisitIn({lit_1_1, lit_3_3, lit_5_5}).value(), {0, 2});
+    CheckResult(reader->VisitNotIn({lit_1_1, lit_3_3, lit_5_5}).value(), {1, 3, 5});
+
+    // range queries
+    // greater than
+    CheckResult(reader->VisitGreaterThan(lit_2_2).value(), {2, 3});
+    CheckResult(reader->VisitGreaterThan(lit_4_4).value(), {});
+
+    // less than
+    CheckResult(reader->VisitLessThan(lit_3_3).value(), {0, 1, 5});
+    CheckResult(reader->VisitLessThan(lit_1_1).value(), {});
+
+    // greater or equal
+    CheckResult(reader->VisitGreaterOrEqual(lit_3_3).value(), {2, 3});
+    CheckResult(reader->VisitGreaterOrEqual(lit_1_1).value(), {0, 1, 2, 3, 5});
+
+    // less or equal
+    CheckResult(reader->VisitLessOrEqual(lit_2_2).value(), {0, 1, 5});
+    CheckResult(reader->VisitLessOrEqual(lit_4_4).value(), {0, 1, 2, 3, 5});
+}
+
+}  // namespace paimon::test

--- a/src/paimon/common/global_index/union_global_index_reader.cpp
+++ b/src/paimon/common/global_index/union_global_index_reader.cpp
@@ -1,0 +1,210 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/global_index/union_global_index_reader.h"
+
+#include <future>
+#include <utility>
+
+#include "paimon/common/executor/future.h"
+
+namespace paimon {
+UnionGlobalIndexReader::UnionGlobalIndexReader(
+    std::vector<std::shared_ptr<GlobalIndexReader>>&& readers,
+    const std::shared_ptr<Executor>& executor)
+    : readers_(std::move(readers)), executor_(executor) {}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitIsNotNull() {
+    return Union(
+        [](const std::shared_ptr<GlobalIndexReader>& reader) { return reader->VisitIsNotNull(); });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitIsNull() {
+    return Union(
+        [](const std::shared_ptr<GlobalIndexReader>& reader) { return reader->VisitIsNull(); });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitEqual(
+    const Literal& literal) {
+    return Union([&literal](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitEqual(literal);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitNotEqual(
+    const Literal& literal) {
+    return Union([&literal](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitNotEqual(literal);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitLessThan(
+    const Literal& literal) {
+    return Union([&literal](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitLessThan(literal);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitLessOrEqual(
+    const Literal& literal) {
+    return Union([&literal](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitLessOrEqual(literal);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitGreaterThan(
+    const Literal& literal) {
+    return Union([&literal](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitGreaterThan(literal);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitGreaterOrEqual(
+    const Literal& literal) {
+    return Union([&literal](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitGreaterOrEqual(literal);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitIn(
+    const std::vector<Literal>& literals) {
+    return Union([&literals](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitIn(literals);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitNotIn(
+    const std::vector<Literal>& literals) {
+    return Union([&literals](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitNotIn(literals);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitStartsWith(
+    const Literal& prefix) {
+    return Union([&prefix](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitStartsWith(prefix);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitEndsWith(
+    const Literal& suffix) {
+    return Union([&suffix](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitEndsWith(suffix);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitContains(
+    const Literal& literal) {
+    return Union([&literal](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitContains(literal);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitLike(
+    const Literal& literal) {
+    return Union([&literal](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitLike(literal);
+    });
+}
+
+Result<std::shared_ptr<ScoredGlobalIndexResult>> UnionGlobalIndexReader::VisitVectorSearch(
+    const std::shared_ptr<VectorSearch>& vector_search) {
+    auto results = ExecuteAllReaders<Result<std::shared_ptr<ScoredGlobalIndexResult>>>(
+        [&vector_search](const std::shared_ptr<GlobalIndexReader>& reader)
+            -> Result<std::shared_ptr<ScoredGlobalIndexResult>> {
+            return reader->VisitVectorSearch(vector_search);
+        });
+
+    std::shared_ptr<ScoredGlobalIndexResult> merged_result = nullptr;
+    for (auto& result_or_status : results) {
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ScoredGlobalIndexResult> result,
+                               std::move(result_or_status));
+        if (result == nullptr) {
+            continue;
+        }
+        if (merged_result == nullptr) {
+            merged_result = std::move(result);
+        } else {
+            PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> merged_as_base,
+                                   merged_result->Or(result));
+            merged_result = std::dynamic_pointer_cast<ScoredGlobalIndexResult>(merged_as_base);
+            if (!merged_result) {
+                return Status::Invalid(
+                    "Or of ScoredGlobalIndexResult did not return ScoredGlobalIndexResult in "
+                    "UnionGlobalIndexReader");
+            }
+        }
+    }
+
+    return merged_result;
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::VisitFullTextSearch(
+    const std::shared_ptr<FullTextSearch>& full_text_search) {
+    return Union([&full_text_search](const std::shared_ptr<GlobalIndexReader>& reader) {
+        return reader->VisitFullTextSearch(full_text_search);
+    });
+}
+
+Result<std::shared_ptr<GlobalIndexResult>> UnionGlobalIndexReader::Union(ReaderAction action) {
+    auto results = ExecuteAllReaders<Result<std::shared_ptr<GlobalIndexResult>>>(
+        [&action](const std::shared_ptr<GlobalIndexReader>& reader)
+            -> Result<std::shared_ptr<GlobalIndexResult>> { return action(reader); });
+
+    std::shared_ptr<GlobalIndexResult> merged_result = nullptr;
+    for (auto& result_or_status : results) {
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<GlobalIndexResult> result,
+                               std::move(result_or_status));
+        if (result == nullptr) {
+            continue;
+        }
+        if (merged_result == nullptr) {
+            merged_result = std::move(result);
+        } else {
+            PAIMON_ASSIGN_OR_RAISE(merged_result, merged_result->Or(result));
+        }
+    }
+
+    return merged_result;
+}
+
+template <typename R>
+std::vector<R> UnionGlobalIndexReader::ExecuteAllReaders(
+    const std::function<R(const std::shared_ptr<GlobalIndexReader>&)>& action) {
+    if (executor_ == nullptr || readers_.size() == 1) {
+        std::vector<R> results;
+        results.reserve(readers_.size());
+        for (const auto& reader : readers_) {
+            results.push_back(action(reader));
+        }
+        return results;
+    }
+
+    // Parallel: submit all tasks to executor, then collect results in submission order
+    std::vector<std::future<R>> futures;
+    futures.reserve(readers_.size());
+    for (const auto& reader : readers_) {
+        futures.push_back(
+            Via(executor_.get(), [&action, &reader]() -> R { return action(reader); }));
+    }
+    return CollectAll(futures);
+}
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/union_global_index_reader.h
+++ b/src/paimon/common/global_index/union_global_index_reader.h
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/executor.h"
+#include "paimon/global_index/global_index_reader.h"
+
+namespace paimon {
+/// A GlobalIndexReader that combines results from multiple readers by performing a union
+/// operation on their results.
+///
+/// When an executor is provided, all sub-reader actions are submitted in parallel and results are
+/// collected in submission order. Otherwise, sub-readers are evaluated sequentially.
+class UnionGlobalIndexReader : public GlobalIndexReader {
+ public:
+    UnionGlobalIndexReader(std::vector<std::shared_ptr<GlobalIndexReader>>&& readers,
+                           const std::shared_ptr<Executor>& executor);
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIsNotNull() override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIsNull() override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitEqual(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitNotEqual(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLessThan(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLessOrEqual(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitGreaterThan(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitGreaterOrEqual(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIn(
+        const std::vector<Literal>& literals) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitNotIn(
+        const std::vector<Literal>& literals) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitStartsWith(const Literal& prefix) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitEndsWith(const Literal& suffix) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitContains(const Literal& literal) override;
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLike(const Literal& literal) override;
+
+    Result<std::shared_ptr<ScoredGlobalIndexResult>> VisitVectorSearch(
+        const std::shared_ptr<VectorSearch>& vector_search) override;
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitFullTextSearch(
+        const std::shared_ptr<FullTextSearch>& full_text_search) override;
+
+    bool IsThreadSafe() const override {
+        return false;
+    }
+
+    std::string GetIndexType() const override {
+        return "union";
+    }
+
+ private:
+    using ReaderAction = std::function<Result<std::shared_ptr<GlobalIndexResult>>(
+        const std::shared_ptr<GlobalIndexReader>&)>;
+
+    /// Executes the given action on all readers and merges results with Union.
+    Result<std::shared_ptr<GlobalIndexResult>> Union(ReaderAction action);
+
+    /// Executes the given action on all readers (parallel or sequential) and collects results.
+    template <typename R>
+    std::vector<R> ExecuteAllReaders(
+        const std::function<R(const std::shared_ptr<GlobalIndexReader>&)>& action);
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers_;
+    std::shared_ptr<Executor> executor_;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/global_index/union_global_index_reader_test.cpp
+++ b/src/paimon/common/global_index/union_global_index_reader_test.cpp
@@ -1,0 +1,537 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/common/global_index/union_global_index_reader.h"
+
+#include <atomic>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/executor.h"
+#include "paimon/global_index/bitmap_global_index_result.h"
+#include "paimon/global_index/bitmap_scored_global_index_result.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/testing/utils/testharness.h"
+#include "paimon/utils/roaring_bitmap64.h"
+
+namespace paimon::test {
+class FakeReader : public GlobalIndexReader {
+ public:
+    /// Sets the result returned by all Visit* methods (default behavior).
+    /// Pass an empty vector for an empty bitmap.
+    void SetDefaultResult(const std::vector<int64_t>& row_ids) {
+        default_result_ = row_ids;
+        return_nullptr_ = false;
+        return_error_ = false;
+    }
+
+    /// Configures this reader to return nullptr for all Visit* methods.
+    void SetReturnNullptr() {
+        return_nullptr_ = true;
+        return_error_ = false;
+    }
+
+    /// Configures this reader to return an error Status for all Visit* methods.
+    void SetReturnError(const std::string& message) {
+        return_error_ = true;
+        return_nullptr_ = false;
+        error_message_ = message;
+    }
+
+    /// Sets a scored result returned by VisitVectorSearch.
+    void SetScoredResult(const std::vector<int64_t>& row_ids, const std::vector<float>& scores) {
+        scored_row_ids_ = row_ids;
+        scored_scores_ = scores;
+        has_scored_result_ = true;
+    }
+
+    /// Counts how many times any Visit* method was invoked. Useful to assert all readers
+    /// are exercised by UnionGlobalIndexReader.
+    int InvocationCount() const {
+        return invocation_count_.load();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIsNotNull() override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIsNull() override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitEqual(const Literal& literal) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitNotEqual(const Literal& literal) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLessThan(const Literal& literal) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLessOrEqual(const Literal& literal) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitGreaterThan(const Literal& literal) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitGreaterOrEqual(
+        const Literal& literal) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitIn(
+        const std::vector<Literal>& literals) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitNotIn(
+        const std::vector<Literal>& literals) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitStartsWith(const Literal& prefix) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitEndsWith(const Literal& suffix) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitContains(const Literal& literal) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitLike(const Literal& literal) override {
+        return MakeResult();
+    }
+
+    Result<std::shared_ptr<ScoredGlobalIndexResult>> VisitVectorSearch(
+        const std::shared_ptr<VectorSearch>& vector_search) override {
+        invocation_count_++;
+        if (return_error_) {
+            return Status::Invalid(error_message_);
+        }
+        if (!has_scored_result_) {
+            return std::shared_ptr<ScoredGlobalIndexResult>(nullptr);
+        }
+        auto bitmap = RoaringBitmap64::From(scored_row_ids_);
+        auto scores = scored_scores_;
+        return std::make_shared<BitmapScoredGlobalIndexResult>(std::move(bitmap),
+                                                               std::move(scores));
+    }
+
+    Result<std::shared_ptr<GlobalIndexResult>> VisitFullTextSearch(
+        const std::shared_ptr<FullTextSearch>& full_text_search) override {
+        return MakeResult();
+    }
+
+    bool IsThreadSafe() const override {
+        return true;
+    }
+
+    std::string GetIndexType() const override {
+        return "fake";
+    }
+
+ private:
+    Result<std::shared_ptr<GlobalIndexResult>> MakeResult() {
+        invocation_count_++;
+        if (return_error_) {
+            return Status::Invalid(error_message_);
+        }
+        if (return_nullptr_) {
+            return std::shared_ptr<GlobalIndexResult>(nullptr);
+        }
+        auto ids = default_result_;
+        return std::make_shared<BitmapGlobalIndexResult>(
+            [ids]() { return RoaringBitmap64::From(ids); });
+    }
+
+ private:
+    std::vector<int64_t> default_result_;
+    bool return_nullptr_ = false;
+    bool return_error_ = false;
+    std::string error_message_;
+    std::vector<int64_t> scored_row_ids_;
+    std::vector<float> scored_scores_;
+    bool has_scored_result_ = false;
+    std::atomic<int32_t> invocation_count_{0};
+};
+
+class UnionGlobalIndexReaderTest : public ::testing::Test {
+ public:
+    static void CheckResult(const std::shared_ptr<GlobalIndexResult>& result,
+                            const std::vector<int64_t>& expected) {
+        ASSERT_TRUE(result);
+        auto typed_result = std::dynamic_pointer_cast<BitmapGlobalIndexResult>(result);
+        ASSERT_TRUE(typed_result);
+        ASSERT_OK_AND_ASSIGN(const RoaringBitmap64* bitmap, typed_result->GetBitmap());
+        ASSERT_TRUE(bitmap);
+        ASSERT_EQ(*bitmap, RoaringBitmap64::From(expected))
+            << "result=" << bitmap->ToString()
+            << ", expected=" << RoaringBitmap64::From(expected).ToString();
+    }
+
+    static void CheckScoredResult(const std::shared_ptr<ScoredGlobalIndexResult>& result,
+                                  const std::vector<int64_t>& expected_row_ids,
+                                  const std::vector<float>& expected_scores) {
+        ASSERT_TRUE(result);
+        auto typed_result = std::dynamic_pointer_cast<BitmapScoredGlobalIndexResult>(result);
+        ASSERT_TRUE(typed_result);
+        ASSERT_OK_AND_ASSIGN(const RoaringBitmap64* bitmap, typed_result->GetBitmap());
+        ASSERT_TRUE(bitmap);
+        ASSERT_EQ(*bitmap, RoaringBitmap64::From(expected_row_ids))
+            << "result=" << bitmap->ToString()
+            << ", expected=" << RoaringBitmap64::From(expected_row_ids).ToString();
+        ASSERT_EQ(typed_result->GetScores(), expected_scores);
+    }
+};
+
+TEST_F(UnionGlobalIndexReaderTest, TestSingleReaderUnion) {
+    auto reader = std::make_shared<FakeReader>();
+    reader->SetDefaultResult({1, 2, 3});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitIsNotNull());
+    CheckResult(result, {1, 2, 3});
+    ASSERT_EQ(reader->InvocationCount(), 1);
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestMultipleReadersUnionSequential) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    auto reader3 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1, 2});
+    reader2->SetDefaultResult({3, 4});
+    reader3->SetDefaultResult({5});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2, reader3};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitIsNotNull());
+    // {1,2} OR {3,4} OR {5} -> {1,2,3,4,5}
+    CheckResult(result, {1, 2, 3, 4, 5});
+    ASSERT_EQ(reader1->InvocationCount(), 1);
+    ASSERT_EQ(reader2->InvocationCount(), 1);
+    ASSERT_EQ(reader3->InvocationCount(), 1);
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestMultipleReadersUnionOverlappingIds) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1, 2, 3});
+    reader2->SetDefaultResult({2, 3, 4});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitIsNotNull());
+    // {1,2,3} OR {2,3,4} -> {1,2,3,4}
+    CheckResult(result, {1, 2, 3, 4});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestMultipleReadersUnionWithExecutor) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    auto reader3 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({10});
+    reader2->SetDefaultResult({20});
+    reader3->SetDefaultResult({30});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2, reader3};
+    std::shared_ptr<Executor> executor = CreateDefaultExecutor();
+    UnionGlobalIndexReader union_reader(std::move(readers), executor);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitIsNotNull());
+    CheckResult(result, {10, 20, 30});
+    ASSERT_EQ(reader1->InvocationCount(), 1);
+    ASSERT_EQ(reader2->InvocationCount(), 1);
+    ASSERT_EQ(reader3->InvocationCount(), 1);
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestEmptyReaderList) {
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers;
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    // No readers means no results to merge -> nullptr
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitIsNotNull());
+    ASSERT_FALSE(result);
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestAllReadersReturnNullptr) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetReturnNullptr();
+    reader2->SetReturnNullptr();
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitIsNotNull());
+    // All readers return nullptr -> merged result is nullptr
+    ASSERT_FALSE(result);
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestPartialReadersReturnNullptr) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    auto reader3 = std::make_shared<FakeReader>();
+    reader1->SetReturnNullptr();
+    reader2->SetDefaultResult({1, 2});
+    reader3->SetReturnNullptr();
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2, reader3};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitIsNotNull());
+    // Nullptrs are skipped, only reader2's result is used
+    CheckResult(result, {1, 2});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestErrorPropagationSequential) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1, 2});
+    reader2->SetReturnError("Unknown error for reader2");
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_NOK_WITH_MSG(union_reader.VisitIsNotNull(), "Unknown error for reader2");
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestErrorPropagationWithExecutor) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1});
+    reader2->SetReturnError("Unknown error for reader2");
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    std::shared_ptr<Executor> executor = CreateDefaultExecutor();
+    UnionGlobalIndexReader union_reader(std::move(readers), executor);
+
+    ASSERT_NOK_WITH_MSG(union_reader.VisitIsNotNull(), "Unknown error for reader2");
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitEqualUnion) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1});
+    reader2->SetDefaultResult({2});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    Literal literal_42(42);
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitEqual(literal_42));
+    CheckResult(result, {1, 2});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitNotEqualUnion) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1});
+    reader2->SetDefaultResult({2});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    Literal literal_42(42);
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitNotEqual(literal_42));
+    CheckResult(result, {1, 2});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitRangeQueriesUnion) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1});
+    reader2->SetDefaultResult({2});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    Literal literal_5(5);
+    ASSERT_OK_AND_ASSIGN(auto lt, union_reader.VisitLessThan(literal_5));
+    CheckResult(lt, {1, 2});
+    ASSERT_OK_AND_ASSIGN(auto le, union_reader.VisitLessOrEqual(literal_5));
+    CheckResult(le, {1, 2});
+    ASSERT_OK_AND_ASSIGN(auto gt, union_reader.VisitGreaterThan(literal_5));
+    CheckResult(gt, {1, 2});
+    ASSERT_OK_AND_ASSIGN(auto ge, union_reader.VisitGreaterOrEqual(literal_5));
+    CheckResult(ge, {1, 2});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitInUnion) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1, 3});
+    reader2->SetDefaultResult({2, 4});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    std::vector<Literal> literals = {Literal(10), Literal(20)};
+    ASSERT_OK_AND_ASSIGN(auto in_result, union_reader.VisitIn(literals));
+    CheckResult(in_result, {1, 2, 3, 4});
+
+    ASSERT_OK_AND_ASSIGN(auto not_in_result, union_reader.VisitNotIn(literals));
+    CheckResult(not_in_result, {1, 2, 3, 4});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitStringQueriesUnion) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1});
+    reader2->SetDefaultResult({2});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    Literal literal_str(FieldType::STRING, "abc", 3);
+    ASSERT_OK_AND_ASSIGN(auto starts, union_reader.VisitStartsWith(literal_str));
+    CheckResult(starts, {1, 2});
+    ASSERT_OK_AND_ASSIGN(auto ends, union_reader.VisitEndsWith(literal_str));
+    CheckResult(ends, {1, 2});
+    ASSERT_OK_AND_ASSIGN(auto contains, union_reader.VisitContains(literal_str));
+    CheckResult(contains, {1, 2});
+    ASSERT_OK_AND_ASSIGN(auto like, union_reader.VisitLike(literal_str));
+    CheckResult(like, {1, 2});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitIsNullUnion) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({100, 200});
+    reader2->SetDefaultResult({300});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitIsNull());
+    CheckResult(result, {100, 200, 300});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitFullTextSearchUnion) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetDefaultResult({1, 5});
+    reader2->SetDefaultResult({2, 6});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitFullTextSearch(nullptr));
+    CheckResult(result, {1, 2, 5, 6});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitVectorSearchAllNullptr) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    // Neither reader has SetScoredResult -> VisitVectorSearch returns nullptr
+    reader1->SetDefaultResult({1});
+    reader2->SetDefaultResult({2});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitVectorSearch(nullptr));
+    ASSERT_FALSE(result);
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitVectorSearchSingleReader) {
+    auto reader = std::make_shared<FakeReader>();
+    reader->SetScoredResult({1, 3, 5}, {0.9f, 0.7f, 0.5f});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitVectorSearch(nullptr));
+    CheckScoredResult(result, {1, 3, 5}, {0.9f, 0.7f, 0.5f});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitVectorSearchMultipleReadersUnion) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetScoredResult({1, 3}, {0.9f, 0.7f});
+    reader2->SetScoredResult({2, 4}, {0.8f, 0.6f});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitVectorSearch(nullptr));
+    // {1,3} OR {2,4} -> {1,2,3,4}, scores merged in row id order
+    CheckScoredResult(result, {1, 2, 3, 4}, {0.9f, 0.8f, 0.7f, 0.6f});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitVectorSearchPartialNullptr) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    auto reader3 = std::make_shared<FakeReader>();
+    reader1->SetScoredResult({1, 2}, {0.9f, 0.8f});
+    // reader2 has no scored result -> returns nullptr
+    reader2->SetDefaultResult({10});
+    reader3->SetScoredResult({5, 6}, {0.5f, 0.4f});
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2, reader3};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_OK_AND_ASSIGN(auto result, union_reader.VisitVectorSearch(nullptr));
+    // reader2 nullptr is skipped, {1,2} OR {5,6} -> {1,2,5,6}
+    CheckScoredResult(result, {1, 2, 5, 6}, {0.9f, 0.8f, 0.5f, 0.4f});
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestVisitVectorSearchErrorPropagation) {
+    auto reader1 = std::make_shared<FakeReader>();
+    auto reader2 = std::make_shared<FakeReader>();
+    reader1->SetScoredResult({1}, {0.9f});
+    reader2->SetReturnError("vector search failure");
+
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader1, reader2};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_NOK_WITH_MSG(union_reader.VisitVectorSearch(nullptr), "vector search failure");
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestIsThreadSafeAlwaysFalse) {
+    auto reader = std::make_shared<FakeReader>();
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers = {reader};
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    // UnionGlobalIndexReader is not thread-safe regardless of inner readers
+    ASSERT_FALSE(union_reader.IsThreadSafe());
+}
+
+TEST_F(UnionGlobalIndexReaderTest, TestGetIndexTypeReturnsUnion) {
+    std::vector<std::shared_ptr<GlobalIndexReader>> readers;
+    UnionGlobalIndexReader union_reader(std::move(readers), nullptr);
+
+    ASSERT_EQ(union_reader.GetIndexType(), "union");
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
## feat: add global index implementations and composite readers

### Changes

#### `BitmapGlobalIndex`
- `GlobalIndexer` implementation for bitmap-based global indexes. Delegates to the existing `BitmapFileIndex` for index construction and wraps `BitmapFileIndexReader` via `FileIndexReaderWrapper` to convert file-level results into `GlobalIndexResult`.

#### `BitmapGlobalIndexFactory`
- `GlobalIndexerFactory` for creating `BitmapGlobalIndex` instances. Registered with identifier `"bitmap-global"`.

#### `BitmapGlobalIndexReader`
- `GlobalIndexReader` adapter wrapping a file-level `BitmapFileIndexReader`. Transforms `FileIndexResult` into `GlobalIndexResult` via a configurable transform function. Not thread-safe.

#### `RangeBitmapGlobalIndex`
- `GlobalIndexer` implementation for range-bitmap global indexes. Delegates to `RangeBitmapFileIndex` for index construction and wraps `RangeBitmapFileIndexReader` for query evaluation.

#### `RangeBitmapGlobalIndexFactory`
- `GlobalIndexerFactory` for creating `RangeBitmapGlobalIndex` instances. Registered with identifier `"range-bitmap-global"`.

#### `RangeBitmapGlobalIndexReader`
- `GlobalIndexReader` adapter wrapping a file-level `RangeBitmapFileIndexReader`. Same pattern as `BitmapGlobalIndexReader`. Not thread-safe.

#### `OffsetGlobalIndexReader`
- `GlobalIndexReader` decorator that wraps another reader and applies a fixed offset to all row ids in the results. Used to convert local row ids into global row ids. Delegates all visitor methods to the inner reader and calls `AddOffset()` on each result.

#### `UnionGlobalIndexReader`
- `GlobalIndexReader` that combines results from multiple sub-readers by performing a union (OR) operation. When an `Executor` is provided, sub-reader queries are submitted in parallel and results are collected in submission order; otherwise evaluated sequentially. Supports all visitor methods including `VisitVectorSearch` and `VisitFullTextSearch`.

### Tests

- `BitmapGlobalIndexTest`
- `RangeBitmapGlobalIndexTest`
- `OffsetGlobalIndexReaderTest`
- `UnionGlobalIndexReaderTest`