### PR TITLE
feat(format): introduce avro file format

### DIFF
--- a/src/paimon/format/avro/avro_file_format.cpp
+++ b/src/paimon/format/avro/avro_file_format.cpp
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/format/avro/avro_file_format.h"
+
+#include <memory>
+#include <utility>
+
+#include "arrow/c/bridge.h"
+#include "arrow/c/helpers.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/format/avro/avro_reader_builder.h"
+#include "paimon/format/avro/avro_stats_extractor.h"
+#include "paimon/format/avro/avro_writer_builder.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+struct ArrowSchema;
+
+namespace paimon::avro {
+
+AvroFileFormat::AvroFileFormat(const std::map<std::string, std::string>& options)
+    : identifier_("avro"), options_(options) {}
+
+Result<std::unique_ptr<ReaderBuilder>> AvroFileFormat::CreateReaderBuilder(
+    int32_t batch_size) const {
+    return std::make_unique<AvroReaderBuilder>(options_, batch_size);
+}
+
+Result<std::unique_ptr<WriterBuilder>> AvroFileFormat::CreateWriterBuilder(
+    ::ArrowSchema* schema, int32_t batch_size) const {
+    if (schema == nullptr) {
+        return Status::Invalid("schema is nullptr");
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Schema> typed_schema,
+                                      arrow::ImportSchema(schema));
+    return std::make_unique<AvroWriterBuilder>(typed_schema, batch_size, options_);
+}
+
+Result<std::unique_ptr<FormatStatsExtractor>> AvroFileFormat::CreateStatsExtractor(
+    ::ArrowSchema* schema) const {
+    ArrowSchemaRelease(schema);
+    return std::make_unique<AvroStatsExtractor>(options_);
+}
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_file_format.h
+++ b/src/paimon/format/avro/avro_file_format.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+
+#include "paimon/format/file_format.h"
+#include "paimon/format/format_stats_extractor.h"
+#include "paimon/format/reader_builder.h"
+#include "paimon/format/writer_builder.h"
+#include "paimon/result.h"
+
+struct ArrowSchema;
+
+namespace paimon::avro {
+
+class AvroFileFormat : public FileFormat {
+ public:
+    explicit AvroFileFormat(const std::map<std::string, std::string>& options);
+
+    const std::string& Identifier() const override {
+        return identifier_;
+    }
+    Result<std::unique_ptr<ReaderBuilder>> CreateReaderBuilder(int32_t batch_size) const override;
+    Result<std::unique_ptr<WriterBuilder>> CreateWriterBuilder(::ArrowSchema* schema,
+                                                               int32_t batch_size) const override;
+    Result<std::unique_ptr<FormatStatsExtractor>> CreateStatsExtractor(
+        ::ArrowSchema* schema) const override;
+
+ private:
+    const std::string identifier_;
+    const std::map<std::string, std::string> options_;
+};
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_file_format_factory.cpp
+++ b/src/paimon/format/avro/avro_file_format_factory.cpp
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/format/avro/avro_file_format_factory.h"
+
+#include <utility>
+
+#include "paimon/factories/factory.h"
+#include "paimon/format/avro/avro_file_format.h"
+
+namespace paimon::avro {
+
+const char AvroFileFormatFactory::IDENTIFIER[] = "avro";
+
+Result<std::unique_ptr<FileFormat>> AvroFileFormatFactory::Create(
+    const std::map<std::string, std::string>& options) const {
+    return std::make_unique<AvroFileFormat>(options);
+}
+
+static __attribute__((constructor)) void AvroFileFormatFactoryRegisterLogicalTypes() {
+    ::avro::CustomLogicalTypeRegistry::instance().registerType(
+        "map", [](const std::string&) { return std::make_shared<MapLogicalType>(); });
+}
+
+REGISTER_PAIMON_FACTORY(AvroFileFormatFactory);
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_file_format_factory.h
+++ b/src/paimon/format/avro/avro_file_format_factory.h
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "avro/LogicalType.hh"
+#include "paimon/format/file_format.h"
+#include "paimon/format/file_format_factory.h"
+#include "paimon/result.h"
+
+namespace paimon::avro {
+
+struct MapLogicalType : public ::avro::CustomLogicalType {
+    MapLogicalType() : ::avro::CustomLogicalType("map") {}
+};
+
+class AvroFileFormatFactory : public FileFormatFactory {
+ public:
+    static const char IDENTIFIER[];
+
+    const char* Identifier() const override {
+        return IDENTIFIER;
+    }
+
+    Result<std::unique_ptr<FileFormat>> Create(
+        const std::map<std::string, std::string>& options) const override;
+};
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_file_format_test.cpp
+++ b/src/paimon/format/avro/avro_file_format_test.cpp
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/file_format_factory.h"
+#include "paimon/format/format_writer.h"
+#include "paimon/format/reader_builder.h"
+#include "paimon/format/writer_builder.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/reader/file_batch_reader.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::avro::test {
+
+class AvroFileFormatTest : public testing::Test, public ::testing::WithParamInterface<std::string> {
+ public:
+    void SetUp() override {
+        ASSERT_OK_AND_ASSIGN(file_format_,
+                             FileFormatFactory::Get("avro", {{Options::FILE_FORMAT, "avro"}}));
+        fs_ = std::make_shared<LocalFileSystem>();
+        dir_ = ::paimon::test::UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir_);
+    }
+    void TearDown() override {}
+
+    void WriteDataAndCheckResult(const arrow::FieldVector& fields, const std::string& data_str) {
+        auto schema = arrow::schema(fields);
+        auto data_type = arrow::struct_(fields);
+
+        ::ArrowSchema c_schema;
+        ASSERT_TRUE(arrow::ExportSchema(*schema, &c_schema).ok());
+        ASSERT_OK_AND_ASSIGN(auto writer_builder,
+                             file_format_->CreateWriterBuilder(&c_schema, 1024));
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<OutputStream> out,
+            fs_->Create(PathUtil::JoinPath(dir_->Str(), "file.avro"), /*overwrite=*/false));
+
+        auto compression = GetParam();
+        ASSERT_OK_AND_ASSIGN(auto writer, writer_builder->Build(out, compression));
+
+        auto input_array =
+            arrow::ipc::internal::json::ArrayFromJSON(data_type, data_str).ValueOrDie();
+        ASSERT_TRUE(input_array);
+        ::ArrowArray c_array;
+        ASSERT_TRUE(arrow::ExportArray(*input_array, &c_array).ok());
+        ASSERT_OK(writer->AddBatch(&c_array));
+        ASSERT_OK(writer->Flush());
+        ASSERT_OK(writer->Finish());
+        ASSERT_OK(out->Flush());
+        ASSERT_OK(out->Close());
+
+        // read
+        ASSERT_OK_AND_ASSIGN(auto reader_builder, file_format_->CreateReaderBuilder(1024));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in,
+                             fs_->Open(PathUtil::JoinPath(dir_->Str(), "file.avro")));
+        ASSERT_OK_AND_ASSIGN(auto batch_reader, reader_builder->Build(in));
+        ASSERT_TRUE(arrow::ExportSchema(*schema, &c_schema).ok());
+        ASSERT_OK(batch_reader->SetReadSchema(&c_schema, /*predicate=*/nullptr,
+                                              /*selection_bitmap=*/std::nullopt));
+        ASSERT_OK_AND_ASSIGN(auto output_array, ::paimon::test::ReadResultCollector::CollectResult(
+                                                    batch_reader.get()));
+        ASSERT_TRUE(output_array->Equals(arrow::ChunkedArray(input_array)))
+            << output_array->ToString() << "\n vs \n"
+            << input_array->ToString();
+    }
+
+ private:
+    std::shared_ptr<FileFormat> file_format_;
+    std::shared_ptr<FileSystem> fs_;
+    std::unique_ptr<paimon::test::UniqueTestDirectory> dir_;
+};
+
+INSTANTIATE_TEST_SUITE_P(Compression, AvroFileFormatTest,
+                         ::testing::ValuesIn(std::vector<std::string>(
+                             {"zstd", "zstandard", "snappy", "null", "deflate"})));
+
+TEST_P(AvroFileFormatTest, TestSimple) {
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::boolean()),       arrow::field("f1", arrow::int8()),
+        arrow::field("f2", arrow::int16()),         arrow::field("f3", arrow::int32()),
+        arrow::field("field_null", arrow::int32()), arrow::field("f4", arrow::int64()),
+        arrow::field("f5", arrow::float32()),       arrow::field("f6", arrow::float64()),
+        arrow::field("f7", arrow::utf8()),          arrow::field("f8", arrow::binary())};
+    std::string data_str =
+        R"([[true, 0, 32767, 2147483647, null, 4294967295, 0.5, 1.141592659, "20250327", "banana"],
+            [false, 1, 32767, null, null, 4294967296, 1.0, 2.141592658, "20250327", "dog"],
+            [null, 1, 32767, 2147483647, null, null, 2.0, 3.141592657, null, "lucy"],
+            [true, -2, -32768, -2147483648, null, -4294967298, 2.0, 3.141592657, "20250326", "mouse"]])";
+    WriteDataAndCheckResult(fields, data_str);
+}
+
+TEST_P(AvroFileFormatTest, TestComplexTypes) {
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::timestamp(arrow::TimeUnit::SECOND)),
+        arrow::field("f1", arrow::timestamp(arrow::TimeUnit::MILLI)),
+        arrow::field("f2", arrow::timestamp(arrow::TimeUnit::MICRO)),
+        arrow::field("f3", arrow::timestamp(arrow::TimeUnit::NANO)),
+        arrow::field("f4", arrow::timestamp(arrow::TimeUnit::SECOND, timezone)),
+        arrow::field("f5", arrow::timestamp(arrow::TimeUnit::MILLI, timezone)),
+        arrow::field("f6", arrow::timestamp(arrow::TimeUnit::MICRO, timezone)),
+        arrow::field("f7", arrow::timestamp(arrow::TimeUnit::NANO, timezone)),
+        arrow::field("f8", arrow::decimal128(30, 5)),
+        arrow::field("f9", arrow::decimal128(2, 2)),
+        arrow::field("f10", arrow::date32()),
+        arrow::field("f11", arrow::list(arrow::int32())),
+        arrow::field("f12", arrow::map(arrow::utf8(), arrow::utf8())),
+        arrow::field("f13", arrow::map(arrow::int32(), arrow::utf8())),
+        arrow::field("f14", arrow::map(arrow::struct_({arrow::field("f0", arrow::int32())}),
+                                       arrow::map(arrow::int32(), arrow::utf8()))),
+        arrow::field("f15", arrow::struct_({arrow::field("sub1", arrow::int64()),
+                                            arrow::field("sub2", arrow::float64()),
+                                            arrow::field("sub3", arrow::boolean())})),
+    };
+    std::string src_data_str = R"([
+        ["1970-01-02 00:00:00", "1970-01-02 00:00:00.001", "1970-01-02 00:00:00.000001", "1970-01-02 00:00:00.000000001",
+         "1970-01-02 00:00:00", "1970-01-02 00:00:00.001", "1970-01-02 00:00:00.000001", "1970-01-02 00:00:00.000000001",
+         "-123456789987654321.45678", "0.78", 12345, [1,2,3], [["test1","a"],["test2","value-3"]], [[1001,"a"],[1002,"value-3"]],
+         [[[1001],[[1,"a"],[2,"b"]]],[[1002],[[11,"aa"],[22,"bb"]]]], [10,11.2,false]]
+    ])";
+    WriteDataAndCheckResult(fields, src_data_str);
+}
+
+TEST_P(AvroFileFormatTest, TestNestedMap) {
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::map(arrow::utf8(), arrow::int16())),
+        arrow::field("f1", arrow::map(arrow::utf8(), arrow::utf8())),
+        arrow::field("f2", arrow::map(arrow::utf8(), arrow::timestamp(arrow::TimeUnit::MICRO))),
+        arrow::field(
+            "f3", arrow::map(arrow::utf8(), arrow::list(arrow::timestamp(arrow::TimeUnit::MICRO)))),
+        arrow::field("f4", arrow::map(arrow::utf8(), arrow::list(arrow::utf8()))),
+        arrow::field(
+            "f5",
+            arrow::map(
+                arrow::int32(),
+                arrow::struct_(
+                    {arrow::field(
+                         "f5.a",
+                         arrow::struct_(
+                             {arrow::field("f5.a.0", arrow::utf8()),
+                              arrow::field("f5.sub2", arrow::int32()),
+                              arrow::field("f5.a.1", arrow::timestamp(arrow::TimeUnit::MICRO))})),
+                     arrow::field("f5.b", arrow::list(arrow::utf8())),
+                     arrow::field("f5.c", arrow::map(arrow::utf8(), arrow::int32()))}))),
+        arrow::field(
+            "f6", arrow::map(arrow::utf8(), arrow::map(arrow::utf8(), arrow::list(arrow::utf8())))),
+        arrow::field("f7", arrow::map(arrow::int32(), arrow::boolean())),
+        arrow::field("f8", arrow::map(arrow::int64(), arrow::decimal128(2, 2))),
+        arrow::field("f9", arrow::map(arrow::date32(), arrow::float32())),
+        arrow::field("f10", arrow::map(arrow::binary(), arrow::float64())),
+        arrow::field("f11", arrow::map(arrow::int32(), arrow::list(arrow::int64()))),
+        arrow::field(
+            "f12",
+            arrow::map(arrow::utf8(),
+                       arrow::list(arrow::struct_(
+                           {arrow::field("name", arrow::utf8()),
+                            arrow::field("scores", arrow::list(arrow::float32())),
+                            arrow::field("info", arrow::map(arrow::float32(), arrow::utf8()))}))))};
+
+    std::string src_data_str = R"([
+        [
+            [["f0_key_0", 1],["f0_key_1", 2]],
+            [["f1_key_0","val-1"],["f1_key_1","value-2"]],
+            [["f2_key_0","1970-01-01 00:00:00.000001"],["f2_key_1","1970-01-02 00:00:00.000001"]],
+            [["f3_key_0",["1970-01-01 00:00:00.000001"]],["f3_key_1",["1970-01-02 00:00:00.000001"]]],
+            [["f4_key_0",["val-1", "val-2"]],["f4_key_1",["val-3","val-4"]]],
+            [[500,[["sub1",1,"1970-01-01 00:00:00.000001"],["test-1","test-2"],[["subkey_0",1],["subkey_1", 2]]]],[600,[["sub2",2,"1970-01-02 00:00:00.000001"],["test-3","test-4"],[["subkey_2", 1],["subkey_3", 2]]]]],
+            [["f6_key_0",[["f6_sub_key_0",["value-0","value-1"]],["f6_sub_key_1",["value-2","value-3"]]]],["f6_key_1",[["f6_sub_key_2",["value-0","value-1"]],["f6_sub_key_3",["value-2","value-3"]]]]],
+            [[100, true], [200, false]],
+            [[1000, "0.78"], [2000, "0.91"]],
+            [[10, 1.5], [20, 2.75]],
+            [["aGVsbG8=", 3.14159], ["d29ybGQ=", 2.71828]],
+            [[1, [1000000, 2000000]], [2, [3000000, 4000000, 5000000]]],
+            [["group1", [["Alice", [95.5, 96.0], [[100.1, "info"]]], ["Bob", [88.0, 89.5],[[200.1,"info"]]]]],["group2", [["Charlie",[92.3, 93.1],[[300.1,"info"]]]]]]
+        ],
+        [
+            null,null,null,null,null,null,null,null,null,null,null,null,null
+        ]
+    ])";
+    WriteDataAndCheckResult(fields, src_data_str);
+}
+
+}  // namespace paimon::avro::test

--- a/src/paimon/format/avro/avro_format_defs.h
+++ b/src/paimon/format/avro/avro_format_defs.h
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+namespace paimon::avro {
+
+// write
+static inline const char AVRO_CODEC[] = "avro.codec";
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_input_stream_impl.cpp
+++ b/src/paimon/format/avro/avro_input_stream_impl.cpp
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Adapted from Apache Iceberg C++
+// https://github.com/apache/iceberg-cpp/blob/main/src/iceberg/avro/avro_stream_internal.cc
+
+#include "paimon/format/avro/avro_input_stream_impl.h"
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "avro/Exception.hh"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+
+namespace paimon::avro {
+
+Result<std::unique_ptr<AvroInputStreamImpl>> AvroInputStreamImpl::Create(
+    const std::shared_ptr<paimon::InputStream>& input_stream, size_t buffer_size,
+    const std::shared_ptr<MemoryPool>& pool) {
+    PAIMON_ASSIGN_OR_RAISE(uint64_t length, input_stream->Length());
+    return std::unique_ptr<AvroInputStreamImpl>(
+        new AvroInputStreamImpl(input_stream, buffer_size, length, pool));
+}
+
+AvroInputStreamImpl::AvroInputStreamImpl(const std::shared_ptr<paimon::InputStream>& input_stream,
+                                         size_t buffer_size, const uint64_t total_length,
+                                         const std::shared_ptr<MemoryPool>& pool)
+    : pool_(pool),
+      in_(input_stream),
+      buffer_size_(buffer_size),
+      total_length_(total_length),
+      buffer_(reinterpret_cast<uint8_t*>(pool_->Malloc(buffer_size))) {}
+
+AvroInputStreamImpl::~AvroInputStreamImpl() {
+    pool_->Free(buffer_, buffer_size_);
+}
+
+bool AvroInputStreamImpl::next(const uint8_t** data, size_t* len) {
+    // Return all unconsumed data in the buffer
+    if (buffer_pos_ < available_bytes_) {
+        *data = buffer_ + buffer_pos_;
+        *len = available_bytes_ - buffer_pos_;
+        byte_count_ += available_bytes_ - buffer_pos_;
+        buffer_pos_ = available_bytes_;
+        return true;
+    }
+
+    // Read from the input stream when the buffer is empty
+    uint64_t remaining = total_length_ - stream_pos_;
+    if (remaining == 0) {
+        return false;  // eof
+    }
+    auto read_length =
+        in_->Read(reinterpret_cast<char*>(buffer_),
+                  static_cast<uint32_t>(std::min<uint64_t>(buffer_size_, remaining)));
+    if (!read_length.ok()) {
+        throw ::avro::Exception("Read failed: {}", read_length.status().ToString());
+    }
+    available_bytes_ = read_length.value();
+    stream_pos_ += available_bytes_;
+    buffer_pos_ = 0;
+
+    // Return the whole buffer
+    *data = buffer_;
+    *len = available_bytes_;
+    byte_count_ += available_bytes_;
+    buffer_pos_ = available_bytes_;
+
+    return true;
+}
+
+void AvroInputStreamImpl::backup(size_t len) {
+    if (len > buffer_pos_) {
+        throw ::avro::Exception("Cannot backup {} bytes, only {} bytes available", len,
+                                buffer_pos_);
+    }
+
+    buffer_pos_ -= len;
+    byte_count_ -= len;
+}
+
+void AvroInputStreamImpl::skip(size_t len) {
+    // The range to skip is within the buffer
+    if (buffer_pos_ + len <= available_bytes_) {
+        buffer_pos_ += len;
+        byte_count_ += len;
+        return;
+    }
+    seek(byte_count_ + len);
+}
+
+size_t AvroInputStreamImpl::byteCount() const {
+    return byte_count_;
+}
+
+void AvroInputStreamImpl::seek(int64_t position) {
+    if (static_cast<uint64_t>(position) > total_length_) {
+        throw ::avro::Exception("Cannot seek to {}, total length is {}", position, total_length_);
+    }
+    auto status = in_->Seek(position, SeekOrigin::FS_SEEK_SET);
+    if (!status.ok()) {
+        throw ::avro::Exception("Failed to seek to {}, got {}", position, status.ToString());
+    }
+
+    stream_pos_ = position;
+    buffer_pos_ = 0;
+    available_bytes_ = 0;
+    byte_count_ = position;
+}
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_input_stream_impl.h
+++ b/src/paimon/format/avro/avro_input_stream_impl.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "avro/Stream.hh"
+#include "paimon/fs/file_system.h"
+#include "paimon/result.h"
+
+namespace paimon {
+class InputStream;
+class MemoryPool;
+}  // namespace paimon
+
+namespace paimon::avro {
+
+class AvroInputStreamImpl : public ::avro::SeekableInputStream {
+ public:
+    static Result<std::unique_ptr<AvroInputStreamImpl>> Create(
+        const std::shared_ptr<paimon::InputStream>& input_stream, size_t buffer_size,
+        const std::shared_ptr<MemoryPool>& pool);
+
+    ~AvroInputStreamImpl() override;
+
+    bool next(const uint8_t** data, size_t* len) override;
+    void backup(size_t len) override;
+    void skip(size_t len) override;
+    size_t byteCount() const override;
+    void seek(int64_t position) override;
+
+ private:
+    AvroInputStreamImpl(const std::shared_ptr<paimon::InputStream>& input_stream,
+                        size_t buffer_size, const uint64_t length,
+                        const std::shared_ptr<MemoryPool>& pool);
+
+    std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<paimon::InputStream> in_;
+    const size_t buffer_size_;
+    const uint64_t total_length_;
+    uint8_t* const buffer_;
+    size_t byte_count_ = 0;       // bytes position in the avro input stream
+    size_t stream_pos_ = 0;       // current position in the paimon input stream
+    size_t buffer_pos_ = 0;       // next position to read in the buffer
+    size_t available_bytes_ = 0;  // bytes available in the buffer
+};
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_input_stream_impl_test.cpp
+++ b/src/paimon/format/avro/avro_input_stream_impl_test.cpp
@@ -1,0 +1,196 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/format/avro/avro_input_stream_impl.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::avro::test {
+
+TEST(AvroInputStreamImplTest, TestNext) {
+    auto dir = paimon::test::UniqueTestDirectory::Create();
+    std::filesystem::path file_path = dir->Str() + "/file";
+    std::ofstream output_file(file_path);
+    ASSERT_TRUE(output_file.is_open());
+    std::string test_data = "hello world";
+    output_file << test_data;
+    output_file.close();
+
+    size_t buffer_size = 10;
+    std::shared_ptr<FileSystem> fs = std::make_shared<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs->Open(file_path));
+    ASSERT_OK_AND_ASSIGN(auto stream,
+                         AvroInputStreamImpl::Create(in, buffer_size, GetDefaultPool()));
+    const uint8_t* data;
+    size_t size;
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(size, 10);
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data), size), test_data.substr(0, 10));
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(size, 1);
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data), size), test_data.substr(10, 1));
+    ASSERT_FALSE(stream->next(&data, &size));
+}
+
+TEST(AvroInputStreamImplTest, TestBackup) {
+    auto dir = paimon::test::UniqueTestDirectory::Create();
+    std::filesystem::path file_path = dir->Str() + "/file";
+    std::ofstream output_file(file_path);
+    ASSERT_TRUE(output_file.is_open());
+    std::string test_data = "abcdefghij";
+    output_file << test_data;
+    output_file.close();
+
+    size_t buffer_size = 10;
+    std::shared_ptr<FileSystem> fs = std::make_shared<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs->Open(file_path));
+    ASSERT_OK_AND_ASSIGN(auto stream,
+                         AvroInputStreamImpl::Create(in, buffer_size, GetDefaultPool()));
+    const uint8_t* data;
+    size_t size;
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(size, 10);
+
+    stream->backup(3);
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(size, 3);
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data), size), "hij");
+    stream->backup(10);
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(size, 10);
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data), size), test_data);
+}
+
+TEST(AvroInputStreamImplTest, TestSkip) {
+    auto dir = paimon::test::UniqueTestDirectory::Create();
+    std::filesystem::path file_path = dir->Str() + "/file";
+    std::ofstream output_file(file_path);
+    ASSERT_TRUE(output_file.is_open());
+    std::string test_data = "abcdefghij";
+    output_file << test_data;
+    output_file.close();
+
+    size_t buffer_size = 10;
+    std::shared_ptr<FileSystem> fs = std::make_shared<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs->Open(file_path));
+    ASSERT_OK_AND_ASSIGN(auto stream,
+                         AvroInputStreamImpl::Create(in, buffer_size, GetDefaultPool()));
+    const uint8_t* data;
+    size_t size;
+    stream->skip(5);
+    ASSERT_EQ(stream->byteCount(), 5);
+
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(size, 5);
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data), size), "fghij");
+    ASSERT_THROW(stream->skip(5), ::avro::Exception);  // already eof, cannot skip more
+    ASSERT_EQ(stream->byteCount(), 10);
+    ASSERT_FALSE(stream->next(&data, &size));  // reach eof
+
+    ASSERT_THROW(stream->backup(7), ::avro::Exception);  // buffer item is 5, cannot backup 7
+    stream->backup(4);
+    ASSERT_EQ(stream->byteCount(), 6);
+    stream->skip(2);  // skip 2 bytes from the available buffer data
+    ASSERT_EQ(stream->byteCount(), 8);
+
+    // verify we can read the remaining 2 bytes from buffer
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(size, 2);
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data), size), "ij");
+    ASSERT_EQ(stream->byteCount(), 10);
+}
+
+TEST(AvroInputStreamImplTest, TestSkipWithAvailableData) {
+    auto dir = paimon::test::UniqueTestDirectory::Create();
+    std::filesystem::path file_path = dir->Str() + "/file";
+    std::ofstream output_file(file_path);
+    ASSERT_TRUE(output_file.is_open());
+    std::string test_data = "abcdefghij";
+    output_file << test_data;
+    output_file.close();
+
+    size_t buffer_size = 10;
+    std::shared_ptr<FileSystem> fs = std::make_shared<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs->Open(file_path));
+    ASSERT_OK_AND_ASSIGN(auto stream,
+                         AvroInputStreamImpl::Create(in, buffer_size, GetDefaultPool()));
+
+    const uint8_t* data;
+    size_t size;
+    // First, load data into buffer by calling next()
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(size, 10);
+    ASSERT_EQ(stream->byteCount(), 10);
+
+    // Now backup some data to make it available in buffer
+    stream->backup(7);
+    ASSERT_EQ(stream->byteCount(), 3);
+
+    // Skip 3 bytes from the available buffer data
+    stream->skip(3);
+    ASSERT_EQ(stream->byteCount(), 6);
+
+    // Verify we can read the remaining 4 bytes from buffer
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(size, 4);
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data), size), "ghij");
+    ASSERT_EQ(stream->byteCount(), 10);
+}
+
+TEST(AvroInputStreamImplTest, TestSeek) {
+    auto dir = paimon::test::UniqueTestDirectory::Create();
+    std::filesystem::path file_path = dir->Str() + "/file";
+    std::ofstream output_file(file_path);
+    ASSERT_TRUE(output_file.is_open());
+    std::string test_data = "abcdefghij";
+    output_file << test_data;
+    output_file.close();
+
+    size_t buffer_size = 5;
+    std::shared_ptr<FileSystem> fs = std::make_shared<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs->Open(file_path));
+    ASSERT_OK_AND_ASSIGN(auto stream,
+                         AvroInputStreamImpl::Create(in, buffer_size, GetDefaultPool()));
+
+    const uint8_t* data;
+    size_t size;
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(stream->byteCount(), 5);
+    ASSERT_EQ(size, 5);
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data), size), "abcde");
+    stream->seek(2);
+    ASSERT_EQ(stream->byteCount(), 2);
+
+    // after seek, buffer will be cleared, cannot backup
+    ASSERT_THROW(stream->backup(2), ::avro::Exception);
+    ASSERT_TRUE(stream->next(&data, &size));
+    ASSERT_EQ(std::string(reinterpret_cast<const char*>(data), size), "cdefg");
+    ASSERT_EQ(stream->byteCount(), 7);
+    ASSERT_EQ(size, 5);
+}
+
+}  // namespace paimon::avro::test

--- a/src/paimon/format/avro/avro_output_stream_impl.cpp
+++ b/src/paimon/format/avro/avro_output_stream_impl.cpp
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/format/avro/avro_output_stream_impl.h"
+
+#include <stdexcept>
+#include <string>
+
+#include "fmt/format.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon::avro {
+
+AvroOutputStreamImpl::AvroOutputStreamImpl(const std::shared_ptr<paimon::OutputStream>& out,
+                                           size_t buffer_size,
+                                           const std::shared_ptr<MemoryPool>& pool)
+    : pool_(pool),
+      buffer_size_(buffer_size),
+      buffer_(reinterpret_cast<uint8_t*>(pool_->Malloc(buffer_size))),
+      out_(out),
+      next_(buffer_),
+      available_(buffer_size_),
+      byte_count_(0) {}
+
+AvroOutputStreamImpl::~AvroOutputStreamImpl() {
+    pool_->Free(buffer_, buffer_size_);
+}
+
+bool AvroOutputStreamImpl::next(uint8_t** data, size_t* len) {
+    if (available_ == 0) {
+        FlushBuffer();
+    }
+    *data = next_;
+    *len = available_;
+    next_ += available_;
+    byte_count_ += available_;
+    available_ = 0;
+    return true;
+}
+
+void AvroOutputStreamImpl::backup(size_t len) {
+    available_ += len;
+    next_ -= len;
+    byte_count_ -= len;
+}
+
+void AvroOutputStreamImpl::FlushBuffer() {
+    size_t length = buffer_size_ - available_;
+    Result<int32_t> write_len = out_->Write(reinterpret_cast<const char*>(buffer_), length);
+    if (!write_len.ok()) {
+        throw std::runtime_error("write failed, status: " + write_len.status().ToString());
+    }
+    if (static_cast<size_t>(write_len.value()) != length) {
+        throw std::runtime_error(
+            fmt::format("write failed, expected length: {}, actual write length: {}", length,
+                        write_len.value()));
+    }
+    Status status = out_->Flush();
+    if (!status.ok()) {
+        throw std::runtime_error("flush failed, status: " + status.ToString());
+    }
+    next_ = buffer_;
+    available_ = buffer_size_;
+}
+
+void AvroOutputStreamImpl::flush() {
+    // In avro-java impl, there is an option to control flush frequency.
+    // See: https://github.com/apache/avro/commit/35750393891c40f0ceb925a852162ec764bcae6c
+    //
+    // However, in the avro-cpp impl, there is no such option. Calling flush() too frequently
+    // generates many small I/O operations, affecting write performance, so we make
+    // ::avro::OutputStream's flush() do nothing
+}
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_output_stream_impl.h
+++ b/src/paimon/format/avro/avro_output_stream_impl.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+#include "avro/Stream.hh"
+#include "paimon/fs/file_system.h"
+
+namespace paimon {
+class MemoryPool;
+class OutputStream;
+}  // namespace paimon
+
+namespace paimon::avro {
+
+class AvroOutputStreamImpl : public ::avro::OutputStream {
+ public:
+    AvroOutputStreamImpl(const std::shared_ptr<paimon::OutputStream>& out, size_t buffer_size,
+                         const std::shared_ptr<MemoryPool>& pool);
+    ~AvroOutputStreamImpl() override;
+
+    // Invariant: byte_count_ == bytes_written + buffer_size_ - available_;
+    bool next(uint8_t** data, size_t* len) final;
+    void backup(size_t len) final;
+    void flush() final;
+    uint64_t byteCount() const final {
+        return byte_count_;
+    }
+
+    void FlushBuffer();
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+    const size_t buffer_size_;
+    uint8_t* const buffer_;
+    std::shared_ptr<paimon::OutputStream> out_;
+    uint8_t* next_;
+    size_t available_;
+    size_t byte_count_;
+};
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_reader_builder.h
+++ b/src/paimon/format/avro/avro_reader_builder.h
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "avro/DataFile.hh"
+#include "paimon/format/avro/avro_file_batch_reader.h"
+#include "paimon/format/avro/avro_input_stream_impl.h"
+#include "paimon/format/reader_builder.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/memory_pool.h"
+
+namespace paimon::avro {
+
+class AvroReaderBuilder : public ReaderBuilder {
+ public:
+    AvroReaderBuilder(const std::map<std::string, std::string>& options, int32_t batch_size)
+        : batch_size_(batch_size), pool_(GetDefaultPool()), options_(options) {}
+
+    ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool) override {
+        pool_ = pool;
+        return this;
+    }
+
+    Result<std::unique_ptr<FileBatchReader>> Build(
+        const std::shared_ptr<InputStream>& path) const override {
+        return AvroFileBatchReader::Create(path, batch_size_, pool_);
+    }
+
+    Result<std::unique_ptr<FileBatchReader>> Build(const std::string& path) const override {
+        return Status::Invalid("do not support build reader with path in avro format");
+    }
+
+ private:
+    const int32_t batch_size_;
+    std::shared_ptr<MemoryPool> pool_;
+    const std::map<std::string, std::string> options_;
+};
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_schema_converter.cpp
+++ b/src/paimon/format/avro/avro_schema_converter.cpp
@@ -1,0 +1,394 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/format/avro/avro_schema_converter.h"
+
+#include <cassert>
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+#include "arrow/util/checked_cast.h"
+#include "avro/CustomAttributes.hh"
+#include "avro/LogicalType.hh"
+#include "avro/Node.hh"
+#include "avro/Schema.hh"
+#include "avro/Types.hh"
+#include "avro/ValidSchema.hh"
+#include "fmt/format.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/format/avro/avro_file_format_factory.h"
+#include "paimon/format/avro/avro_utils.h"
+#include "paimon/macros.h"
+#include "paimon/status.h"
+namespace paimon::avro {
+
+/// Returns schema with nullable true.
+::avro::Schema AvroSchemaConverter::NullableSchema(const ::avro::Schema& schema) {
+    assert(schema.type() != ::avro::AVRO_UNION);
+    ::avro::UnionSchema union_schema;
+    union_schema.addType(::avro::NullSchema());
+    union_schema.addType(schema);
+    return union_schema;
+}
+
+void AvroSchemaConverter::AddRecordField(::avro::RecordSchema* record_schema,
+                                         const std::string& field_name,
+                                         const ::avro::Schema& field_schema) {
+    if (field_schema.type() == ::avro::Type::AVRO_UNION) {
+        ::avro::CustomAttributes attrs;
+        attrs.addAttribute("default", "null", /*addQuotes=*/false);
+        record_schema->addField(field_name, field_schema, attrs);
+    } else {
+        record_schema->addField(field_name, field_schema);
+    }
+}
+
+Result<bool> AvroSchemaConverter::CheckUnionType(const ::avro::NodePtr& avro_node) {
+    auto type = avro_node->type();
+    if (type == ::avro::AVRO_UNION) {
+        if (avro_node->leaves() != 2) {
+            return Status::Invalid("not support avro union leaves not 2");
+        }
+        auto node = avro_node->leafAt(0);
+        if (node->type() != ::avro::AVRO_NULL) {
+            return Status::Invalid("not support avro union first leaf is not avro null");
+        }
+        return true;
+    }
+    return false;
+}
+
+Result<std::shared_ptr<arrow::DataType>> AvroSchemaConverter::AvroSchemaToArrowDataType(
+    const ::avro::ValidSchema& avro_schema) {
+    ::avro::NodePtr root = avro_schema.root();
+    PAIMON_ASSIGN_OR_RAISE(bool is_union, CheckUnionType(root));
+    if (is_union) {
+        root = root->leafAt(1);
+    }
+    if (PAIMON_UNLIKELY(root->type() != ::avro::AVRO_RECORD)) {
+        return Status::Invalid("Avro schema root node is not a record type");
+    }
+    bool nullable = false;
+    return GetArrowType(root, &nullable);
+}
+
+Result<std::shared_ptr<arrow::Field>> AvroSchemaConverter::GetArrowField(
+    const std::string& name, const ::avro::NodePtr& avro_node) {
+    bool nullable = false;
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::DataType> arrow_type,
+                           GetArrowType(avro_node, &nullable));
+    return arrow::field(name, std::move(arrow_type), nullable);
+}
+
+Result<std::shared_ptr<arrow::DataType>> AvroSchemaConverter::GetArrowType(
+    const ::avro::NodePtr& avro_node, bool* nullable) {
+    PAIMON_ASSIGN_OR_RAISE(bool is_union, CheckUnionType(avro_node));
+    if (is_union) {
+        *nullable = true;
+        return GetArrowType(avro_node->leafAt(1), nullable);
+    }
+    auto type = avro_node->type();
+    auto logical_type = avro_node->logicalType();
+    switch (logical_type.type()) {
+        case ::avro::LogicalType::Type::NONE:
+            break;
+        case ::avro::LogicalType::Type::DATE:
+            if (type != ::avro::AVRO_INT) {
+                return Status::TypeError("invalid avro date stored as ", toString(type));
+            }
+            return arrow::date32();
+        case ::avro::LogicalType::Type::DECIMAL:
+            if (type != ::avro::AVRO_BYTES) {
+                return Status::TypeError("invalid avro decimal stored as ", toString(type));
+            }
+            return arrow::decimal128(logical_type.precision(), logical_type.scale());
+        case ::avro::LogicalType::Type::TIMESTAMP_MILLIS: {
+            if (type != ::avro::AVRO_LONG) {
+                return Status::TypeError("invalid avro timestamp stored as ", toString(type));
+            }
+            return arrow::timestamp(arrow::TimeUnit::MILLI);
+        }
+        case ::avro::LogicalType::Type::TIMESTAMP_MICROS: {
+            if (type != ::avro::AVRO_LONG) {
+                return Status::TypeError("invalid avro timestamp stored as ", toString(type));
+            }
+            return arrow::timestamp(arrow::TimeUnit::MICRO);
+        }
+        case ::avro::LogicalType::Type::TIMESTAMP_NANOS: {
+            if (type != ::avro::AVRO_LONG) {
+                return Status::TypeError("invalid avro timestamp stored as ", toString(type));
+            }
+            return arrow::timestamp(arrow::TimeUnit::NANO);
+        }
+        case ::avro::LogicalType::Type::LOCAL_TIMESTAMP_MILLIS: {
+            if (type != ::avro::AVRO_LONG) {
+                return Status::TypeError("invalid avro timestamp stored as ", toString(type));
+            }
+            auto timezone = DateTimeUtils::GetLocalTimezoneName();
+            return arrow::timestamp(arrow::TimeUnit::MILLI, timezone);
+        }
+        case ::avro::LogicalType::Type::LOCAL_TIMESTAMP_MICROS: {
+            if (type != ::avro::AVRO_LONG) {
+                return Status::TypeError("invalid avro timestamp stored as ", toString(type));
+            }
+            auto timezone = DateTimeUtils::GetLocalTimezoneName();
+            return arrow::timestamp(arrow::TimeUnit::MICRO, timezone);
+        }
+        case ::avro::LogicalType::Type::LOCAL_TIMESTAMP_NANOS: {
+            if (type != ::avro::AVRO_LONG) {
+                return Status::TypeError("invalid avro timestamp stored as ", toString(type));
+            }
+            auto timezone = DateTimeUtils::GetLocalTimezoneName();
+            return arrow::timestamp(arrow::TimeUnit::NANO, timezone);
+        }
+        case ::avro::LogicalType::Type::CUSTOM: {
+            if (!AvroUtils::HasMapLogicalType(avro_node)) {
+                return Status::TypeError("invalid avro logical map type");
+            }
+            if (type != ::avro::AVRO_ARRAY) {
+                return Status::TypeError("invalid avro logical map stored as ", toString(type));
+            }
+            size_t subtype_count = avro_node->leaves();
+            if (subtype_count != 1) {
+                return Status::TypeError("invalid avro logical map type");
+            }
+            PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Field> logical_map_field,
+                                   GetArrowField("item", avro_node->leafAt(0)));
+            auto logical_map_type = logical_map_field->type();
+            if (logical_map_type->id() != arrow::Type::STRUCT) {
+                return Status::TypeError("invalid avro logical map item type");
+            }
+            auto struct_type =
+                arrow::internal::checked_pointer_cast<arrow::StructType>(logical_map_type);
+            const auto& fields = struct_type->fields();
+            if (fields.size() != 2) {
+                return Status::TypeError("invalid avro logical map struct fields size");
+            }
+            auto key_field = fields[0]->WithNullable(false);
+            auto value_field = fields[1];
+            if (key_field->name() != "key" || value_field->name() != "value") {
+                return Status::TypeError("invalid avro logical map struct field names");
+            }
+            return std::make_shared<arrow::MapType>(std::move(key_field), std::move(value_field));
+        }
+        default:
+            return Status::Invalid("invalid avro logical type: ",
+                                   AvroUtils::ToString(logical_type));
+    }
+
+    size_t subtype_count = avro_node->leaves();
+    switch (type) {
+        case ::avro::AVRO_BOOL: {
+            return arrow::boolean();
+        }
+        case ::avro::AVRO_INT: {
+            return arrow::int32();
+        }
+        case ::avro::AVRO_LONG: {
+            return arrow::int64();
+        }
+        case ::avro::AVRO_FLOAT: {
+            return arrow::float32();
+        }
+        case ::avro::AVRO_DOUBLE: {
+            return arrow::float64();
+        }
+        case ::avro::AVRO_STRING: {
+            return arrow::utf8();
+        }
+        case ::avro::AVRO_BYTES: {
+            return arrow::binary();
+        }
+        case ::avro::AVRO_ARRAY: {
+            if (subtype_count != 1) {
+                return Status::TypeError("Invalid Avro List type");
+            }
+            PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Field> child_field,
+                                   GetArrowField("item", avro_node->leafAt(0)));
+            return arrow::list(std::move(child_field));
+        }
+        case ::avro::AVRO_MAP: {
+            if (subtype_count != 2) {
+                return Status::TypeError("Invalid Avro Map type");
+            }
+            PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Field> key_field,
+                                   GetArrowField("key", avro_node->leafAt(0)));
+            key_field = key_field->WithNullable(false);
+            PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Field> value_field,
+                                   GetArrowField("value", avro_node->leafAt(1)));
+            return std::make_shared<arrow::MapType>(std::move(key_field), std::move(value_field));
+        }
+        case ::avro::AVRO_RECORD: {
+            arrow::FieldVector fields(subtype_count);
+            for (size_t child = 0; child < subtype_count; ++child) {
+                const auto& name = avro_node->nameAt(child);
+                PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Field> child_field,
+                                       GetArrowField(name, avro_node->leafAt(child)));
+                fields[child] = std::move(child_field);
+            }
+            return arrow::struct_(std::move(fields));
+        }
+        default:
+            return Status::TypeError("Unknown Avro type kind: ", toString(type));
+    }
+}
+
+Result<::avro::Schema> AvroSchemaConverter::ArrowTypeToAvroSchema(
+    const std::shared_ptr<arrow::Field>& field, const std::string& row_name) {
+    bool nullable = field->nullable();
+    auto arrow_type = field->type();
+    switch (arrow_type->id()) {
+        case arrow::Type::BOOL:
+            return nullable ? NullableSchema(::avro::BoolSchema()) : ::avro::BoolSchema();
+        case arrow::Type::INT8:
+        case arrow::Type::INT16:
+        case arrow::Type::INT32:
+            return nullable ? NullableSchema(::avro::IntSchema()) : ::avro::IntSchema();
+        case arrow::Type::INT64:
+            return nullable ? NullableSchema(::avro::LongSchema()) : ::avro::LongSchema();
+        case arrow::Type::FLOAT:
+            return nullable ? NullableSchema(::avro::FloatSchema()) : ::avro::FloatSchema();
+        case arrow::Type::DOUBLE:
+            return nullable ? NullableSchema(::avro::DoubleSchema()) : ::avro::DoubleSchema();
+        case arrow::Type::STRING:
+            return nullable ? NullableSchema(::avro::StringSchema()) : ::avro::StringSchema();
+        case arrow::Type::BINARY:
+            return nullable ? NullableSchema(::avro::BytesSchema()) : ::avro::BytesSchema();
+        case arrow::Type::type::DATE32: {
+            ::avro::IntSchema date_schema;
+            ::avro::LogicalType date_type = ::avro::LogicalType(::avro::LogicalType::DATE);
+            date_schema.root()->setLogicalType(date_type);
+            return nullable ? NullableSchema(date_schema) : date_schema;
+        }
+        case arrow::Type::type::TIMESTAMP: {
+            const auto& arrow_timestamp_type =
+                arrow::internal::checked_pointer_cast<arrow::TimestampType>(arrow_type);
+            bool has_timezone = !arrow_timestamp_type->timezone().empty();
+            ::avro::LongSchema timestamp_schema;
+            switch (arrow_timestamp_type->unit()) {
+                // Avro doesn't support seconds, convert to milliseconds
+                case arrow::TimeUnit::type::SECOND:
+                case arrow::TimeUnit::type::MILLI: {
+                    ::avro::LogicalType logical_type = ::avro::LogicalType(
+                        has_timezone ? ::avro::LogicalType::LOCAL_TIMESTAMP_MILLIS
+                                     : ::avro::LogicalType::TIMESTAMP_MILLIS);
+                    timestamp_schema.root()->setLogicalType(logical_type);
+                    break;
+                }
+                case arrow::TimeUnit::type::MICRO: {
+                    ::avro::LogicalType logical_type = ::avro::LogicalType(
+                        has_timezone ? ::avro::LogicalType::LOCAL_TIMESTAMP_MICROS
+                                     : ::avro::LogicalType::TIMESTAMP_MICROS);
+                    timestamp_schema.root()->setLogicalType(logical_type);
+                    break;
+                }
+                case arrow::TimeUnit::type::NANO: {
+                    ::avro::LogicalType logical_type = ::avro::LogicalType(
+                        has_timezone ? ::avro::LogicalType::LOCAL_TIMESTAMP_NANOS
+                                     : ::avro::LogicalType::TIMESTAMP_NANOS);
+                    timestamp_schema.root()->setLogicalType(logical_type);
+                    break;
+                }
+                default:
+                    return Status::Invalid("Unknown TimeUnit in TimestampType");
+            }
+            return nullable ? NullableSchema(timestamp_schema) : timestamp_schema;
+        }
+        case arrow::Type::type::DECIMAL128: {
+            const auto& arrow_decimal_type =
+                arrow::internal::checked_pointer_cast<arrow::Decimal128Type>(arrow_type);
+            ::avro::BytesSchema decimal_schema;
+            ::avro::LogicalType decimal_type = ::avro::LogicalType(::avro::LogicalType::DECIMAL);
+            decimal_type.setPrecision(arrow_decimal_type->precision());
+            decimal_type.setScale(arrow_decimal_type->scale());
+            decimal_schema.root()->setLogicalType(decimal_type);
+            return nullable ? NullableSchema(decimal_schema) : decimal_schema;
+        }
+        case arrow::Type::LIST: {
+            const auto& list_type =
+                arrow::internal::checked_pointer_cast<const arrow::ListType>(arrow_type);
+            const auto& value_field = list_type->value_field();
+            PAIMON_ASSIGN_OR_RAISE(::avro::Schema value_schema,
+                                   ArrowTypeToAvroSchema(value_field, row_name));
+            ::avro::ArraySchema array_schema(value_schema);
+            return nullable ? NullableSchema(array_schema) : array_schema;
+        }
+        case arrow::Type::STRUCT: {
+            const auto& struct_type =
+                arrow::internal::checked_pointer_cast<const arrow::StructType>(arrow_type);
+            const auto& fields = struct_type->fields();
+
+            ::avro::RecordSchema record_schema(row_name);
+            for (const auto& f : fields) {
+                PAIMON_ASSIGN_OR_RAISE(::avro::Schema field_schema,
+                                       ArrowTypeToAvroSchema(f, row_name + "_" + f->name()));
+                AddRecordField(&record_schema, f->name(), field_schema);
+            }
+            return nullable ? NullableSchema(record_schema) : record_schema;
+        }
+        case arrow::Type::MAP: {
+            const auto& map_type =
+                arrow::internal::checked_pointer_cast<const arrow::MapType>(arrow_type);
+            const auto& key_field = map_type->key_field();
+            const auto& item_field = map_type->item_field();
+            if (key_field->nullable()) {
+                return Status::Invalid("Avro Map key cannot be nullable");
+            }
+            if (key_field->type()->id() == arrow::Type::STRING) {
+                PAIMON_ASSIGN_OR_RAISE(::avro::Schema item_schema,
+                                       ArrowTypeToAvroSchema(item_field, row_name));
+                ::avro::MapSchema map_schema(item_schema);
+                return nullable ? NullableSchema(map_schema) : map_schema;
+            } else {
+                // convert to list<record<key,value>>
+                PAIMON_ASSIGN_OR_RAISE(::avro::Schema key_schema,
+                                       ArrowTypeToAvroSchema(key_field, row_name + "_key"));
+                PAIMON_ASSIGN_OR_RAISE(::avro::Schema item_schema,
+                                       ArrowTypeToAvroSchema(item_field, row_name + "_value"));
+                ::avro::LogicalType logical_map_type =
+                    ::avro::LogicalType(std::make_shared<MapLogicalType>());
+                ::avro::RecordSchema record_schema(row_name);
+                AddRecordField(&record_schema, "key", key_schema);
+                AddRecordField(&record_schema, "value", item_schema);
+                ::avro::ArraySchema logical_map_schema(record_schema);
+                logical_map_schema.root()->setLogicalType(logical_map_type);
+                return nullable ? NullableSchema(logical_map_schema) : logical_map_schema;
+            }
+        }
+        default:
+            return Status::Invalid(fmt::format("Not support arrow type '{}' convert to avro",
+                                               field->type()->ToString()));
+    }
+}
+
+Result<::avro::ValidSchema> AvroSchemaConverter::ArrowSchemaToAvroSchema(
+    const std::shared_ptr<arrow::Schema>& arrow_schema) {
+    // top level row name of avro record, the same as java paimon
+    static const std::string kTopLevelRowName = "org.apache.paimon.avro.generated.record";
+    ::avro::RecordSchema record_schema(kTopLevelRowName);
+    for (const auto& field : arrow_schema->fields()) {
+        PAIMON_ASSIGN_OR_RAISE(
+            ::avro::Schema field_schema,
+            ArrowTypeToAvroSchema(field, kTopLevelRowName + "_" + field->name()));
+        AddRecordField(&record_schema, field->name(), field_schema);
+    }
+    return ::avro::ValidSchema(record_schema);
+}
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_schema_converter.h
+++ b/src/paimon/format/avro/avro_schema_converter.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "arrow/api.h"
+#include "avro/Node.hh"
+#include "avro/Schema.hh"
+#include "avro/ValidSchema.hh"
+#include "paimon/result.h"
+
+namespace paimon::avro {
+
+class AvroSchemaConverter {
+ public:
+    AvroSchemaConverter() = delete;
+    ~AvroSchemaConverter() = delete;
+
+    // TODO(menglingda.mld): add field id for avro
+    static Result<::avro::ValidSchema> ArrowSchemaToAvroSchema(
+        const std::shared_ptr<arrow::Schema>& arrow_schema);
+
+    static Result<std::shared_ptr<arrow::DataType>> AvroSchemaToArrowDataType(
+        const ::avro::ValidSchema& avro_schema);
+
+ private:
+    static Result<std::shared_ptr<arrow::DataType>> GetArrowType(const ::avro::NodePtr& avro_node,
+                                                                 bool* nullable);
+
+    static Result<::avro::Schema> ArrowTypeToAvroSchema(const std::shared_ptr<arrow::Field>& field,
+                                                        const std::string& row_name);
+
+    static ::avro::Schema NullableSchema(const ::avro::Schema& schema);
+
+    static void AddRecordField(::avro::RecordSchema* record_schema, const std::string& field_name,
+                               const ::avro::Schema& field_schema);
+
+    static Result<bool> CheckUnionType(const ::avro::NodePtr& avro_node);
+
+    static Result<std::shared_ptr<arrow::Field>> GetArrowField(const std::string& name,
+                                                               const ::avro::NodePtr& avro_node);
+};
+
+}  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_schema_converter_test.cpp
+++ b/src/paimon/format/avro/avro_schema_converter_test.cpp
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/format/avro/avro_schema_converter.h"
+
+#include "arrow/api.h"
+#include "avro/Compiler.hh"
+#include "avro/ValidSchema.hh"
+#include "gtest/gtest.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/core/manifest/manifest_file_meta.h"
+#include "paimon/core/utils/versioned_object_serializer.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::avro::test {
+
+TEST(AvroSchemaConverterTest, TestSimple) {
+    // Test a basic record with primitive types
+    std::string schema_json = R"({
+        "type": "record",
+        "namespace": "org.apache.paimon.avro.generated",
+        "name": "record",
+        "fields": [
+            {"name": "f_bool", "type": "boolean"},
+            {"name": "f_int", "type": "int"},
+            {"name": "f_long", "type": "long"},
+            {"name": "f_float", "type": "float"},
+            {"name": "f_double", "type": "double"},
+            {"name": "f_string", "type": "string"},
+            {"name": "f_bytes", "type": "bytes"}
+        ]
+    })";
+
+    auto avro_schema = ::avro::compileJsonSchemaFromString(schema_json);
+
+    ASSERT_OK_AND_ASSIGN(auto arrow_type,
+                         AvroSchemaConverter::AvroSchemaToArrowDataType(avro_schema));
+
+    // Expected Arrow Schema
+    auto expected_fields = {
+        arrow::field("f_bool", arrow::boolean(), false),
+        arrow::field("f_int", arrow::int32(), false),
+        arrow::field("f_long", arrow::int64(), false),
+        arrow::field("f_float", arrow::float32(), false),
+        arrow::field("f_double", arrow::float64(), false),
+        arrow::field("f_string", arrow::utf8(), false),
+        arrow::field("f_bytes", arrow::binary(), false),
+    };
+    auto arrow_schema = arrow::schema(expected_fields);
+
+    // The converted type should be a StructType
+    ASSERT_EQ(arrow_type->id(), arrow::Type::STRUCT);
+    ASSERT_TRUE(arrow_type->Equals(arrow::struct_(arrow_schema->fields())));
+
+    ASSERT_OK_AND_ASSIGN(auto expected_avro_schema,
+                         AvroSchemaConverter::ArrowSchemaToAvroSchema(arrow_schema));
+    ASSERT_EQ(expected_avro_schema.toJson(), avro_schema.toJson());
+}
+
+TEST(AvroSchemaConverterTest, TestAvroSchemaToArrowDataTypeWithNullableAndComplexType) {
+    // Test a schema with nullable types and nested types (array, record)
+    std::string schema_json = R"({
+    "type": "record",
+    "namespace": "org.apache.paimon.avro.generated",
+    "name": "record",
+    "fields": [
+        {
+            "name": "_VERSION",
+            "type": "int"
+        },
+        {
+            "name": "_FILE_NAME",
+            "type": "string"
+        },
+        {
+            "name": "_FILE_SIZE",
+            "type": "long"
+        },
+        {
+            "name": "_NUM_ADDED_FILES",
+            "type": "long"
+        },
+        {
+            "name": "_NUM_DELETED_FILES",
+            "type": "long"
+        },
+        {
+            "name": "_PARTITION_STATS",
+            "type": {
+                "type": "record",
+                "namespace": "org.apache.paimon.avro.generated",
+                "name": "record__PARTITION_STATS",
+                "fields": [
+                    {
+                        "name": "_MIN_VALUES",
+                        "type": "bytes"
+                    },
+                    {
+                        "name": "_MAX_VALUES",
+                        "type": "bytes"
+                    },
+                    {
+                        "name": "_NULL_COUNTS",
+                        "type": [
+                            "null",
+                            {
+                                "type": "array",
+                                "items": [
+                                    "null",
+                                    "long"
+                                ]
+                            }
+                        ],
+                        "default": null
+                    }
+                ]
+            }
+        },
+        {
+            "name": "_SCHEMA_ID",
+            "type": "long"
+        },
+        {
+            "name": "_MIN_BUCKET",
+            "type": [
+                "null",
+                "int"
+            ],
+            "default": null
+        },
+        {
+            "name": "_MAX_BUCKET",
+            "type": [
+                "null",
+                "int"
+            ],
+            "default": null
+        },
+        {
+            "name": "_MIN_LEVEL",
+            "type": [
+                "null",
+                "int"
+            ],
+            "default": null
+        },
+        {
+            "name": "_MAX_LEVEL",
+            "type": [
+                "null",
+                "int"
+            ],
+            "default": null
+        },
+        {
+            "name": "_MIN_ROW_ID",
+            "type": [
+                "null",
+                "long"
+            ],
+            "default": null
+        },
+        {
+            "name": "_MAX_ROW_ID",
+            "type": [
+                "null",
+                "long"
+            ],
+            "default": null
+        }
+    ]
+})";
+
+    auto avro_schema = ::avro::compileJsonSchemaFromString(schema_json);
+    ASSERT_OK_AND_ASSIGN(auto arrow_type,
+                         AvroSchemaConverter::AvroSchemaToArrowDataType(avro_schema));
+
+    ASSERT_EQ(arrow_type->id(), arrow::Type::STRUCT);
+    ASSERT_TRUE(arrow_type->Equals(
+        VersionedObjectSerializer<ManifestFileMeta>::VersionType(ManifestFileMeta::DataType())));
+}
+
+TEST(AvroSchemaConverterTest, TestAvroSchemaToArrowDataTypeWithTimestampType) {
+    std::string schema_json = R"({
+    "type": "record",
+    "namespace": "org.apache.paimon.avro.generated",
+    "name": "record",
+    "fields": [
+        {
+            "name": "ts_milli",
+            "type": { "type": "long", "logicalType": "timestamp-millis"}
+        },
+        {
+            "name": "ts_micro",
+            "type": { "type": "long", "logicalType": "timestamp-micros"}
+        },
+        {
+            "name": "ts_nano",
+            "type": { "type": "long", "logicalType": "timestamp-nanos"}
+        },
+        {
+            "name": "ts_milli_tz",
+            "type": { "type": "long", "logicalType": "local-timestamp-millis"}
+        },
+        {
+            "name": "ts_micro_tz",
+            "type": { "type": "long", "logicalType": "local-timestamp-micros"}
+        },
+        {
+            "name": "ts_nano_tz",
+            "type": { "type": "long", "logicalType": "local-timestamp-nanos"}
+        }
+    ]
+})";
+
+    auto avro_schema = ::avro::compileJsonSchemaFromString(schema_json);
+    ASSERT_OK_AND_ASSIGN(auto arrow_type,
+                         AvroSchemaConverter::AvroSchemaToArrowDataType(avro_schema));
+
+    ASSERT_EQ(arrow_type->id(), arrow::Type::STRUCT);
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    auto expected_fields = {
+        arrow::field("ts_milli", arrow::timestamp(arrow::TimeUnit::MILLI), false),
+        arrow::field("ts_micro", arrow::timestamp(arrow::TimeUnit::MICRO), false),
+        arrow::field("ts_nano", arrow::timestamp(arrow::TimeUnit::NANO), false),
+        arrow::field("ts_milli_tz", arrow::timestamp(arrow::TimeUnit::MILLI, timezone), false),
+        arrow::field("ts_micro_tz", arrow::timestamp(arrow::TimeUnit::MICRO, timezone), false),
+        arrow::field("ts_nano_tz", arrow::timestamp(arrow::TimeUnit::NANO, timezone), false),
+    };
+    ASSERT_TRUE(arrow_type->Equals(arrow::struct_(expected_fields))) << arrow_type->ToString();
+}
+
+}  // namespace paimon::avro::test

--- a/src/paimon/format/avro/avro_utils.h
+++ b/src/paimon/format/avro/avro_utils.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <sstream>
+#include <string>
+
+#include "avro/Node.hh"
+
+namespace paimon::avro {
+
+class AvroUtils {
+ public:
+    AvroUtils() = delete;
+    ~AvroUtils() = delete;
+
+    static std::string ToString(const ::avro::NodePtr& node) {
+        std::stringstream ss;
+        ss << *node;
+        return ss.str();
+    }
+
+    static std::string ToString(const ::avro::LogicalType& type) {
+        std::stringstream ss;
+        type.printJson(ss);
+        return ss.str();
+    }
+
+    static bool HasMapLogicalType(const ::avro::NodePtr& node) {
+        return node->logicalType().type() == ::avro::LogicalType::CUSTOM &&
+               node->logicalType().customLogicalType() != nullptr &&
+               node->logicalType().customLogicalType()->name() == "map";
+    }
+};
+
+}  // namespace paimon::avro


### PR DESCRIPTION
### Purpose

Linked issue: N/A

This pull request introduces the exact-scope Avro format migration batch from the Alibaba Paimon C++ repository.

Migrated files:
- `src/paimon/format/avro/avro_format_defs.h`
- `src/paimon/format/avro/avro_utils.h`
- `src/paimon/format/avro/avro_file_format.h`
- `src/paimon/format/avro/avro_file_format.cpp`
- `src/paimon/format/avro/avro_file_format_test.cpp`
- `src/paimon/format/avro/avro_file_format_factory.h`
- `src/paimon/format/avro/avro_file_format_factory.cpp`
- `src/paimon/format/avro/avro_reader_builder.h`
- `src/paimon/format/avro/avro_schema_converter.h`
- `src/paimon/format/avro/avro_schema_converter.cpp`
- `src/paimon/format/avro/avro_schema_converter_test.cpp`
- `src/paimon/format/avro/avro_input_stream_impl.h`
- `src/paimon/format/avro/avro_input_stream_impl.cpp`
- `src/paimon/format/avro/avro_input_stream_impl_test.cpp`
- `src/paimon/format/avro/avro_output_stream_impl.h`
- `src/paimon/format/avro/avro_output_stream_impl.cpp`

No extra dependency files are included in this batch. The migrated files reference `avro_file_batch_reader.h`, `avro_stats_extractor.h`, and `avro_writer_builder.h`; those files are intentionally left for a follow-up migration batch.

The Alibaba copyright headers were converted to ASF license headers. No third-party license or NOTICE updates are needed for this batch. External contributor analysis did not require a `Co-authored-by` trailer.

### Tests


### API and Format

This introduces Avro format implementation files under `src/paimon/format/avro`. It does not add new files under `include/`.

### Documentation

No documentation changes.

### Generative AI tooling

Migrated-by: OpenAI Codex
