### PR TITLE
feat: Migrate merge function module

### DIFF
--- a/src/paimon/core/mergetree/compact/deduplicate_merge_function.h
+++ b/src/paimon/core/mergetree/compact/deduplicate_merge_function.h
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <optional>
+#include <utility>
+
+#include "paimon/common/types/row_kind.h"
+#include "paimon/core/key_value.h"
+#include "paimon/core/mergetree/compact/merge_function.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+/// A `MergeFunction` where key is primary key (unique) and value is the full record, only keep
+/// the latest one.
+class DeduplicateMergeFunction : public MergeFunction {
+ public:
+    explicit DeduplicateMergeFunction(bool ignore_delete) : ignore_delete_(ignore_delete) {}
+
+    void Reset() override {
+        latest_kv_ = std::nullopt;
+    }
+
+    Status Add(KeyValue&& kv) override {
+        // In 0.7- versions, the delete records might be written into data file even when
+        // ignore-delete configured, so ignoreDelete still needs to be checked
+        if (ignore_delete_ && kv.value_kind->IsRetract()) {
+            return Status::OK();
+        }
+        latest_kv_ = std::move(kv);
+        return Status::OK();
+    }
+
+    Result<std::optional<KeyValue>> GetResult() override {
+        return std::move(latest_kv_);
+    }
+
+ private:
+    bool ignore_delete_;
+    std::optional<KeyValue> latest_kv_;
+};
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/deduplicate_merge_function_test.cpp
+++ b/src/paimon/core/mergetree/compact/deduplicate_merge_function_test.cpp
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
+
+#include <memory>
+#include <variant>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(DeduplicateMergeFunctionTest, TestSimple) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+
+    DeduplicateMergeFunction mfunc(/*ignore_delete=*/true);
+    mfunc.Reset();
+    ASSERT_EQ(std::nullopt, mfunc.GetResult().value());
+    mfunc.Reset();
+    ASSERT_OK(mfunc.Add(std::move(kv1)));
+    ASSERT_OK(mfunc.Add(std::move(kv2)));
+
+    KeyValue result_kv = std::move(mfunc.GetResult().value().value());
+    KeyValue expected(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0, /*key=*/
+                      BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                      /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValueChecker::CheckResult(expected, result_kv, /*key_arity=*/1, /*value_arity=*/1);
+
+    mfunc.Reset();
+    ASSERT_EQ(std::nullopt, mfunc.GetResult().value());
+    ASSERT_OK(mfunc.Add(std::move(kv3)));
+    result_kv = std::move(mfunc.GetResult().value().value());
+    KeyValue expected2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0, /*key=*/
+                       BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                       /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+    KeyValueChecker::CheckResult(expected2, result_kv, /*key_arity=*/1, /*value_arity=*/1);
+}
+
+TEST(DeduplicateMergeFunctionTest, TestIgnoreDelete) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Delete(), /*sequence_number=*/1, /*level=*/0,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+
+    DeduplicateMergeFunction mfunc(/*ignore_delete=*/true);
+    mfunc.Reset();
+    ASSERT_EQ(std::nullopt, mfunc.GetResult().value());
+    ASSERT_OK(mfunc.Add(std::move(kv1)));
+    ASSERT_OK(mfunc.Add(std::move(kv2)));
+    KeyValue result_kv = std::move(mfunc.GetResult().value().value());
+    KeyValue expected(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                      BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                      /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValueChecker::CheckResult(expected, result_kv, /*key_arity=*/1, /*value_arity=*/1);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/first_row_merge_function.h
+++ b/src/paimon/core/mergetree/compact/first_row_merge_function.h
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <optional>
+#include <utility>
+
+#include "paimon/common/types/row_kind.h"
+#include "paimon/core/key_value.h"
+#include "paimon/core/mergetree/compact/merge_function.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+/// A `MergeFunction` where key is primary key (unique) and value is the full record, only keep
+/// the first one.
+class FirstRowMergeFunction : public MergeFunction {
+ public:
+    explicit FirstRowMergeFunction(bool ignore_delete) : ignore_delete_(ignore_delete) {}
+
+    void Reset() override {
+        first_kv_ = std::nullopt;
+        contains_high_level_ = false;
+    }
+
+    bool ContainsHighLevel() const {
+        return contains_high_level_;
+    }
+
+    Status Add(KeyValue&& moved_kv) override {
+        KeyValue kv = std::move(moved_kv);
+        if (kv.value_kind->IsRetract()) {
+            // In 0.7- versions, the delete records might be written into data file even when
+            // ignore-delete configured, so ignoreDelete still needs to be checked
+            if (ignore_delete_) {
+                return Status::OK();
+            } else {
+                return Status::Invalid(
+                    "By default, First row merge engine can not accept DELETE/UPDATE_BEFORE "
+                    "records. You can config 'first-row.ignore-delete' to ignore the "
+                    "DELETE/UPDATE_BEFORE records.");
+            }
+        }
+
+        if (kv.level > 0) {
+            contains_high_level_ = true;
+        }
+        if (first_kv_ == std::nullopt) {
+            first_kv_ = std::move(kv);
+        }
+        return Status::OK();
+    }
+
+    Result<std::optional<KeyValue>> GetResult() override {
+        return std::move(first_kv_);
+    }
+
+ private:
+    bool ignore_delete_;
+    bool contains_high_level_ = false;
+    std::optional<KeyValue> first_kv_;
+};
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/first_row_merge_function_test.cpp
+++ b/src/paimon/core/mergetree/compact/first_row_merge_function_test.cpp
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/first_row_merge_function.h"
+
+#include <memory>
+#include <variant>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(FirstRowMergeFunctionTest, TestSimple) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/1, /*level=*/1,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/2, /*level=*/2, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+
+    FirstRowMergeFunction mfunc(/*ignore_delete=*/true);
+    mfunc.Reset();
+    ASSERT_EQ(std::nullopt, mfunc.GetResult().value());
+    ASSERT_OK(mfunc.Add(std::move(kv1)));
+    ASSERT_EQ(mfunc.contains_high_level_, false);
+    ASSERT_OK(mfunc.Add(std::move(kv2)));
+    KeyValue result_kv = std::move(mfunc.GetResult().value().value());
+    KeyValue expected(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                      BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                      /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValueChecker::CheckResult(expected, result_kv, /*key_arity=*/1, /*value_arity=*/1);
+    ASSERT_EQ(mfunc.contains_high_level_, true);
+
+    mfunc.Reset();
+    ASSERT_EQ(mfunc.contains_high_level_, false);
+    ASSERT_EQ(std::nullopt, mfunc.GetResult().value());
+    ASSERT_OK(mfunc.Add(std::move(kv3)));
+    result_kv = std::move(mfunc.GetResult().value().value());
+    KeyValue expected2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/2, /*key=*/
+                       BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                       /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+    KeyValueChecker::CheckResult(expected2, result_kv, /*key_arity=*/1, /*value_arity=*/1);
+    ASSERT_EQ(mfunc.contains_high_level_, true);
+}
+
+TEST(FirstRowMergeFunctionTest, TestIgnoreDelete) {
+    auto pool = GetDefaultPool();
+    KeyValue kv0(RowKind::Delete(), /*sequence_number=*/0, /*level=*/2,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({50}, pool.get()));
+
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Delete(), /*sequence_number=*/1, /*level=*/2,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+
+    FirstRowMergeFunction mfunc(/*ignore_delete=*/true);
+    mfunc.Reset();
+    ASSERT_EQ(std::nullopt, mfunc.GetResult().value());
+    ASSERT_OK(mfunc.Add(std::move(kv0)));
+    ASSERT_EQ(std::nullopt, mfunc.GetResult().value());
+    ASSERT_EQ(mfunc.contains_high_level_, false);
+
+    mfunc.Reset();
+    ASSERT_OK(mfunc.Add(std::move(kv1)));
+    ASSERT_EQ(mfunc.contains_high_level_, false);
+    ASSERT_OK(mfunc.Add(std::move(kv2)));
+
+    auto result_kv = std::move(mfunc.GetResult().value().value());
+    KeyValue expected(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                      BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                      /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValueChecker::CheckResult(expected, result_kv, /*key_arity=*/1, /*value_arity=*/1);
+    ASSERT_EQ(mfunc.contains_high_level_, false);
+}
+
+TEST(FirstRowMergeFunctionTest, TestDeleteRecordWithoutSetIgnoreDelete) {
+    auto pool = GetDefaultPool();
+    KeyValue kv0(RowKind::Delete(), /*sequence_number=*/0, /*level=*/2,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({50}, pool.get()));
+    FirstRowMergeFunction mfunc(/*ignore_delete=*/false);
+    mfunc.Reset();
+    ASSERT_EQ(std::nullopt, mfunc.GetResult().value());
+    ASSERT_NOK(mfunc.Add(std::move(kv0)));
+}
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/first_row_merge_function_wrapper.h
+++ b/src/paimon/core/mergetree/compact/first_row_merge_function_wrapper.h
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cassert>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "paimon/core/key_value.h"
+#include "paimon/core/mergetree/compact/first_row_merge_function.h"
+#include "paimon/core/mergetree/compact/merge_function_wrapper.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+/// Wrapper for `MergeFunction`s to produce changelog by lookup for first row.
+class FirstRowMergeFunctionWrapper : public MergeFunctionWrapper<KeyValue> {
+ public:
+    FirstRowMergeFunctionWrapper(
+        std::unique_ptr<FirstRowMergeFunction>&& merge_function,
+        std::function<Result<bool>(const std::shared_ptr<InternalRow>&)> contains)
+        : merge_function_(std::move(merge_function)), contains_(std::move(contains)) {}
+
+    void Reset() override {
+        merge_function_->Reset();
+    }
+
+    Status Add(KeyValue&& kv) override {
+        return merge_function_->Add(std::move(kv));
+    }
+
+    Result<std::optional<KeyValue>> GetResult() override {
+        PAIMON_ASSIGN_OR_RAISE(std::optional<KeyValue> result, merge_function_->GetResult());
+        if (merge_function_->ContainsHighLevel()) {
+            Reset();
+            return result;
+        }
+        if (!result) {
+            Reset();
+            return Status::Invalid(
+                "In FirstRowMergeFunctionWrapper when call GetResult, there must have a result");
+        }
+        PAIMON_ASSIGN_OR_RAISE(bool contains, contains_(result.value().key));
+        if (contains) {
+            // empty
+            Reset();
+            return std::optional<KeyValue>();
+        }
+        // new record, output changelog
+        // TODO(xinyu.lxy) support changelog
+        Reset();
+        return result;
+    }
+
+ private:
+    std::unique_ptr<FirstRowMergeFunction> merge_function_;
+    std::function<Result<bool>(const std::shared_ptr<InternalRow>&)> contains_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/first_row_merge_function_wrapper_test.cpp
+++ b/src/paimon/core/mergetree/compact/first_row_merge_function_wrapper_test.cpp
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/first_row_merge_function_wrapper.h"
+
+#include <memory>
+#include <variant>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(FirstRowMergeFunctionWrapperTest, TestSimple) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/1, /*level=*/1,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/2, /*level=*/2, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+
+    auto mfunc = std::make_unique<FirstRowMergeFunction>(/*ignore_delete=*/true);
+
+    auto contains = [](const std::shared_ptr<InternalRow>& row) { return true; };
+
+    FirstRowMergeFunctionWrapper wrapper(std::move(mfunc), std::move(contains));
+    wrapper.Reset();
+    ASSERT_OK(wrapper.Add(std::move(kv1)));
+    ASSERT_OK(wrapper.Add(std::move(kv2)));
+    ASSERT_OK(wrapper.Add(std::move(kv3)));
+    ASSERT_OK_AND_ASSIGN(auto result, wrapper.GetResult());
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result.value().sequence_number, 0);
+}
+
+TEST(FirstRowMergeFunctionWrapperTest, TestAllLevel0WithContain) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+
+    auto mfunc = std::make_unique<FirstRowMergeFunction>(/*ignore_delete=*/true);
+
+    auto contains = [](const std::shared_ptr<InternalRow>& row) { return true; };
+
+    FirstRowMergeFunctionWrapper wrapper(std::move(mfunc), std::move(contains));
+    wrapper.Reset();
+    ASSERT_OK(wrapper.Add(std::move(kv1)));
+    ASSERT_OK(wrapper.Add(std::move(kv2)));
+    ASSERT_OK(wrapper.Add(std::move(kv3)));
+    ASSERT_OK_AND_ASSIGN(auto result, wrapper.GetResult());
+    ASSERT_FALSE(result);
+}
+
+TEST(FirstRowMergeFunctionWrapperTest, TestAllLevel0WithoutContain) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+
+    auto mfunc = std::make_unique<FirstRowMergeFunction>(/*ignore_delete=*/true);
+
+    auto contains = [](const std::shared_ptr<InternalRow>& row) { return false; };
+
+    FirstRowMergeFunctionWrapper wrapper(std::move(mfunc), std::move(contains));
+    wrapper.Reset();
+    ASSERT_OK(wrapper.Add(std::move(kv1)));
+    ASSERT_OK(wrapper.Add(std::move(kv2)));
+    ASSERT_OK(wrapper.Add(std::move(kv3)));
+    ASSERT_OK_AND_ASSIGN(auto result, wrapper.GetResult());
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result.value().sequence_number, 0);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/lookup_changelog_merge_function_wrapper.h
+++ b/src/paimon/core/mergetree/compact/lookup_changelog_merge_function_wrapper.h
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/deletionvectors/bucketed_dv_maintainer.h"
+#include "paimon/core/key_value.h"
+#include "paimon/core/mergetree/compact/lookup_merge_function.h"
+#include "paimon/core/mergetree/compact/merge_function_wrapper.h"
+#include "paimon/core/mergetree/lookup/file_position.h"
+#include "paimon/core/mergetree/lookup/positioned_key_value.h"
+#include "paimon/core/options/lookup_strategy.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+namespace paimon {
+/// Wrapper for `MergeFunction`s to produce changelog by lookup during the compaction involving
+/// level 0 files.
+///
+/// Changelog records are generated in the process of the level-0 file participating in the
+/// compaction, if during the compaction processing:
+///
+///  Without level-0 records, no changelog.
+///  With level-0 record, with level-x (x > 0) record, level-x record should be BEFORE, level-0
+///       should be AFTER.
+///  With level-0 record, without level-x record, need to lookup the history value of the upper
+///       level as BEFORE.
+/// TODO(xinyu.lxy) : add changelog
+template <typename T>
+class LookupChangelogMergeFunctionWrapper : public MergeFunctionWrapper<KeyValue> {
+ public:
+    static Result<std::unique_ptr<LookupChangelogMergeFunctionWrapper>> Create(
+        std::unique_ptr<LookupMergeFunction>&& merge_function,
+        std::function<Result<std::optional<T>>(const std::shared_ptr<InternalRow>&)> lookup,
+        const LookupStrategy& lookup_strategy,
+        const std::shared_ptr<BucketedDvMaintainer>& deletion_vectors_maintainer,
+        const std::shared_ptr<FieldsComparator>& comparator) {
+        if (lookup_strategy.deletion_vector && !deletion_vectors_maintainer) {
+            return Status::Invalid("deletionVectorsMaintainer should not be null, there is a bug.");
+        }
+        return std::unique_ptr<LookupChangelogMergeFunctionWrapper>(
+            new LookupChangelogMergeFunctionWrapper(std::move(merge_function), std::move(lookup),
+                                                    lookup_strategy, deletion_vectors_maintainer,
+                                                    comparator));
+    }
+    void Reset() override {
+        merge_function_->Reset();
+    }
+
+    Status Add(KeyValue&& kv) override {
+        return merge_function_->Add(std::move(kv));
+    }
+
+    Result<std::optional<KeyValue>> GetResult() override {
+        // 1. Find the latest high level record and compute containLevel0
+        std::optional<int32_t> high_level_idx = merge_function_->PickHighLevelIdx();
+
+        // 2. Lookup if latest high level record is absent
+        if (high_level_idx == std::nullopt) {
+            std::optional<KeyValue> lookup_high_level;
+            PAIMON_ASSIGN_OR_RAISE(std::optional<T> lookup_result,
+                                   lookup_(merge_function_->GetKey()));
+            if (lookup_result) {
+                std::string file_name;
+                int64_t row_position = -1;
+                if constexpr (std::is_same_v<T, PositionedKeyValue>) {
+                    lookup_high_level = std::move(lookup_result->key_value);
+                    file_name = lookup_result->file_name;
+                    row_position = lookup_result->row_position;
+                } else if constexpr (std::is_same_v<T, FilePosition>) {
+                    file_name = lookup_result->file_name;
+                    row_position = lookup_result->row_position;
+                } else if constexpr (std::is_same_v<T, KeyValue>) {
+                    lookup_high_level = std::move(lookup_result);
+                } else {
+                    return Status::Invalid(
+                        "deletion vector mode must have PositionedKeyValue or FilePosition "
+                        "lookup result");
+                }
+                if (lookup_strategy_.deletion_vector) {
+                    PAIMON_RETURN_NOT_OK(
+                        deletion_vectors_maintainer_->NotifyNewDeletion(file_name, row_position));
+                }
+            }
+            if (lookup_high_level) {
+                merge_function_->InsertInto(std::move(lookup_high_level), comparator_);
+            }
+        }
+
+        // 3. Calculate result
+        PAIMON_ASSIGN_OR_RAISE(std::optional<KeyValue> result, merge_function_->GetResult());
+        Reset();
+        // 4. Set changelog when there's level-0 records
+        // TODO(liancheng.lsz): setChangelog
+        return result;
+    }
+
+ private:
+    LookupChangelogMergeFunctionWrapper(
+        std::unique_ptr<LookupMergeFunction>&& merge_function,
+        std::function<Result<std::optional<T>>(const std::shared_ptr<InternalRow>&)> lookup,
+        const LookupStrategy& lookup_strategy,
+        const std::shared_ptr<BucketedDvMaintainer>& deletion_vectors_maintainer,
+        const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator)
+        : merge_function_(std::move(merge_function)),
+          lookup_(std::move(lookup)),
+          lookup_strategy_(lookup_strategy),
+          deletion_vectors_maintainer_(deletion_vectors_maintainer),
+          comparator_(CreateSequenceComparator(user_defined_seq_comparator)) {}
+
+    static std::function<bool(const KeyValue& o1, const KeyValue& o2)> CreateSequenceComparator(
+        const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator) {
+        auto cmp_func = [user_defined_seq_comparator](const KeyValue& o1, const KeyValue& o2) {
+            if (user_defined_seq_comparator == nullptr) {
+                return o1.sequence_number < o2.sequence_number;
+            }
+            auto user_defined_result =
+                user_defined_seq_comparator->CompareTo(*(o1.value), *(o2.value));
+            if (user_defined_result != 0) {
+                return user_defined_result < 0;
+            }
+            return o1.sequence_number < o2.sequence_number;
+        };
+        return cmp_func;
+    }
+
+ private:
+    std::unique_ptr<LookupMergeFunction> merge_function_;
+    std::function<Result<std::optional<T>>(const std::shared_ptr<InternalRow>&)> lookup_;
+    LookupStrategy lookup_strategy_;
+    std::shared_ptr<BucketedDvMaintainer> deletion_vectors_maintainer_;
+    std::function<bool(const KeyValue& o1, const KeyValue& o2)> comparator_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/lookup_changelog_merge_function_wrapper_test.cpp
+++ b/src/paimon/core/mergetree/compact/lookup_changelog_merge_function_wrapper_test.cpp
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/lookup_changelog_merge_function_wrapper.h"
+
+#include <memory>
+#include <variant>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/core/deletionvectors/bucketed_dv_maintainer.h"
+#include "paimon/core/mergetree/compact/aggregate/aggregate_merge_function.h"
+#include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(LookupChangelogMergeFunctionWrapperTest, TestCreateInvalid) {
+    auto pool = GetDefaultPool();
+    auto mfunc = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/true);
+    auto lookup_mfunc = std::make_unique<LookupMergeFunction>(std::move(mfunc));
+    auto lookup = [&](const std::shared_ptr<InternalRow>& key) -> Result<std::optional<KeyValue>> {
+        return std::optional<KeyValue>(
+            KeyValue(RowKind::Insert(), /*sequence_number=*/1000, /*level=*/3, key,
+                     BinaryRowGenerator::GenerateRowPtr({1001}, pool.get())));
+    };
+    LookupStrategy lookup_strategy(/*is_first_row=*/false, /*produce_changelog=*/false,
+                                   /*deletion_vector=*/true, /*force_lookup=*/true);
+    ASSERT_NOK_WITH_MSG(LookupChangelogMergeFunctionWrapper<KeyValue>::Create(
+                            std::move(lookup_mfunc), lookup, lookup_strategy,
+                            /*deletion_vectors_maintainer=*/nullptr,
+                            /*comparator=*/nullptr),
+                        "deletionVectorsMaintainer should not be null, there is a bug.");
+}
+
+TEST(LookupChangelogMergeFunctionWrapperTest, TestSimple) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/0, /*level=*/2, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/1, /*level=*/1,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+
+    auto mfunc = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/true);
+    auto lookup_mfunc = std::make_unique<LookupMergeFunction>(std::move(mfunc));
+    auto lookup = [&](const std::shared_ptr<InternalRow>& key) -> Result<std::optional<KeyValue>> {
+        return std::optional<KeyValue>(
+            KeyValue(RowKind::Insert(), /*sequence_number=*/1000, /*level=*/3, key,
+                     BinaryRowGenerator::GenerateRowPtr({1001}, pool.get())));
+    };
+    LookupStrategy lookup_strategy(/*is_first_row=*/false, /*produce_changelog=*/false,
+                                   /*deletion_vector=*/false, /*force_lookup=*/true);
+    ASSERT_OK_AND_ASSIGN(auto wrapper, LookupChangelogMergeFunctionWrapper<KeyValue>::Create(
+                                           std::move(lookup_mfunc), lookup, lookup_strategy,
+                                           /*deletion_vectors_maintainer=*/nullptr,
+                                           /*comparator=*/nullptr));
+
+    wrapper->Reset();
+    ASSERT_OK(wrapper->Add(std::move(kv1)));
+    ASSERT_OK(wrapper->Add(std::move(kv2)));
+    ASSERT_OK(wrapper->Add(std::move(kv3)));
+    ASSERT_OK_AND_ASSIGN(auto result, wrapper->GetResult());
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result.value().sequence_number, 2);
+}
+
+TEST(LookupChangelogMergeFunctionWrapperTest, TestWithLookup) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/3, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+
+    auto mfunc = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/true);
+    auto lookup_mfunc = std::make_unique<LookupMergeFunction>(std::move(mfunc));
+    auto lookup = [&](const std::shared_ptr<InternalRow>& key) -> Result<std::optional<KeyValue>> {
+        return std::optional<KeyValue>(
+            KeyValue(RowKind::Insert(), /*sequence_number=*/0, /*level=*/3, key,
+                     BinaryRowGenerator::GenerateRowPtr({1001}, pool.get())));
+    };
+    LookupStrategy lookup_strategy(/*is_first_row=*/false, /*produce_changelog=*/false,
+                                   /*deletion_vector=*/false, /*force_lookup=*/true);
+    ASSERT_OK_AND_ASSIGN(auto wrapper, LookupChangelogMergeFunctionWrapper<KeyValue>::Create(
+                                           std::move(lookup_mfunc), lookup, lookup_strategy,
+                                           /*deletion_vectors_maintainer=*/nullptr,
+                                           /*comparator=*/nullptr));
+
+    wrapper->Reset();
+    ASSERT_OK(wrapper->Add(std::move(kv1)));
+    ASSERT_OK(wrapper->Add(std::move(kv2)));
+    ASSERT_OK(wrapper->Add(std::move(kv3)));
+    ASSERT_OK_AND_ASSIGN(auto result, wrapper->GetResult());
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result.value().sequence_number, 3);
+}
+
+TEST(LookupChangelogMergeFunctionWrapperTest, TestWithLookupWithDv) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/3, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options,
+                         CoreOptions::FromMap({{Options::FIELDS_DEFAULT_AGG_FUNC, "sum"}}));
+    ASSERT_OK_AND_ASSIGN(auto mfunc, AggregateMergeFunction::Create(
+                                         arrow::schema({arrow::field("value", arrow::int32())}),
+                                         {"key"}, core_options));
+    auto lookup_mfunc = std::make_unique<LookupMergeFunction>(std::move(mfunc));
+    auto lookup =
+        [&](const std::shared_ptr<InternalRow>& key) -> Result<std::optional<PositionedKeyValue>> {
+        return std::optional<PositionedKeyValue>(
+            {KeyValue(RowKind::Insert(), /*sequence_number=*/0, /*level=*/3, key,
+                      BinaryRowGenerator::GenerateRowPtr({1001}, pool.get())),
+             "data.file", /*row_position=*/10});
+    };
+    auto dv_index_file =
+        std::make_shared<DeletionVectorsIndexFile>(/*fs=*/nullptr, /*path_factory=*/nullptr,
+                                                   /*bitmap64=*/false, pool);
+    std::map<std::string, std::shared_ptr<DeletionVector>> deletion_vectors;
+    auto dv_maintainer = std::make_shared<BucketedDvMaintainer>(dv_index_file, deletion_vectors);
+
+    LookupStrategy lookup_strategy(/*is_first_row=*/false, /*produce_changelog=*/false,
+                                   /*deletion_vector=*/true, /*force_lookup=*/false);
+    ASSERT_OK_AND_ASSIGN(auto wrapper,
+                         LookupChangelogMergeFunctionWrapper<PositionedKeyValue>::Create(
+                             std::move(lookup_mfunc), lookup, lookup_strategy, dv_maintainer,
+                             /*comparator=*/nullptr));
+
+    wrapper->Reset();
+    ASSERT_OK(wrapper->Add(std::move(kv1)));
+    ASSERT_OK(wrapper->Add(std::move(kv2)));
+    ASSERT_OK(wrapper->Add(std::move(kv3)));
+    ASSERT_OK_AND_ASSIGN(auto result, wrapper->GetResult());
+    ASSERT_TRUE(result);
+    ASSERT_EQ(result.value().sequence_number, 3);
+    ASSERT_EQ(result.value().value->GetInt(0), 100 + 200 + 300 + 1001);
+
+    auto dv = dv_maintainer->DeletionVectorOf("data.file");
+    ASSERT_TRUE(dv);
+    ASSERT_FALSE(dv.value()->IsDeleted(0).value());
+    ASSERT_TRUE(dv.value()->IsDeleted(10).value());
+}
+
+TEST(LookupChangelogMergeFunctionWrapperTest, TestCreateSequenceComparator) {
+    auto pool = GetDefaultPool();
+    {
+        // test no user_defined_seq_comparator
+        auto cmp = LookupChangelogMergeFunctionWrapper<bool>::CreateSequenceComparator(
+            /*user_defined_seq_comparator=*/nullptr);
+        KeyValue kv1(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0, /*key=*/
+                     BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                     /*value=*/BinaryRowGenerator::GenerateRowPtr({500}, pool.get()));
+        KeyValue kv2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0,
+                     /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                     /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+        ASSERT_TRUE(cmp(kv1, kv2));
+        ASSERT_FALSE(cmp(kv2, kv1));
+    }
+    {
+        // test with user_defined_seq_comparator
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<FieldsComparator> user_defined_seq_comparator,
+            FieldsComparator::Create({DataField(1, arrow::field("value", arrow::int32()))},
+                                     /*is_ascending_order=*/true));
+        auto cmp = LookupChangelogMergeFunctionWrapper<bool>::CreateSequenceComparator(
+            user_defined_seq_comparator);
+        KeyValue kv1(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0, /*key=*/
+                     BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                     /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+        KeyValue kv2(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0,
+                     /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                     /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+        ASSERT_TRUE(cmp(kv1, kv2));
+        ASSERT_FALSE(cmp(kv2, kv1));
+
+        // same sequence field, compare sequence number
+        KeyValue kv3(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0, /*key=*/
+                     BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                     /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+        KeyValue kv4(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0,
+                     /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                     /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+        ASSERT_TRUE(cmp(kv3, kv4));
+        ASSERT_FALSE(cmp(kv4, kv3));
+    }
+}
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/lookup_merge_function.h
+++ b/src/paimon/core/mergetree/compact/lookup_merge_function.h
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+#include "paimon/core/key_value.h"
+#include "paimon/core/mergetree/compact/merge_function.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+/// A `MergeFunction` for lookup, this wrapper only considers the latest high level record,
+/// because each merge will query the old merged record, so the latest high level record should be
+/// the final merged value.
+class LookupMergeFunction : public MergeFunction {
+ public:
+    explicit LookupMergeFunction(std::unique_ptr<MergeFunction>&& merge_function)
+        : merge_function_(std::move(merge_function)) {}
+
+    void Reset() override {
+        candidates_.clear();
+        current_key_ = nullptr;
+        contain_level0_ = false;
+    }
+
+    Status Add(KeyValue&& kv) override {
+        current_key_ = kv.key;
+        if (kv.level == 0) {
+            contain_level0_ = true;
+        }
+        candidates_.emplace_back(std::move(kv));
+        return Status::OK();
+    }
+
+    bool ContainLevel0() const {
+        return contain_level0_;
+    }
+
+    const std::shared_ptr<InternalRow>& GetKey() const {
+        return current_key_;
+    }
+
+    Result<std::optional<KeyValue>> GetResult() override {
+        merge_function_->Reset();
+        std::optional<int32_t> high_level_idx = PickHighLevelIdx();
+        for (int32_t i = 0; i < static_cast<int32_t>(candidates_.size()); ++i) {
+            // records that has not been stored on the disk yet, such as the data in the write
+            // buffer being at level -1
+            if (candidates_[i].level <= 0 || i == high_level_idx.value()) {
+                PAIMON_RETURN_NOT_OK(merge_function_->Add(std::move(candidates_[i])));
+            }
+        }
+        return merge_function_->GetResult();
+    }
+
+    void InsertInto(std::optional<KeyValue>&& high_level,
+                    std::function<bool(const KeyValue& o1, const KeyValue& o2)> cmp_function) {
+        if (!high_level) {
+            return;
+        }
+        candidates_.push_back(std::move(high_level.value()));
+        std::sort(candidates_.begin(), candidates_.end(), cmp_function);
+    }
+
+    std::optional<int32_t> PickHighLevelIdx() const {
+        std::optional<int32_t> high_level_idx;
+        for (int32_t i = 0; i < static_cast<int32_t>(candidates_.size()); i++) {
+            const auto& kv = candidates_[i];
+            // records that has not been stored on the disk yet, such as the data in the write
+            // buffer being at level -1
+            if (kv.level <= 0) {
+                continue;
+            }
+            // For high-level comparison logic (not involving Level 0), only the value of the
+            // minimum Level should be selected
+            if (!high_level_idx || kv.level < candidates_[high_level_idx.value()].level) {
+                high_level_idx = i;
+            }
+        }
+        return high_level_idx;
+    }
+
+ private:
+    std::unique_ptr<MergeFunction> merge_function_;
+    std::vector<KeyValue> candidates_;
+    std::shared_ptr<InternalRow> current_key_;
+    bool contain_level0_ = false;
+};
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/lookup_merge_function_test.cpp
+++ b/src/paimon/core/mergetree/compact/lookup_merge_function_test.cpp
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/lookup_merge_function.h"
+
+#include <map>
+#include <string>
+#include <variant>
+
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/mergetree/compact/aggregate/aggregate_merge_function.h"
+#include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
+#include "paimon/defs.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(LookupMergeFunctionTest, TestSimple) {
+    arrow::FieldVector fields = {arrow::field("k0", arrow::int32()),
+                                 arrow::field("v0", arrow::int32())};
+    auto value_schema = arrow::schema(fields);
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options,
+                         CoreOptions::FromMap({{Options::FIELDS_DEFAULT_AGG_FUNC, "sum"}}));
+    ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<AggregateMergeFunction> agg_merge_func,
+        AggregateMergeFunction::Create(value_schema, /*primary_keys=*/{"k0"}, core_options));
+    auto merge_func = std::make_unique<LookupMergeFunction>(std::move(agg_merge_func));
+
+    auto pool = GetDefaultPool();
+    KeyValue kv0(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 50}, pool.get()));
+    ASSERT_OK(merge_func->Add(std::move(kv0)));
+    auto result_kv = std::move(merge_func->GetResult().value().value());
+    KeyValue expected(RowKind::Insert(), /*sequence_number=*/0,
+                      /*level=*/KeyValue::UNKNOWN_LEVEL, /*key=*/
+                      BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                      /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 50}, pool.get()));
+    KeyValueChecker::CheckResult(expected, result_kv, /*key_arity=*/1, /*value_arity=*/2);
+
+    merge_func->Reset();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/2,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/3, /*level=*/1, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 300}, pool.get()));
+
+    // only kv1 (level 0) and kv3 (level 1) will be merged, and kv2 will be ignored
+    ASSERT_OK(merge_func->Add(std::move(kv1)));
+    ASSERT_OK(merge_func->Add(std::move(kv2)));
+    ASSERT_OK(merge_func->Add(std::move(kv3)));
+    result_kv = std::move(merge_func->GetResult().value().value());
+    KeyValue expected2(RowKind::Insert(), /*sequence_number=*/3,
+                       /*level=*/KeyValue::UNKNOWN_LEVEL, /*key=*/
+                       BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                       /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 400}, pool.get()));
+    KeyValueChecker::CheckResult(expected2, result_kv, /*key_arity=*/1, /*value_arity=*/2);
+}
+
+TEST(LookupMergeFunctionTest, TestDeduplicate) {
+    auto deduplicate_merge_func =
+        std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/false);
+    auto merge_func = std::make_unique<LookupMergeFunction>(std::move(deduplicate_merge_func));
+
+    auto pool = GetDefaultPool();
+    KeyValue kv0(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 50}, pool.get()));
+    ASSERT_OK(merge_func->Add(std::move(kv0)));
+    auto result_kv = std::move(merge_func->GetResult().value().value());
+    KeyValue expected(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                      BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                      /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 50}, pool.get()));
+    KeyValueChecker::CheckResult(expected, result_kv, /*key_arity=*/1, /*value_arity=*/2);
+
+    merge_func->Reset();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/2,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/3, /*level=*/1, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 300}, pool.get()));
+
+    // only kv1 (level 0) and kv3 (level 1) will be merged, and kv2 will be ignored
+    // as add order is kv1, then kv3, the result is 300
+    ASSERT_OK(merge_func->Add(std::move(kv1)));
+    ASSERT_OK(merge_func->Add(std::move(kv2)));
+    ASSERT_OK(merge_func->Add(std::move(kv3)));
+    result_kv = std::move(merge_func->GetResult().value().value());
+    KeyValue expected2(RowKind::Insert(), /*sequence_number=*/3, /*level=*/1, /*key=*/
+                       BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                       /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 300}, pool.get()));
+    KeyValueChecker::CheckResult(expected2, result_kv, /*key_arity=*/1, /*value_arity=*/2);
+}
+
+TEST(LookupMergeFunctionTest, TestPickHighLevel) {
+    auto deduplicate_merge_func =
+        std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/false);
+    auto merge_func = std::make_unique<LookupMergeFunction>(std::move(deduplicate_merge_func));
+
+    auto pool = GetDefaultPool();
+
+    merge_func->Reset();
+    ASSERT_FALSE(merge_func->PickHighLevelIdx());
+    ASSERT_FALSE(merge_func->ContainLevel0());
+
+    merge_func->Reset();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/1, /*level=*/2, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/1,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/4, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 300}, pool.get()));
+
+    ASSERT_OK(merge_func->Add(std::move(kv1)));
+    ASSERT_OK(merge_func->Add(std::move(kv2)));
+    ASSERT_OK(merge_func->Add(std::move(kv3)));
+    ASSERT_TRUE(merge_func->ContainLevel0());
+    ASSERT_EQ(merge_func->GetKey()->GetInt(0), 10);
+    ASSERT_EQ(merge_func->PickHighLevelIdx(), 1);
+}
+
+TEST(LookupMergeFunctionTest, TestInsertInto) {
+    auto deduplicate_merge_func =
+        std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/false);
+    auto merge_func = std::make_unique<LookupMergeFunction>(std::move(deduplicate_merge_func));
+
+    auto pool = GetDefaultPool();
+
+    merge_func->Reset();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/0, /*level=*/3, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 300}, pool.get()));
+
+    ASSERT_OK(merge_func->Add(std::move(kv1)));
+    ASSERT_OK(merge_func->Add(std::move(kv2)));
+    merge_func->InsertInto(std::move(kv3), [](const KeyValue& o1, const KeyValue& o2) {
+        return o1.sequence_number < o2.sequence_number;
+    });
+    ASSERT_EQ(merge_func->candidates_.size(), 3);
+    ASSERT_EQ(merge_func->candidates_[0].sequence_number, 0);
+    ASSERT_EQ(merge_func->candidates_[1].sequence_number, 1);
+    ASSERT_EQ(merge_func->candidates_[2].sequence_number, 2);
+
+    auto result_kv = std::move(merge_func->GetResult().value().value());
+    KeyValue expected(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0,
+                      /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                      /*value=*/BinaryRowGenerator::GenerateRowPtr({10, 200}, pool.get()));
+    KeyValueChecker::CheckResult(expected, result_kv, /*key_arity=*/1, /*value_arity=*/2);
+}
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/partial_update_merge_function.cpp
+++ b/src/paimon/core/mergetree/compact/partial_update_merge_function.cpp
@@ -1,0 +1,478 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/partial_update_merge_function.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <variant>
+
+#include "arrow/type.h"
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/common/data/data_define.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/internal_row_utils.h"
+#include "paimon/common/utils/object_utils.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/mergetree/compact/aggregate/field_aggregator_factory.h"
+#include "paimon/core/mergetree/compact/aggregate/field_last_non_null_value_agg.h"
+#include "paimon/core/mergetree/compact/aggregate/field_primary_key_agg.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/defs.h"
+
+namespace paimon {
+PartialUpdateMergeFunction::PartialUpdateMergeFunction(
+    bool ignore_delete, bool remove_record_on_delete, bool field_sequence_enabled,
+    std::vector<InternalRow::FieldGetterFunc>&& getters,
+    std::map<int32_t, std::shared_ptr<FieldsComparator>>&& field_comparators,
+    std::map<int32_t, std::shared_ptr<FieldAggregator>>&& field_aggregators,
+    std::set<int32_t>&& sequence_group_partial_delete)
+    : ignore_delete_(ignore_delete),
+      remove_record_on_delete_(remove_record_on_delete),
+      field_sequence_enabled_(field_sequence_enabled),
+      getters_(std::move(getters)),
+      field_comparators_(std::move(field_comparators)),
+      field_aggregators_(std::move(field_aggregators)),
+      sequence_group_partial_delete_(std::move(sequence_group_partial_delete)) {}
+
+Status PartialUpdateMergeFunction::ParseSequenceGroupFields(
+    const CoreOptions& options,
+    std::map<std::string, std::vector<std::string>>* value_field_to_seq_group_field,
+    std::set<std::string>* seq_group_key_set) {
+    auto fields_seq_group_map = options.GetFieldsSequenceGroups();
+    for (const auto& [key, value] : fields_seq_group_map) {
+        auto seq_fields =
+            StringUtils::Split(key, Options::FIELDS_SEPARATOR, /*ignore_empty=*/false);
+        auto seq_value_fields =
+            StringUtils::Split(value, Options::FIELDS_SEPARATOR, /*ignore_empty=*/false);
+        for (const auto& field : seq_value_fields) {
+            auto iter = value_field_to_seq_group_field->find(field);
+            if (iter != value_field_to_seq_group_field->end()) {
+                return Status::Invalid(
+                    fmt::format("field {} is defined repeatedly by multiple groups: {} and {}",
+                                field, key, fmt::join(iter->second, ",")));
+            }
+            (*value_field_to_seq_group_field)[field] = seq_fields;
+        }
+        for (const auto& field : seq_fields) {
+            (*value_field_to_seq_group_field)[field] = seq_fields;
+            seq_group_key_set->insert(field);
+        }
+    }
+    return Status::OK();
+}
+
+Status PartialUpdateMergeFunction::CompleteSequenceGroupFields(
+    const TableSchema& table_schema,
+    const std::map<std::string, std::vector<std::string>>& value_field_to_seq_group_field,
+    std::vector<DataField>* value_fields) {
+    if (value_field_to_seq_group_field.empty()) {
+        // no field sequence group config
+        return Status::OK();
+    }
+    std::set<std::string> value_field_names;
+    for (const auto& field : *value_fields) {
+        value_field_names.insert(field.Name());
+    }
+
+    std::vector<DataField> extra_sequence_fields;
+    for (const auto& field : *value_fields) {
+        auto iter = value_field_to_seq_group_field.find(field.Name());
+        if (iter == value_field_to_seq_group_field.end()) {
+            continue;
+        }
+        const auto& seq_group_fields = iter->second;
+        for (const auto& seq_field : seq_group_fields) {
+            auto iter_seq = value_field_names.find(seq_field);
+            if (iter_seq == value_field_names.end()) {
+                // complete sequence group field
+                PAIMON_ASSIGN_OR_RAISE(DataField extra_sequence_field,
+                                       table_schema.GetField(seq_field));
+                extra_sequence_fields.emplace_back(extra_sequence_field);
+                value_field_names.insert(seq_field);
+            }
+        }
+    }
+    if (!extra_sequence_fields.empty()) {
+        value_fields->insert(value_fields->end(), extra_sequence_fields.begin(),
+                             extra_sequence_fields.end());
+    }
+    return Status::OK();
+}
+
+Result<std::unique_ptr<PartialUpdateMergeFunction>> PartialUpdateMergeFunction::Create(
+    const std::shared_ptr<arrow::Schema>& value_schema,
+    const std::vector<std::string>& primary_keys, const CoreOptions& options,
+    const std::map<std::string, std::vector<std::string>>& value_field_to_seq_group_field,
+    const std::set<std::string>& seq_group_key_set) {
+    // 1. create field aggregator
+    std::map<int32_t, std::shared_ptr<FieldAggregator>> field_aggregators;
+    PAIMON_ASSIGN_OR_RAISE(
+        field_aggregators,
+        CreateFieldAggregators(value_schema, primary_keys, options, value_field_to_seq_group_field,
+                               seq_group_key_set));
+    // 2. create field seq comparator
+    std::map<int32_t, std::shared_ptr<FieldsComparator>> field_comparators;
+    PAIMON_ASSIGN_OR_RAISE(field_comparators,
+                           CreateFieldSeqComparator(value_schema, value_field_to_seq_group_field));
+
+    // 3. fetch and check retract config
+    bool remove_record_on_delete = options.PartialUpdateRemoveRecordOnDelete();
+    bool ignore_delete = options.IgnoreDelete();
+    if (remove_record_on_delete && ignore_delete) {
+        return Status::Invalid(fmt::format(
+            "{} and {} have conflicting behavior so should not be enabled at the same time.",
+            Options::IGNORE_DELETE, Options::PARTIAL_UPDATE_REMOVE_RECORD_ON_DELETE));
+    }
+    if (remove_record_on_delete && !field_comparators.empty()) {
+        return Status::Invalid(
+            fmt::format("sequence group and {} have conflicting behavior so should not be "
+                        "enabled at the same time.",
+                        Options::PARTIAL_UPDATE_REMOVE_RECORD_ON_DELETE));
+    }
+
+    std::vector<std::string> remove_record_on_sequence_group_fields =
+        options.GetPartialUpdateRemoveRecordOnSequenceGroup();
+    std::set<int32_t> sequence_group_partial_delete;
+    if (!remove_record_on_sequence_group_fields.empty()) {
+        if (!ObjectUtils::ContainsAll(seq_group_key_set, remove_record_on_sequence_group_fields)) {
+            return Status::Invalid(
+                fmt::format("field {} defined in {} option must be part of sequence groups.",
+                            fmt::join(remove_record_on_sequence_group_fields, ","),
+                            Options::PARTIAL_UPDATE_REMOVE_RECORD_ON_SEQUENCE_GROUP));
+        }
+        for (const auto& remove_sequence_group_field : remove_record_on_sequence_group_fields) {
+            auto field_idx = value_schema->GetFieldIndex(remove_sequence_group_field);
+            if (field_idx != -1) {
+                sequence_group_partial_delete.insert(field_idx);
+            }
+        }
+    }
+
+    // 4. create data getters
+    PAIMON_ASSIGN_OR_RAISE(std::vector<InternalRow::FieldGetterFunc> getters,
+                           InternalRowUtils::CreateFieldGetters(value_schema, /*use_view=*/true));
+    return std::unique_ptr<PartialUpdateMergeFunction>(new PartialUpdateMergeFunction(
+        ignore_delete, remove_record_on_delete,
+        /*field_sequence_enabled=*/!value_field_to_seq_group_field.empty(), std::move(getters),
+        std::move(field_comparators), std::move(field_aggregators),
+        std::move(sequence_group_partial_delete)));
+}
+Result<std::map<int32_t, std::shared_ptr<FieldsComparator>>>
+PartialUpdateMergeFunction::CreateFieldSeqComparator(
+    const std::shared_ptr<arrow::Schema>& value_schema,
+    const std::map<std::string, std::vector<std::string>>& value_field_to_seq_group_field) {
+    PAIMON_ASSIGN_OR_RAISE(std::vector<DataField> value_data_fields,
+                           DataField::ConvertArrowSchemaToDataFields(value_schema));
+    std::map<int32_t, std::shared_ptr<FieldsComparator>> field_seq_comparators;
+    // seq group fields -> FieldsComparator
+    std::map<std::vector<std::string>, std::shared_ptr<FieldsComparator>>
+        field_seq_group_comparator_map;
+    for (size_t i = 0; i < value_data_fields.size(); i++) {
+        const auto& value_field = value_data_fields[i];
+        auto iter = value_field_to_seq_group_field.find(value_field.Name());
+        if (iter == value_field_to_seq_group_field.end()) {
+            continue;
+        }
+        const auto& seq_group = iter->second;
+        auto comparator_iter = field_seq_group_comparator_map.find(seq_group);
+        if (comparator_iter != field_seq_group_comparator_map.end()) {
+            // comparator has been created
+            field_seq_comparators[i] = comparator_iter->second;
+            continue;
+        }
+        // create comparator
+        std::vector<int32_t> sort_fields;
+        sort_fields.reserve(seq_group.size());
+        for (const auto& seq_group_field : seq_group) {
+            auto field_idx = value_schema->GetFieldIndex(seq_group_field);
+            if (field_idx == -1) {
+                return Status::Invalid(
+                    fmt::format("cannot find sequence group field {} in value schema, unexpected.",
+                                seq_group_field));
+            }
+            sort_fields.push_back(field_idx);
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FieldsComparator> cmp,
+                               FieldsComparator::Create(value_data_fields, sort_fields,
+                                                        /*is_ascending_order=*/true));
+        field_seq_group_comparator_map[seq_group] = cmp;
+        field_seq_comparators[i] = cmp;
+    }
+    return field_seq_comparators;
+}
+
+Result<std::map<int32_t, std::shared_ptr<FieldAggregator>>>
+PartialUpdateMergeFunction::CreateFieldAggregators(
+    const std::shared_ptr<arrow::Schema>& value_schema,
+    const std::vector<std::string>& primary_keys, const CoreOptions& options,
+    const std::map<std::string, std::vector<std::string>>& value_field_to_seq_group_field,
+    const std::set<std::string>& seq_group_key_set) {
+    std::map<int32_t, std::shared_ptr<FieldAggregator>> aggregators;
+    std::optional<std::string> default_agg_func = options.GetFieldsDefaultFunc();
+    for (int32_t i = 0; i < value_schema->num_fields(); i++) {
+        const auto& field_name = value_schema->field(i)->name();
+        const auto& field_type = value_schema->field(i)->type();
+        if (seq_group_key_set.find(field_name) != seq_group_key_set.end()) {
+            // no agg for sequence fields
+            continue;
+        }
+        auto primary_key_iter = std::find(primary_keys.begin(), primary_keys.end(), field_name);
+        if (primary_key_iter != primary_keys.end()) {
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FieldAggregator> agg,
+                                   FieldAggregatorFactory::CreateFieldAggregator(
+                                       field_name, field_type, FieldPrimaryKeyAgg::NAME, options));
+            aggregators[i] = std::move(agg);
+            continue;
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::string> str_agg,
+                               options.GetFieldAggFunc(field_name));
+        if (str_agg == std::nullopt) {
+            str_agg = default_agg_func;
+        }
+        if (str_agg) {
+            // last_non_null_value doesn't require sequence group
+            if (str_agg.value() != FieldLastNonNullValueAgg::NAME &&
+                value_field_to_seq_group_field.find(field_name) ==
+                    value_field_to_seq_group_field.end()) {
+                return Status::Invalid(fmt::format(
+                    "Must use sequence group for aggregation functions but not found for field {}",
+                    field_name));
+            }
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FieldAggregator> agg,
+                                   FieldAggregatorFactory::CreateFieldAggregator(
+                                       field_name, field_type, str_agg.value(), options));
+            aggregators[i] = std::move(agg);
+        }
+    }
+
+    return aggregators;
+}
+
+void PartialUpdateMergeFunction::Reset() {
+    current_key_.reset();
+    meet_insert_ = false;
+    not_null_column_filled_ = false;
+    row_ = std::make_unique<GenericRow>(getters_.size());
+    last_seq_num_ = 0;
+    for (auto& [_, agg] : field_aggregators_) {
+        assert(agg);
+        agg->Reset();
+    }
+}
+
+Status PartialUpdateMergeFunction::Add(KeyValue&& moved_kv) {
+    // refresh key object to avoid reference overwritten
+    KeyValue kv = std::move(moved_kv);
+    current_key_ = kv.key;
+    current_delete_row_ = false;
+
+    if (kv.value_kind->IsRetract()) {
+        // In 0.7- versions, the delete records might be written into data file even when
+        // ignore-delete configured, so ignoreDelete still needs to be checked
+        if (ignore_delete_) {
+            if (!not_null_column_filled_) {
+                InitRowAndHoldData(std::move(kv.value));
+                not_null_column_filled_ = true;
+            }
+            return Status::OK();
+        }
+
+        last_seq_num_ = kv.sequence_number;
+
+        if (field_sequence_enabled_) {
+            // RetractWithSequenceGroup handles InitRow and AddDataHolder internally
+            PAIMON_RETURN_NOT_OK(RetractWithSequenceGroup(std::move(kv)));
+            return Status::OK();
+        }
+        if (remove_record_on_delete_) {
+            if (kv.value_kind == RowKind::Delete()) {
+                current_delete_row_ = true;
+                row_ = std::make_unique<GenericRow>(getters_.size());
+                InitRowAndHoldData(std::move(kv.value));
+            } else if (!not_null_column_filled_) {
+                InitRowAndHoldData(std::move(kv.value));
+                not_null_column_filled_ = true;
+            }
+            return Status::OK();
+        }
+
+        return Status::Invalid(
+            "By default, Partial update can not accept delete records, you can choose one of "
+            "the following solutions:\n"
+            "1. Configure 'ignore-delete' to ignore delete records.\n"
+            "2. Configure 'partial-update.remove-record-on-delete' to remove the whole row "
+            "when receiving delete records.\n"
+            "3. Configure 'sequence-group's to retract partial columns. Also configure "
+            "'partial-update.remove-record-on-sequence-group' to remove the whole row when "
+            "receiving deleted records of specified sequence group.");
+    }
+    last_seq_num_ = kv.sequence_number;
+    if (field_comparators_.empty()) {
+        UpdateNonNullFields(std::move(kv));
+    } else {
+        UpdateWithSequenceGroup(std::move(kv));
+    }
+    meet_insert_ = true;
+    not_null_column_filled_ = true;
+    return Status::OK();
+}
+
+void PartialUpdateMergeFunction::UpdateNonNullFields(KeyValue&& kv) {
+    for (size_t i = 0; i < getters_.size(); ++i) {
+        VariantType field = getters_[i](*(kv.value));
+        if (!DataDefine::IsVariantNull(field)) {
+            row_->SetField(i, field);
+        }
+    }
+    row_->AddDataHolder(std::move(kv.value));
+}
+
+void PartialUpdateMergeFunction::UpdateWithSequenceGroup(KeyValue&& kv) {
+    for (size_t i = 0; i < getters_.size(); ++i) {
+        VariantType field = getters_[i](*(kv.value));
+        VariantType accumulator = getters_[i](*row_);
+        auto comp_iter = field_comparators_.find(i);
+        auto agg_iter = field_aggregators_.find(i);
+        FieldAggregator* agg =
+            (agg_iter == field_aggregators_.end() ? nullptr : agg_iter->second.get());
+        if (comp_iter == field_comparators_.end()) {
+            if (agg) {
+                row_->SetField(i, agg->Agg(accumulator, field));
+            } else if (!DataDefine::IsVariantNull(field)) {
+                row_->SetField(i, field);
+            }
+        } else {
+            auto& seq_comparator = comp_iter->second;
+            assert(seq_comparator);
+            if (IsEmptySequenceGroup(kv, seq_comparator)) {
+                // skip null sequence group
+                continue;
+            }
+            if (seq_comparator->CompareTo(*(kv.value), *row_) >= 0) {
+                int32_t idx = i;
+                bool contain_idx = ObjectUtils::Contains(seq_comparator->CompareFields(), idx);
+                if (contain_idx) {
+                    // Multiple sequence fields should be updated at once.
+                    for (const auto& field_idx : seq_comparator->CompareFields()) {
+                        row_->SetField(field_idx, getters_[field_idx](*(kv.value)));
+                    }
+                    continue;
+                }
+                row_->SetField(i, agg ? agg->Agg(accumulator, field) : field);
+            } else if (agg) {
+                row_->SetField(i, agg->AggReversed(accumulator, field));
+            }
+        }
+    }
+    row_->AddDataHolder(std::move(kv.value));
+}
+
+Status PartialUpdateMergeFunction::RetractWithSequenceGroup(KeyValue&& kv) {
+    // Initialize row with all field values if this is the first record.
+    // InitRow only reads field values (string_view etc.) from kv.value without taking ownership.
+    // kv.value remains alive throughout this method, so the views are safe until AddDataHolder
+    // at the end transfers ownership to row_.
+    if (!not_null_column_filled_) {
+        InitRow(*(kv.value));
+        not_null_column_filled_ = true;
+    }
+
+    std::set<int32_t> updated_sequence_fields;
+    for (size_t i = 0; i < getters_.size(); ++i) {
+        auto cmp_iter = field_comparators_.find(i);
+        if (cmp_iter != field_comparators_.end()) {
+            auto& seq_comparator = cmp_iter->second;
+            assert(seq_comparator);
+            if (IsEmptySequenceGroup(kv, seq_comparator)) {
+                // skip null sequence group
+                continue;
+            }
+            auto agg_iter = field_aggregators_.find(i);
+            FieldAggregator* agg =
+                (agg_iter == field_aggregators_.end() ? nullptr : agg_iter->second.get());
+            if (seq_comparator->CompareTo(*(kv.value), *row_) >= 0) {
+                int32_t idx = i;
+                bool contain_idx = ObjectUtils::Contains(seq_comparator->CompareFields(), idx);
+                if (contain_idx) {
+                    // Multiple sequence fields should be updated at once.
+                    for (const auto& field_idx : seq_comparator->CompareFields()) {
+                        if (updated_sequence_fields.find(field_idx) ==
+                            updated_sequence_fields.end()) {
+                            if (kv.value_kind == RowKind::Delete() &&
+                                sequence_group_partial_delete_.find(field_idx) !=
+                                    sequence_group_partial_delete_.end()) {
+                                current_delete_row_ = true;
+                                row_ = std::make_unique<GenericRow>(getters_.size());
+                                InitRowAndHoldData(std::move(kv.value));
+                                return Status::OK();
+                            } else {
+                                row_->SetField(field_idx, getters_[field_idx](*(kv.value)));
+                                updated_sequence_fields.insert(field_idx);
+                            }
+                        }
+                    }
+                } else {
+                    if (!agg) {
+                        // retract normal field
+                        row_->SetField(i, NullType());
+                    } else {
+                        // retract agg field
+                        PAIMON_ASSIGN_OR_RAISE(
+                            VariantType ret,
+                            agg->Retract(getters_[i](*row_), getters_[i](*(kv.value))));
+                        row_->SetField(i, ret);
+                    }
+                }
+            } else if (agg) {
+                // retract agg field for old sequence
+                PAIMON_ASSIGN_OR_RAISE(VariantType ret,
+                                       agg->Retract(getters_[i](*row_), getters_[i](*(kv.value))));
+                row_->SetField(i, ret);
+            }
+        }
+    }
+    row_->AddDataHolder(std::move(kv.value));
+    return Status::OK();
+}
+
+void PartialUpdateMergeFunction::InitRow(const InternalRow& value) {
+    for (size_t i = 0; i < getters_.size(); ++i) {
+        VariantType field = getters_[i](value);
+        row_->SetField(i, field);
+    }
+}
+
+void PartialUpdateMergeFunction::InitRowAndHoldData(std::unique_ptr<InternalRow>&& value) {
+    InitRow(*value);
+    row_->AddDataHolder(std::move(value));
+}
+
+bool PartialUpdateMergeFunction::IsEmptySequenceGroup(
+    const KeyValue& kv, const std::shared_ptr<FieldsComparator>& comparator) const {
+    for (const auto& field_idx : comparator->CompareFields()) {
+        if (!DataDefine::IsVariantNull(getters_[field_idx](*(kv.value)))) {
+            return false;
+        }
+    }
+    return true;
+}
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/partial_update_merge_function.h
+++ b/src/paimon/core/mergetree/compact/partial_update_merge_function.h
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <cassert>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "paimon/common/data/generic_row.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/key_value.h"
+#include "paimon/core/mergetree/compact/aggregate/field_aggregator.h"
+#include "paimon/core/mergetree/compact/merge_function.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class CoreOptions;
+class DataField;
+class TableSchema;
+
+/// A `MergeFunction` where key is primary key (unique) and value is the partial record, update
+/// non-null fields on merge.
+class PartialUpdateMergeFunction : public MergeFunction {
+ public:
+    static Status ParseSequenceGroupFields(
+        const CoreOptions& options,
+        std::map<std::string, std::vector<std::string>>* value_field_to_seq_group_field,
+        std::set<std::string>* seq_group_key_set);
+
+    static Status CompleteSequenceGroupFields(
+        const TableSchema& table_schema,
+        const std::map<std::string, std::vector<std::string>>& value_field_to_seq_group_field,
+        std::vector<DataField>* value_fields);
+
+    // precondition: value_schema is completed with fields_seq_group
+    static Result<std::unique_ptr<PartialUpdateMergeFunction>> Create(
+        const std::shared_ptr<arrow::Schema>& value_schema,
+        const std::vector<std::string>& primary_keys, const CoreOptions& options,
+        const std::map<std::string, std::vector<std::string>>& value_field_to_seq_group_field,
+        const std::set<std::string>& seq_group_key_set);
+
+    void Reset() override;
+
+    Status Add(KeyValue&& kv) override;
+
+    Result<std::optional<KeyValue>> GetResult() override {
+        const RowKind* row_kind =
+            (current_delete_row_ || !meet_insert_) ? RowKind::Delete() : RowKind::Insert();
+        return std::optional<KeyValue>(KeyValue(row_kind, last_seq_num_, KeyValue::UNKNOWN_LEVEL,
+                                                std::move(current_key_), std::move(row_)));
+    };
+
+ private:
+    PartialUpdateMergeFunction(
+        bool ignore_delete, bool remove_record_on_delete, bool field_sequence_enabled,
+        std::vector<InternalRow::FieldGetterFunc>&& getters,
+        std::map<int32_t, std::shared_ptr<FieldsComparator>>&& field_comparators,
+        std::map<int32_t, std::shared_ptr<FieldAggregator>>&& field_aggregators,
+        std::set<int32_t>&& sequence_group_partial_delete);
+
+    static Result<std::map<int32_t, std::shared_ptr<FieldsComparator>>> CreateFieldSeqComparator(
+        const std::shared_ptr<arrow::Schema>& value_schema,
+        const std::map<std::string, std::vector<std::string>>& value_field_to_seq_group_field);
+
+    static Result<std::map<int32_t, std::shared_ptr<FieldAggregator>>> CreateFieldAggregators(
+        const std::shared_ptr<arrow::Schema>& value_schema,
+        const std::vector<std::string>& primary_keys, const CoreOptions& options,
+        const std::map<std::string, std::vector<std::string>>& value_field_to_seq_group_field,
+        const std::set<std::string>& seq_group_key_set);
+
+    bool IsEmptySequenceGroup(const KeyValue& kv,
+                              const std::shared_ptr<FieldsComparator>& comparator) const;
+
+    /// Initialize row_ with all field values from the given InternalRow.
+    /// This only reads field values without taking ownership of the source row.
+    void InitRow(const InternalRow& value);
+
+    /// Initialize row_ with all field values and transfer data ownership to row_.
+    void InitRowAndHoldData(std::unique_ptr<InternalRow>&& value);
+
+    void UpdateNonNullFields(KeyValue&& kv);
+
+    void UpdateWithSequenceGroup(KeyValue&& kv);
+
+    Status RetractWithSequenceGroup(KeyValue&& kv);
+
+ private:
+    bool ignore_delete_;
+    bool remove_record_on_delete_;
+    bool field_sequence_enabled_;
+    std::vector<InternalRow::FieldGetterFunc> getters_;
+    std::map<int32_t, std::shared_ptr<FieldsComparator>> field_comparators_;
+    std::map<int32_t, std::shared_ptr<FieldAggregator>> field_aggregators_;
+    std::set<int32_t> sequence_group_partial_delete_;
+
+    std::shared_ptr<InternalRow> current_key_;
+    std::unique_ptr<GenericRow> row_;
+    int64_t last_seq_num_ = KeyValue::UNKNOWN_SEQUENCE;
+    bool current_delete_row_ = false;
+
+    /// If the first value is retract, and no insert record is received, the row kind should be
+    /// RowKind::Delete. (Partial update sequence group may not correctly set current_delete_row_
+    /// if no RowKind::Insert value is received)
+    bool meet_insert_ = false;
+
+    /// Whether the row has been initialized with non-null column values from the first record.
+    bool not_null_column_filled_ = false;
+};
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/partial_update_merge_function_test.cpp
+++ b/src/paimon/core/mergetree/compact/partial_update_merge_function_test.cpp
@@ -1,0 +1,877 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/partial_update_merge_function.h"
+
+#include <algorithm>
+#include <ostream>
+#include <variant>
+
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/data_define.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/mergetree/compact/aggregate/field_last_non_null_value_agg.h"
+#include "paimon/core/mergetree/compact/aggregate/field_min_agg.h"
+#include "paimon/core/mergetree/compact/aggregate/field_primary_key_agg.h"
+#include "paimon/core/mergetree/compact/aggregate/field_sum_agg.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/defs.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class PartialUpdateMergeFunctionTest : public testing::Test {
+ public:
+    void SetUp() override {
+        sequence_ = 0;
+        pool_ = GetDefaultPool();
+    }
+    void TearDown() override {}
+
+    void Add(const std::unique_ptr<PartialUpdateMergeFunction>& mfunc,
+             const BinaryRowGenerator::ValueType& values) {
+        Add(mfunc, RowKind::Insert(), values);
+    }
+    void Add(const std::unique_ptr<PartialUpdateMergeFunction>& mfunc, const RowKind* row_kind,
+             const BinaryRowGenerator::ValueType& values) {
+        std::shared_ptr<InternalRow> key = BinaryRowGenerator::GenerateRowPtr({1}, pool_.get());
+        ASSERT_OK(
+            mfunc->Add(KeyValue(row_kind, sequence_++, KeyValue::UNKNOWN_LEVEL, std::move(key),
+                                BinaryRowGenerator::GenerateRowPtr(values, pool_.get()))));
+    }
+
+    std::vector<DataField> CreateDataFields(int32_t value_arity) {
+        std::vector<DataField> data_fields;
+        for (int32_t i = 0; i < value_arity; i++) {
+            data_fields.emplace_back(i, arrow::field("f" + std::to_string(i), arrow::int32()));
+        }
+        return data_fields;
+    }
+
+    void CheckResult(const std::unique_ptr<PartialUpdateMergeFunction>& mfunc,
+                     const std::vector<VariantType>& expected) {
+        auto typed_row = mfunc->row_.get();
+        ASSERT_TRUE(typed_row);
+        auto expected_row = GenericRow::Of(expected);
+        ASSERT_EQ(*expected_row, *typed_row) << "expect:" << expected_row->ToString() << std::endl
+                                             << "result:" << typed_row->ToString();
+    }
+
+    Result<std::unique_ptr<PartialUpdateMergeFunction>> CreateMergeFunctionResult(
+        int32_t value_arity, const std::map<std::string, std::string>& options_map) {
+        std::vector<DataField> data_fields = CreateDataFields(value_arity);
+        auto value_schema = DataField::ConvertDataFieldsToArrowSchema(data_fields);
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options, CoreOptions::FromMap(options_map));
+        std::map<std::string, std::vector<std::string>> value_field_to_seq_group_field;
+        std::set<std::string> seq_group_key_set;
+        PAIMON_RETURN_NOT_OK(PartialUpdateMergeFunction::ParseSequenceGroupFields(
+            options, &value_field_to_seq_group_field, &seq_group_key_set));
+        return PartialUpdateMergeFunction::Create(value_schema, /*primary_keys=*/{"f0"}, options,
+                                                  value_field_to_seq_group_field,
+                                                  seq_group_key_set);
+    }
+
+    std::string CreateMergeFunctionWithInvalidOptions(
+        int32_t value_arity, const std::map<std::string, std::string>& options_map) {
+        auto mfunc = CreateMergeFunctionResult(value_arity, options_map);
+        EXPECT_FALSE(mfunc.ok());
+        return mfunc.status().ToString();
+    }
+
+    std::unique_ptr<PartialUpdateMergeFunction> CreateMergeFunction(
+        int32_t value_arity, const std::map<std::string, std::string>& options_map) {
+        EXPECT_OK_AND_ASSIGN(std::unique_ptr<PartialUpdateMergeFunction> mfunc,
+                             CreateMergeFunctionResult(value_arity, options_map));
+        return mfunc;
+    }
+
+    std::unique_ptr<PartialUpdateMergeFunction> CreateMergeFunctionWithProjection(
+        const std::vector<DataField>& table_fields, const std::vector<DataField>& value_fields,
+        const std::map<std::string, std::string>& options_map,
+        const std::vector<DataField>& expected_completed_value_fields) {
+        TableSchema table_schema;
+        table_schema.fields_ = table_fields;
+
+        std::vector<DataField> copy_value_fields = value_fields;
+        EXPECT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap(options_map));
+        std::map<std::string, std::vector<std::string>> value_field_to_seq_group_field;
+        std::set<std::string> seq_group_key_set;
+        EXPECT_OK(PartialUpdateMergeFunction::ParseSequenceGroupFields(
+            options, &value_field_to_seq_group_field, &seq_group_key_set));
+        EXPECT_OK(PartialUpdateMergeFunction::CompleteSequenceGroupFields(
+            table_schema, value_field_to_seq_group_field, &copy_value_fields));
+        EXPECT_EQ(copy_value_fields, expected_completed_value_fields);
+        auto value_schema = DataField::ConvertDataFieldsToArrowSchema(copy_value_fields);
+        EXPECT_OK_AND_ASSIGN(
+            std::unique_ptr<PartialUpdateMergeFunction> mfunc,
+            PartialUpdateMergeFunction::Create(value_schema, {"f0"}, options,
+                                               value_field_to_seq_group_field, seq_group_key_set));
+        return mfunc;
+    }
+
+ private:
+    int64_t sequence_ = 0;
+    std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+};
+TEST_F(PartialUpdateMergeFunctionTest, TestNonNull) {
+    auto mfunc = CreateMergeFunction(/*value_arity=*/7, {});
+    mfunc->Reset();
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {1, 2, 2, 2, 2, 2, NullType()});
+    CheckResult(mfunc, {1, 2, 2, 2, 2, 2, 1});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestSequenceGroup) {
+    std::map<std::string, std::string> options = {{"fields.f3.sequence-group", "f1,f2"},
+                                                  {"fields.f6.sequence-group", "f4,f5"}};
+    auto mfunc = CreateMergeFunction(/*value_arity=*/7, options);
+    mfunc->Reset();
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {1, 2, 2, 2, 2, 2, NullType()});
+    CheckResult(mfunc, {1, 2, 2, 2, 1, 1, 1});
+    Add(mfunc, {1, 3, 3, 1, 3, 3, 3});
+    CheckResult(mfunc, {1, 2, 2, 2, 3, 3, 3});
+
+    // test delete
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 3, 1, 1, NullType()});
+    CheckResult(mfunc, {1, NullType(), NullType(), 3, 3, 3, 3});
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 3, 1, 1, 4});
+    CheckResult(mfunc, {1, NullType(), NullType(), 3, NullType(), NullType(), 4});
+    Add(mfunc, {1, 4, 4, 4, 5, 5, 5});
+    CheckResult(mfunc, {1, 4, 4, 4, 5, 5, 5});
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 6, 1, 1, 6});
+    CheckResult(mfunc, {1, NullType(), NullType(), 6, NullType(), NullType(), 6});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestSequenceGroupPartialDelete) {
+    std::map<std::string, std::string> options = {
+        {"fields.f3.sequence-group", "f1,f2"},
+        {"fields.f6.sequence-group", "f4,f5"},
+        {"partial-update.remove-record-on-sequence-group", "f6"}};
+    auto mfunc = CreateMergeFunction(/*value_arity=*/7, options);
+    mfunc->Reset();
+
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {1, 2, 2, 2, 2, 2, NullType()});
+    CheckResult(mfunc, {1, 2, 2, 2, 1, 1, 1});
+    Add(mfunc, {1, 3, 3, 1, 3, 3, 3});
+    CheckResult(mfunc, {1, 2, 2, 2, 3, 3, 3});
+
+    // delete
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 3, 1, 1, NullType()});
+    CheckResult(mfunc, {1, NullType(), NullType(), 3, 3, 3, 3});
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 3, 1, 1, 4});
+    CheckResult(mfunc, {1, 1, 1, 3, 1, 1, 4});
+    Add(mfunc, {1, 4, 4, 4, 5, 5, 5});
+    CheckResult(mfunc, {1, 4, 4, 4, 5, 5, 5});
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 6, 1, 1, 6});
+    CheckResult(mfunc, {1, 1, 1, 6, 1, 1, 6});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestMultiSequenceFields) {
+    std::map<std::string, std::string> options = {{"fields.f3,f4.sequence-group", "f1,f2"},
+                                                  {"fields.f7,f8.sequence-group", "f5,f6"}};
+    auto mfunc = CreateMergeFunction(/*value_arity=*/9, options);
+    mfunc->Reset();
+
+    // test null sequence field
+    Add(mfunc, {1, NullType(), NullType(), NullType(), NullType(), 1, 1, 1, 3});
+    Add(mfunc, {1, 2, 2, NullType(), NullType(), 2, 2, 1, 3});
+    CheckResult(mfunc, {1, NullType(), NullType(), NullType(), NullType(), 2, 2, 1, 3});
+    mfunc->Reset();
+
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1, 1, 3});
+    Add(mfunc, {1, 2, 2, 2, 2, 2, 1, 1, NullType()});
+    CheckResult(mfunc, {1, 2, 2, 2, 2, 1, 1, 1, 3});
+    Add(mfunc, {1, 1, 3, 1, 3, 3, 3, 3, 2});
+    CheckResult(mfunc, {1, 2, 2, 2, 2, 3, 3, 3, 2});
+
+    // delete
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 3, 3, 1, 1, NullType(), NullType()});
+    CheckResult(mfunc, {1, NullType(), NullType(), 3, 3, 3, 3, 3, 2});
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 3, 1, 1, 1, 4, 4});
+    CheckResult(mfunc, {1, NullType(), NullType(), 3, 3, NullType(), NullType(), 4, 4});
+    Add(mfunc, {1, 4, 4, 4, 4, 5, 5, 5, 5});
+    CheckResult(mfunc, {1, 4, 4, 4, 4, 5, 5, 5, 5});
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 6, 1, 1, 1, 6, 1});
+    CheckResult(mfunc, {1, NullType(), NullType(), 6, 1, NullType(), NullType(), 6, 1});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestSequenceGroupDefaultAggFunc) {
+    std::map<std::string, std::string> options = {
+        {"fields.f3.sequence-group", "f1,f2"},
+        {"fields.f6.sequence-group", "f4,f5"},
+        {Options::FIELDS_DEFAULT_AGG_FUNC, "last_non_null_value"}};
+    auto mfunc = CreateMergeFunction(/*value_arity=*/7, options);
+    mfunc->Reset();
+
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {1, 2, 2, 2, 2, 2, NullType()});
+    CheckResult(mfunc, {1, 2, 2, 2, 1, 1, 1});
+    Add(mfunc, {1, 3, 3, 1, 3, 3, 3});
+    CheckResult(mfunc, {1, 2, 2, 2, 3, 3, 3});
+    Add(mfunc, {1, 4, NullType(), 4, 5, NullType(), 5});
+    CheckResult(mfunc, {1, 4, 2, 4, 5, 3, 5});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestMultiSequenceFieldsDefaultAggFunc) {
+    std::map<std::string, std::string> options = {
+        {"fields.f3,f4.sequence-group", "f1,f2"},
+        {"fields.f7,f8.sequence-group", "f5,f6"},
+        {Options::FIELDS_DEFAULT_AGG_FUNC, "last_non_null_value"}};
+    auto mfunc = CreateMergeFunction(/*value_arity=*/9, options);
+    mfunc->Reset();
+
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {1, 2, 2, 2, 2, 2, 2, NullType(), NullType()});
+    CheckResult(mfunc, {1, 2, 2, 2, 2, 1, 1, 1, 1});
+    Add(mfunc, {1, 3, 3, 1, 1, 3, 3, 3, 3});
+    CheckResult(mfunc, {1, 2, 2, 2, 2, 3, 3, 3, 3});
+    Add(mfunc, {1, 4, NullType(), 4, 4, 5, NullType(), 5, 5});
+    CheckResult(mfunc, {1, 4, 2, 4, 4, 5, 3, 5, 5});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestSequenceGroupDefinedNoField) {
+    std::map<std::string, std::string> options = {{"fields.f7.sequence-group", "f1,f2"},
+                                                  {"fields.f6.sequence-group", "f4,f5"}};
+    auto error_msg = CreateMergeFunctionWithInvalidOptions(/*value_arity=*/7, options);
+    ASSERT_TRUE(
+        error_msg.find("cannot find sequence group field f7 in value schema, unexpected.") !=
+        std::string::npos);
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestSequenceGroupRepeatDefine) {
+    std::map<std::string, std::string> options_map = {{"fields.f3.sequence-group", "f1,f2"},
+                                                      {"fields.f4.sequence-group", "f1,f2"}};
+    ASSERT_OK_AND_ASSIGN(auto options, CoreOptions::FromMap(options_map));
+
+    std::map<std::string, std::vector<std::string>> value_field_to_seq_group_field;
+    std::set<std::string> seq_group_key_set;
+    ASSERT_NOK_WITH_MSG(PartialUpdateMergeFunction::ParseSequenceGroupFields(
+                            options, &value_field_to_seq_group_field, &seq_group_key_set),
+                        "field f1 is defined repeatedly by multiple groups: f4 and f3");
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestMultiSequenceFieldsRepeatDefine) {
+    std::map<std::string, std::string> options_map = {{"fields.f3,f4.sequence-group", "f1,f2"},
+                                                      {"fields.f5,f6.sequence-group", "f1,f2"}};
+    ASSERT_OK_AND_ASSIGN(auto options, CoreOptions::FromMap(options_map));
+    std::map<std::string, std::vector<std::string>> value_field_to_seq_group_field;
+    std::set<std::string> seq_group_key_set;
+    ASSERT_NOK_WITH_MSG(PartialUpdateMergeFunction::ParseSequenceGroupFields(
+                            options, &value_field_to_seq_group_field, &seq_group_key_set),
+                        "field f1 is defined repeatedly by multiple groups: f5,f6 and f3,f4");
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestAdjustProjection) {
+    std::map<std::string, std::string> options_map = {{"fields.f4.sequence-group", "f1,f3"},
+                                                      {"fields.f5.sequence-group", "f7"}};
+
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    std::vector<DataField> value_fields = {table_fields[1], table_fields[3], table_fields[7]};
+
+    std::vector<DataField> expected_completed_value_fields = {
+        table_fields[1], table_fields[3], table_fields[7], table_fields[4], table_fields[5]};
+
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+    Add(mfunc, {1, 1, 1, 1, 1});
+    Add(mfunc, {2, 6, 2, 2, 2});
+    CheckResult(mfunc, {2, 6, 2, 2, 2});
+
+    // enable field updated by null
+    Add(mfunc, {3, NullType(), 7, 4, NullType()});
+    CheckResult(mfunc, {3, NullType(), 2, 4, 2});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestMultiSequenceFieldsAdjustProjection) {
+    std::map<std::string, std::string> options_map = {{"fields.f2,f4.sequence-group", "f1,f3"},
+                                                      {"fields.f5,f6.sequence-group", "f7"}};
+
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    std::vector<DataField> value_fields = {table_fields[1], table_fields[3], table_fields[7]};
+
+    std::vector<DataField> expected_completed_value_fields = {
+        table_fields[1], table_fields[3], table_fields[7], table_fields[2],
+        table_fields[4], table_fields[5], table_fields[6]};
+
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {2, 6, 2, 2, 2, 2, 6});
+    CheckResult(mfunc, {2, 6, 2, 2, 2, 2, 6});
+
+    // update first sequence group
+    Add(mfunc, {3, NullType(), 7, 4, NullType(), 1, 8});
+    CheckResult(mfunc, {3, NullType(), 2, 4, NullType(), 2, 6});
+
+    // update second sequence group
+    Add(mfunc, {5, 3, 3, 3, 5, 5, 6});
+    CheckResult(mfunc, {3, NullType(), 3, 4, NullType(), 5, 6});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestAdjustProjectionSequenceFieldsProject) {
+    std::map<std::string, std::string> options_map = {{"fields.f4.sequence-group", "f1,f3"},
+                                                      {"fields.f5.sequence-group", "f7"}};
+
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    // the sequence field 'f4' is projected too
+    std::vector<DataField> value_fields = {table_fields[1], table_fields[4], table_fields[3],
+                                           table_fields[7]};
+
+    std::vector<DataField> expected_completed_value_fields = {
+        table_fields[1], table_fields[4], table_fields[3], table_fields[7], table_fields[5]};
+
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+    // if sequence field is null, the related fields should not be updated
+    Add(mfunc, {1, 1, 1, 1, 1});
+    Add(mfunc, {1, NullType(), 1, 2, 2});
+    CheckResult(mfunc, {1, 1, 1, 2, 2});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestMultiSequenceFieldsAdjustProjectionProject) {
+    std::map<std::string, std::string> options_map = {{"fields.f2,f4.sequence-group", "f1,f3"},
+                                                      {"fields.f5,f6.sequence-group", "f7"}};
+
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    // the sequence field 'f4' is projected too
+    std::vector<DataField> value_fields = {table_fields[1], table_fields[4], table_fields[3],
+                                           table_fields[7]};
+
+    std::vector<DataField> expected_completed_value_fields = {
+        table_fields[1], table_fields[4], table_fields[3], table_fields[7],
+        table_fields[2], table_fields[5], table_fields[6]};
+
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {1, NullType(), 1, 3, 2, 2, 2});
+    CheckResult(mfunc, {1, NullType(), 1, 3, 2, 2, 2});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestAdjustProjectionAllFieldsProject) {
+    std::map<std::string, std::string> options_map = {{"fields.f4.sequence-group", "f1,f3"},
+                                                      {"fields.f5.sequence-group", "f7"}};
+
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    // all fields are projected
+    std::vector<DataField> value_fields = table_fields;
+    std::vector<DataField> expected_completed_value_fields = table_fields;
+
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+    // 'f6' has no sequence group, it should not be updated by null
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {4, 2, 4, 2, 2, 0, NullType(), 3});
+    CheckResult(mfunc, {4, 2, 4, 2, 2, 1, 1, 1});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestMultiSequenceFieldsAdjustProjectionAllFieldsProject) {
+    std::map<std::string, std::string> options_map = {{"fields.f2,f4.sequence-group", "f1,f3"},
+                                                      {"fields.f5,f6.sequence-group", "f7"}};
+
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    // all fields are projected
+    std::vector<DataField> value_fields = table_fields;
+    std::vector<DataField> expected_completed_value_fields = table_fields;
+
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+    // 'f6' has no sequence group, it should not be updated by null
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {4, 2, 4, 2, 2, 0, NullType(), 3});
+    CheckResult(mfunc, {4, 2, 4, 2, 2, 1, 1, 1});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestAdjustProjectionNoSequenceGroup) {
+    std::map<std::string, std::string> options_map = {};
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    std::vector<DataField> value_fields = {table_fields[0], table_fields[1], table_fields[3],
+                                           table_fields[4], table_fields[7]};
+    std::vector<DataField> expected_completed_value_fields = value_fields;
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+    // Without sequence group, all the fields should not be updated by null
+    Add(mfunc, {1, 1, 1, 1, 1});
+    Add(mfunc, {3, 3, NullType(), 3, 3});
+    CheckResult(mfunc, {3, 3, 1, 3, 3});
+    Add(mfunc, {2, 2, 2, 2, 2});
+    CheckResult(mfunc, {2, 2, 2, 2, 2});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestAdjustProjectionCreateDirectly) {
+    std::map<std::string, std::string> options_map = {{"fields.f4.sequence-group", "f1,f3"},
+                                                      {"fields.f5.sequence-group", "f7"}};
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    std::vector<DataField> value_fields = {table_fields[1], table_fields[7]};
+    auto value_schema = DataField::ConvertDataFieldsToArrowSchema(value_fields);
+    ASSERT_OK_AND_ASSIGN(auto options, CoreOptions::FromMap(options_map));
+
+    std::map<std::string, std::vector<std::string>> value_field_to_seq_group_field;
+    std::set<std::string> seq_group_key_set;
+
+    ASSERT_OK(PartialUpdateMergeFunction::ParseSequenceGroupFields(
+        options, &value_field_to_seq_group_field, &seq_group_key_set));
+    ASSERT_NOK_WITH_MSG(
+        PartialUpdateMergeFunction::Create(value_schema, {"f0"}, options,
+                                           value_field_to_seq_group_field, seq_group_key_set),
+        "cannot find sequence group field f4 in value schema, unexpected.");
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestFirstValue) {
+    std::map<std::string, std::string> options = {{"fields.f1.sequence-group", "f2,f3"},
+                                                  {"fields.f2.aggregate-function", "first_value"},
+                                                  {"fields.f3.aggregate-function", "last_value"}};
+    auto mfunc = CreateMergeFunction(/*value_arity=*/4, options);
+    mfunc->Reset();
+
+    Add(mfunc, {1, 1, 1, 1});
+    Add(mfunc, {1, 2, 2, 2});
+    CheckResult(mfunc, {1, 2, 1, 2});
+    Add(mfunc, {1, 0, 3, 3});
+    CheckResult(mfunc, {1, 2, 3, 2});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestMultiSequenceFieldsFirstValue) {
+    std::map<std::string, std::string> options = {{"fields.f1,f2.sequence-group", "f3,f4"},
+                                                  {"fields.f3.aggregate-function", "first_value"},
+                                                  {"fields.f4.aggregate-function", "last_value"}};
+    auto mfunc = CreateMergeFunction(/*value_arity=*/5, options);
+    mfunc->Reset();
+
+    Add(mfunc, {1, 1, 1, 1, 1});
+    Add(mfunc, {1, 2, 2, 2, 2});
+    CheckResult(mfunc, {1, 2, 2, 1, 2});
+    Add(mfunc, {1, 0, 1, 3, 3});
+    CheckResult(mfunc, {1, 2, 2, 3, 2});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestPartialUpdateWithAggregation) {
+    std::map<std::string, std::string> options = {
+        {"fields.f1.sequence-group", "f2,f3,f4"},
+        {"fields.f7.sequence-group", "f6"},
+        {"fields.f0.aggregate-function", "listagg"},
+        {"fields.f2.aggregate-function", "sum"},
+        {"fields.f4.aggregate-function", "last_value"},
+        {"fields.f6.aggregate-function", "last_non_null_value"},
+        {"fields.f4.ignore-retract", "true"},
+        {"fields.f6.ignore-retract", "true"}};
+
+    auto mfunc = CreateMergeFunction(/*value_arity=*/8, options);
+    mfunc->Reset();
+
+    // f0 pk
+    // f1 sequence group
+    // f2 in f1 group with sum agg
+    // f3 in f1 group without agg
+    // f4 in f1 group with last_value agg
+    // f5 not in group
+    // f6 in f7 group with last_not_null agg
+    // f7 sequence group 2
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {1, 2, 1, 2, 2, 2, 2, 0});
+    CheckResult(mfunc, {1, 2, 2, 2, 2, 2, 1, 1});
+
+    // g_1, g_2 not advanced
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 2, 0});
+    CheckResult(mfunc, {1, 2, 3, 2, 2, 1, 1, 1});
+    Add(mfunc, {1, 1, -1, 1, 1, 2, 2, 0});
+    CheckResult(mfunc, {1, 2, 2, 2, 2, 2, 1, 1});
+
+    // test null
+    Add(mfunc, {1, 3, NullType(), NullType(), NullType(), NullType(), NullType(), 2});
+    CheckResult(mfunc, {1, 3, 2, NullType(), NullType(), 2, 1, 2});
+
+    // test retract
+    Add(mfunc, {1, 3, 1, 1, 1, 1, 1, 3});
+    CheckResult(mfunc, {1, 3, 3, 1, 1, 1, 1, 3});
+    Add(mfunc, RowKind::UpdateBefore(), {1, 3, 2, 1, 1, 1, 1, 3});
+    CheckResult(mfunc, {1, 3, 1, NullType(), 1, 1, 1, 3});
+    Add(mfunc, RowKind::Delete(), {1, 3, 2, 1, 1, 1, 1, 3});
+    CheckResult(mfunc, {1, 3, -1, NullType(), 1, 1, 1, 3});
+    // retract for old sequence
+    Add(mfunc, RowKind::Delete(), {1, 2, 2, 1, 1, 1, 1, 3});
+    CheckResult(mfunc, {1, 3, -3, NullType(), 1, 1, 1, 3});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestMultiSequenceFieldsPartialUpdateWithAggregation) {
+    std::map<std::string, std::string> options = {
+        {"fields.f1,f2.sequence-group", "f3,f4,f5"},
+        {"fields.f7,f8.sequence-group", "f6"},
+        {"fields.f0.aggregate-function", "listagg"},
+        {"fields.f3.aggregate-function", "sum"},
+        {"fields.f4.aggregate-function", "first_value"},
+        {"fields.f5.aggregate-function", "last_value"},
+        {"fields.f6.aggregate-function", "last_non_null_value"},
+        {"fields.f4.ignore-retract", "true"},
+        {"fields.f6.ignore-retract", "true"}};
+
+    auto mfunc = CreateMergeFunction(/*value_arity=*/9, options);
+    mfunc->Reset();
+
+    // f0 pk
+    // f1, f2 sequence group 1
+    // f3 in f1, f2 group with sum agg
+    // f4 in f1, f2 group with first_value agg
+    // f5 in f1, f2 group with last_value agg
+    // f6 in f7, f8 group with last_not_null agg
+    // f7, f8 sequence group 2
+
+    // test null retract
+    Add(mfunc, {1, NullType(), NullType(), 1, 1, 1, 1, 1, 1});
+    CheckResult(mfunc, {1, NullType(), NullType(), NullType(), NullType(), NullType(), 1, 1, 1});
+
+    Add(mfunc, RowKind::Delete(), {1, NullType(), NullType(), 1, 1, 1, 0, 1, 1});
+    CheckResult(mfunc, {1, NullType(), NullType(), NullType(), NullType(), NullType(), 1, 1, 1});
+
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1, 1, 1});
+    CheckResult(mfunc, {1, 1, 1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {1, 1, 2, 1, 2, 2, NullType(), 2, 0});
+    CheckResult(mfunc, {1, 1, 2, 2, 1, 2, 1, 2, 0});
+
+    // sequence group not advanced
+    Add(mfunc, {1, 1, 1, 1, 3, 1, 1, 2, 0});
+    CheckResult(mfunc, {1, 1, 2, 3, 3, 2, 1, 2, 0});
+
+    // test null
+    Add(mfunc, {1, 1, 3, NullType(), NullType(), NullType(), NullType(), 4, 2});
+    CheckResult(mfunc, {1, 1, 3, 3, 3, NullType(), 1, 4, 2});
+
+    // test retract
+    Add(mfunc, {1, 2, 3, 1, 1, 1, 1, 4, 3});
+    CheckResult(mfunc, {1, 2, 3, 4, 3, 1, 1, 4, 3});
+    Add(mfunc, RowKind::UpdateBefore(), {1, 2, 3, 2, 1, 2, 1, 4, 3});
+    CheckResult(mfunc, {1, 2, 3, 2, 3, NullType(), 1, 4, 3});
+    Add(mfunc, RowKind::Delete(), {1, 3, 2, 3, 1, 1, 4, 3, 1});
+    CheckResult(mfunc, {1, 3, 2, -1, 3, NullType(), 1, 4, 3});
+    // retract for old sequence
+    Add(mfunc, RowKind::Delete(), {1, 2, 2, 2, 1, 1, 1, 1, 3});
+    CheckResult(mfunc, {1, 3, 2, -3, 3, NullType(), 1, 4, 3});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestPartialUpdateWithAggregationProjectPushDown) {
+    std::map<std::string, std::string> options_map = {
+        {"fields.f1.sequence-group", "f2,f3,f4"},
+        {"fields.f7.sequence-group", "f6"},
+        {"fields.f0.aggregate-function", "listagg"},
+        {"fields.f2.aggregate-function", "sum"},
+        {"fields.f4.aggregate-function", "last_value"},
+        {"fields.f6.aggregate-function", "last_non_null_value"},
+        {"fields.f4.ignore-retract", "true"},
+        {"fields.f6.ignore-retract", "true"}};
+
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    std::vector<DataField> value_fields = {table_fields[3], table_fields[2], table_fields[5]};
+
+    std::vector<DataField> expected_completed_value_fields = {table_fields[3], table_fields[2],
+                                                              table_fields[5], table_fields[1]};
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+
+    // f0 pk
+    // f1 sequence group
+    // f2 in f1 group with sum agg
+    // f3 in f1 group without agg
+    // f4 in f1 group with last_value agg
+    // f5 not in group
+    // f6 in f7 group with last_not_null agg
+    // f7 sequence group 2
+    Add(mfunc, {1, 1, 1, 1});
+    Add(mfunc, {2, 1, 2, 2});
+    CheckResult(mfunc, {2, 2, 2, 2});
+
+    Add(mfunc, RowKind::Insert(), {NullType(), NullType(), NullType(), 3});
+    CheckResult(mfunc, {NullType(), 2, 2, 3});
+
+    // test retract
+    Add(mfunc, RowKind::UpdateBefore(), {1, 2, 1, 3});
+    CheckResult(mfunc, {NullType(), 0, 2, 3});
+    Add(mfunc, RowKind::Delete(), {1, 2, 1, 3});
+    CheckResult(mfunc, {NullType(), -2, 2, 3});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest,
+       TestMultiSequenceFieldsPartialUpdateWithAggregationProjectPushDown) {
+    std::map<std::string, std::string> options_map = {
+        {"fields.f1,f8.sequence-group", "f2,f3,f4"},
+        {"fields.f7,f9.sequence-group", "f6"},
+        {"fields.f0.aggregate-function", "listagg"},
+        {"fields.f2.aggregate-function", "sum"},
+        {"fields.f4.aggregate-function", "last_value"},
+        {"fields.f6.aggregate-function", "last_non_null_value"},
+        {"fields.f4.ignore-retract", "true"},
+        {"fields.f6.ignore-retract", "true"}};
+
+    auto table_fields = CreateDataFields(/*value_arity=*/10);
+    std::vector<DataField> value_fields = {table_fields[3], table_fields[2], table_fields[5]};
+
+    std::vector<DataField> expected_completed_value_fields = {
+        table_fields[3], table_fields[2], table_fields[5], table_fields[1], table_fields[8]};
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+
+    // f0 pk
+    // f1, f8 sequence group
+    // f2 in f1, f8 group with sum agg
+    // f3 in f1, f8 group without agg
+    // f4 in f1, f8 group with last_value agg
+    // f5 not in group
+    // f6 in f7, f9 group with last_not_null agg
+    // f7, f9 sequence group 2
+    Add(mfunc, {1, 1, 1, 1, 1});
+    Add(mfunc, {2, 1, 2, 2, 2});
+    CheckResult(mfunc, {2, 2, 2, 2, 2});
+
+    Add(mfunc, RowKind::Insert(), {NullType(), NullType(), NullType(), 3, 3});
+    CheckResult(mfunc, {NullType(), 2, 2, 3, 3});
+
+    // test retract
+    Add(mfunc, RowKind::UpdateBefore(), {1, 2, 1, 3, 3});
+    CheckResult(mfunc, {NullType(), 0, 2, 3, 3});
+    Add(mfunc, RowKind::Delete(), {1, 2, 1, 3, 3});
+    CheckResult(mfunc, {NullType(), -2, 2, 3, 3});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestAggregationWithoutSequenceGroup) {
+    std::map<std::string, std::string> options = {{"fields.f1.aggregate-function", "sum"}};
+    auto error_msg = CreateMergeFunctionWithInvalidOptions(/*value_arity=*/2, options);
+    ASSERT_TRUE(
+        error_msg.find(
+            "Must use sequence group for aggregation functions but not found for field f1") !=
+        std::string::npos)
+        << error_msg;
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestConflictsInDeleteConfig) {
+    {
+        std::map<std::string, std::string> options = {
+            {"ignore-delete", "true"}, {"partial-update.remove-record-on-delete", "true"}};
+        auto error_msg = CreateMergeFunctionWithInvalidOptions(/*value_arity=*/2, options);
+        ASSERT_TRUE(
+            error_msg.find("ignore-delete and partial-update.remove-record-on-delete have "
+                           "conflicting behavior so should not be enabled at the same time.") !=
+            std::string::npos)
+            << error_msg;
+    }
+    {
+        std::map<std::string, std::string> options = {
+            {"fields.f1.sequence-group", "f2"}, {"partial-update.remove-record-on-delete", "true"}};
+        auto error_msg = CreateMergeFunctionWithInvalidOptions(/*value_arity=*/3, options);
+        ASSERT_TRUE(
+            error_msg.find("sequence group and partial-update.remove-record-on-delete have "
+                           "conflicting behavior so should not be enabled at the same time.") !=
+            std::string::npos)
+            << error_msg;
+    }
+    {
+        std::map<std::string, std::string> options = {
+            {"fields.f1.sequence-group", "f2"},
+            {"partial-update.remove-record-on-sequence-group", "f2,f3"}};
+        auto error_msg = CreateMergeFunctionWithInvalidOptions(/*value_arity=*/3, options);
+        ASSERT_TRUE(
+            error_msg.find("field f2,f3 defined in partial-update.remove-record-on-sequence-group "
+                           "option must be part of sequence groups.") != std::string::npos)
+            << error_msg;
+    }
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestInvalidDeleteRecord) {
+    auto mfunc = CreateMergeFunction(/*value_arity=*/3, {});
+    mfunc->Reset();
+    std::shared_ptr<InternalRow> key = BinaryRowGenerator::GenerateRowPtr({1}, pool_.get());
+    ASSERT_NOK_WITH_MSG(
+        mfunc->Add(KeyValue(RowKind::Delete(), sequence_++, KeyValue::UNKNOWN_LEVEL, std::move(key),
+                            BinaryRowGenerator::GenerateRowPtr({1, 2, 3}, pool_.get()))),
+        "By default, Partial update can not accept delete records, "
+        "you can choose one of the following solutions");
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestRemoveRecordOnSequenceGroupNotRecalled) {
+    // fields f0-f6, only recall f0-f3, f6 is not recalled therefore, remove config will be ignored
+    std::map<std::string, std::string> options = {
+        {"fields.f3.sequence-group", "f1,f2"},
+        {"fields.f6.sequence-group", "f4,f5"},
+        {"partial-update.remove-record-on-sequence-group", "f6"}};
+    auto mfunc = CreateMergeFunction(/*value_arity=*/4, options);
+    mfunc->Reset();
+
+    Add(mfunc, {1, 1, 1, 1});
+    Add(mfunc, {1, 2, 2, 2});
+    CheckResult(mfunc, {1, 2, 2, 2});
+    // delete
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 3});
+    CheckResult(mfunc, {1, NullType(), NullType(), 3});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestCreateFieldAggregatorsWithDefaultAgg) {
+    auto value_schema = arrow::schema(
+        arrow::FieldVector({arrow::field("p0", arrow::int32()), arrow::field("f0", arrow::int32()),
+                            arrow::field("f1", arrow::int32()), arrow::field("f2", arrow::int32()),
+                            arrow::field("f3", arrow::int32())}));
+
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({
+                             {Options::FIELDS_DEFAULT_AGG_FUNC, "sum"},
+                             {"fields.f1.aggregate-function", "min"},
+                             {"fields.f0.sequence-group", "f1,f2"},
+                             {"fields.f3.aggregate-function", "last_non_null_value"},
+                         }));
+    std::map<std::string, std::vector<std::string>> value_field_to_seq_group_field;
+    std::set<std::string> seq_group_key_set;
+    ASSERT_OK(PartialUpdateMergeFunction::ParseSequenceGroupFields(
+        options, &value_field_to_seq_group_field, &seq_group_key_set));
+    std::map<int32_t, std::shared_ptr<FieldAggregator>> aggs;
+    ASSERT_OK_AND_ASSIGN(aggs, PartialUpdateMergeFunction::CreateFieldAggregators(
+                                   value_schema,
+                                   /*primary_keys=*/{"p0"}, options, value_field_to_seq_group_field,
+                                   seq_group_key_set));
+    ASSERT_EQ(4, aggs.size());
+    // test primary key: p0
+    ASSERT_TRUE(dynamic_cast<FieldPrimaryKeyAgg*>(aggs[0].get()));
+    // test sequence group field without agg: f0
+    ASSERT_TRUE(aggs.find(1) == aggs.end());
+    // test specify agg: f1
+    ASSERT_TRUE(dynamic_cast<FieldMinAgg*>(aggs[2].get()));
+    // test default agg: f2
+    ASSERT_TRUE(dynamic_cast<FieldSumAgg*>(aggs[3].get()));
+    // test last_non_null_value agg without sequence group: f3
+    ASSERT_TRUE(dynamic_cast<FieldLastNonNullValueAgg*>(aggs[4].get()));
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestCreateFieldAggregatorsWithoutDefaultAgg) {
+    auto value_schema = arrow::schema(arrow::FieldVector(
+        {arrow::field("p0", arrow::int32()), arrow::field("f0", arrow::int32()),
+         arrow::field("f1", arrow::int32()), arrow::field("f2", arrow::int32())}));
+
+    ASSERT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap({
+                                                  {"fields.f1.aggregate-function", "min"},
+                                                  {"fields.f0.sequence-group", "f1,f2"},
+                                              }));
+    std::map<std::string, std::vector<std::string>> value_field_to_seq_group_field;
+    std::set<std::string> seq_group_key_set;
+    ASSERT_OK(PartialUpdateMergeFunction::ParseSequenceGroupFields(
+        options, &value_field_to_seq_group_field, &seq_group_key_set));
+    std::map<int32_t, std::shared_ptr<FieldAggregator>> aggs;
+    ASSERT_OK_AND_ASSIGN(aggs, PartialUpdateMergeFunction::CreateFieldAggregators(
+                                   value_schema,
+                                   /*primary_keys=*/{"p0"}, options, value_field_to_seq_group_field,
+                                   seq_group_key_set));
+    ASSERT_EQ(2, aggs.size());
+    // test primary key: p0
+    ASSERT_TRUE(dynamic_cast<FieldPrimaryKeyAgg*>(aggs[0].get()));
+    // test sequence group field without agg: f0
+    ASSERT_TRUE(aggs.find(1) == aggs.end());
+    // test specify agg: f1
+    ASSERT_TRUE(dynamic_cast<FieldMinAgg*>(aggs[2].get()));
+    // test no agg: f2
+    ASSERT_TRUE(aggs.find(3) == aggs.end());
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestSequenceGroupPartialDeleteWithProjection) {
+    std::map<std::string, std::string> options_map = {
+        {"fields.f3.sequence-group", "f1,f2"},
+        {"fields.f6.sequence-group", "f4,f5"},
+        {"partial-update.remove-record-on-sequence-group", "f3,f6"}};
+
+    auto table_fields = CreateDataFields(/*value_arity=*/7);
+    // Reordered fields: f3, f6, f0, f1, f2, f4, f5
+    std::vector<DataField> value_fields = {table_fields[3], table_fields[6], table_fields[0],
+                                           table_fields[1], table_fields[2], table_fields[4],
+                                           table_fields[5]};
+    std::vector<DataField> expected_completed_value_fields = value_fields;
+
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+    // Reordered: f3=11, f6=22, f0=100, f1=200, f2=1, f4=12, f5=21
+    Add(mfunc, {11, 22, 100, 200, 1, 12, 21});
+    Add(mfunc, RowKind::Delete(), {11, 22, 100, 200, 1, 12, 21});
+    CheckResult(mfunc, {11, 22, 100, 200, 1, 12, 21});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestAdjustProjectionNonProject) {
+    std::map<std::string, std::string> options_map = {{"fields.f4.sequence-group", "f1,f3"},
+                                                      {"fields.f5.sequence-group", "f7"}};
+    auto table_fields = CreateDataFields(/*value_arity=*/8);
+    // Non-projection: use all fields
+    std::vector<DataField> value_fields = table_fields;
+    std::vector<DataField> expected_completed_value_fields = table_fields;
+
+    auto mfunc = CreateMergeFunctionWithProjection(table_fields, value_fields, options_map,
+                                                   expected_completed_value_fields);
+    mfunc->Reset();
+    Add(mfunc, {1, 1, 1, 1, 1, 1, 1, 1});
+    Add(mfunc, {4, 2, 4, 2, 2, 0, NullType(), 3});
+    CheckResult(mfunc, {4, 2, 4, 2, 2, 1, 1, 1});
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestDeleteReproduceCorrectSequenceNumber) {
+    std::map<std::string, std::string> options_map = {
+        {"partial-update.remove-record-on-delete", "true"}};
+    auto mfunc = CreateMergeFunction(/*value_arity=*/5, options_map);
+    mfunc->Reset();
+
+    Add(mfunc, {1, 1, 1, 1, 1});
+    Add(mfunc, RowKind::Delete(), {1, 1, 1, 1, 1});
+
+    ASSERT_OK_AND_ASSIGN(auto result, mfunc->GetResult());
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result->sequence_number, 1);
+}
+
+TEST_F(PartialUpdateMergeFunctionTest, TestInitRowWithNullableFieldOnDelete) {
+    std::map<std::string, std::string> options_map = {
+        {"partial-update.remove-record-on-delete", "true"}};
+    // f0 and f1 are not nullable, f2 and f3 are nullable
+    std::vector<DataField> data_fields = {
+        DataField(0, arrow::field("f0", arrow::int32(), /*nullable=*/false)),
+        DataField(1, arrow::field("f1", arrow::int32(), /*nullable=*/false)),
+        DataField(2, arrow::field("f2", arrow::int32(), /*nullable=*/true)),
+        DataField(3, arrow::field("f3", arrow::int32(), /*nullable=*/true))};
+    auto value_schema = DataField::ConvertDataFieldsToArrowSchema(data_fields);
+    ASSERT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap(options_map));
+    std::map<std::string, std::vector<std::string>> value_field_to_seq_group_field;
+    std::set<std::string> seq_group_key_set;
+    ASSERT_OK(PartialUpdateMergeFunction::ParseSequenceGroupFields(
+        options, &value_field_to_seq_group_field, &seq_group_key_set));
+    ASSERT_OK_AND_ASSIGN(auto mfunc, PartialUpdateMergeFunction::Create(
+                                         value_schema, /*primary_keys=*/{"f0"}, options,
+                                         value_field_to_seq_group_field, seq_group_key_set));
+    mfunc->Reset();
+
+    // insert some data first
+    Add(mfunc, {1, 3, 5, 7});
+    // send a DELETE with nullable field as null, triggers initRow
+    Add(mfunc, RowKind::Delete(), {1, 2, 2, NullType()});
+    // after delete with removeRecordOnDelete, row is re-initialized via initRow
+    CheckResult(mfunc, {1, 2, 2, NullType()});
+}
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/reducer_merge_function_wrapper.h
+++ b/src/paimon/core/mergetree/compact/reducer_merge_function_wrapper.h
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <utility>
+
+#include "paimon/core/key_value.h"
+#include "paimon/core/mergetree/compact/merge_function.h"
+#include "paimon/core/mergetree/compact/merge_function_wrapper.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+/// Wrapper for `MergeFunction`s which works like a reducer.
+///
+/// A reducer is a type of function. If there is only one input the result is equal to that input;
+/// Otherwise the result is calculated by merging all the inputs in some way.
+///
+/// This wrapper optimize the wrapped `MergeFunction`. If there is only one input, the input
+/// will be stored and the inner merge function will not be called, thus saving some computing time.
+class ReducerMergeFunctionWrapper : public MergeFunctionWrapper<KeyValue> {
+ public:
+    explicit ReducerMergeFunctionWrapper(std::unique_ptr<MergeFunction>&& merge_function)
+        : merge_function_(std::move(merge_function)) {}
+
+    /// Resets the `MergeFunction` helper to its default state.
+    void Reset() override {
+        initial_kv_ = std::nullopt;
+        merge_function_->Reset();
+        is_initialized_ = false;
+    }
+
+    /// Adds the given `KeyValue` to the `MergeFunction` helper.
+    Status Add(KeyValue&& kv) override {
+        if (!initial_kv_) {
+            initial_kv_ = std::move(kv);
+        } else {
+            if (!is_initialized_) {
+                PAIMON_RETURN_NOT_OK(Merge(std::move(initial_kv_).value()));
+                is_initialized_ = true;
+            }
+            PAIMON_RETURN_NOT_OK(Merge(std::move(kv)));
+        }
+        return Status::OK();
+    }
+
+    /// Get current value of the `MergeFunction` helper.
+    Result<std::optional<KeyValue>> GetResult() override {
+        std::optional<KeyValue> result;
+        if (is_initialized_) {
+            PAIMON_ASSIGN_OR_RAISE(result, merge_function_->GetResult());
+        } else {
+            result = std::move(initial_kv_);
+        }
+        Reset();
+        return result;
+    }
+
+ private:
+    Status Merge(KeyValue&& kv) {
+        return merge_function_->Add(std::move(kv));
+    }
+
+ private:
+    std::unique_ptr<MergeFunction> merge_function_;
+    std::optional<KeyValue> initial_kv_;
+    bool is_initialized_ = false;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/reducer_merge_function_wrapper_test.cpp
+++ b/src/paimon/core/mergetree/compact/reducer_merge_function_wrapper_test.cpp
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/reducer_merge_function_wrapper.h"
+
+#include <variant>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/key_value_checker.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(ReducerMergeFunctionWrapperTest, TestSimple) {
+    auto pool = GetDefaultPool();
+    KeyValue kv1(RowKind::Insert(), /*sequence_number=*/0, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({100}, pool.get()));
+    KeyValue kv2(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0,
+                 /*key=*/BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValue kv3(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0, /*key=*/
+                 BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                 /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+
+    auto mfunc = std::make_unique<DeduplicateMergeFunction>(/*ignore_delete=*/true);
+    ReducerMergeFunctionWrapper func_wrapper(std::move(mfunc));
+
+    func_wrapper.Reset();
+    ASSERT_EQ(std::nullopt, func_wrapper.GetResult().value());
+    ASSERT_OK(func_wrapper.Add(std::move(kv1)));
+    ASSERT_OK(func_wrapper.Add(std::move(kv2)));
+    auto result_kv = std::move(func_wrapper.GetResult().value().value());
+    KeyValue expected(RowKind::Insert(), /*sequence_number=*/1, /*level=*/0, /*key=*/
+                      BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                      /*value=*/BinaryRowGenerator::GenerateRowPtr({200}, pool.get()));
+    KeyValueChecker::CheckResult(expected, result_kv, /*key_arity=*/1, /*value_arity=*/1);
+
+    func_wrapper.Reset();
+    ASSERT_EQ(std::nullopt, func_wrapper.GetResult().value());
+    ASSERT_OK(func_wrapper.Add(std::move(kv3)));
+    result_kv = std::move(func_wrapper.GetResult().value().value());
+    KeyValue expected2(RowKind::Insert(), /*sequence_number=*/2, /*level=*/0, /*key=*/
+                       BinaryRowGenerator::GenerateRowPtr({10}, pool.get()),
+                       /*value=*/BinaryRowGenerator::GenerateRowPtr({300}, pool.get()));
+    KeyValueChecker::CheckResult(expected2, result_kv, /*key_arity=*/1, /*value_arity=*/1);
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.
Migrate merge function implementations and tests under `src/paimon/core/mergetree/compact/`:

Merge function interfaces and implementations:
- `DeduplicateMergeFunction` — keeps the latest row for the same key (`deduplicate_merge_function.h`)
- `FirstRowMergeFunction` — keeps the first row for the same key (`first_row_merge_function.h`)
- `FirstRowMergeFunctionWrapper` — wraps first-row merge behavior with retract handling (`first_row_merge_function_wrapper.h`)
- `ReducerMergeFunctionWrapper` — wraps reducer-style merge functions (`reducer_merge_function_wrapper.h`)
- `LookupMergeFunction` — merge function for lookup-based merge tree reads (`lookup_merge_function.h`)
- `LookupChangelogMergeFunctionWrapper` — produces changelog rows for lookup merge functions (`lookup_changelog_merge_function_wrapper.h`)
- `PartialUpdateMergeFunction` — supports partial-update merge semantics (`partial_update_merge_function.h/cpp`)
<!-- What is the purpose of the change -->

### Tests
- `deduplicate_merge_function_test.cpp` — deduplicate merge behavior
- `first_row_merge_function_test.cpp` — first-row merge behavior
- `first_row_merge_function_wrapper_test.cpp` — first-row wrapper behavior
- `reducer_merge_function_wrapper_test.cpp` — reducer wrapper behavior
- `lookup_merge_function_test.cpp` — lookup merge behavior
- `lookup_changelog_merge_function_wrapper_test.cpp` — lookup changelog wrapper behavior
- `partial_update_merge_function_test.cpp` — partial-update merge behavior
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Migrate-by: Codex
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
