### PR TITLE
feat: Migrate split read modules

### DIFF
--- a/src/paimon/core/operation/data_evolution_split_read.cpp
+++ b/src/paimon/core/operation/data_evolution_split_read.cpp
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/data_evolution_split_read.h"
+
+#include <map>
+#include <utility>
+
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/file_index/bitmap/apply_bitmap_index_batch_reader.h"
+#include "paimon/common/global_index/complete_index_score_batch_reader.h"
+#include "paimon/common/reader/complete_row_kind_batch_reader.h"
+#include "paimon/common/reader/concat_batch_reader.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/utils/object_utils.h"
+#include "paimon/common/utils/range_helper.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/global_index/indexed_split_impl.h"
+namespace paimon {
+Status DataEvolutionSplitRead::BlobBunch::Add(const std::shared_ptr<DataFileMeta>& file) {
+    if (!BlobUtils::IsBlobFile(file->file_name)) {
+        return Status::Invalid("Only blob file can be added to a blob bunch.");
+    }
+    PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+    if (first_row_id == latest_first_row_id_) {
+        if (file->max_sequence_number >= latest_max_sequence_number_) {
+            return Status::Invalid(
+                "Blob file with same first row id should have decreasing sequence number.");
+        }
+        // for files with the same first row id, file with larger sequence_number will be chosen,
+        // other files will be skipped
+        return Status::OK();
+    }
+    if (!files_.empty()) {
+        if (has_row_ids_selection_) {
+            // for the case:
+            // snapshot 1: blob0 [0, 9]
+            // snapshot 2: blob1 [0, 4] + blob2 [5, 9]
+            // when selected row id is {5}, only blob0 and blob2 is reserved in scan process, as
+            // blob1 has no intersect with {5}
+            // BlobBunch will first add blob0 [0, 9]
+            // then when it comes to blob2 [5, 9], blob0 will be removed as it has smaller sequence
+            // number
+            if (first_row_id < expected_next_first_row_id_) {
+                if (file->max_sequence_number > latest_max_sequence_number_) {
+                    row_count_ -= files_.back()->row_count;
+                    files_.pop_back();
+                } else {
+                    return Status::OK();
+                }
+            }
+        } else {
+            if (first_row_id < expected_next_first_row_id_) {
+                if (file->max_sequence_number >= latest_max_sequence_number_) {
+                    return Status::Invalid(
+                        "Blob file with overlapping row id should have decreasing sequence "
+                        "number.");
+                }
+                // for files with overlapping, if the file with smaller sequence_number is chosen,
+                // there will not exist file with larger sequence_number
+                return Status::OK();
+            } else if (first_row_id > expected_next_first_row_id_) {
+                return Status::Invalid(
+                    fmt::format("Blob file first row id should be continuous, expect {} but got {}",
+                                expected_next_first_row_id_, first_row_id));
+            }
+        }
+        if (!files_.empty()) {
+            if (file->schema_id != files_[0]->schema_id) {
+                return Status::Invalid("All files in a blob bunch should have the same schema id.");
+            }
+            if (file->write_cols != files_[0]->write_cols) {
+                return Status::Invalid(
+                    "All files in a blob bunch should have the same write columns.");
+            }
+        }
+    }
+    row_count_ += file->row_count;
+    if (row_count_ > expected_row_count_) {
+        return Status::Invalid(
+            fmt::format("Blob files row count exceed the expect {}", expected_row_count_));
+    }
+    files_.push_back(file);
+    latest_max_sequence_number_ = file->max_sequence_number;
+    latest_first_row_id_ = first_row_id;
+    expected_next_first_row_id_ = latest_first_row_id_ + file->row_count;
+    return Status::OK();
+}
+DataEvolutionSplitRead::DataEvolutionSplitRead(
+    const std::shared_ptr<FileStorePathFactory>& path_factory,
+    const std::shared_ptr<InternalReadContext>& context,
+    const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor)
+    : AbstractSplitRead(path_factory, context,
+                        std::make_unique<SchemaManager>(context->GetCoreOptions().GetFileSystem(),
+                                                        context->GetPath(),
+                                                        context->GetCoreOptions().GetBranch()),
+                        memory_pool, executor) {}
+
+bool DataEvolutionSplitRead::HasIndexScoreField(const std::shared_ptr<arrow::Schema>& read_schema) {
+    return read_schema->GetFieldIndex(SpecialFields::IndexScore().Name()) != -1;
+}
+
+Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateReader(
+    const std::shared_ptr<Split>& split) {
+    if (auto indexed_split = std::dynamic_pointer_cast<IndexedSplitImpl>(split)) {
+        PAIMON_RETURN_NOT_OK(indexed_split->Validate());
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<BatchReader> batch_reader,
+            InnerCreateReader(indexed_split->GetDataSplit(), indexed_split->RowRanges()));
+        if (HasIndexScoreField(raw_read_schema_)) {
+            return std::make_unique<CompleteIndexScoreBatchReader>(std::move(batch_reader),
+                                                                   indexed_split->Scores(), pool_);
+        }
+        return batch_reader;
+    } else if (auto data_split = std::dynamic_pointer_cast<DataSplit>(split)) {
+        if (HasIndexScoreField(raw_read_schema_)) {
+            return Status::Invalid(
+                "Invalid read schema, read _INDEX_SCORE while split cannot cast to IndexedSplit");
+        }
+        return InnerCreateReader(data_split, /*row_ranges=*/std::nullopt);
+    }
+    return Status::Invalid("Invalid Split, cannot cast to IndexedSplit or DataSplit");
+}
+
+Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::InnerCreateReader(
+    const std::shared_ptr<DataSplit>& data_split,
+    const std::optional<std::vector<Range>>& row_ranges) const {
+    auto split_impl = dynamic_cast<DataSplitImpl*>(data_split.get());
+    if (split_impl == nullptr) {
+        return Status::Invalid("unexpected error, split cast to impl failed");
+    }
+    assert(raw_read_schema_->num_fields() > 0);
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<DataFilePathFactory> data_file_path_factory,
+        path_factory_->CreateDataFilePathFactory(split_impl->Partition(), split_impl->Bucket()));
+    auto metas = split_impl->DataFiles();
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> split_by_row_id,
+                           MergeRangesAndSort(std::move(metas)));
+
+    std::vector<std::unique_ptr<BatchReader>> sub_readers;
+    for (const std::vector<std::shared_ptr<DataFileMeta>>& need_merge_files : split_by_row_id) {
+        if (need_merge_files.size() == 1) {
+            // No need to merge fields, just create a single file reader
+            PAIMON_ASSIGN_OR_RAISE(
+                std::vector<std::unique_ptr<FileBatchReader>> raw_file_readers,
+                CreateRawFileReaders(split_impl->Partition(), need_merge_files, raw_read_schema_,
+                                     /*predicate=*/nullptr,
+                                     /*dv_factory=*/nullptr, row_ranges, data_file_path_factory));
+            assert(raw_file_readers.size() == 1);
+            sub_readers.push_back(std::move(raw_file_readers[0]));
+        } else {
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<DataEvolutionFileReader> evolution_reader,
+                                   CreateUnionReader(split_impl->Partition(), need_merge_files,
+                                                     row_ranges, data_file_path_factory));
+            sub_readers.push_back(std::move(evolution_reader));
+        }
+    }
+    auto concat_batch_reader = std::make_unique<ConcatBatchReader>(std::move(sub_readers), pool_);
+    PAIMON_ASSIGN_OR_RAISE(
+        std::unique_ptr<BatchReader> batch_reader,
+        ApplyPredicateFilterIfNeeded(std::move(concat_batch_reader), context_->GetPredicate()));
+    return std::make_unique<CompleteRowKindBatchReader>(std::move(batch_reader), pool_);
+}
+Result<std::unique_ptr<FileBatchReader>> DataEvolutionSplitRead::ApplyIndexAndDvReaderIfNeeded(
+    std::unique_ptr<FileBatchReader>&& file_reader, const std::shared_ptr<DataFileMeta>& file,
+    const std::shared_ptr<arrow::Schema>& data_schema,
+    const std::shared_ptr<arrow::Schema>& read_schema, const std::shared_ptr<Predicate>& predicate,
+    DeletionVector::Factory dv_factory, const std::optional<std::vector<Range>>& row_ranges,
+    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const {
+    if (dv_factory) {
+        return Status::Invalid("DataEvolutionSplitRead do not support deletion vector");
+    }
+    if (predicate) {
+        assert(false);
+        // as DataEvolutionSplitRead will skip predicate
+        return Status::Invalid("DataEvolutionSplitRead do not support predicate");
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::optional<RoaringBitmap32> selection_row_ids,
+                           file->ToFileSelection(row_ranges));
+    ::ArrowSchema c_read_schema;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportSchema(*read_schema, &c_read_schema));
+    PAIMON_RETURN_NOT_OK(
+        file_reader->SetReadSchema(&c_read_schema, /*predicate=*/nullptr, selection_row_ids));
+
+    std::unique_ptr<FileBatchReader> reader;
+    if (!file_reader->SupportPreciseBitmapSelection() && selection_row_ids) {
+        // several format(e.g. lance, blob) will return accurate batch result, where
+        // ApplyBitmapIndexBatchReader is not necessary
+        reader = std::make_unique<ApplyBitmapIndexBatchReader>(
+            std::move(file_reader), std::move(selection_row_ids).value());
+    } else {
+        reader = std::move(file_reader);
+    }
+
+    return std::move(reader);
+}
+
+Result<std::vector<std::shared_ptr<DataEvolutionSplitRead::FieldBunch>>>
+DataEvolutionSplitRead::SplitFieldBunches(
+    const std::vector<std::shared_ptr<DataFileMeta>>& need_merge_files,
+    const std::function<Result<int32_t>(const std::shared_ptr<DataFileMeta>&)>&
+        blob_field_to_field_id,
+    bool has_row_ranges_selection) {
+    std::vector<std::shared_ptr<DataEvolutionSplitRead::FieldBunch>> fields_files;
+    std::map<int32_t, std::shared_ptr<DataEvolutionSplitRead::BlobBunch>> blob_bunch_map;
+    int64_t row_count = -1;
+    for (const auto& file : need_merge_files) {
+        if (BlobUtils::IsBlobFile(file->file_name)) {
+            PAIMON_ASSIGN_OR_RAISE(int32_t field_id, blob_field_to_field_id(file));
+            auto iter = blob_bunch_map.find(field_id);
+            if (iter == blob_bunch_map.end()) {
+                auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+                    row_count, has_row_ranges_selection);
+                PAIMON_RETURN_NOT_OK(blob_bunch->Add(file));
+                blob_bunch_map.insert(std::make_pair(field_id, blob_bunch));
+            } else {
+                assert(iter->second);
+                PAIMON_RETURN_NOT_OK(iter->second->Add(file));
+            }
+        } else {
+            // Normal file, just add it to the current merge split
+            fields_files.push_back(std::make_shared<DataEvolutionSplitRead::DataBunch>(file));
+            row_count = file->row_count;
+        }
+    }
+    for (const auto& [field_id, blob_bunch] : blob_bunch_map) {
+        fields_files.push_back(blob_bunch);
+    }
+    return fields_files;
+}
+
+Result<std::unique_ptr<DataEvolutionFileReader>> DataEvolutionSplitRead::CreateUnionReader(
+    const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& need_merge_files,
+    const std::optional<std::vector<Range>>& row_ranges,
+    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const {
+    auto blob_field_to_field_id =
+        [&](const std::shared_ptr<DataFileMeta>& file_meta) -> Result<int32_t> {
+        if (!BlobUtils::IsBlobFile(file_meta->file_name)) {
+            return Status::Invalid("Only blob file need to call this method.");
+        }
+        auto data_schema = context_->GetTableSchema();
+        if (data_schema->Id() != file_meta->schema_id) {
+            PAIMON_ASSIGN_OR_RAISE(data_schema, schema_manager_->ReadSchema(file_meta->schema_id));
+        }
+        const auto& write_cols = file_meta->write_cols;
+        if (write_cols == std::nullopt || write_cols.value().size() != 1) {
+            return Status::Invalid("Blob file only has one blob field");
+        }
+        PAIMON_ASSIGN_OR_RAISE(DataField data_field, data_schema->GetField(write_cols.value()[0]));
+        return data_field.Id();
+    };
+
+    PAIMON_ASSIGN_OR_RAISE(
+        std::vector<std::shared_ptr<DataEvolutionSplitRead::FieldBunch>> fields_files,
+        SplitFieldBunches(need_merge_files, blob_field_to_field_id,
+                          /*has_row_ranges_selection=*/row_ranges.has_value()));
+
+    assert(!fields_files.empty());
+    int64_t row_count = fields_files[0]->RowCount();
+    PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, fields_files[0]->Files()[0]->NonNullFirstRowId());
+    if (!row_ranges) {
+        for (const auto& bunch : fields_files) {
+            if (bunch->RowCount() != row_count) {
+                return Status::Invalid(
+                    "All files in a field merge split should have the same row count.");
+            }
+            PAIMON_ASSIGN_OR_RAISE(int64_t current_bunch_first_row_id,
+                                   bunch->Files()[0]->NonNullFirstRowId());
+            if (current_bunch_first_row_id != first_row_id) {
+                return Status::Invalid(
+                    "All files in a field merge split should have the same first row id and could "
+                    "not be null.");
+            }
+        }
+    }
+
+    // Init all we need to create a compound reader
+    PAIMON_ASSIGN_OR_RAISE(std::vector<DataField> all_read_fields,
+                           DataField::ConvertArrowSchemaToDataFields(raw_read_schema_));
+    std::vector<std::unique_ptr<BatchReader>> file_batch_readers(fields_files.size());
+    std::vector<int32_t> read_field_ids = DataField::GetAllFieldIds(all_read_fields);
+    // which row the read field index belongs to
+    std::vector<int32_t> reader_offsets(all_read_fields.size(), -1);
+    // which field index in the reading row
+    std::vector<int32_t> field_offsets(all_read_fields.size(), -1);
+
+    for (int32_t file_idx = 0; file_idx < static_cast<int32_t>(fields_files.size()); file_idx++) {
+        const auto& bunch = fields_files[file_idx];
+        const auto& first_file = bunch->Files()[0];
+        int64_t schema_id = first_file->schema_id;
+        std::shared_ptr<TableSchema> data_schema = context_->GetTableSchema();
+        if (schema_id != data_schema->Id()) {
+            PAIMON_ASSIGN_OR_RAISE(data_schema, schema_manager_->ReadSchema(schema_id));
+        }
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<DataField> data_fields,
+            ProjectFieldsForRowTrackingAndDataEvolution(data_schema, first_file->write_cols));
+        std::vector<int32_t> data_field_ids = DataField::GetAllFieldIds(data_fields);
+        std::vector<DataField> read_fields_in_file;
+        for (int32_t read_field_idx = 0;
+             read_field_idx < static_cast<int32_t>(read_field_ids.size()); read_field_idx++) {
+            // -1 indicates that the read fields are not matched
+            if (reader_offsets[read_field_idx] != -1) {
+                continue;
+            }
+            for (int32_t data_field_id : data_field_ids) {
+                // Check if the read field index matches the file field
+                // index
+                if (data_field_id == read_field_ids[read_field_idx]) {
+                    // "file_idx" is the reader index, and "read_fields_in_file.size()"
+                    // is the offset the that row
+                    reader_offsets[read_field_idx] = file_idx;
+                    field_offsets[read_field_idx] = read_fields_in_file.size();
+                    read_fields_in_file.push_back(all_read_fields[read_field_idx]);
+                    break;
+                }
+            }
+        }
+
+        if (!read_fields_in_file.empty()) {
+            // create new FieldMappingReader for read partial fields
+            auto file_read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields_in_file);
+            PAIMON_ASSIGN_OR_RAISE(std::vector<std::unique_ptr<FileBatchReader>> file_readers,
+                                   CreateRawFileReaders(partition, bunch->Files(), file_read_schema,
+                                                        /*predicate=*/nullptr, /*dv_factory=*/{},
+                                                        row_ranges, data_file_path_factory));
+            if (file_readers.size() == 1) {
+                file_batch_readers[file_idx] = std::move(file_readers[0]);
+            } else {
+                auto raw_readers =
+                    ObjectUtils::MoveVector<std::unique_ptr<BatchReader>>(std::move(file_readers));
+                // Concat multiple blob files that map to the same data file.
+                file_batch_readers[file_idx] =
+                    std::make_unique<ConcatBatchReader>(std::move(raw_readers), pool_);
+            }
+        }
+    }
+    // TODO(xinyu.lxy): check nullable when reader_offsets[read_field_idx] = -1
+    return DataEvolutionFileReader::Create(std::move(file_batch_readers), raw_read_schema_,
+                                           options_.GetReadBatchSize(), reader_offsets,
+                                           field_offsets, pool_);
+}
+
+Result<bool> DataEvolutionSplitRead::Match(const std::shared_ptr<Split>& split,
+                                           bool force_keep_delete) const {
+    return true;
+}
+
+Result<std::vector<std::vector<std::shared_ptr<DataFileMeta>>>>
+DataEvolutionSplitRead::MergeRangesAndSort(std::vector<std::shared_ptr<DataFileMeta>>&& files) {
+    // group by row id range
+    RangeHelper<std::shared_ptr<DataFileMeta>> range_helper(
+        [](const std::shared_ptr<DataFileMeta>& meta) -> Result<int64_t> {
+            return meta->NonNullFirstRowId();
+        },
+        [](const std::shared_ptr<DataFileMeta>& meta) -> Result<int64_t> {
+            PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, meta->NonNullFirstRowId());
+            return first_row_id + meta->row_count - 1;
+        });
+
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> result,
+                           range_helper.MergeOverlappingRanges(std::move(files)));
+    // in group, sort by blob file and max_seq
+    for (auto& group : result) {
+        // split to data files and blob files
+        std::vector<std::shared_ptr<DataFileMeta>> data_files;
+        data_files.reserve(group.size());
+        std::vector<std::shared_ptr<DataFileMeta>> blob_files;
+        blob_files.reserve(group.size());
+        for (auto& meta : group) {
+            if (BlobUtils::IsBlobFile(meta->file_name)) {
+                blob_files.push_back(std::move(meta));
+            } else {
+                data_files.push_back(std::move(meta));
+            }
+        }
+
+        // data files sort by reversed max sequence number
+        std::stable_sort(
+            data_files.begin(), data_files.end(),
+            [](const std::shared_ptr<DataFileMeta>& m1, const std::shared_ptr<DataFileMeta>& m2) {
+                return m1->max_sequence_number > m2->max_sequence_number;
+            });
+
+        PAIMON_ASSIGN_OR_RAISE(bool all_range_same, range_helper.AreAllRangesSame(data_files));
+        if (!all_range_same) {
+            return Status::Invalid("Data files should be all row id ranges same.");
+        }
+
+        // blob files sort by first row id then by reversed max sequence number
+        std::stable_sort(
+            blob_files.begin(), blob_files.end(),
+            [](const std::shared_ptr<DataFileMeta>& m1, const std::shared_ptr<DataFileMeta>& m2) {
+                if (m1->first_row_id.value() != m2->first_row_id.value()) {
+                    return m1->first_row_id.value() < m2->first_row_id.value();
+                }
+                return m1->max_sequence_number > m2->max_sequence_number;
+            });
+        // concat data files and blob files
+        group.clear();
+        group.insert(group.end(), std::make_move_iterator(data_files.begin()),
+                     std::make_move_iterator(data_files.end()));
+        group.insert(group.end(), std::make_move_iterator(blob_files.begin()),
+                     std::make_move_iterator(blob_files.end()));
+    }
+    return result;
+}
+}  // namespace paimon

--- a/src/paimon/core/operation/data_evolution_split_read.h
+++ b/src/paimon/core/operation/data_evolution_split_read.h
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "paimon/common/reader/data_evolution_file_reader.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/operation/abstract_split_read.h"
+#include "paimon/read_context.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class Schema;
+}
+
+namespace paimon {
+class DataFilePathFactory;
+class DataSplit;
+class Executor;
+class FileBatchReader;
+class FileStorePathFactory;
+class InternalReadContext;
+class MemoryPool;
+class Predicate;
+class BinaryRow;
+struct DeletionFile;
+
+/// If the class name below is enclosed in parentheses, it might be present in the read path;
+/// otherwise, it must be present in the read path.
+///
+/// Readers Overview: (ConcatBatchReader across
+/// splits)->(CompleteIndexScoreBatchReader)->CompleteRowKindBatchReader->(PredicateBatchReader)
+/// ->ConcatBatchReader across files->DataEvolutionFileReader->(ConcatBatchReader across blob files)
+/// ->FieldMappingReader->(CompleteRowTrackingFieldsBatchReader)
+/// ->(DelegatingPrefetchReader)->(PrefetchFileBatchReader)->FormatReader
+///
+///
+/// A union `SplitRead` to read multiple inner files to merge columns, note that this class
+/// does not support filtering push down and deletion vectors, as they can interfere with the
+/// process of merging columns.
+class DataEvolutionSplitRead : public AbstractSplitRead {
+ public:
+    DataEvolutionSplitRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
+                           const std::shared_ptr<InternalReadContext>& context,
+                           const std::shared_ptr<MemoryPool>& memory_pool,
+                           const std::shared_ptr<Executor>& executor);
+
+    Result<std::unique_ptr<BatchReader>> CreateReader(const std::shared_ptr<Split>& split) override;
+
+    Result<bool> Match(const std::shared_ptr<Split>& split, bool force_keep_delete) const override;
+
+    Result<std::unique_ptr<FileBatchReader>> ApplyIndexAndDvReaderIfNeeded(
+        std::unique_ptr<FileBatchReader>&& file_reader, const std::shared_ptr<DataFileMeta>& file,
+        const std::shared_ptr<arrow::Schema>& data_schema,
+        const std::shared_ptr<arrow::Schema>& read_schema,
+        const std::shared_ptr<Predicate>& predicate, DeletionVector::Factory dv_factory,
+        const std::optional<std::vector<Range>>& row_ranges,
+        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const override;
+
+ private:
+    /// Files for partial field.
+    class FieldBunch {
+     public:
+        virtual ~FieldBunch() = default;
+        virtual int64_t RowCount() const = 0;
+        virtual const std::vector<std::shared_ptr<DataFileMeta>>& Files() const = 0;
+    };
+
+    class DataBunch : public FieldBunch {
+     public:
+        explicit DataBunch(const std::shared_ptr<DataFileMeta>& data_file)
+            : data_files_({data_file}) {}
+        int64_t RowCount() const override {
+            return data_files_[0]->row_count;
+        }
+        const std::vector<std::shared_ptr<DataFileMeta>>& Files() const override {
+            return data_files_;
+        }
+
+     private:
+        std::vector<std::shared_ptr<DataFileMeta>> data_files_;
+    };
+
+    class BlobBunch : public FieldBunch {
+     public:
+        explicit BlobBunch(int64_t expected_row_count, bool has_row_ids_selection)
+            : expected_row_count_(expected_row_count),
+              has_row_ids_selection_(has_row_ids_selection) {}
+        int64_t RowCount() const override {
+            return row_count_;
+        }
+        const std::vector<std::shared_ptr<DataFileMeta>>& Files() const override {
+            return files_;
+        }
+        Status Add(const std::shared_ptr<DataFileMeta>& file);
+
+     private:
+        int64_t expected_row_count_ = -1;
+        int64_t latest_first_row_id_ = -1;
+        int64_t expected_next_first_row_id_ = -1;
+        int64_t latest_max_sequence_number_ = -1;
+        int64_t row_count_ = 0;
+        bool has_row_ids_selection_ = false;
+        std::vector<std::shared_ptr<DataFileMeta>> files_;
+    };
+
+ private:
+    Result<std::unique_ptr<BatchReader>> InnerCreateReader(
+        const std::shared_ptr<DataSplit>& data_split,
+        const std::optional<std::vector<Range>>& row_ranges) const;
+
+    static Result<std::vector<std::shared_ptr<DataEvolutionSplitRead::FieldBunch>>>
+    SplitFieldBunches(const std::vector<std::shared_ptr<DataFileMeta>>& need_merge_files,
+                      const std::function<Result<int32_t>(const std::shared_ptr<DataFileMeta>&)>&
+                          blob_field_to_field_id,
+                      bool has_row_ranges_selection);
+    static Result<std::vector<std::vector<std::shared_ptr<DataFileMeta>>>> MergeRangesAndSort(
+        std::vector<std::shared_ptr<DataFileMeta>>&& files);
+
+    static bool HasIndexScoreField(const std::shared_ptr<arrow::Schema>& read_schema);
+
+ private:
+    Result<std::unique_ptr<DataEvolutionFileReader>> CreateUnionReader(
+        const BinaryRow& partition,
+        const std::vector<std::shared_ptr<DataFileMeta>>& need_merge_files,
+        const std::optional<std::vector<Range>>& row_ranges,
+        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/operation/data_evolution_split_read_test.cpp
+++ b/src/paimon/core/operation/data_evolution_split_read_test.cpp
@@ -1,0 +1,653 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/data_evolution_split_read.h"
+
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/operation/internal_read_context.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/defs.h"
+#include "paimon/executor.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/read_context.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class DataEvolutionSplitReadTest : public ::testing::Test {
+ public:
+    std::shared_ptr<DataFileMeta> CreateDataFileMeta(
+        const std::string& file_name, const std::optional<int64_t>& first_row_id,
+        const std::optional<FileSource>& file_source) const {
+        return DataFileMeta::ForAppend(file_name, /*file_size=*/100, /*row_count=*/100,
+                                       /*row_stats=*/SimpleStats::EmptyStats(),
+                                       /*min_sequence_number=*/0,
+                                       /*max_sequence_number=*/100, /*schema_id=*/0, file_source,
+                                       /*value_stats_cols=*/std::nullopt,
+                                       /*external_path=*/std::nullopt, first_row_id,
+                                       /*write_cols=*/std::nullopt)
+            .value();
+    }
+
+    std::shared_ptr<DataFileMeta> CreateDataFileMeta(const std::string& file_name,
+                                                     const std::optional<int64_t>& first_row_id,
+                                                     int64_t row_count, int64_t max_seq) const {
+        return DataFileMeta::ForAppend(
+                   file_name, /*file_size=*/100, row_count,
+                   /*row_stats=*/SimpleStats::EmptyStats(),
+                   /*min_sequence_number=*/0,
+                   /*max_sequence_number=*/max_seq, /*schema_id=*/0, FileSource::Append(),
+                   /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt, first_row_id,
+                   /*write_cols=*/std::nullopt)
+            .value();
+    }
+
+    std::shared_ptr<DataFileMeta> CreateNormalFile(const std::string& file_name,
+                                                   int64_t first_row_id, int64_t row_count,
+                                                   int64_t max_sequence_number) const {
+        return DataFileMeta::ForAppend(file_name, /*file_size=*/row_count,
+                                       /*row_count=*/row_count,
+                                       /*row_stats=*/SimpleStats::EmptyStats(),
+                                       /*min_sequence_number=*/0, max_sequence_number,
+                                       /*schema_id=*/0, FileSource::Append(),
+                                       /*value_stats_cols=*/std::nullopt,
+                                       /*external_path=*/std::nullopt, first_row_id,
+                                       /*write_cols=*/std::nullopt)
+            .value();
+    }
+
+    std::shared_ptr<DataFileMeta> CreateBlobFile(
+        const std::string& file_name, int64_t first_row_id, int64_t row_count,
+        int64_t max_sequence_number,
+        const std::optional<std::vector<std::string>>& write_cols) const {
+        return DataFileMeta::ForAppend(file_name + ".blob", /*file_size=*/row_count,
+                                       /*row_count=*/row_count,
+                                       /*row_stats=*/SimpleStats::EmptyStats(),
+                                       /*min_sequence_number=*/0, max_sequence_number,
+                                       /*schema_id=*/0, FileSource::Append(),
+                                       /*value_stats_cols=*/std::nullopt,
+                                       /*external_path=*/std::nullopt, first_row_id, write_cols)
+            .value();
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+};
+
+TEST_F(DataEvolutionSplitReadTest, TestAddSingleBlobEntry) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+
+    ASSERT_EQ(blob_bunch->Files().size(), 1);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_entry);
+    ASSERT_EQ(blob_bunch->RowCount(), 100);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestAddBlobEntryAndTail) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_tail =
+        CreateBlobFile("blob2", /*first_row_id=*/100, /*row_count=*/200,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+    ASSERT_OK(blob_bunch->Add(blob_tail));
+
+    ASSERT_EQ(blob_bunch->Files().size(), 2);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_entry);
+    ASSERT_EQ(blob_bunch->Files()[1], blob_tail);
+    ASSERT_EQ(blob_bunch->RowCount(), 300);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestAddNonBlobFileInvalid) {
+    auto blob_entry =
+        CreateDataFileMeta("normal1.parquet", /*first_row_id=*/0, FileSource::Append());
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_NOK_WITH_MSG(blob_bunch->Add(blob_entry),
+                        "Only blob file can be added to a blob bunch.");
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestAddBlobWithSameFirstRowId) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_tail =
+        CreateBlobFile("blob2", /*first_row_id=*/0, /*row_count=*/50,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+    ASSERT_NOK_WITH_MSG(blob_bunch->Add(blob_tail),
+                        "Blob file with same first row id should have decreasing sequence number.");
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestAddBlobFileWithSameFirstRowIdAndLowerSequenceNumber) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_tail =
+        CreateBlobFile("blob2", /*first_row_id=*/0, /*row_count=*/50,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+    // Adding file with same firstRowId and lower sequence number should be ignored
+    ASSERT_OK(blob_bunch->Add(blob_tail));
+
+    ASSERT_EQ(blob_bunch->Files().size(), 1);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_entry);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestAddBlobFileWithOverlappingRowId) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_tail =
+        CreateBlobFile("blob2", /*first_row_id=*/50, /*row_count=*/150,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+    // Adding file with overlapping row id and lower sequence number should be ignored
+    ASSERT_OK(blob_bunch->Add(blob_tail));
+
+    ASSERT_EQ(blob_bunch->Files().size(), 1);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_entry);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestAddBlobFileWithOverlappingRowIdAndHigherSequenceNumber) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_tail =
+        CreateBlobFile("blob2", /*first_row_id=*/50, /*row_count=*/150,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+    ASSERT_NOK_WITH_MSG(
+        blob_bunch->Add(blob_tail),
+        "Blob file with overlapping row id should have decreasing sequence number.");
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestAddBlobFileWithNonContinuousRowId) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_tail =
+        CreateBlobFile("blob2", /*first_row_id=*/200, /*row_count=*/300,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+    // Adding file with non-continuous row id should return bad status
+    ASSERT_NOK_WITH_MSG(blob_bunch->Add(blob_tail),
+                        "Blob file first row id should be continuous, expect 100 but got 200");
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestAddBlobFileWithDifferentWriteCols) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_tail =
+        CreateBlobFile("blob2", /*first_row_id=*/100, /*row_count=*/200,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"diff_col"}));
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+    // Adding file with different write columns should return bad status
+    ASSERT_NOK_WITH_MSG(blob_bunch->Add(blob_tail),
+                        "All files in a blob bunch should have the same write columns.");
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestRowIdSelectionWithOverlap) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/10,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+
+    auto blob_sub1 =
+        CreateBlobFile("blob2", /*first_row_id=*/0, /*row_count=*/5,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_sub2 =
+        CreateBlobFile("blob3", /*first_row_id=*/5, /*row_count=*/5,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/true);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+    // blob_sub1 will not be added, for it has been skipped by row_ids in scan process.
+    // after blob_sub2 is added, blob_entry is removed
+    ASSERT_OK(blob_bunch->Add(blob_sub2));
+    ASSERT_EQ(blob_bunch->Files().size(), 1);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_sub2);
+    ASSERT_EQ(blob_bunch->RowCount(), 5);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestRowIdSelectionWithOverlap2) {
+    auto blob_entry =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/10,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+
+    auto blob_sub1 =
+        CreateBlobFile("blob2", /*first_row_id=*/0, /*row_count=*/5,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_sub2 =
+        CreateBlobFile("blob3", /*first_row_id=*/5, /*row_count=*/5,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/true);
+    ASSERT_OK(blob_bunch->Add(blob_entry));
+    // blob_sub1 will not be added, for it has been skipped by row_ids in scan process.
+    // after blob_sub2 is added, as blob_sub2 has smaller sequence number, blob_sub2 will be
+    // skipped.
+    ASSERT_OK(blob_bunch->Add(blob_sub2));
+    ASSERT_EQ(blob_bunch->Files().size(), 1);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_entry);
+    ASSERT_EQ(blob_bunch->RowCount(), 10);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestRowIdSelection) {
+    auto blob_entry0 =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/10,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+
+    auto blob_entry1 =
+        CreateBlobFile("blob2", /*first_row_id=*/10, /*row_count=*/10,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_entry2 =
+        CreateBlobFile("blob3", /*first_row_id=*/20, /*row_count=*/10,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/true);
+    ASSERT_OK(blob_bunch->Add(blob_entry0));
+    // blob_entry1 will not be added, for it has been skipped by row_ids in scan process.
+    ASSERT_OK(blob_bunch->Add(blob_entry2));
+    ASSERT_EQ(blob_bunch->Files().size(), 2);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_entry0);
+    ASSERT_EQ(blob_bunch->Files()[1], blob_entry2);
+    ASSERT_EQ(blob_bunch->RowCount(), 20);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestComplexBlobBunchScenario) {
+    auto blob_entry1 =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_entry2 =
+        CreateBlobFile("blob2", /*first_row_id=*/100, /*row_count=*/200,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_entry3 =
+        CreateBlobFile("blob3", /*first_row_id=*/300, /*row_count=*/300,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_entry4 =
+        CreateBlobFile("blob4", /*first_row_id=*/600, /*row_count=*/400,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_bunch = std::make_shared<DataEvolutionSplitRead::BlobBunch>(
+        INT64_MAX, /*has_row_ids_selection=*/false);
+    ASSERT_OK(blob_bunch->Add(blob_entry1));
+    ASSERT_OK(blob_bunch->Add(blob_entry2));
+    ASSERT_OK(blob_bunch->Add(blob_entry3));
+    ASSERT_OK(blob_bunch->Add(blob_entry4));
+
+    ASSERT_EQ(blob_bunch->Files().size(), 4);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_entry1);
+    ASSERT_EQ(blob_bunch->Files()[1], blob_entry2);
+    ASSERT_EQ(blob_bunch->Files()[2], blob_entry3);
+    ASSERT_EQ(blob_bunch->Files()[3], blob_entry4);
+    ASSERT_EQ(blob_bunch->RowCount(), 1000);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestComplexBlobBunchScenario2) {
+    std::vector<std::shared_ptr<DataFileMeta>> waited;
+    auto data = CreateNormalFile("others.parquet", /*first_row_id=*/0, /*row_count=*/1000,
+                                 /*max_sequence_number=*/1);
+    auto blob_entry1 =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/1000,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+
+    auto blob_entry2 =
+        CreateBlobFile("blob2", /*first_row_id=*/0, /*row_count=*/500,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_entry3 =
+        CreateBlobFile("blob3", /*first_row_id=*/500, /*row_count=*/250,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_entry4 =
+        CreateBlobFile("blob4", /*first_row_id=*/750, /*row_count=*/250,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+
+    auto blob_entry5 =
+        CreateBlobFile("blob5", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_entry6 =
+        CreateBlobFile("blob6", /*first_row_id=*/100, /*row_count=*/400,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_entry7 =
+        CreateBlobFile("blob7", /*first_row_id=*/750, /*row_count=*/100,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    auto blob_entry8 =
+        CreateBlobFile("blob8", /*first_row_id=*/850, /*row_count=*/150,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+
+    auto blob_entry9 =
+        CreateBlobFile("blob9", /*first_row_id=*/100, /*row_count=*/650,
+                       /*max_sequence_number=*/4,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"blob_col"}));
+    waited.push_back(data);
+    waited.push_back(blob_entry1);
+    waited.push_back(blob_entry2);
+    waited.push_back(blob_entry3);
+    waited.push_back(blob_entry4);
+    waited.push_back(blob_entry5);
+    waited.push_back(blob_entry6);
+    waited.push_back(blob_entry7);
+    waited.push_back(blob_entry8);
+    waited.push_back(blob_entry9);
+
+    auto input_metas = waited;
+    ASSERT_OK_AND_ASSIGN(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> batches,
+                         DataEvolutionSplitRead::MergeRangesAndSort(std::move(input_metas)));
+    ASSERT_EQ(batches.size(), 1);
+
+    std::vector<std::shared_ptr<DataFileMeta>> batch = batches[0];
+    ASSERT_EQ(batch.size(), 10);
+    ASSERT_EQ(batch[0], data);
+    ASSERT_EQ(batch[1], blob_entry5);  // pick
+    ASSERT_EQ(batch[2], blob_entry2);  // skip
+    ASSERT_EQ(batch[3], blob_entry1);  // skip
+    ASSERT_EQ(batch[4], blob_entry9);  // pick
+    ASSERT_EQ(batch[5], blob_entry6);  // skip
+    ASSERT_EQ(batch[6], blob_entry3);  // skip
+    ASSERT_EQ(batch[7], blob_entry7);  // pick
+    ASSERT_EQ(batch[8], blob_entry4);  // skip
+    ASSERT_EQ(batch[9], blob_entry8);  // pick
+
+    auto blob_field_to_field_id = [](const std::shared_ptr<DataFileMeta>&) -> Result<int32_t> {
+        return 0;
+    };
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<DataEvolutionSplitRead::FieldBunch>> bunch,
+                         DataEvolutionSplitRead::SplitFieldBunches(
+                             batch, blob_field_to_field_id, /*has_row_ranges_selection=*/false));
+
+    ASSERT_EQ(bunch.size(), 2);
+    auto blob_bunch = std::dynamic_pointer_cast<DataEvolutionSplitRead::BlobBunch>(bunch[1]);
+
+    ASSERT_EQ(blob_bunch->Files().size(), 4);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_entry5);
+    ASSERT_EQ(blob_bunch->Files()[1], blob_entry9);
+    ASSERT_EQ(blob_bunch->Files()[2], blob_entry7);
+    ASSERT_EQ(blob_bunch->Files()[3], blob_entry8);
+    ASSERT_EQ(blob_bunch->RowCount(), 1000);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestComplexBlobBunchScenario3) {
+    std::vector<std::shared_ptr<DataFileMeta>> waited;
+    auto data = CreateNormalFile("others.parquet", /*first_row_id=*/0, /*row_count=*/1000,
+                                 /*max_sequence_number=*/1);
+    auto blob_entry1 =
+        CreateBlobFile("blob1", /*first_row_id=*/0, /*row_count=*/1000,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"1"}));
+    auto blob_entry2 =
+        CreateBlobFile("blob2", /*first_row_id=*/0, /*row_count=*/500,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"1"}));
+    auto blob_entry3 =
+        CreateBlobFile("blob3", /*first_row_id=*/500, /*row_count=*/250,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"1"}));
+    auto blob_entry4 =
+        CreateBlobFile("blob4", /*first_row_id=*/750, /*row_count=*/250,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"1"}));
+    auto blob_entry5 =
+        CreateBlobFile("blob5", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"1"}));
+    auto blob_entry6 =
+        CreateBlobFile("blob6", /*first_row_id=*/100, /*row_count=*/400,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"1"}));
+    auto blob_entry7 =
+        CreateBlobFile("blob7", /*first_row_id=*/750, /*row_count=*/100,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"1"}));
+    auto blob_entry8 =
+        CreateBlobFile("blob8", /*first_row_id=*/850, /*row_count=*/150,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"1"}));
+    auto blob_entry9 =
+        CreateBlobFile("blob9", /*first_row_id=*/100, /*row_count=*/650,
+                       /*max_sequence_number=*/4,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"1"}));
+
+    auto blob_entry11 =
+        CreateBlobFile("blob11", /*first_row_id=*/0, /*row_count=*/1000,
+                       /*max_sequence_number=*/1,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"2"}));
+    auto blob_entry12 =
+        CreateBlobFile("blob12", /*first_row_id=*/0, /*row_count=*/500,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"2"}));
+    auto blob_entry13 =
+        CreateBlobFile("blob13", /*first_row_id=*/500, /*row_count=*/250,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"2"}));
+    auto blob_entry14 =
+        CreateBlobFile("blob14", /*first_row_id=*/750, /*row_count=*/250,
+                       /*max_sequence_number=*/2,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"2"}));
+    auto blob_entry15 =
+        CreateBlobFile("blob15", /*first_row_id=*/0, /*row_count=*/100,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"2"}));
+    auto blob_entry16 =
+        CreateBlobFile("blob16", /*first_row_id=*/100, /*row_count=*/400,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"2"}));
+    auto blob_entry17 =
+        CreateBlobFile("blob17", /*first_row_id=*/750, /*row_count=*/100,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"2"}));
+    auto blob_entry18 =
+        CreateBlobFile("blob18", /*first_row_id=*/850, /*row_count=*/150,
+                       /*max_sequence_number=*/3,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"2"}));
+    auto blob_entry19 =
+        CreateBlobFile("blob19", /*first_row_id=*/100, /*row_count=*/650,
+                       /*max_sequence_number=*/4,
+                       /*write_cols=*/std::optional<std::vector<std::string>>({"2"}));
+    waited.push_back(data);
+    waited.push_back(blob_entry1);
+    waited.push_back(blob_entry2);
+    waited.push_back(blob_entry3);
+    waited.push_back(blob_entry4);
+    waited.push_back(blob_entry5);
+    waited.push_back(blob_entry6);
+    waited.push_back(blob_entry7);
+    waited.push_back(blob_entry8);
+    waited.push_back(blob_entry9);
+
+    waited.push_back(blob_entry11);
+    waited.push_back(blob_entry12);
+    waited.push_back(blob_entry13);
+    waited.push_back(blob_entry14);
+    waited.push_back(blob_entry15);
+    waited.push_back(blob_entry16);
+    waited.push_back(blob_entry17);
+    waited.push_back(blob_entry18);
+    waited.push_back(blob_entry19);
+
+    auto input_metas = waited;
+    ASSERT_OK_AND_ASSIGN(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> batches,
+                         DataEvolutionSplitRead::MergeRangesAndSort(std::move(input_metas)));
+    ASSERT_EQ(batches.size(), 1);
+
+    std::vector<std::shared_ptr<DataFileMeta>> batch = batches[0];
+    auto blob_field_to_field_id = [](const std::shared_ptr<DataFileMeta>& meta) -> Result<int32_t> {
+        return std::stoi(meta->write_cols.value()[0]);
+    };
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<DataEvolutionSplitRead::FieldBunch>> bunch,
+                         DataEvolutionSplitRead::SplitFieldBunches(
+                             batch, blob_field_to_field_id, /*has_row_ranges_selection=*/false));
+
+    ASSERT_EQ(bunch.size(), 3);
+    auto blob_bunch = std::dynamic_pointer_cast<DataEvolutionSplitRead::BlobBunch>(bunch[1]);
+    ASSERT_EQ(blob_bunch->Files().size(), 4);
+    ASSERT_EQ(blob_bunch->Files()[0], blob_entry5);
+    ASSERT_EQ(blob_bunch->Files()[1], blob_entry9);
+    ASSERT_EQ(blob_bunch->Files()[2], blob_entry7);
+    ASSERT_EQ(blob_bunch->Files()[3], blob_entry8);
+    ASSERT_EQ(blob_bunch->RowCount(), 1000);
+
+    auto blob_bunch2 = std::dynamic_pointer_cast<DataEvolutionSplitRead::BlobBunch>(bunch[2]);
+    ASSERT_EQ(blob_bunch2->Files().size(), 4);
+    ASSERT_EQ(blob_bunch2->Files()[0], blob_entry15);
+    ASSERT_EQ(blob_bunch2->Files()[1], blob_entry19);
+    ASSERT_EQ(blob_bunch2->Files()[2], blob_entry17);
+    ASSERT_EQ(blob_bunch2->Files()[3], blob_entry18);
+    ASSERT_EQ(blob_bunch2->RowCount(), 1000);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestDifferentRowIdRange) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateNormalFile("file0.parquet", 1l, 100, 10),
+        CreateNormalFile("file1.parquet", 1l, 50, 20)};
+    ASSERT_NOK_WITH_MSG(DataEvolutionSplitRead::MergeRangesAndSort(std::move(files)),
+                        "Data files should be all row id ranges same.");
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestSplitWithSameFirstRowId) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {CreateDataFileMeta("file0", 1l, 1, 10),
+                                                        CreateDataFileMeta("file1", 1l, 1, 20),
+                                                        CreateDataFileMeta("file2", 1l, 1, 30)};
+    auto tmp_files = files;
+    ASSERT_OK_AND_ASSIGN(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> split_metas,
+                         DataEvolutionSplitRead::MergeRangesAndSort(std::move(tmp_files)));
+    std::vector<std::vector<std::shared_ptr<DataFileMeta>>> expected_metas = {
+        {files[2], files[1], files[0]}};
+    ASSERT_EQ(expected_metas, split_metas);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestSplitWithMixedFirstRowId) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateDataFileMeta("file0", 1l, 1, 1), CreateDataFileMeta("file1", 2l, 1, 2),
+        CreateDataFileMeta("file2", 1l, 1, 3), CreateDataFileMeta("file3", 2l, 1, 4),
+        CreateDataFileMeta("file4", 3l, 1, 5),
+    };
+    auto tmp_files = files;
+    ASSERT_OK_AND_ASSIGN(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> split_metas,
+                         DataEvolutionSplitRead::MergeRangesAndSort(std::move(tmp_files)));
+    std::vector<std::vector<std::shared_ptr<DataFileMeta>>> expected_metas = {
+        {files[2], files[0]}, {files[3], files[1]}, {files[4]}};
+    ASSERT_EQ(expected_metas, split_metas);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestSplitWithComplexScenario) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateDataFileMeta("file0", 1l, 1, 1), CreateDataFileMeta("file1", 2l, 1, 3),
+        CreateDataFileMeta("file2", 3l, 1, 5), CreateDataFileMeta("file3", 1l, 1, 2),
+        CreateDataFileMeta("file4", 4l, 1, 8), CreateDataFileMeta("file5", 2l, 1, 4),
+        CreateDataFileMeta("file6", 3l, 1, 6), CreateDataFileMeta("file7", 3l, 1, 7),
+        CreateDataFileMeta("file8", 5l, 1, 9),
+    };
+    auto tmp_files = files;
+    ASSERT_OK_AND_ASSIGN(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> split_metas,
+                         DataEvolutionSplitRead::MergeRangesAndSort(std::move(tmp_files)));
+    std::vector<std::vector<std::shared_ptr<DataFileMeta>>> expected_metas = {
+        {files[3], files[0]},
+        {files[5], files[1]},
+        {files[7], files[6], files[2]},
+        {files[4]},
+        {files[8]}};
+    ASSERT_EQ(expected_metas, split_metas);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestSplitWithMultipleBlobFilesPerGroup) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateDataFileMeta("file0.parquet", 1l, 10, 1),
+        CreateDataFileMeta("file1.blob", 1l, 1, 1),
+        CreateDataFileMeta("file2.blob", 2l, 9, 1),
+        CreateDataFileMeta("file3.parquet", 20l, 10, 2),
+        CreateDataFileMeta("file4.blob", 20l, 5, 2),
+        CreateDataFileMeta("file5.blob", 25l, 5, 2),
+        CreateDataFileMeta("file6.parquet", 1l, 10, 3)};
+    auto tmp_files = files;
+    ASSERT_OK_AND_ASSIGN(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> split_metas,
+                         DataEvolutionSplitRead::MergeRangesAndSort(std::move(tmp_files)));
+    std::vector<std::vector<std::shared_ptr<DataFileMeta>>> expected_metas = {
+        {files[6], files[0], files[1], files[2]}, {files[3], files[4], files[5]}};
+    ASSERT_EQ(expected_metas, split_metas);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/operation/raw_file_split_read.cpp
+++ b/src/paimon/core/operation/raw_file_split_read.cpp
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/raw_file_split_read.h"
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "paimon/common/file_index/bitmap/apply_bitmap_index_batch_reader.h"
+#include "paimon/common/reader/complete_row_kind_batch_reader.h"
+#include "paimon/common/reader/concat_batch_reader.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/object_utils.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
+#include "paimon/core/deletionvectors/deletion_vector.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/file_index_evaluator.h"
+#include "paimon/core/operation/internal_read_context.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/file_index/bitmap_index_result.h"
+#include "paimon/file_index/file_index_result.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/reader/file_batch_reader.h"
+#include "paimon/status.h"
+#include "paimon/table/source/data_split.h"
+#include "paimon/utils/roaring_bitmap32.h"
+
+namespace paimon {
+class DataFilePathFactory;
+class Executor;
+class Predicate;
+
+RawFileSplitRead::RawFileSplitRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
+                                   const std::shared_ptr<InternalReadContext>& context,
+                                   const std::shared_ptr<MemoryPool>& memory_pool,
+                                   const std::shared_ptr<Executor>& executor)
+    : AbstractSplitRead(path_factory, context,
+                        std::make_unique<SchemaManager>(context->GetCoreOptions().GetFileSystem(),
+                                                        context->GetPath(),
+                                                        context->GetCoreOptions().GetBranch()),
+                        memory_pool, executor) {}
+
+Result<std::unique_ptr<BatchReader>> RawFileSplitRead::CreateReader(
+    const std::shared_ptr<Split>& split) {
+    auto data_split = std::dynamic_pointer_cast<DataSplitImpl>(split);
+    if (!data_split) {
+        return Status::Invalid("cannot cast split to data_split in RawFileSplitRead");
+    }
+    return CreateReader(data_split->Partition(), data_split->Bucket(), data_split->DataFiles(),
+                        data_split->DeletionFiles());
+}
+
+Result<std::unique_ptr<BatchReader>> RawFileSplitRead::CreateReader(
+    const BinaryRow& partition, int32_t bucket,
+    const std::vector<std::shared_ptr<DataFileMeta>>& data_files,
+    DeletionVector::Factory dv_factory) {
+    const auto& predicate = context_->GetPredicate();
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<DataFilePathFactory> data_file_path_factory,
+                           path_factory_->CreateDataFilePathFactory(partition, bucket));
+
+    PAIMON_ASSIGN_OR_RAISE(
+        std::vector<std::unique_ptr<FileBatchReader>> raw_file_readers,
+        CreateRawFileReaders(partition, data_files, raw_read_schema_, predicate, dv_factory,
+                             /*row_ranges=*/{}, data_file_path_factory));
+
+    auto raw_readers =
+        ObjectUtils::MoveVector<std::unique_ptr<BatchReader>>(std::move(raw_file_readers));
+    auto concat_batch_reader = std::make_unique<ConcatBatchReader>(std::move(raw_readers), pool_);
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> batch_reader,
+                           ApplyPredicateFilterIfNeeded(std::move(concat_batch_reader), predicate));
+    return std::make_unique<CompleteRowKindBatchReader>(std::move(batch_reader), pool_);
+}
+
+Result<std::unique_ptr<BatchReader>> RawFileSplitRead::CreateReader(
+    const BinaryRow& partition, int32_t bucket,
+    const std::vector<std::shared_ptr<DataFileMeta>>& data_files,
+    const std::vector<std::optional<DeletionFile>>& deletion_files) {
+    auto dv_factory = DeletionVector::CreateFactory(
+        options_.GetFileSystem(), CreateDeletionFileMap(data_files, deletion_files), pool_);
+    return CreateReader(partition, bucket, data_files, dv_factory);
+}
+
+Result<bool> RawFileSplitRead::Match(const std::shared_ptr<Split>& split,
+                                     bool force_keep_delete) const {
+    auto split_impl = dynamic_cast<DataSplitImpl*>(split.get());
+    if (split_impl == nullptr) {
+        return Status::Invalid("unexpected error, split cast to impl failed");
+    }
+    if (context_->GetTableSchema()->PrimaryKeys().empty()) {
+        // for append table, always return true
+        return true;
+    }
+    bool matched = !force_keep_delete && !split_impl->IsStreaming() && split_impl->RawConvertible();
+    if (matched) {
+        // for legacy version, we are not sure if there are delete rows, but in order to be
+        // compatible with the query acceleration of the OLAP engine, we have generated raw
+        // files.
+        // Here, for the sake of correctness, we still need to perform drop delete filtering.
+        for (const auto& file : split_impl->DataFiles()) {
+            if (file->delete_row_count == std::nullopt) {
+                return false;
+            }
+        }
+    }
+    return matched;
+}
+
+Result<std::unique_ptr<FileBatchReader>> RawFileSplitRead::ApplyIndexAndDvReaderIfNeeded(
+    std::unique_ptr<FileBatchReader>&& file_reader, const std::shared_ptr<DataFileMeta>& file,
+    const std::shared_ptr<arrow::Schema>& data_schema,
+    const std::shared_ptr<arrow::Schema>& read_schema, const std::shared_ptr<Predicate>& predicate,
+    DeletionVector::Factory dv_factory, const std::optional<std::vector<Range>>& ranges,
+    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const {
+    std::shared_ptr<FileIndexResult> file_index_result;
+    if (options_.FileIndexReadEnabled()) {
+        PAIMON_ASSIGN_OR_RAISE(
+            file_index_result,
+            FileIndexEvaluator::Evaluate(data_schema, predicate, data_file_path_factory, file,
+                                         options_.GetFileSystem(), pool_));
+        PAIMON_ASSIGN_OR_RAISE(bool is_remain, file_index_result->IsRemain());
+        if (!is_remain) {
+            return std::unique_ptr<FileBatchReader>();
+        }
+    }
+    // prepare selection bitmap for index
+    const RoaringBitmap32* selection = nullptr;
+    if (auto* bitmap_file_index = dynamic_cast<BitmapIndexResult*>(file_index_result.get())) {
+        PAIMON_ASSIGN_OR_RAISE(selection, bitmap_file_index->GetBitmap());
+    }
+
+    // prepare deletion bitmap for deletion vector
+    std::shared_ptr<DeletionVector> deletion_vector;
+    if (dv_factory) {
+        PAIMON_ASSIGN_OR_RAISE(deletion_vector, dv_factory(file->file_name));
+    }
+    const RoaringBitmap32* deletion = nullptr;
+    if (auto* bitmap_dv = dynamic_cast<BitmapDeletionVector*>(deletion_vector.get())) {
+        deletion = bitmap_dv->GetBitmap();
+    }
+
+    // merge deletion and bitmap index selection
+    std::optional<RoaringBitmap32> actual_selection;
+    if (selection && deletion) {
+        actual_selection = RoaringBitmap32::AndNot(*selection, *deletion);
+    } else if (selection) {
+        actual_selection = *selection;
+    } else if (deletion) {
+        actual_selection = *deletion;
+        PAIMON_ASSIGN_OR_RAISE(uint64_t num_rows, file_reader->GetNumberOfRows());
+        actual_selection.value().Flip(0, num_rows);
+    }
+
+    if (actual_selection && actual_selection.value().IsEmpty()) {
+        return std::unique_ptr<FileBatchReader>();
+    }
+
+    ::ArrowSchema c_read_schema;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportSchema(*read_schema, &c_read_schema));
+    PAIMON_RETURN_NOT_OK(file_reader->SetReadSchema(&c_read_schema, predicate, actual_selection));
+
+    std::unique_ptr<FileBatchReader> reader;
+    if (!file_reader->SupportPreciseBitmapSelection() && actual_selection) {
+        // several format(e.g. lance, blob) will return accurate batch result, where
+        // ApplyBitmapIndexBatchReader is not necessary
+        reader = std::make_unique<ApplyBitmapIndexBatchReader>(std::move(file_reader),
+                                                               std::move(actual_selection).value());
+    } else {
+        reader = std::move(file_reader);
+    }
+
+    if (deletion_vector && !deletion && !deletion_vector->IsEmpty()) {
+        // TODO(xinyu.lxy): if deletion vector is bitmap64, use ApplyBitmapIndexBatchReader to
+        // filter result
+        return Status::NotImplemented("Only support BitmapDeletionVector");
+    }
+    return std::move(reader);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/operation/raw_file_split_read.h
+++ b/src/paimon/core/operation/raw_file_split_read.h
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "paimon/core/core_options.h"
+#include "paimon/core/deletionvectors/deletion_vector.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/operation/abstract_split_read.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/read_context.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class Schema;
+}
+
+namespace paimon {
+class DataFilePathFactory;
+class DataSplit;
+class Executor;
+class FileBatchReader;
+class FileStorePathFactory;
+class InternalReadContext;
+class MemoryPool;
+class Predicate;
+struct DataFileMeta;
+struct DeletionFile;
+
+/// If the class name below is enclosed in parentheses, it might be present in the read path;
+/// otherwise, it must be present in the read path.
+///
+/// Readers Overview: (ConcatBatchReader across
+/// splits)->CompleteRowKindBatchReader->(PredicateBatchReader)
+/// ->ConcatBatchReader across
+/// files->FieldMappingReader->(ApplyBitmapIndexBatchReader)->(CompleteRowTrackingFieldsBatchReader)
+/// ->(DelegatingPrefetchReader)->(PrefetchFileBatchReader)->FormatReader
+
+class RawFileSplitRead : public AbstractSplitRead {
+ public:
+    RawFileSplitRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
+                     const std::shared_ptr<InternalReadContext>& context,
+                     const std::shared_ptr<MemoryPool>& memory_pool,
+                     const std::shared_ptr<Executor>& executor);
+
+    Result<std::unique_ptr<BatchReader>> CreateReader(const std::shared_ptr<Split>& split) override;
+    Result<std::unique_ptr<BatchReader>> CreateReader(
+        const BinaryRow& partition, int32_t bucket,
+        const std::vector<std::shared_ptr<DataFileMeta>>& files,
+        const std::vector<std::optional<DeletionFile>>& deletion_files);
+
+    Result<std::unique_ptr<BatchReader>> CreateReader(
+        const BinaryRow& partition, int32_t bucket,
+        const std::vector<std::shared_ptr<DataFileMeta>>& files,
+        DeletionVector::Factory dv_factory);
+
+    Result<bool> Match(const std::shared_ptr<Split>& split, bool force_keep_delete) const override;
+
+    Result<std::unique_ptr<FileBatchReader>> ApplyIndexAndDvReaderIfNeeded(
+        std::unique_ptr<FileBatchReader>&& file_reader, const std::shared_ptr<DataFileMeta>& file,
+        const std::shared_ptr<arrow::Schema>& data_schema,
+        const std::shared_ptr<arrow::Schema>& read_schema,
+        const std::shared_ptr<Predicate>& predicate, DeletionVector::Factory dv_factory,
+        const std::optional<std::vector<Range>>& ranges,
+        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/operation/raw_file_split_read_test.cpp
+++ b/src/paimon/core/operation/raw_file_split_read_test.cpp
@@ -1,0 +1,510 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/operation/raw_file_split_read.h"
+
+#include <optional>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/reader/concat_batch_reader.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/operation/internal_read_context.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/executor.h"
+#include "paimon/format/file_format.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/read_context.h"
+#include "paimon/status.h"
+#include "paimon/table/source/data_split.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class RawFileSplitReadTest : public ::testing::Test {
+    std::vector<std::shared_ptr<DataSplit>> PrepareDataSplits() const {
+        auto meta1 = std::make_shared<DataFileMeta>(
+            "data-01b6a930-6564-409b-b8f4-ed1307790d72-0.orc", /*file_size=*/575, /*row_count=*/3,
+            /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+            /*key_stats=*/SimpleStats::EmptyStats(),
+            BinaryRowGenerator::GenerateStats({std::string("Bob"), 10, 0, 12.1},
+                                              {std::string("Tony"), 10, 0, 14.1}, {0, 0, 0, 0},
+                                              pool_.get()),
+            /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+            /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(1728497439433ll, 0),
+            /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+            /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+            /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt);
+        DataSplitImpl::Builder builder1(BinaryRowGenerator::GenerateRow({10, 0}, pool_.get()),
+                                        /*bucket=*/0, /*bucket_path=*/
+                                        paimon::test::GetDataDir() +
+                                            "/orc/multi_partition_append_table.db/"
+                                            "multi_partition_append_table/f1=10/f2=0/bucket-0",
+                                        {meta1});
+        EXPECT_OK_AND_ASSIGN(
+            auto data_split1,
+            builder1.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build());
+
+        auto meta2 = std::make_shared<DataFileMeta>(
+            "data-b79de94d-abe4-47d6-8e6c-911816487252-0.orc", /*file_size=*/541, /*row_count=*/1,
+            /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+            /*key_stats=*/SimpleStats::EmptyStats(),
+            BinaryRowGenerator::GenerateStats({std::string("Lucy"), 20, 1, 14.1},
+                                              {std::string("Lucy"), 20, 1, 14.1}, {0, 0, 0, 0},
+                                              pool_.get()),
+            /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/0,
+            /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(1728497439453ll, 0),
+            /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+            /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+            /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt);
+        DataSplitImpl::Builder builder2(BinaryRowGenerator::GenerateRow({20, 1}, pool_.get()),
+                                        /*bucket=*/0, /*bucket_path=*/
+                                        paimon::test::GetDataDir() +
+                                            "/orc/multi_partition_append_table.db/"
+                                            "multi_partition_append_table/f1=20/f2=1/bucket-0",
+                                        {meta2});
+        EXPECT_OK_AND_ASSIGN(
+            auto data_split2,
+            builder2.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build());
+
+        auto meta3 = std::make_shared<DataFileMeta>(
+            "data-955cbedd-ffcc-4234-8b98-4c3f08f78309-0.orc", /*file_size=*/543, /*row_count=*/1,
+            /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+            /*key_stats=*/SimpleStats::EmptyStats(),
+            BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 1, 11.1},
+                                              {std::string("Alice"), 10, 1, 11.1}, {0, 0, 0, 0},
+                                              pool_.get()),
+            /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/0,
+            /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(1728497439469ll, 0),
+            /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+            /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+            /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt);
+        DataSplitImpl::Builder builder3(BinaryRowGenerator::GenerateRow({10, 1}, pool_.get()),
+                                        /*bucket=*/0, /*bucket_path=*/
+                                        paimon::test::GetDataDir() +
+                                            "/orc/multi_partition_append_table.db/"
+                                            "multi_partition_append_table/f1=10/f2=1/bucket-0",
+                                        {meta3});
+        EXPECT_OK_AND_ASSIGN(
+            auto data_split3,
+            builder3.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build());
+        std::vector<std::shared_ptr<DataSplit>> data_splits = {data_split1, data_split2,
+                                                               data_split3};
+        return data_splits;
+    }
+
+    void CheckReadResult(const std::shared_ptr<arrow::Schema>& read_schema,
+                         const std::shared_ptr<arrow::ChunkedArray>& expected_array) const {
+        std::string path = paimon::test::GetDataDir() +
+                           "/orc/multi_partition_append_table.db/"
+                           "multi_partition_append_table";
+        ReadContextBuilder context_builder(path);
+        context_builder.SetReadSchema(read_schema->field_names());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<ReadContext> read_context, context_builder.Finish());
+        SchemaManager schema_manager(std::make_shared<LocalFileSystem>(), read_context->GetPath());
+        ASSERT_OK_AND_ASSIGN(auto table_schema, schema_manager.ReadSchema(0));
+
+        ASSERT_OK_AND_ASSIGN(auto internal_context,
+                             InternalReadContext::Create(std::move(read_context), table_schema,
+                                                         table_schema->Options()));
+        auto data_splits = PrepareDataSplits();
+        const auto& core_options = internal_context->GetCoreOptions();
+        auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+        ASSERT_OK_AND_ASSIGN(std::vector<std::string> external_paths,
+                             core_options.CreateExternalPaths());
+        ASSERT_OK_AND_ASSIGN(std::optional<std::string> global_index_external_path,
+                             core_options.CreateGlobalIndexExternalPath());
+
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<FileStorePathFactory> path_factory,
+            FileStorePathFactory::Create(
+                internal_context->GetPath(), arrow_schema, table_schema->PartitionKeys(),
+                core_options.GetPartitionDefaultName(), core_options.GetFileFormat()->Identifier(),
+                core_options.DataFilePrefix(), core_options.LegacyPartitionNameEnabled(),
+                external_paths, global_index_external_path, core_options.IndexFileInDataFileDir(),
+                pool_));
+        auto split_read =
+            std::make_unique<RawFileSplitRead>(path_factory, std::move(internal_context), pool_,
+                                               CreateDefaultExecutor(/*thread_count=*/2));
+
+        std::vector<std::unique_ptr<BatchReader>> batch_readers;
+        batch_readers.reserve(data_splits.size());
+        for (const auto& split : data_splits) {
+            ASSERT_OK_AND_ASSIGN(std::unique_ptr<BatchReader> reader,
+                                 split_read->CreateReader(split));
+            batch_readers.emplace_back(std::move(reader));
+        }
+        auto batch_reader = std::make_unique<ConcatBatchReader>(std::move(batch_readers), pool_);
+        ASSERT_OK_AND_ASSIGN(auto result_array,
+                             ReadResultCollector::CollectResult(batch_reader.get()));
+        ASSERT_TRUE(result_array->Equals(expected_array));
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+};
+
+// test simple, recall all columns with sequence in data
+TEST_F(RawFileSplitReadTest, TestCreateReader) {
+    std::vector<DataField> read_fields = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(1, arrow::field("f1", arrow::int32())),
+                                          DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(3, arrow::field("f3", arrow::float64()))};
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto fields_with_row_kind = read_schema->fields();
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+
+    std::shared_ptr<arrow::ChunkedArray> expected_array;
+    auto array_status =
+        arrow::ipc::internal::json::ChunkedArrayFromJSON(arrow::struct_(fields_with_row_kind), {R"([
+      [0, "Bob", 10, 0, 12.1],
+      [0, "Emily", 10, 0, 13.1],
+      [0, "Tony", 10, 0, 14.1],
+      [0, "Lucy", 20, 1, 14.1],
+      [0, "Alice", 10, 1, 11.1]
+    ])"},
+                                                         &expected_array);
+    ASSERT_TRUE(array_status.ok());
+    CheckReadResult(read_schema, expected_array);
+}
+
+// recall all columns with reverse sequence in data
+TEST_F(RawFileSplitReadTest, TestCreateReaderWithReserveSequence) {
+    std::vector<DataField> read_fields = {DataField(3, arrow::field("f3", arrow::float64())),
+                                          DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(1, arrow::field("f1", arrow::int32())),
+                                          DataField(0, arrow::field("f0", arrow::utf8()))};
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto fields_with_row_kind = read_schema->fields();
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+
+    std::shared_ptr<arrow::ChunkedArray> expected_array;
+    auto array_status =
+        arrow::ipc::internal::json::ChunkedArrayFromJSON(arrow::struct_(fields_with_row_kind), {R"([
+      [0, 12.1, 0, 10, "Bob"],
+      [0, 13.1, 0, 10, "Emily"],
+      [0, 14.1, 0, 10, "Tony"],
+      [0, 14.1, 1, 20, "Lucy"],
+      [0, 11.1, 1, 10, "Alice"]
+    ])"},
+                                                         &expected_array);
+    ASSERT_TRUE(array_status.ok());
+    CheckReadResult(read_schema, expected_array);
+}
+
+// recall all partition columns with sequence in data
+TEST_F(RawFileSplitReadTest, TestCreateReaderWithPartitionKeys) {
+    std::vector<DataField> read_fields = {DataField(1, arrow::field("f1", arrow::int32())),
+                                          DataField(2, arrow::field("f2", arrow::int32()))};
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto fields_with_row_kind = read_schema->fields();
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+
+    std::shared_ptr<arrow::ChunkedArray> expected_array;
+    auto array_status =
+        arrow::ipc::internal::json::ChunkedArrayFromJSON(arrow::struct_(fields_with_row_kind), {R"([
+      [0, 10, 0],
+      [0, 10, 0],
+      [0, 10, 0],
+      [0, 20, 1],
+      [0, 10, 1]
+    ])"},
+                                                         &expected_array);
+    ASSERT_TRUE(array_status.ok());
+    CheckReadResult(read_schema, expected_array);
+}
+
+// recall all partition columns with reverse sequence in data
+TEST_F(RawFileSplitReadTest, TestCreateReaderWithPartitionKeysWithReverseSequence) {
+    std::vector<DataField> read_fields = {DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(1, arrow::field("f1", arrow::int32()))};
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto fields_with_row_kind = read_schema->fields();
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+
+    std::shared_ptr<arrow::ChunkedArray> expected_array;
+    auto array_status =
+        arrow::ipc::internal::json::ChunkedArrayFromJSON(arrow::struct_(fields_with_row_kind), {R"([
+      [0, 0, 10],
+      [0, 0, 10],
+      [0, 0, 10],
+      [0, 1, 20],
+      [0, 1, 10]
+    ])"},
+                                                         &expected_array);
+    ASSERT_TRUE(array_status.ok());
+    CheckReadResult(read_schema, expected_array);
+}
+
+// recall part partition keys with sequence in data
+TEST_F(RawFileSplitReadTest, TestCreateReaderWithPartPartition) {
+    std::vector<DataField> read_fields = {DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(3, arrow::field("f3", arrow::float64()))};
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto fields_with_row_kind = read_schema->fields();
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+
+    std::shared_ptr<arrow::ChunkedArray> expected_array;
+    auto array_status =
+        arrow::ipc::internal::json::ChunkedArrayFromJSON(arrow::struct_(fields_with_row_kind), {R"([
+      [0, 0, 12.1],
+      [0, 0, 13.1],
+      [0, 0, 14.1],
+      [0, 1, 14.1],
+      [0, 1, 11.1]
+    ])"},
+                                                         &expected_array);
+    ASSERT_TRUE(array_status.ok());
+    CheckReadResult(read_schema, expected_array);
+}
+
+// recall part partition keys with reverse sequence in data
+TEST_F(RawFileSplitReadTest, TestCreateReaderWithPartPartitionWithReserveSequence) {
+    std::vector<DataField> read_fields = {DataField(1, arrow::field("f1", arrow::int32())),
+                                          DataField(0, arrow::field("f0", arrow::utf8()))};
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto fields_with_row_kind = read_schema->fields();
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+
+    std::shared_ptr<arrow::ChunkedArray> expected_array;
+    auto array_status =
+        arrow::ipc::internal::json::ChunkedArrayFromJSON(arrow::struct_(fields_with_row_kind), {R"([
+      [0, 10, "Bob"],
+      [0, 10, "Emily"],
+      [0, 10, "Tony"],
+      [0, 20, "Lucy"],
+      [0, 10, "Alice"]
+    ])"},
+                                                         &expected_array);
+    ASSERT_TRUE(array_status.ok());
+    CheckReadResult(read_schema, expected_array);
+}
+
+// recall non partition columns with sequence in data
+TEST_F(RawFileSplitReadTest, TestCreateReaderWithNonPartition) {
+    std::vector<DataField> read_fields = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                          DataField(3, arrow::field("f3", arrow::float64()))};
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto fields_with_row_kind = read_schema->fields();
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+
+    std::shared_ptr<arrow::ChunkedArray> expected_array;
+    auto array_status =
+        arrow::ipc::internal::json::ChunkedArrayFromJSON(arrow::struct_(fields_with_row_kind), {R"([
+      [0, "Bob", 12.1],
+      [0, "Emily", 13.1],
+      [0, "Tony", 14.1],
+      [0, "Lucy", 14.1],
+      [0, "Alice", 11.1]
+    ])"},
+                                                         &expected_array);
+    ASSERT_TRUE(array_status.ok());
+    CheckReadResult(read_schema, expected_array);
+}
+
+// recall non partition columns with reverse sequence in data
+TEST_F(RawFileSplitReadTest, TestCreateReaderWithNonPartitionWithReserveSequence) {
+    std::vector<DataField> read_fields = {DataField(3, arrow::field("f3", arrow::float64())),
+                                          DataField(0, arrow::field("f0", arrow::utf8()))};
+    auto read_schema = DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto fields_with_row_kind = read_schema->fields();
+    fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                arrow::field("_VALUE_KIND", arrow::int8()));
+
+    std::shared_ptr<arrow::ChunkedArray> expected_array;
+    auto array_status =
+        arrow::ipc::internal::json::ChunkedArrayFromJSON(arrow::struct_(fields_with_row_kind), {R"([
+      [0, 12.1, "Bob"],
+      [0, 13.1, "Emily"],
+      [0, 14.1, "Tony"],
+      [0, 14.1, "Lucy"],
+      [0, 11.1, "Alice"]
+    ])"},
+                                                         &expected_array);
+    ASSERT_TRUE(array_status.ok());
+    CheckReadResult(read_schema, expected_array);
+}
+
+TEST_F(RawFileSplitReadTest, TestEmptyPlan) {
+    std::string path = paimon::test::GetDataDir() +
+                       "/orc/multi_partition_append_table.db/"
+                       "multi_partition_append_table";
+    ReadContextBuilder context_builder(path);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<ReadContext> read_context, context_builder.Finish());
+    SchemaManager schema_manager(std::make_shared<LocalFileSystem>(), read_context->GetPath());
+    ASSERT_OK_AND_ASSIGN(auto table_schema, schema_manager.ReadSchema(0));
+
+    ASSERT_OK_AND_ASSIGN(auto internal_context,
+                         InternalReadContext::Create(std::move(read_context), table_schema,
+                                                     table_schema->Options()));
+    const auto& core_options = internal_context->GetCoreOptions();
+    auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> external_paths,
+                         core_options.CreateExternalPaths());
+    ASSERT_OK_AND_ASSIGN(std::optional<std::string> global_index_external_path,
+                         core_options.CreateGlobalIndexExternalPath());
+
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<FileStorePathFactory> path_factory,
+        FileStorePathFactory::Create(
+            internal_context->GetPath(), arrow_schema, table_schema->PartitionKeys(),
+            core_options.GetPartitionDefaultName(), core_options.GetFileFormat()->Identifier(),
+            core_options.DataFilePrefix(), core_options.LegacyPartitionNameEnabled(),
+            external_paths, global_index_external_path, core_options.IndexFileInDataFileDir(),
+            pool_));
+
+    auto split_read =
+        std::make_unique<RawFileSplitRead>(path_factory, std::move(internal_context), pool_,
+                                           CreateDefaultExecutor(/*thread_count=*/2));
+    DataSplitImpl::Builder builder(BinaryRowGenerator::GenerateRow({10, 0}, pool_.get()),
+                                   /*bucket=*/0, /*bucket_path=*/
+                                   paimon::test::GetDataDir() +
+                                       "/orc/multi_partition_append_table.db/"
+                                       "multi_partition_append_table/f1=10/f2=0/bucket-0",
+                                   {});
+    ASSERT_OK_AND_ASSIGN(auto data_split,
+                         builder.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build());
+
+    std::vector<std::unique_ptr<BatchReader>> batch_readers;
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<BatchReader> reader, split_read->CreateReader(data_split));
+    batch_readers.push_back(std::move(reader));
+    auto batch_reader = std::make_unique<ConcatBatchReader>(std::move(batch_readers), pool_);
+    ASSERT_OK_AND_ASSIGN(auto result_array, ReadResultCollector::CollectResult(batch_reader.get()));
+    ASSERT_EQ(result_array, nullptr);
+}
+
+TEST_F(RawFileSplitReadTest, TestMatch) {
+    std::string path = paimon::test::GetDataDir() +
+                       "/orc/pk_table_with_total_buckets.db/pk_table_with_total_buckets";
+    ReadContextBuilder context_builder(path);
+    context_builder.SetReadSchema({"f0", "f1", "f2", "f3"});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<ReadContext> read_context, context_builder.Finish());
+    SchemaManager schema_manager(std::make_shared<LocalFileSystem>(), read_context->GetPath());
+    ASSERT_OK_AND_ASSIGN(auto table_schema, schema_manager.ReadSchema(0));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InternalReadContext> internal_context,
+                         InternalReadContext::Create(std::move(read_context), table_schema,
+                                                     table_schema->Options()));
+    auto split_read =
+        std::make_unique<RawFileSplitRead>(/*path_factory=*/nullptr, std::move(internal_context),
+                                           pool_, CreateDefaultExecutor(/*thread_count=*/2));
+    auto create_data_split = [this](bool is_streaming,
+                                    bool raw_convertible) -> std::shared_ptr<DataSplit> {
+        auto meta = std::make_shared<DataFileMeta>(
+            "data-d7725088-6bd4-4e70-9ce6-714ae93b47cc-0.orc", /*file_size=*/863, /*row_count=*/1,
+            /*min_key=*/BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool_.get()),
+            /*max_key=*/BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool_.get()),
+            /*key_stats=*/
+            BinaryRowGenerator::GenerateStats({std::string("Alice"), 1}, {std::string("Alice"), 1},
+                                              {0, 0}, pool_.get()),
+            /*value_stats=*/
+            BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 1, 11.1},
+                                              {std::string("Alice"), 10, 1, 11.1}, {0, 0, 0, 0},
+                                              pool_.get()),
+            /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/0,
+            /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(1743525392885ll, 0),
+            /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+            /*value_stats_cols=*/std::nullopt,
+            /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt);
+        DataSplitImpl::Builder builder(BinaryRowGenerator::GenerateRow({10, 0}, pool_.get()),
+                                       /*bucket=*/0, /*bucket_path=*/
+                                       paimon::test::GetDataDir() +
+                                           "/orc/multi_partition_append_table.db/"
+                                           "multi_partition_append_table/f1=10/f2=0/bucket-0",
+                                       {meta});
+        return builder.WithSnapshot(1)
+            .IsStreaming(is_streaming)
+            .RawConvertible(raw_convertible)
+            .Build()
+            .value();
+    };
+    {
+        auto data_split = create_data_split(/*is_streaming=*/false, /*raw_convertible=*/true);
+        auto split_impl = std::dynamic_pointer_cast<DataSplitImpl>(data_split);
+        ASSERT_TRUE(split_impl);
+        ASSERT_OK_AND_ASSIGN(bool match_result,
+                             split_read->Match(data_split, /*force_keep_delete=*/true));
+        ASSERT_FALSE(match_result);
+    }
+    {
+        auto data_split = create_data_split(/*is_streaming=*/false, /*raw_convertible=*/true);
+        auto split_impl = std::dynamic_pointer_cast<DataSplitImpl>(data_split);
+        ASSERT_TRUE(split_impl);
+        ASSERT_OK_AND_ASSIGN(bool match_result,
+                             split_read->Match(data_split, /*force_keep_delete=*/false));
+        ASSERT_TRUE(match_result);
+    }
+    {
+        auto data_split = create_data_split(/*is_streaming=*/true, /*raw_convertible=*/true);
+        auto split_impl = std::dynamic_pointer_cast<DataSplitImpl>(data_split);
+        ASSERT_TRUE(split_impl);
+        ASSERT_OK_AND_ASSIGN(bool match_result,
+                             split_read->Match(data_split, /*force_keep_delete=*/false));
+        ASSERT_FALSE(match_result);
+    }
+    {
+        auto data_split = create_data_split(/*is_streaming=*/false, /*raw_convertible=*/false);
+        auto split_impl = std::dynamic_pointer_cast<DataSplitImpl>(data_split);
+        ASSERT_TRUE(split_impl);
+        ASSERT_OK_AND_ASSIGN(bool match_result,
+                             split_read->Match(data_split, /*force_keep_delete=*/false));
+        ASSERT_FALSE(match_result);
+    }
+    {
+        ASSERT_NOK(split_read->Match(nullptr, /*force_keep_delete=*/false));
+    }
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Migrate split read implementations for raw file and data evolution:

Split read (`src/paimon/core/operation/`):
- `RawFileSplitRead` — reads data splits from raw data files with projection and filter pushdown (`raw_file_split_read.h/cpp`)
- `DataEvolutionSplitRead` — reads data splits with schema evolution support, handling field additions/deletions across versions (`data_evolution_split_read.h/cpp`)

<!-- What is the purpose of the change -->

### Tests
- `raw_file_split_read_test.cpp` — raw file split read with projection, filter, file index
- `data_evolution_split_read_test.cpp` — split read with schema evolution across snapshots

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Migrate-by: Aone Copilot (Claude)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
