### PR TITLE
feat(manifest): add manifest and index manifest support

### DIFF
--- a/src/paimon/core/manifest/index_manifest_entry.h
+++ b/src/paimon/core/manifest/index_manifest_entry.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+
+namespace paimon {
+/// Manifest entry for index file.
+struct IndexManifestEntry {
+    static const std::shared_ptr<arrow::DataType>& DataType() {
+        static std::shared_ptr<arrow::DataType> data_type = arrow::struct_({
+            arrow::field("_KIND", arrow::int8(), false),
+            arrow::field("_PARTITION", arrow::binary(), false),
+            arrow::field("_BUCKET", arrow::int32(), false),
+            arrow::field("_INDEX_TYPE", arrow::utf8(), false),
+            arrow::field("_FILE_NAME", arrow::utf8(), false),
+            arrow::field("_FILE_SIZE", arrow::int64(), false),
+            arrow::field("_ROW_COUNT", arrow::int64(), false),
+            arrow::field("_DELETIONS_VECTORS_RANGES",
+                         arrow::list(arrow::field("item", DeletionVectorMeta::DataType(), true)),
+                         true),
+            arrow::field("_EXTERNAL_PATH", arrow::utf8(), true),
+            arrow::field("_GLOBAL_INDEX", GlobalIndexMeta::DataType(), true),
+        });
+        return data_type;
+    }
+
+    IndexManifestEntry(const FileKind& _kind, const BinaryRow& _partition, int32_t _bucket,
+                       const std::shared_ptr<IndexFileMeta>& _index_file)
+        : kind(_kind), partition(_partition), bucket(_bucket), index_file(_index_file) {}
+
+    bool operator==(const IndexManifestEntry& other) const {
+        if (this == &other) {
+            return true;
+        }
+        return kind == other.kind && partition == other.partition && bucket == other.bucket &&
+               *index_file == *(other.index_file);
+    }
+
+    std::string ToString() const {
+        return fmt::format("IndexManifestEntry{{kind={}, partition={}, bucket={}, indexFile={}}}",
+                           kind.ToByteValue(), partition.ToString(), bucket,
+                           index_file->ToString());
+    }
+
+    FileKind kind;
+    BinaryRow partition;
+    int32_t bucket;
+    std::shared_ptr<IndexFileMeta> index_file;
+};
+}  // namespace paimon

--- a/src/paimon/core/manifest/index_manifest_entry_serializer.cpp
+++ b/src/paimon/core/manifest/index_manifest_entry_serializer.cpp
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/index_manifest_entry_serializer.h"
+
+#include <cassert>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/common/data/binary_string.h"
+#include "paimon/common/data/internal_row.h"
+#include "paimon/common/utils/linked_hash_map.h"
+#include "paimon/common/utils/serialization_utils.h"
+#include "paimon/core/index/deletion_vector_meta.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/index/index_file_meta_serializer.h"
+#include "paimon/core/index/index_file_meta_v2_deserializer.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/status.h"
+
+namespace paimon {
+Result<IndexManifestEntry> IndexManifestEntrySerializer::ConvertFrom(int32_t version,
+                                                                     const InternalRow& row) const {
+    if (version != VERSION) {
+        return Status::Invalid("Unsupported version", std::to_string(version));
+    }
+    auto kind = row.GetByte(0);
+    PAIMON_ASSIGN_OR_RAISE(FileKind file_kind, FileKind::FromByteValue(kind));
+    auto partition_bytes = row.GetBinary(1);
+    PAIMON_ASSIGN_OR_RAISE(BinaryRow partition,
+                           SerializationUtils::DeserializeBinaryRow(partition_bytes));
+    auto bucket = row.GetInt(2);
+
+    // for IndexFileMeta
+    auto index_type = row.GetString(3).ToString();
+    auto file_name = row.GetString(4).ToString();
+    int64_t file_size = row.GetLong(5);
+    int64_t row_count = row.GetLong(6);
+    std::optional<LinkedHashMap<std::string, DeletionVectorMeta>> dv_ranges;
+    if (!row.IsNullAt(7)) {
+        auto dv_range_array = row.GetArray(7);
+        assert(dv_range_array);
+        dv_ranges = IndexFileMetaV2Deserializer::RowArrayDataToDvRanges(dv_range_array.get());
+    }
+    std::optional<std::string> external_path;
+    if (!row.IsNullAt(8)) {
+        external_path = row.GetString(8).ToString();
+    }
+    // for global index meta
+    std::optional<GlobalIndexMeta> global_index_meta;
+    if (!row.IsNullAt(9)) {
+        std::shared_ptr<InternalRow> global_index_meta_row =
+            row.GetRow(9, GlobalIndexMeta::NUM_FIELDS);
+        assert(global_index_meta_row);
+        PAIMON_ASSIGN_OR_RAISE(global_index_meta, GlobalIndexMeta::FromRow(*global_index_meta_row));
+    }
+    auto index_file_meta = std::make_shared<IndexFileMeta>(
+        index_type, file_name, file_size, row_count, dv_ranges, external_path, global_index_meta);
+
+    return IndexManifestEntry(file_kind, partition, bucket, index_file_meta);
+}
+
+Result<BinaryRow> IndexManifestEntrySerializer::ToRow(const IndexManifestEntry& record) const {
+    BinaryRow row(GetDataType()->num_fields());
+    BinaryRowWriter writer(&row, 32 * 1024, pool_.get());
+
+    writer.WriteInt(0, GetVersion());
+    writer.WriteByte(1, record.kind.ToByteValue());
+    auto partition_bytes = SerializationUtils::SerializeBinaryRow(record.partition, pool_.get());
+    assert(partition_bytes);
+    writer.WriteBinary(2, *partition_bytes);
+    writer.WriteInt(3, record.bucket);
+    IndexFileMetaSerializer::WriteIndexFileMeta(4, record.index_file, &writer, pool_.get());
+    writer.Complete();
+    return row;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/manifest/index_manifest_entry_serializer.h
+++ b/src/paimon/core/manifest/index_manifest_entry_serializer.h
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "arrow/status.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/core/manifest/index_manifest_entry.h"
+#include "paimon/core/utils/versioned_object_serializer.h"
+#include "paimon/result.h"
+
+struct ArrowArray;
+
+namespace paimon {
+class InternalRow;
+class MemoryPool;
+
+/// Serializer for `IndexManifestEntry`.
+class IndexManifestEntrySerializer : public VersionedObjectSerializer<IndexManifestEntry> {
+ public:
+    explicit IndexManifestEntrySerializer(const std::shared_ptr<MemoryPool>& pool)
+        : VersionedObjectSerializer<IndexManifestEntry>(pool), arrow_pool_(GetArrowPool(pool_)) {}
+
+    int32_t GetVersion() const override {
+        return VERSION;
+    }
+
+    Result<IndexManifestEntry> ConvertFrom(int32_t version, const InternalRow& row) const override;
+
+    Result<BinaryRow> ToRow(const IndexManifestEntry& record) const override;
+
+ private:
+    static constexpr int32_t VERSION = 1;
+    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+};
+}  // namespace paimon

--- a/src/paimon/core/manifest/index_manifest_entry_serializer_test.cpp
+++ b/src/paimon/core/manifest/index_manifest_entry_serializer_test.cpp
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/index_manifest_entry_serializer.h"
+
+#include <optional>
+#include <string>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/columnar/columnar_row.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+namespace paimon::test {
+TEST(IndexManifestEntrySerializerTest, TestSerialize) {
+    auto pool = GetDefaultPool();
+    auto bytes = std::make_shared<Bytes>("apple", pool.get());
+    LinkedHashMap<std::string, DeletionVectorMeta> deletion_vectors_ranges;
+    deletion_vectors_ranges.insert_or_assign(
+        "my_file_name1", DeletionVectorMeta("my_file_name1", rand(), rand(), std::nullopt));
+    deletion_vectors_ranges.insert_or_assign(
+        "my_file_name2", DeletionVectorMeta("my_file_name2", rand(), rand(), std::nullopt));
+    std::vector<IndexManifestEntry> entries = {
+        IndexManifestEntry(
+            FileKind::Add(), /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+            /*bucket=*/0,
+            std::make_shared<IndexFileMeta>(
+                "bsi", "bsi.index", /*file_size=*/110, /*row_count=*/210,
+                /*dv_ranges=*/std::nullopt,
+                /*external_path=*/std::nullopt,
+                GlobalIndexMeta(/*row_range_start=*/41, /*row_range_end=*/71, /*index_field_id=*/2,
+                                /*extra_field_ids=*/std::nullopt, /*index_meta=*/nullptr))),
+        IndexManifestEntry(
+            FileKind::Add(), /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+            /*bucket=*/0,
+            std::make_shared<IndexFileMeta>(
+                "bitmap", "bitmap.index", /*file_size=*/100, /*row_count=*/200,
+                /*dv_ranges=*/std::nullopt,
+                /*external_path=*/std::optional<std::string>("FILE:/tmp/external/bitmap.index"),
+                GlobalIndexMeta(/*row_range_start=*/30, /*row_range_end=*/70, /*index_field_id=*/0,
+                                /*extra_field_ids=*/std::optional<std::vector<int32_t>>({3, 4}),
+                                /*index_meta=*/bytes))),
+        IndexManifestEntry(
+            FileKind::Delete(), /*partition=*/BinaryRowGenerator::GenerateRow({30}, pool.get()),
+            /*bucket=*/3,
+            std::make_shared<IndexFileMeta>("deletion_vector", "dev.index", /*file_size=*/200,
+                                            /*row_count=*/20, deletion_vectors_ranges,
+                                            /*external_path=*/std::nullopt)),
+        IndexManifestEntry(
+            FileKind::Add(), /*partition=*/BinaryRowGenerator::GenerateRow({20}, pool.get()),
+            /*bucket=*/2,
+            std::make_shared<IndexFileMeta>("deletion_vector", "dev.index1", /*file_size=*/210,
+                                            /*row_count=*/40, deletion_vectors_ranges,
+                                            /*external_path=*/"oss:///tmp"))};
+    IndexManifestEntrySerializer serializer(pool);
+    for (const auto& entry : entries) {
+        ASSERT_OK_AND_ASSIGN(auto row, serializer.ToRow(entry));
+        ASSERT_OK_AND_ASSIGN(auto result_entry, serializer.FromRow(row));
+        ASSERT_EQ(result_entry, entry);
+        ASSERT_EQ(result_entry.ToString(), entry.ToString());
+    }
+}
+}  // namespace paimon::test

--- a/src/paimon/core/manifest/index_manifest_file.cpp
+++ b/src/paimon/core/manifest/index_manifest_file.cpp
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/index_manifest_file.h"
+
+#include <utility>
+
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/manifest/index_manifest_entry.h"
+#include "paimon/core/manifest/index_manifest_entry_serializer.h"
+#include "paimon/core/manifest/index_manifest_file_handler.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/core/utils/object_serializer.h"
+#include "paimon/core/utils/path_factory.h"
+#include "paimon/core/utils/versioned_object_serializer.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/reader_builder.h"
+#include "paimon/format/writer_builder.h"
+
+namespace arrow {
+class DataType;
+}  // namespace arrow
+
+namespace paimon {
+class FileSystem;
+class MemoryPool;
+
+Result<std::unique_ptr<IndexManifestFile>> IndexManifestFile::Create(
+    const std::shared_ptr<FileSystem>& file_system, const std::shared_ptr<FileFormat>& file_format,
+    const std::string& compression, const std::shared_ptr<FileStorePathFactory>& path_factory,
+    int32_t bucket_mode, const std::shared_ptr<MemoryPool>& pool, const CoreOptions& options) {
+    std::shared_ptr<arrow::DataType> data_type =
+        VersionedObjectSerializer<IndexManifestEntry>::VersionType(IndexManifestEntry::DataType());
+
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ReaderBuilder> reader_builder,
+                           file_format->CreateReaderBuilder(options.GetReadBatchSize()));
+    reader_builder->WithMemoryPool(pool);
+    ArrowSchema schema;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportType(*data_type, &schema));
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<WriterBuilder> writer_builder,
+                           file_format->CreateWriterBuilder(&schema, options.GetWriteBatchSize()));
+    writer_builder->WithMemoryPool(pool);
+
+    std::shared_ptr<PathFactory> index_manifest_file_factory =
+        path_factory->CreateIndexManifestFileFactory();
+    return std::unique_ptr<IndexManifestFile>(
+        new IndexManifestFile(file_system, reader_builder, writer_builder, compression,
+                              index_manifest_file_factory, bucket_mode, pool));
+}
+
+IndexManifestFile::IndexManifestFile(const std::shared_ptr<FileSystem>& file_system,
+                                     const std::shared_ptr<ReaderBuilder>& reader_builder,
+                                     const std::shared_ptr<WriterBuilder>& writer_builder,
+                                     const std::string& compression,
+                                     const std::shared_ptr<PathFactory>& path_factory,
+                                     int32_t bucket_mode, const std::shared_ptr<MemoryPool>& pool)
+    : ObjectsFile<IndexManifestEntry>(file_system, reader_builder, writer_builder,
+                                      std::make_unique<IndexManifestEntrySerializer>(pool),
+                                      compression, path_factory, pool),
+      bucket_mode_(bucket_mode) {}
+
+Result<std::optional<std::string>> IndexManifestFile::WriteIndexFiles(
+    const std::optional<std::string>& previous_index_manifest,
+    const std::vector<IndexManifestEntry>& new_index_files) {
+    if (new_index_files.empty()) {
+        return previous_index_manifest;
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::string file,
+                           IndexManifestFileHandler::Write(previous_index_manifest, new_index_files,
+                                                           bucket_mode_, this));
+    return std::optional<std::string>(file);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/manifest/index_manifest_file.h
+++ b/src/paimon/core/manifest/index_manifest_file.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "paimon/core/core_options.h"
+#include "paimon/core/manifest/index_manifest_entry.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/core/utils/objects_file.h"
+#include "paimon/format/file_format.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+
+namespace paimon {
+class CoreOptions;
+class FileFormat;
+class FileStorePathFactory;
+class FileSystem;
+class MemoryPool;
+class PathFactory;
+class ReaderBuilder;
+class WriterBuilder;
+struct IndexManifestEntry;
+
+/// Index manifest file.
+class IndexManifestFile : public ObjectsFile<IndexManifestEntry> {
+ public:
+    static Result<std::unique_ptr<IndexManifestFile>> Create(
+        const std::shared_ptr<FileSystem>& file_system,
+        const std::shared_ptr<FileFormat>& file_format, const std::string& compression,
+        const std::shared_ptr<FileStorePathFactory>& path_factory, int32_t bucket_mode,
+        const std::shared_ptr<MemoryPool>& pool, const CoreOptions& options);
+
+    /// Write new index files to index manifest.
+    Result<std::optional<std::string>> WriteIndexFiles(
+        const std::optional<std::string>& previous_index_manifest,
+        const std::vector<IndexManifestEntry>& new_index_files);
+
+ private:
+    IndexManifestFile(const std::shared_ptr<FileSystem>& file_system,
+                      const std::shared_ptr<ReaderBuilder>& reader_builder,
+                      const std::shared_ptr<WriterBuilder>& writer_builder,
+                      const std::string& compression,
+                      const std::shared_ptr<PathFactory>& path_factory, int32_t bucket_mode,
+                      const std::shared_ptr<MemoryPool>& pool);
+
+    const int32_t bucket_mode_;
+};
+}  // namespace paimon

--- a/src/paimon/core/manifest/index_manifest_file_handler.cpp
+++ b/src/paimon/core/manifest/index_manifest_file_handler.cpp
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/index_manifest_file_handler.h"
+
+#include <set>
+#include <unordered_map>
+#include <utility>
+
+#include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
+namespace paimon {
+
+using BucketIdentifier = std::tuple<BinaryRow, int32_t, std::string>;
+
+std::vector<IndexManifestEntry> IndexManifestFileHandler::BucketedCombiner::Combine(
+    const std::vector<IndexManifestEntry>& prev_index_files,
+    const std::vector<IndexManifestEntry>& new_index_files) const {
+    std::unordered_map<BucketIdentifier, IndexManifestEntry> index_entries;
+    for (const auto& entry : prev_index_files) {
+        index_entries.emplace(
+            BucketIdentifier(entry.partition, entry.bucket, entry.index_file->IndexType()), entry);
+    }
+
+    std::unordered_map<BucketIdentifier, IndexManifestEntry> removed;
+    removed.reserve(new_index_files.size());
+    std::unordered_map<BucketIdentifier, IndexManifestEntry> added;
+    added.reserve(new_index_files.size());
+
+    for (const auto& entry : new_index_files) {
+        if (entry.kind == FileKind::Delete()) {
+            removed.emplace(
+                BucketIdentifier(entry.partition, entry.bucket, entry.index_file->IndexType()),
+                entry);
+        } else if (entry.kind == FileKind::Add()) {
+            added.emplace(
+                BucketIdentifier(entry.partition, entry.bucket, entry.index_file->IndexType()),
+                entry);
+        }
+    }
+
+    // The deleted entry is processed first to avoid overwriting a new entry.
+    for (const auto& entry : removed) {
+        index_entries.erase(entry.first);
+    }
+    for (const auto& entry : added) {
+        index_entries.emplace(entry.first, entry.second);
+    }
+
+    std::vector<IndexManifestEntry> result_entries;
+    result_entries.reserve(index_entries.size());
+    for (const auto& [_, entry] : index_entries) {
+        result_entries.push_back(entry);
+    }
+    return result_entries;
+}
+
+std::vector<IndexManifestEntry> IndexManifestFileHandler::GlobalFileNameCombiner::Combine(
+    const std::vector<IndexManifestEntry>& prev_index_files,
+    const std::vector<IndexManifestEntry>& new_index_files) const {
+    std::map<std::string, IndexManifestEntry> index_entries;
+    for (const auto& entry : prev_index_files) {
+        index_entries.emplace(entry.index_file->FileName(), entry);
+    }
+
+    std::vector<IndexManifestEntry> removed;
+    removed.reserve(new_index_files.size());
+    std::vector<IndexManifestEntry> added;
+    added.reserve(new_index_files.size());
+
+    for (const auto& entry : new_index_files) {
+        if (entry.kind == FileKind::Delete()) {
+            removed.push_back(entry);
+        } else if (entry.kind == FileKind::Add()) {
+            added.push_back(entry);
+        }
+    }
+
+    // The deleted entry is processed first to avoid overwriting a new entry.
+    for (const auto& entry : removed) {
+        index_entries.erase(entry.index_file->FileName());
+    }
+    for (const auto& entry : added) {
+        index_entries.emplace(entry.index_file->FileName(), entry);
+    }
+
+    std::vector<IndexManifestEntry> result_entries;
+    result_entries.reserve(index_entries.size());
+    for (const auto& [_, entry] : index_entries) {
+        result_entries.push_back(entry);
+    }
+    return result_entries;
+}
+
+Result<std::string> IndexManifestFileHandler::Write(
+    const std::optional<std::string>& previous_index_manifest,
+    const std::vector<IndexManifestEntry>& new_index_entries, int32_t bucket_mode,
+    IndexManifestFile* index_manifest_file) {
+    std::vector<IndexManifestEntry> entries;
+    if (previous_index_manifest != std::nullopt) {
+        PAIMON_RETURN_NOT_OK(index_manifest_file->Read(previous_index_manifest.value(),
+                                                       /*filter=*/nullptr, &entries));
+    }
+    for (const auto& entry : entries) {
+        if (!(entry.kind == FileKind::Add())) {
+            return Status::Invalid("Invalid entry, file kind is not add.");
+        }
+    }
+    std::map<std::string, std::vector<IndexManifestEntry>> previous = SeparateIndexEntries(entries);
+    std::map<std::string, std::vector<IndexManifestEntry>> current =
+        SeparateIndexEntries(new_index_entries);
+
+    std::set<std::string> index_types;
+    for (const auto& [index_type, _] : previous) {
+        index_types.insert(index_type);
+    }
+    for (const auto& [index_type, _] : current) {
+        index_types.insert(index_type);
+    }
+
+    std::vector<IndexManifestEntry> index_entries;
+    index_entries.reserve(previous.size() + current.size());
+    for (const auto& index_type : index_types) {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<IndexManifestFileHandler::IndexManifestFileCombiner> combiner,
+            GetIndexManifestFileCombine(index_type, bucket_mode));
+        std::vector<IndexManifestEntry> typed_previous_entries = previous[index_type];
+        std::vector<IndexManifestEntry> typed_current_entries = current[index_type];
+        std::vector<IndexManifestEntry> combined_entries =
+            combiner->Combine(typed_previous_entries, typed_current_entries);
+
+        index_entries.insert(index_entries.end(), combined_entries.begin(), combined_entries.end());
+    }
+
+    std::pair<std::string, int64_t> file_path_and_length;
+    PAIMON_ASSIGN_OR_RAISE(file_path_and_length,
+                           index_manifest_file->WriteWithoutRolling(index_entries));
+    return file_path_and_length.first;
+}
+
+std::map<std::string, std::vector<IndexManifestEntry>>
+IndexManifestFileHandler::SeparateIndexEntries(
+    const std::vector<IndexManifestEntry>& index_entries) {
+    std::map<std::string, std::vector<IndexManifestEntry>> result;
+    for (const auto& index_entry : index_entries) {
+        std::string index_type = index_entry.index_file->IndexType();
+        result[index_type].push_back(index_entry);
+    }
+    return result;
+}
+
+Result<std::unique_ptr<IndexManifestFileHandler::IndexManifestFileCombiner>>
+IndexManifestFileHandler::GetIndexManifestFileCombine(const std::string& index_type,
+                                                      int32_t bucket_mode) {
+    if (index_type != DeletionVectorsIndexFile::DELETION_VECTORS_INDEX && index_type != "HASH") {
+        return std::make_unique<GlobalFileNameCombiner>();
+    }
+    if (index_type == DeletionVectorsIndexFile::DELETION_VECTORS_INDEX && bucket_mode == -1) {
+        return Status::NotImplemented("not yet support dv with BUCKET_UNAWARE mode");
+    }
+    return std::make_unique<BucketedCombiner>();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/manifest/index_manifest_file_handler.h
+++ b/src/paimon/core/manifest/index_manifest_file_handler.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "paimon/core/manifest/index_manifest_file.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+/// IndexManifestFile Handler.
+class IndexManifestFileHandler {
+ public:
+    IndexManifestFileHandler() = delete;
+    ~IndexManifestFileHandler() = delete;
+
+    static Result<std::string> Write(const std::optional<std::string>& previous_index_manifest,
+                                     const std::vector<IndexManifestEntry>& new_index_entries,
+                                     int32_t bucket_mode, IndexManifestFile* index_manifest_file);
+
+ private:
+    class IndexManifestFileCombiner {
+     public:
+        virtual ~IndexManifestFileCombiner() = default;
+        virtual std::vector<IndexManifestEntry> Combine(
+            const std::vector<IndexManifestEntry>& prev_index_files,
+            const std::vector<IndexManifestEntry>& new_index_files) const = 0;
+    };
+
+    /// Combine previous and new global index files by file `BucketIdentifier`.
+    class BucketedCombiner : public IndexManifestFileCombiner {
+     public:
+        std::vector<IndexManifestEntry> Combine(
+            const std::vector<IndexManifestEntry>& prev_index_files,
+            const std::vector<IndexManifestEntry>& new_index_files) const override;
+    };
+
+    /// Combine previous and new global index files by file name.
+    class GlobalFileNameCombiner : public IndexManifestFileCombiner {
+     public:
+        std::vector<IndexManifestEntry> Combine(
+            const std::vector<IndexManifestEntry>& prev_index_files,
+            const std::vector<IndexManifestEntry>& new_index_files) const override;
+    };
+
+    static std::map<std::string, std::vector<IndexManifestEntry>> SeparateIndexEntries(
+        const std::vector<IndexManifestEntry>& index_entries);
+
+    static Result<std::unique_ptr<IndexManifestFileCombiner>> GetIndexManifestFileCombine(
+        const std::string& index_type, int32_t bucket_mode);
+};
+}  // namespace paimon

--- a/src/paimon/core/manifest/index_manifest_file_handler_test.cpp
+++ b/src/paimon/core/manifest/index_manifest_file_handler_test.cpp
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/index_manifest_file_handler.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "gtest/gtest.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/index_manifest_file.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/defs.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/file_format_factory.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class IndexManifestFileHandlerTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+        dir_ = UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir_ != nullptr);
+    }
+
+    Result<std::unique_ptr<IndexManifestFile>> CreateManifestFile(int32_t bucket_mode) const {
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileFormat> file_format,
+                               FileFormatFactory::Get("orc", {}));
+        auto schema = arrow::schema({arrow::field("f0", arrow::int32())});
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<FileStorePathFactory> path_factory,
+            FileStorePathFactory::Create(
+                dir_->Str(), schema, /*partition_keys=*/{}, /*default_part_value=*/"",
+                file_format->Identifier(), /*data_file_prefix=*/"data-",
+                /*legacy_partition_name_enabled=*/true, /*external_paths=*/{},
+                /*global_index_external_path=*/std::nullopt,
+                /*index_file_in_data_file_dir=*/false, pool_));
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options,
+                               CoreOptions::FromMap({{Options::MANIFEST_FORMAT, "orc"}}));
+        return IndexManifestFile::Create(dir_->GetFileSystem(), file_format, "zstd", path_factory,
+                                         bucket_mode, pool_, options);
+    }
+
+    static IndexManifestEntry MakeEntry(const FileKind& kind, const BinaryRow& partition,
+                                        int32_t bucket, const std::string& index_type,
+                                        const std::string& file_name, int64_t row_count) {
+        return IndexManifestEntry(
+            kind, partition, bucket,
+            std::make_shared<IndexFileMeta>(index_type, file_name, /*file_size=*/row_count * 10,
+                                            row_count, /*dv_ranges=*/std::nullopt,
+                                            /*external_path=*/std::nullopt));
+    }
+
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<UniqueTestDirectory> dir_;
+};
+
+TEST_F(IndexManifestFileHandlerTest, GlobalCombinerDeletesThenAddsByFileName) {
+    ASSERT_OK_AND_ASSIGN(auto index_manifest_file, CreateManifestFile(/*bucket_mode=*/4));
+
+    auto partition = BinaryRow::EmptyRow();
+    std::vector<IndexManifestEntry> previous_entries = {
+        MakeEntry(FileKind::Add(), partition, /*bucket=*/0, /*index_type=*/"BTREE", "global-0", 1)};
+
+    ASSERT_OK_AND_ASSIGN(std::string previous_manifest,
+                         IndexManifestFileHandler::Write(
+                             /*previous_index_manifest=*/std::nullopt, previous_entries,
+                             /*bucket_mode=*/4, index_manifest_file.get()));
+
+    std::vector<IndexManifestEntry> new_entries = {
+        MakeEntry(FileKind::Delete(), partition, /*bucket=*/999, /*index_type=*/"BTREE", "global-0",
+                  1),
+        MakeEntry(FileKind::Add(), partition, /*bucket=*/1, /*index_type=*/"BTREE", "global-0", 2)};
+
+    ASSERT_OK_AND_ASSIGN(
+        std::string current_manifest,
+        IndexManifestFileHandler::Write(previous_manifest, new_entries,
+                                        /*bucket_mode=*/4, index_manifest_file.get()));
+
+    std::vector<IndexManifestEntry> written_entries;
+    ASSERT_OK(index_manifest_file->Read(current_manifest, /*filter=*/nullptr, &written_entries));
+    ASSERT_EQ(written_entries.size(), 1);
+    ASSERT_EQ(written_entries[0].index_file->FileName(), "global-0");
+    ASSERT_EQ(written_entries[0].index_file->RowCount(), 2);
+}
+
+TEST_F(IndexManifestFileHandlerTest, BucketedCombinerUsesPartitionBucketAndIndexType) {
+    ASSERT_OK_AND_ASSIGN(auto index_manifest_file, CreateManifestFile(/*bucket_mode=*/2));
+
+    auto partition_10 = BinaryRowGenerator::GenerateRow({10}, pool_.get());
+    std::vector<IndexManifestEntry> previous_entries = {
+        MakeEntry(FileKind::Add(), partition_10, /*bucket=*/0,
+                  DeletionVectorsIndexFile::DELETION_VECTORS_INDEX, "dv-0-old", 10),
+        MakeEntry(FileKind::Add(), partition_10, /*bucket=*/1,
+                  DeletionVectorsIndexFile::DELETION_VECTORS_INDEX, "dv-1-keep", 11)};
+
+    ASSERT_OK_AND_ASSIGN(std::string previous_manifest,
+                         IndexManifestFileHandler::Write(
+                             /*previous_index_manifest=*/std::nullopt, previous_entries,
+                             /*bucket_mode=*/2, index_manifest_file.get()));
+
+    std::vector<IndexManifestEntry> new_entries = {
+        MakeEntry(FileKind::Delete(), partition_10, /*bucket=*/0,
+                  DeletionVectorsIndexFile::DELETION_VECTORS_INDEX, "ignored", 10),
+        MakeEntry(FileKind::Add(), partition_10, /*bucket=*/0,
+                  DeletionVectorsIndexFile::DELETION_VECTORS_INDEX, "dv-0-new", 12)};
+
+    ASSERT_OK_AND_ASSIGN(
+        std::string current_manifest,
+        IndexManifestFileHandler::Write(previous_manifest, new_entries,
+                                        /*bucket_mode=*/2, index_manifest_file.get()));
+
+    std::vector<IndexManifestEntry> written_entries;
+    ASSERT_OK(index_manifest_file->Read(current_manifest, /*filter=*/nullptr, &written_entries));
+    ASSERT_EQ(written_entries.size(), 2);
+
+    bool found_bucket0 = false;
+    bool found_bucket1 = false;
+    for (const auto& entry : written_entries) {
+        if (entry.bucket == 0) {
+            found_bucket0 = true;
+            ASSERT_EQ(entry.index_file->FileName(), "dv-0-new");
+            ASSERT_EQ(entry.index_file->RowCount(), 12);
+        } else if (entry.bucket == 1) {
+            found_bucket1 = true;
+            ASSERT_EQ(entry.index_file->FileName(), "dv-1-keep");
+            ASSERT_EQ(entry.index_file->RowCount(), 11);
+        }
+    }
+    ASSERT_TRUE(found_bucket0);
+    ASSERT_TRUE(found_bucket1);
+}
+
+TEST_F(IndexManifestFileHandlerTest, DvWithBucketUnawareModeReturnsNotImplemented) {
+    ASSERT_OK_AND_ASSIGN(auto index_manifest_file, CreateManifestFile(/*bucket_mode=*/-1));
+
+    auto partition = BinaryRow::EmptyRow();
+    std::vector<IndexManifestEntry> new_entries = {
+        MakeEntry(FileKind::Add(), partition, /*bucket=*/0,
+                  DeletionVectorsIndexFile::DELETION_VECTORS_INDEX, "dv-0", 1)};
+
+    ASSERT_NOK_WITH_MSG(IndexManifestFileHandler::Write(
+                            /*previous_index_manifest=*/std::nullopt, new_entries,
+                            /*bucket_mode=*/-1, index_manifest_file.get()),
+                        "not yet support dv with BUCKET_UNAWARE mode");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/manifest/manifest_committable.h
+++ b/src/paimon/core/manifest/manifest_committable.h
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/commit_message.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+
+namespace paimon {
+
+// Manifest commit message.
+class ManifestCommittable {
+ public:
+    explicit ManifestCommittable(int64_t identifier)
+        : ManifestCommittable(identifier, std::nullopt) {}
+
+    ManifestCommittable(int64_t identifier, std::optional<int64_t> watermark)
+        : ManifestCommittable(identifier, watermark, {}, {}, {}) {}
+
+    ManifestCommittable(int64_t identifier, std::optional<int64_t> watermark,
+                        const std::map<int32_t, int64_t>& log_offsets,
+                        const std::map<std::string, std::string>& properties,
+                        const std::vector<std::shared_ptr<CommitMessage>>& commit_messages)
+        : identifier_(identifier),
+          watermark_(watermark),
+          log_offsets_(log_offsets),
+          properties_(properties),
+          commit_messages_(commit_messages) {}
+
+    int64_t Identifier() const {
+        return identifier_;
+    }
+
+    std::optional<int64_t> Watermark() const {
+        return watermark_;
+    }
+
+    const std::map<int32_t, int64_t>& LogOffsets() const {
+        return log_offsets_;
+    }
+
+    const std::map<std::string, std::string>& Properties() const {
+        return properties_;
+    }
+
+    const std::vector<std::shared_ptr<CommitMessage>>& FileCommittables() const {
+        return commit_messages_;
+    }
+
+    void AddFileCommittable(const std::shared_ptr<CommitMessage>& commit_messages) {
+        commit_messages_.push_back(commit_messages);
+    }
+
+    Result<std::string> ToString() const {
+        std::vector<std::string> commit_messages_str;
+        commit_messages_str.reserve(commit_messages_.size());
+        for (const auto& message : commit_messages_) {
+            PAIMON_ASSIGN_OR_RAISE(std::string message_str, CommitMessage::ToDebugString(message));
+            commit_messages_str.emplace_back(message_str);
+        }
+        std::string watermark_str =
+            watermark_ == std::nullopt ? "null" : std::to_string(watermark_.value());
+
+        std::vector<std::string> log_offsets_str;
+        log_offsets_str.reserve(log_offsets_.size());
+        for (const auto& [key, value] : log_offsets_) {
+            log_offsets_str.emplace_back(fmt::format("{}: {}", key, value));
+        }
+
+        std::vector<std::string> properties_str;
+        properties_str.reserve(properties_.size());
+        for (const auto& [key, value] : properties_) {
+            properties_str.emplace_back(fmt::format("{}: {}", key, value));
+        }
+
+        return fmt::format(
+            "ManifestCommittable {{identifier = {}, watermark = {}, logOffsets = {}, "
+            "commitMessages = {}, properties = {}}}",
+            identifier_, watermark_str, fmt::join(log_offsets_str, ", "),
+            fmt::join(commit_messages_str, ", "), fmt::join(properties_str, ", "));
+    }
+
+ private:
+    int64_t identifier_;
+    std::optional<int64_t> watermark_;
+    std::map<int32_t, int64_t> log_offsets_;
+    std::map<std::string, std::string> properties_;
+    std::vector<std::shared_ptr<CommitMessage>> commit_messages_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/manifest/manifest_committable_test.cpp
+++ b/src/paimon/core/manifest/manifest_committable_test.cpp
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/manifest_committable.h"
+
+#include <cstddef>
+
+#include "gtest/gtest.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class ManifestCommittableTest : public testing::Test {
+ private:
+    bool IsEqualMap(const std::map<int32_t, int64_t>& actual_map,
+                    const std::map<int32_t, int64_t>& expected_map) {
+        if (expected_map.size() != actual_map.size()) {
+            return false;
+        }
+        for (const auto& kv : expected_map) {
+            const auto& key = kv.first;
+            const auto& value = kv.second;
+            auto iter = actual_map.find(key);
+            if (iter != actual_map.end()) {
+                if (iter->second == value) {
+                    continue;
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    std::vector<std::shared_ptr<CommitMessage>> GetCommitMessages(const std::string& path,
+                                                                  int32_t version) const {
+        auto file_system = std::make_shared<LocalFileSystem>();
+        auto buffer_length = file_system->GetFileStatus(path).value()->GetLen();
+        std::vector<uint8_t> buffer(buffer_length, 0);
+
+        EXPECT_OK_AND_ASSIGN(auto in_stream, file_system->Open(path));
+        EXPECT_OK_AND_ASSIGN(
+            [[maybe_unused]] int32_t read_bytes,
+            in_stream->Read(reinterpret_cast<char*>(buffer.data()), buffer.size()));
+        EXPECT_OK(in_stream->Close());
+
+        auto pool = GetDefaultPool();
+        EXPECT_OK_AND_ASSIGN(
+            auto ret, CommitMessage::DeserializeList(
+                          version, reinterpret_cast<char*>(buffer.data()), buffer.size(), pool));
+        return ret;
+    }
+
+    bool IsEqualMsgs(const std::vector<std::shared_ptr<CommitMessage>>& expected_msgs,
+                     const std::vector<std::shared_ptr<CommitMessage>>& actual_msgs) {
+        if (expected_msgs.size() != actual_msgs.size()) {
+            return false;
+        }
+        for (size_t i = 0; i < expected_msgs.size(); i++) {
+            auto actual = std::dynamic_pointer_cast<CommitMessageImpl>(actual_msgs[i]);
+            auto expected = std::dynamic_pointer_cast<CommitMessageImpl>(expected_msgs[i]);
+            if (*actual == *expected) {
+                continue;
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+TEST_F(ManifestCommittableTest, TestSimple) {
+    {
+        ManifestCommittable committable(123);
+        ASSERT_EQ(committable.Identifier(), 123);
+    }
+    {
+        ManifestCommittable committable(/*identifier=*/123, /*watermark=*/456);
+        ASSERT_EQ(committable.Identifier(), 123);
+        ASSERT_EQ(committable.Watermark().value(), 456);
+    }
+    {
+        std::map<int32_t, int64_t> log_offsets = {{123, 444}, {234, 555}};
+        std::map<std::string, std::string> properties = {};
+        std::vector<std::shared_ptr<CommitMessage>> msgs =
+            GetCommitMessages(paimon::test::GetDataDir() +
+                                  "/orc/append_09.db/append_09/commit_messages/commit_messages-01",
+                              /*version=*/3);
+        ManifestCommittable committable(/*identifier=*/123, /*watermark=*/456, log_offsets,
+                                        properties, msgs);
+        ASSERT_TRUE(IsEqualMap(committable.LogOffsets(), log_offsets));
+        ASSERT_TRUE(IsEqualMsgs(msgs, committable.FileCommittables()));
+    }
+    {
+        std::map<int32_t, int64_t> log_offsets = {};
+        std::map<std::string, std::string> properties = {{"key1", "value1"}, {"key2", "value2"}};
+        std::vector<std::shared_ptr<CommitMessage>> msgs =
+            GetCommitMessages(paimon::test::GetDataDir() +
+                                  "/orc/append_09.db/append_09/commit_messages/commit_messages-01",
+                              /*version=*/3);
+        ManifestCommittable committable(/*identifier=*/123, /*watermark=*/456,
+                                        /*log_offsets=*/{}, properties, msgs);
+        ASSERT_EQ(committable.Properties(), properties);
+        ASSERT_TRUE(IsEqualMsgs(msgs, committable.FileCommittables()));
+    }
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/manifest/manifest_file.cpp
+++ b/src/paimon/core/manifest/manifest_file.cpp
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/manifest_file.h"
+
+#include <cassert>
+#include <utility>
+
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/core/io/rolling_file_writer.h"
+#include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/manifest/manifest_entry_serializer.h"
+#include "paimon/core/manifest/manifest_entry_writer.h"
+#include "paimon/core/manifest/manifest_file_meta.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/core/utils/object_serializer.h"
+#include "paimon/core/utils/path_factory.h"
+#include "paimon/core/utils/versioned_object_serializer.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/reader_builder.h"
+#include "paimon/format/writer_builder.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class DataType;
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+
+ManifestFile::ManifestFile(const std::shared_ptr<FileSystem>& file_system,
+                           const std::shared_ptr<ReaderBuilder>& reader_builder,
+                           const std::shared_ptr<WriterBuilder>& writer_builder,
+                           const std::string& compression,
+                           const std::shared_ptr<PathFactory>& path_factory,
+                           int64_t target_file_size, const std::shared_ptr<MemoryPool>& pool,
+                           const CoreOptions& options,
+                           const std::shared_ptr<arrow::Schema>& partition_type)
+    : ObjectsFile<ManifestEntry>(file_system, reader_builder, writer_builder,
+                                 std::make_unique<ManifestEntrySerializer>(pool), compression,
+                                 path_factory, pool),
+      target_file_size_(target_file_size),
+      options_(options),
+      partition_type_(partition_type) {}
+
+Result<std::unique_ptr<ManifestFile>> ManifestFile::Create(
+    const std::shared_ptr<FileSystem>& file_system, const std::shared_ptr<FileFormat>& file_format,
+    const std::string& compression, const std::shared_ptr<FileStorePathFactory>& path_factory,
+    int64_t target_file_size, const std::shared_ptr<MemoryPool>& pool, const CoreOptions& options,
+    const std::shared_ptr<arrow::Schema>& partition_type) {
+    assert(partition_type);
+    std::shared_ptr<arrow::DataType> data_type =
+        VersionedObjectSerializer<ManifestEntry>::VersionType(ManifestEntry::DataType());
+
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ReaderBuilder> reader_builder,
+                           file_format->CreateReaderBuilder(options.GetReadBatchSize()));
+    reader_builder->WithMemoryPool(pool);
+    ArrowSchema schema;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportType(*data_type, &schema));
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<WriterBuilder> writer_builder,
+                           file_format->CreateWriterBuilder(&schema, options.GetWriteBatchSize()));
+    writer_builder->WithMemoryPool(pool);
+
+    std::shared_ptr<PathFactory> manifest_file_factory = path_factory->CreateManifestFileFactory();
+    return std::unique_ptr<ManifestFile>(
+        new ManifestFile(file_system, reader_builder, writer_builder, compression,
+                         manifest_file_factory, target_file_size, pool, options, partition_type));
+}
+
+Result<std::vector<ManifestFileMeta>> ManifestFile::Write(
+    const std::vector<ManifestEntry>& entries) {
+    if (entries.empty()) {
+        return std::vector<ManifestFileMeta>();
+    }
+    auto converter = [this](ManifestEntry entry, ::ArrowArray* dest) -> Status {
+        if (!to_array_converter_) {
+            PAIMON_ASSIGN_OR_RAISE(to_array_converter_, MetaToArrowArrayConverter::Create(
+                                                            serializer_->GetDataType(), pool_));
+        }
+        PAIMON_ASSIGN_OR_RAISE(BinaryRow entry_row, serializer_->ToRow(entry));
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> array,
+                               to_array_converter_->NextBatch({entry_row}));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*array, dest));
+        return Status::OK();
+    };
+
+    auto create_file_writer = [&]() -> Result<std::unique_ptr<ManifestEntryWriter>> {
+        auto writer = std::make_unique<ManifestEntryWriter>(options_.GetManifestCompression(),
+                                                            converter, pool_, partition_type_);
+        PAIMON_RETURN_NOT_OK(
+            writer->Init(options_.GetFileSystem(), path_factory_->NewPath(), writer_builder_));
+        return writer;
+    };
+    std::unique_ptr<RollingFileWriter<const ManifestEntry&, ManifestFileMeta>> writer =
+        std::make_unique<RollingFileWriter<const ManifestEntry&, ManifestFileMeta>>(
+            target_file_size_, create_file_writer);
+    for (const auto& entry : entries) {
+        auto s = writer->Write(entry);
+        if (!s.ok()) {
+            writer->Abort();
+            return s;
+        }
+    }
+    PAIMON_RETURN_NOT_OK(writer->Close());
+    return writer->GetResult();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/manifest/manifest_file.h
+++ b/src/paimon/core/manifest/manifest_file.h
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/stats/simple_stats_collector.h"
+#include "paimon/core/utils/objects_file.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+class FileSystem;
+class FileFormat;
+class FileStorePathFactory;
+class ReaderBuilder;
+class WriterBuilder;
+class PathFactory;
+class ManifestFileMeta;
+class ManifestEntry;
+class MemoryPool;
+
+/// This file includes several `ManifestEntry`s, representing the additional changes since last
+/// snapshot.
+class ManifestFile : public ObjectsFile<ManifestEntry> {
+ public:
+    static Result<std::unique_ptr<ManifestFile>> Create(
+        const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<FileFormat>& file_format,
+        const std::string& compression, const std::shared_ptr<FileStorePathFactory>& path_factory,
+        int64_t target_file_size, const std::shared_ptr<MemoryPool>& pool,
+        const CoreOptions& options, const std::shared_ptr<arrow::Schema>& partition_type);
+
+    /// Write several `ManifestEntry`s into manifest files.
+    ///
+    /// @note This method is atomic.
+    Result<std::vector<ManifestFileMeta>> Write(const std::vector<ManifestEntry>& entries);
+
+ private:
+    ManifestFile(const std::shared_ptr<FileSystem>& file_system,
+                 const std::shared_ptr<ReaderBuilder>& reader_builder,
+                 const std::shared_ptr<WriterBuilder>& writer_builder,
+                 const std::string& compression, const std::shared_ptr<PathFactory>& path_factory,
+                 int64_t target_file_size, const std::shared_ptr<MemoryPool>& pool,
+                 const CoreOptions& options, const std::shared_ptr<arrow::Schema>& partition_type);
+
+ private:
+    int64_t target_file_size_;
+    CoreOptions options_;
+    std::shared_ptr<arrow::Schema> partition_type_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/manifest/manifest_file_test.cpp
+++ b/src/paimon/core/manifest/manifest_file_test.cpp
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/manifest_file.h"
+
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "arrow/api.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/data_define.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/file_format_factory.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class ManifestFileTest : public testing::Test {
+ public:
+    std::vector<ManifestEntry> ReadManifestEntry(const std::string& file_format_str,
+                                                 const std::string& root_path,
+                                                 const std::string& file_name,
+                                                 const std::shared_ptr<MemoryPool>& pool) const {
+        std::shared_ptr<FileSystem> file_system = std::make_shared<LocalFileSystem>();
+        EXPECT_OK_AND_ASSIGN(std::shared_ptr<FileFormat> file_format,
+                             FileFormatFactory::Get(file_format_str, {}));
+        auto unused_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+        EXPECT_OK_AND_ASSIGN(std::shared_ptr<FileStorePathFactory> path_factory,
+                             FileStorePathFactory::Create(
+                                 root_path, unused_schema, /*partition_keys=*/{},
+                                 /*default_part_value=*/"", file_format->Identifier(),
+                                 /*data_file_prefix=*/"data-",
+                                 /*legacy_partition_name_enabled=*/true, /*external_paths=*/{},
+                                 /*global_index_external_path=*/std::nullopt,
+                                 /*index_file_in_data_file_dir=*/false, pool));
+        EXPECT_OK_AND_ASSIGN(CoreOptions options,
+                             CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"},
+                                                   {Options::MANIFEST_FORMAT, file_format_str}}));
+        EXPECT_OK_AND_ASSIGN(
+            std::unique_ptr<ManifestFile> manifest_file,
+            ManifestFile::Create(file_system, file_format, "zstd", path_factory,
+                                 /*target_file_size=*/1024, pool, options, unused_schema));
+        std::vector<ManifestEntry> manifest_entries;
+        EXPECT_OK(manifest_file->Read(file_name, /*filter=*/nullptr, &manifest_entries));
+
+        return manifest_entries;
+    }
+};
+
+TEST_F(ManifestFileTest, TestSimple) {
+    auto pool = GetDefaultPool();
+    auto manifest_entries =
+        ReadManifestEntry("orc", paimon::test::GetDataDir() + "/orc/append_09.db/append_09",
+                          "manifest-3ea5ee21-d399-4f1c-a749-2fc63dbf0852-1", pool);
+    ASSERT_EQ(manifest_entries.size(), 5);
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-4e30d6c0-f109-4300-a010-4ba03047dd9d-0.orc", /*file_size=*/575, /*row_count=*/3,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Bob"), 10, 0, 12.1},
+                                          {std::string("Tony"), 10, 0, 14.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643142456ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto manifest_entry1 =
+        ManifestEntry(FileKind::Delete(), BinaryRowGenerator::GenerateRow({10}, pool.get()),
+                      /*bucket=*/1, /*total_buckets=*/2, file_meta1);
+
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-10b9eea8-241d-4e4b-8ab8-2a82d72d79a2-0.orc", /*file_size=*/589, /*row_count=*/3,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 10, 0, 12.1},
+                                          {std::string("Emily"), 10, 0, 16.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/3, /*max_sequence_number=*/5, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643267385ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto manifest_entry2 =
+        ManifestEntry(FileKind::Delete(), BinaryRowGenerator::GenerateRow({10}, pool.get()),
+                      /*bucket=*/1, /*total_buckets=*/2, file_meta2);
+
+    auto file_meta3 = std::make_shared<DataFileMeta>(
+        "data-e2bb59ee-ae25-4e5b-9bcc-257250bc5fdd-0.orc", /*file_size=*/541, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("David"), 10, 0, 17.1},
+                                          {std::string("David"), 10, 0, 17.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/6, /*max_sequence_number=*/6, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643314161ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto manifest_entry3 =
+        ManifestEntry(FileKind::Delete(), BinaryRowGenerator::GenerateRow({10}, pool.get()),
+                      /*bucket=*/1, /*total_buckets=*/2, file_meta3);
+
+    auto file_meta4 = std::make_shared<DataFileMeta>(
+        "data-2d5ea1ea-77c1-47ff-bb87-19a509962a37-0.orc", /*file_size=*/538, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Lily"), 10, 0, 17.1},
+                                          {std::string("Lily"), 10, 0, 17.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/7, /*max_sequence_number=*/7, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643834400ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto manifest_entry4 =
+        ManifestEntry(FileKind::Delete(), BinaryRowGenerator::GenerateRow({10}, pool.get()),
+                      /*bucket=*/1, /*total_buckets=*/2, file_meta4);
+
+    auto file_meta5 = std::make_shared<DataFileMeta>(
+        "data-b9e7c41f-66e8-4dad-b25a-e6e1963becc4-0.orc", /*file_size=*/640, /*row_count=*/8,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 10, 0, 12.1},
+                                          {std::string("Tony"), 10, 0, 17.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/7, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643834472ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Compact(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto manifest_entry5 =
+        ManifestEntry(FileKind::Add(), BinaryRowGenerator::GenerateRow({10}, pool.get()),
+                      /*bucket=*/1, /*total_buckets=*/2, file_meta5);
+
+    std::vector<ManifestEntry> expected_manifest_entries;
+    expected_manifest_entries.emplace_back(manifest_entry1);
+    expected_manifest_entries.emplace_back(manifest_entry2);
+    expected_manifest_entries.emplace_back(manifest_entry3);
+    expected_manifest_entries.emplace_back(manifest_entry4);
+    expected_manifest_entries.emplace_back(manifest_entry5);
+    ASSERT_EQ(expected_manifest_entries, manifest_entries);
+}
+
+TEST_F(ManifestFileTest, TestWithNullCount) {
+    auto pool = GetDefaultPool();
+    auto manifest_entries =
+        ReadManifestEntry("orc", paimon::test::GetDataDir() + "/orc/append_09.db/append_09",
+                          "manifest-3a44a0da-1008-463c-914e-28d271375e24-0", pool);
+    ASSERT_EQ(manifest_entries.size(), 2);
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-10b9eea8-241d-4e4b-8ab8-2a82d72d79a2-0.orc", /*file_size=*/589, /*row_count=*/3,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 10, 0, 12.1},
+                                          {std::string("Emily"), 10, 0, 16.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/3, /*max_sequence_number=*/5, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643267385ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto manifest_entry1 =
+        ManifestEntry(FileKind::Add(), BinaryRowGenerator::GenerateRow({10}, pool.get()),
+                      /*bucket=*/1, /*total_buckets=*/2, file_meta1);
+
+    ASSERT_EQ(manifest_entries[0].Kind(), FileKind::Add());
+    ASSERT_EQ(manifest_entries[0].Partition(), BinaryRowGenerator::GenerateRow({10}, pool.get()));
+    ASSERT_EQ(manifest_entries[0].Bucket(), 1);
+    ASSERT_EQ(manifest_entries[0].Level(), 0);
+    ASSERT_EQ(manifest_entries[0].FileName(), "data-10b9eea8-241d-4e4b-8ab8-2a82d72d79a2-0.orc");
+    ASSERT_EQ(manifest_entries[0].MinKey(), BinaryRow::EmptyRow());
+    ASSERT_EQ(manifest_entries[0].MaxKey(), BinaryRow::EmptyRow());
+    ASSERT_EQ(manifest_entries[0].CreateIdentifier(), manifest_entry1.CreateIdentifier());
+
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-b913a160-a4d1-4084-af2a-18333c35668e-0.orc", /*file_size=*/506, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Paul"), 20, 1, NullType()},
+                                          {std::string("Paul"), 20, 1, NullType()}, {0, 0, 0, 1},
+                                          pool.get()),
+        /*min_sequence_number=*/1, /*max_sequence_number=*/1, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643267404ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto manifest_entry2 =
+        ManifestEntry(FileKind::Add(), BinaryRowGenerator::GenerateRow({20}, pool.get()),
+                      /*bucket=*/0, /*total_buckets=*/2, file_meta2);
+    std::vector<ManifestEntry> expected_manifest_entries;
+    expected_manifest_entries.emplace_back(manifest_entry1);
+    expected_manifest_entries.emplace_back(manifest_entry2);
+    ASSERT_EQ(expected_manifest_entries, manifest_entries);
+}
+
+TEST_F(ManifestFileTest, TestManifestFileCompatibleWithJavaPaimon09) {
+    auto pool = GetDefaultPool();
+    auto manifest_entries =
+        ReadManifestEntry("avro", paimon::test::GetDataDir() + "/avro", "avro_manifest_09", pool);
+    ASSERT_EQ(manifest_entries.size(), 1);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-dd28db13-0f8f-43a5-a0df-684e7dc93c55-0.avro", /*file_size=*/1625, /*row_count=*/3,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        ::paimon::test::BinaryRowGenerator::GenerateStats(
+            {false, static_cast<int8_t>(-128), static_cast<int16_t>(-32768),
+             static_cast<int32_t>(-2147483648), -9999999999999, -1234.56f, -1234567890.0987654321,
+             std::string("aa"), NullType(), NullType(), NullType(),
+             TimestampType(Timestamp(123123, 123000), 9), 2456, Decimal(2, 2, -22),
+             Decimal(10, 10, -1234567890), Decimal(19, 19, 1234567890987654321)},
+            {true, static_cast<int8_t>(127), static_cast<int16_t>(32767),
+             static_cast<int32_t>(2147483647), 9999999999999, 1234.56f, 1234567890.0987654321,
+             std::string("aa"), NullType(), NullType(), NullType(),
+             TimestampType(Timestamp(999999, 999000), 9), 2456, Decimal(2, 2, 22),
+             Decimal(10, 10, 1234567890), Decimal(19, 19, 1234567890987654321)},
+            {1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 2, 1, 1, 2}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1754496160777ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto manifest_entry = ManifestEntry(FileKind::Add(), /*partition=*/BinaryRow::EmptyRow(),
+                                        /*bucket=*/0, /*total_buckets=*/-1, file_meta);
+
+    std::vector<ManifestEntry> expected_manifest_entries;
+    expected_manifest_entries.emplace_back(manifest_entry);
+    ASSERT_EQ(expected_manifest_entries, manifest_entries);
+}
+
+TEST_F(ManifestFileTest, TestManifestFileCompatibleWithJavaPaimon11) {
+    auto pool = GetDefaultPool();
+    auto manifest_entries =
+        ReadManifestEntry("avro", paimon::test::GetDataDir() + "/avro", "avro_manifest_11", pool);
+    ASSERT_EQ(manifest_entries.size(), 1);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-0ff223ba-0d95-4c43-a25f-bcee3c051e58-0.avro", /*file_size=*/1615, /*row_count=*/3,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        ::paimon::test::BinaryRowGenerator::GenerateStats(
+            {false, static_cast<int8_t>(-128), static_cast<int16_t>(-32768),
+             static_cast<int32_t>(-2147483648), -9999999999999, -1234.56f, -1234567890.0987654321,
+             std::string("aa"), NullType(), NullType(), NullType(),
+             TimestampType(Timestamp(123123, 123000), 9), 2456, Decimal(2, 2, -22),
+             Decimal(10, 10, -1234567890), Decimal(19, 19, 1234567890987654321)},
+            {true, static_cast<int8_t>(127), static_cast<int16_t>(32767),
+             static_cast<int32_t>(2147483647), 9999999999999, 1234.56f, 1234567890.0987654321,
+             std::string("aa"), NullType(), NullType(), NullType(),
+             TimestampType(Timestamp(999999, 999000), 9), 2456, Decimal(2, 2, 22),
+             Decimal(10, 10, 1234567890), Decimal(19, 19, 1234567890987654321)},
+            {1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 2, 1, 1, 2}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1754048761150ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto manifest_entry = ManifestEntry(FileKind::Add(), /*partition=*/BinaryRow::EmptyRow(),
+                                        /*bucket=*/0, /*total_buckets=*/-1, file_meta);
+
+    std::vector<ManifestEntry> expected_manifest_entries;
+    expected_manifest_entries.emplace_back(manifest_entry);
+    ASSERT_EQ(expected_manifest_entries, manifest_entries);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/manifest/manifest_list.cpp
+++ b/src/paimon/core/manifest/manifest_list.cpp
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/manifest_list.h"
+
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/core/manifest/manifest_file_meta.h"
+#include "paimon/core/manifest/manifest_file_meta_serializer.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/core/utils/object_serializer.h"
+#include "paimon/core/utils/path_factory.h"
+#include "paimon/core/utils/versioned_object_serializer.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/reader_builder.h"
+#include "paimon/format/writer_builder.h"
+
+namespace arrow {
+class DataType;
+}  // namespace arrow
+
+namespace paimon {
+class MemoryPool;
+
+ManifestList::ManifestList(const std::shared_ptr<FileSystem>& file_system,
+                           const std::shared_ptr<ReaderBuilder>& reader_builder,
+                           const std::shared_ptr<WriterBuilder>& writer_builder,
+                           const std::string& compression,
+                           const std::shared_ptr<PathFactory>& path_factory,
+                           const std::shared_ptr<MemoryPool>& pool)
+    : ObjectsFile<ManifestFileMeta>(file_system, reader_builder, writer_builder,
+                                    std::make_unique<ManifestFileMetaSerializer>(pool), compression,
+                                    std::move(path_factory), pool) {}
+
+Result<std::unique_ptr<ManifestList>> ManifestList::Create(
+    const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<FileFormat>& file_format,
+    const std::string& compression, const std::shared_ptr<FileStorePathFactory>& path_factory,
+    const std::shared_ptr<MemoryPool>& pool) {
+    std::shared_ptr<arrow::DataType> data_type =
+        VersionedObjectSerializer<ManifestFileMeta>::VersionType(ManifestFileMeta::DataType());
+    // prepare format reader builder
+    // TODO(jinli.zjw) pass batch size
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ReaderBuilder> reader_builder,
+                           file_format->CreateReaderBuilder(/*batch_size=*/1024));
+    reader_builder->WithMemoryPool(pool);
+
+    // prepare format writer builder
+    ArrowSchema schema;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportType(*data_type, &schema));
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<WriterBuilder> writer_builder,
+                           file_format->CreateWriterBuilder(&schema, /*batch_size=*/1024));
+    writer_builder->WithMemoryPool(pool);
+
+    // create manifest list
+    std::shared_ptr<PathFactory> manifest_list_path_factory =
+        path_factory->CreateManifestListFactory();
+    return std::unique_ptr<ManifestList>(new ManifestList(
+        fs, reader_builder, writer_builder, compression, manifest_list_path_factory, pool));
+}
+
+Result<std::pair<std::string, int64_t>> ManifestList::Write(
+    const std::vector<ManifestFileMeta>& metas) {
+    return WriteWithoutRolling(metas);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/manifest/manifest_list.h
+++ b/src/paimon/core/manifest/manifest_list.h
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "paimon/core/manifest/manifest_file_meta.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/utils/objects_file.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+
+class FileFormat;
+class FileSystem;
+class FileStorePathFactory;
+class ManifestFileMeta;
+class MemoryPool;
+class PathFactory;
+class ReaderBuilder;
+class WriterBuilder;
+
+/// This file includes several `ManifestFileMeta`, representing all data of the whole
+/// table at the corresponding snapshot.
+class ManifestList : public ObjectsFile<ManifestFileMeta> {
+ public:
+    static Result<std::unique_ptr<ManifestList>> Create(
+        const std::shared_ptr<FileSystem>& file_system,
+        const std::shared_ptr<FileFormat>& file_format, const std::string& compression,
+        const std::shared_ptr<FileStorePathFactory>& path_factory,
+        const std::shared_ptr<MemoryPool>& pool);
+
+    /// Write several `ManifestFileMeta`s into a manifest list.
+    ///
+    /// @note This method is atomic.
+    Result<std::pair<std::string, int64_t>> Write(const std::vector<ManifestFileMeta>& metas);
+
+    /// Return all `ManifestFileMeta` instances for either data or changelog manifests in this
+    /// snapshot.
+    ///
+    /// @param snapshot The input snapshot.
+    /// @param manifests The vector to store the manifest file metadata.
+    /// @return Status indicating whether the operation was successful or not.
+    Status ReadAllManifests(const Snapshot& snapshot,
+                            std::vector<ManifestFileMeta>* manifests) const {
+        PAIMON_RETURN_NOT_OK(ReadDataManifests(snapshot, manifests));
+        return ReadChangelogManifests(snapshot, manifests);
+    }
+
+    /// Return a `ManifestFileMeta` for each data manifest in this snapshot.
+    ///
+    /// @param snapshot The input snapshot.
+    /// @param manifests The vector to store the manifest file metadata.
+    /// @return Status indicating whether the operation was successful or not.
+    Status ReadDataManifests(const Snapshot& snapshot,
+                             std::vector<ManifestFileMeta>* manifests) const {
+        PAIMON_RETURN_NOT_OK(ReadBaseManifests(snapshot, manifests));
+        return ReadDeltaManifests(snapshot, manifests);
+    }
+
+    /// Return a `ManifestFileMeta` for each base manifest in this snapshot.
+    ///
+    /// @param snapshot The input snapshot.
+    /// @param manifests The vector to store the manifest file metadata.
+    /// @return Status indicating whether the operation was successful or not.
+    Status ReadBaseManifests(const Snapshot& snapshot,
+                             std::vector<ManifestFileMeta>* manifests) const {
+        return Read(snapshot.BaseManifestList(), /*filter=*/nullptr, manifests);
+    }
+
+    /// Return a `ManifestFileMeta` for each delta manifest in this snapshot.
+    ///
+    /// @param snapshot The input snapshot.
+    /// @param manifests The vector to store the manifest file metadata.
+    /// @return Status indicating whether the operation was successful or not.
+    Status ReadDeltaManifests(const Snapshot& snapshot,
+                              std::vector<ManifestFileMeta>* manifests) const {
+        return Read(snapshot.DeltaManifestList(), /*filter=*/nullptr, manifests);
+    }
+
+    /// Return a `ManifestFileMeta` for each changelog manifest in this snapshot.
+    ///
+    /// @param snapshot The input snapshot.
+    /// @param manifests The vector to store the manifest file metadata.
+    /// @return Status indicating whether the operation was successful or not.
+    Status ReadChangelogManifests(const Snapshot& snapshot,
+                                  std::vector<ManifestFileMeta>* manifests) const {
+        const std::optional<std::string>& changelog_manifest_list =
+            snapshot.ChangelogManifestList();
+        if (changelog_manifest_list) {
+            return Status::NotImplemented("do not support read changelog manifest list");
+            // return Read(changelog_manifest_list.value(), /*filter=*/nullptr, manifests);
+        } else {
+            return Status::OK();
+        }
+    }
+
+ private:
+    ManifestList(const std::shared_ptr<FileSystem>& file_system,
+                 const std::shared_ptr<ReaderBuilder>& reader_builder,
+                 const std::shared_ptr<WriterBuilder>& writer_builder,
+                 const std::string& compression, const std::shared_ptr<PathFactory>& path_factory,
+                 const std::shared_ptr<MemoryPool>& pool);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/manifest/manifest_list_test.cpp
+++ b/src/paimon/core/manifest/manifest_list_test.cpp
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/manifest_list.h"
+
+#include <map>
+#include <variant>
+
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/core/manifest/manifest_file_meta.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/file_format_factory.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class ManifestListTest : public testing::Test {
+ public:
+    std::unique_ptr<ManifestList> CreateManifestList(
+        const std::string& file_format_str, const std::string& root_path,
+        const std::shared_ptr<MemoryPool>& pool) const {
+        std::shared_ptr<FileSystem> file_system = std::make_shared<LocalFileSystem>();
+        EXPECT_OK_AND_ASSIGN(std::shared_ptr<FileFormat> file_format,
+                             FileFormatFactory::Get(file_format_str, {}));
+        auto unused_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+        EXPECT_OK_AND_ASSIGN(std::shared_ptr<FileStorePathFactory> path_factory,
+                             FileStorePathFactory::Create(
+                                 root_path, unused_schema, /*partition_keys=*/{},
+                                 /*default_part_value=*/"", file_format->Identifier(),
+                                 /*data_file_prefix=*/"data-",
+                                 /*legacy_partition_name_enabled=*/true, /*external_paths=*/{},
+                                 /*global_index_external_path=*/std::nullopt,
+                                 /*index_file_in_data_file_dir=*/false, pool));
+        EXPECT_OK_AND_ASSIGN(auto manifest_list, ManifestList::Create(file_system, file_format,
+                                                                      "zstd", path_factory, pool));
+        return manifest_list;
+    }
+
+    std::vector<ManifestFileMeta> ReadManifestFileMeta(
+        const std::string& file_format_str, const std::string& root_path,
+        const std::string& file_name, const std::shared_ptr<MemoryPool>& pool) const {
+        auto manifest_list = CreateManifestList(file_format_str, root_path, pool);
+        std::vector<ManifestFileMeta> manifest_file_metas;
+        EXPECT_OK(manifest_list->Read(file_name, /*filter=*/nullptr, &manifest_file_metas));
+        return manifest_file_metas;
+    }
+};
+
+TEST_F(ManifestListTest, TestSimple) {
+    auto pool = GetDefaultPool();
+    auto manifest_file_metas =
+        ReadManifestFileMeta("orc", paimon::test::GetDataDir() + "/orc/append_09.db/append_09",
+                             "manifest-list-f2d59cb8-3ec6-4860-b34b-050b1a533416-2", pool);
+    ASSERT_EQ(manifest_file_metas.size(), 4);
+
+    std::vector<ManifestFileMeta> expected_manifest_file_metas;
+    auto expected_meta1 =
+        ManifestFileMeta("manifest-f8b15cfc-437a-4d21-a6a0-e45b639ae7ed-0", /*file_size=*/2666,
+                         /*num_added_files=*/3, /*num_deleted_files=*/0,
+                         BinaryRowGenerator::GenerateStats({10}, {20}, {0}, pool.get()),
+                         /*schema_id=*/0, /*min_bucket=*/std::nullopt, /*max_bucket=*/std::nullopt,
+                         /*min_level=*/std::nullopt, /*max_level=*/std::nullopt,
+                         /*min_row_id=*/std::nullopt, /*max_row_id=*/std::nullopt);
+    auto expected_meta2 =
+        ManifestFileMeta("manifest-3a44a0da-1008-463c-914e-28d271375e24-0", /*file_size=*/2617,
+                         /*num_added_files=*/2, /*num_deleted_files=*/0,
+                         BinaryRowGenerator::GenerateStats({10}, {20}, {0}, pool.get()),
+                         /*schema_id=*/0, /*min_bucket=*/std::nullopt, /*max_bucket=*/std::nullopt,
+                         /*min_level=*/std::nullopt, /*max_level=*/std::nullopt,
+                         /*min_row_id=*/std::nullopt, /*max_row_id=*/std::nullopt);
+    auto expected_meta3 =
+        ManifestFileMeta("manifest-c5904353-0236-46a2-891f-62a326dd8e5e-0", /*file_size=*/2360,
+                         /*num_added_files=*/1, /*num_deleted_files=*/0,
+                         BinaryRowGenerator::GenerateStats({10}, {10}, {0}, pool.get()),
+                         /*schema_id=*/0, /*min_bucket=*/std::nullopt, /*max_bucket=*/std::nullopt,
+                         /*min_level=*/std::nullopt, /*max_level=*/std::nullopt,
+                         /*min_row_id=*/std::nullopt, /*max_row_id=*/std::nullopt);
+    auto expected_meta4 =
+        ManifestFileMeta("manifest-3ea5ee21-d399-4f1c-a749-2fc63dbf0852-0", /*file_size=*/2366,
+                         /*num_added_files=*/1, /*num_deleted_files=*/0,
+                         BinaryRowGenerator::GenerateStats({10}, {10}, {0}, pool.get()),
+                         /*schema_id=*/0, /*min_bucket=*/std::nullopt, /*max_bucket=*/std::nullopt,
+                         /*min_level=*/std::nullopt, /*max_level=*/std::nullopt,
+                         /*min_row_id=*/std::nullopt, /*max_row_id=*/std::nullopt);
+    expected_manifest_file_metas.emplace_back(expected_meta1);
+    expected_manifest_file_metas.emplace_back(expected_meta2);
+    expected_manifest_file_metas.emplace_back(expected_meta3);
+    expected_manifest_file_metas.emplace_back(expected_meta4);
+    ASSERT_EQ(manifest_file_metas, expected_manifest_file_metas);
+}
+
+TEST_F(ManifestListTest, TestReadWithBucketsAndLevel) {
+    auto pool = GetDefaultPool();
+    auto manifest_file_metas =
+        ReadManifestFileMeta("orc",
+                             paimon::test::GetDataDir() +
+                                 "/orc/pk_table_with_total_buckets.db/pk_table_with_total_buckets",
+                             "manifest-list-673be11d-f405-4921-84dc-6f53028c55ea-1", pool);
+    ASSERT_EQ(manifest_file_metas.size(), 1);
+
+    std::vector<ManifestFileMeta> expected_manifest_file_metas;
+    auto expected_meta1 =
+        ManifestFileMeta("manifest-2026dc88-7f67-4944-8c33-ea775d34108c-0", /*file_size=*/3046,
+                         /*num_added_files=*/2, /*num_deleted_files=*/0,
+                         BinaryRowGenerator::GenerateStats({10}, {10}, {0}, pool.get()),
+                         /*schema_id=*/0, /*min_bucket=*/0, /*max_bucket=*/1,
+                         /*min_level=*/0, /*max_level=*/0,
+                         /*min_row_id=*/std::nullopt, /*max_row_id=*/std::nullopt);
+    expected_manifest_file_metas.emplace_back(expected_meta1);
+    ASSERT_EQ(manifest_file_metas, expected_manifest_file_metas);
+}
+
+TEST_F(ManifestListTest, TestEmptyManifestList) {
+    auto pool = GetDefaultPool();
+    auto manifest_file_metas =
+        ReadManifestFileMeta("orc", paimon::test::GetDataDir() + "/orc/append_09.db/append_09",
+                             "manifest-list-616d1847-a02c-495f-9cca-2c8b7def0fec-0", pool);
+    ASSERT_EQ(manifest_file_metas.size(), 0);
+}
+
+TEST_F(ManifestListTest, TestManifestListCompatibleWithJavaPaimon09) {
+    auto pool = GetDefaultPool();
+    auto manifest_file_metas = ReadManifestFileMeta("avro", paimon::test::GetDataDir() + "/avro",
+                                                    "avro_manifest_list_09", pool);
+    ASSERT_EQ(manifest_file_metas.size(), 1);
+
+    std::vector<ManifestFileMeta> expected_manifest_file_metas;
+    auto expected_meta =
+        ManifestFileMeta("manifest-b09d5588-5614-46e2-b441-f196d29e60dc-0", /*file_size=*/2010,
+                         /*num_added_files=*/1, /*num_deleted_files=*/0, SimpleStats::EmptyStats(),
+                         /*schema_id=*/0, /*min_bucket=*/std::nullopt, /*max_bucket=*/std::nullopt,
+                         /*min_level=*/std::nullopt, /*max_level=*/std::nullopt,
+                         /*min_row_id=*/std::nullopt, /*max_row_id=*/std::nullopt);
+    expected_manifest_file_metas.emplace_back(expected_meta);
+    ASSERT_EQ(manifest_file_metas, expected_manifest_file_metas);
+}
+
+TEST_F(ManifestListTest, TestManifestListCompatibleWithJavaPaimon11) {
+    auto pool = GetDefaultPool();
+    auto manifest_file_metas = ReadManifestFileMeta("avro", paimon::test::GetDataDir() + "/avro",
+                                                    "avro_manifest_list_11", pool);
+    ASSERT_EQ(manifest_file_metas.size(), 1);
+
+    std::vector<ManifestFileMeta> expected_manifest_file_metas;
+    auto expected_meta = ManifestFileMeta(
+        "manifest-3c977409-ebff-4d68-8265-86d237e24e9a-0", /*file_size=*/2081,
+        /*num_added_files=*/1, /*num_deleted_files=*/0, SimpleStats::EmptyStats(),
+        /*schema_id=*/0, /*min_bucket=*/0, /*max_bucket=*/0, /*min_level=*/0, /*max_level=*/0,
+        /*min_row_id=*/std::nullopt, /*max_row_id=*/std::nullopt);
+    expected_manifest_file_metas.emplace_back(expected_meta);
+    ASSERT_EQ(manifest_file_metas, expected_manifest_file_metas);
+}
+
+TEST_F(ManifestListTest, TestReadWithMinAndMaxRowId) {
+    auto pool = GetDefaultPool();
+    // test read meta from java
+    auto manifest_file_metas = ReadManifestFileMeta(
+        "orc",
+        paimon::test::GetDataDir() + "orc/append_with_global_index.db/append_with_global_index/",
+        "manifest-list-2bccccf8-9f5e-48f2-b706-5b33f8c3bfc0-0", pool);
+    ASSERT_EQ(manifest_file_metas.size(), 1);
+
+    std::vector<ManifestFileMeta> expected_manifest_file_metas;
+    auto expected_meta =
+        ManifestFileMeta("manifest-65b0d403-a1bc-4157-b242-bff73c46596d-0", /*file_size=*/2779,
+                         /*num_added_files=*/1, /*num_deleted_files=*/0, SimpleStats::EmptyStats(),
+                         /*schema_id=*/0, /*min_bucket=*/0, /*max_bucket=*/0,
+                         /*min_level=*/0, /*max_level=*/0,
+                         /*min_row_id=*/0, /*max_row_id=*/7);
+    expected_manifest_file_metas.emplace_back(expected_meta);
+    ASSERT_EQ(manifest_file_metas, expected_manifest_file_metas);
+
+    // test write meta
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    auto manifest_list = CreateManifestList("orc", dir->Str(), pool);
+    std::pair<std::string, int64_t> file_meta;
+    ASSERT_OK_AND_ASSIGN(file_meta, manifest_list->Write({expected_meta}));
+    // test read meta from C++
+    auto manifest_file_metas2 = ReadManifestFileMeta("orc", dir->Str(), file_meta.first, pool);
+    ASSERT_EQ(manifest_file_metas2.size(), 1);
+    ASSERT_EQ(manifest_file_metas2, expected_manifest_file_metas);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/manifest/partition_entry.cpp
+++ b/src/paimon/core/manifest/partition_entry.cpp
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/partition_entry.h"
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <tuple>
+#include <utility>
+
+#include "paimon/common/utils/binary_row_partition_computer.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+
+namespace paimon {
+PartitionEntry::PartitionEntry(const BinaryRow& partition, int64_t record_count,
+                               int64_t file_size_in_bytes, int64_t file_count,
+                               int64_t last_file_creation_time, int32_t total_buckets)
+    : partition_(partition),
+      record_count_(record_count),
+      file_size_in_bytes_(file_size_in_bytes),
+      file_count_(file_count),
+      last_file_creation_time_(last_file_creation_time),
+      total_buckets_(total_buckets) {}
+
+PartitionEntry PartitionEntry::Merge(const PartitionEntry& entry) const {
+    return PartitionEntry(
+        partition_, record_count_ + entry.record_count_,
+        file_size_in_bytes_ + entry.file_size_in_bytes_, file_count_ + entry.file_count_,
+        std::max(last_file_creation_time_, entry.last_file_creation_time_), entry.total_buckets_);
+}
+
+Result<PartitionEntry> PartitionEntry::FromDataFile(const BinaryRow& partition,
+                                                    const FileKind& kind,
+                                                    const std::shared_ptr<DataFileMeta>& file,
+                                                    const int32_t total_buckets) {
+    int64_t record_count = kind == FileKind::Delete() ? -file->row_count : file->row_count;
+    int64_t file_size_in_bytes = kind == FileKind::Delete() ? -file->file_size : file->file_size;
+    int64_t file_count = kind == FileKind::Delete() ? -1 : 1;
+    PAIMON_ASSIGN_OR_RAISE(int64_t utc_millis, file->CreationTimeEpochMillis());
+    return PartitionEntry(partition, record_count, file_size_in_bytes, file_count, utc_millis,
+                          total_buckets);
+}
+
+Status PartitionEntry::Merge(const std::vector<ManifestEntry>& from,
+                             std::unordered_map<BinaryRow, PartitionEntry>* to) {
+    for (const auto& entry : from) {
+        PAIMON_ASSIGN_OR_RAISE(PartitionEntry partition_entry, FromManifestEntry(entry));
+        auto iter = to->find(partition_entry.Partition());
+        if (iter == to->end()) {
+            to->emplace(std::piecewise_construct,
+                        std::forward_as_tuple(partition_entry.Partition()),
+                        std::forward_as_tuple(partition_entry));
+        } else {
+            iter->second = iter->second.Merge(partition_entry);
+        }
+    }
+    return Status::OK();
+}
+
+Result<PartitionStatistics> PartitionEntry::ToPartitionStatistics(
+    const BinaryRowPartitionComputer* partition_computer) const {
+    std::vector<std::pair<std::string, std::string>> part_values;
+    PAIMON_ASSIGN_OR_RAISE(part_values, partition_computer->GeneratePartitionVector(partition_));
+    std::map<std::string, std::string> part_values_map(part_values.begin(), part_values.end());
+    return PartitionStatistics(part_values_map, record_count_, file_size_in_bytes_, file_count_,
+                               last_file_creation_time_, total_buckets_);
+}
+
+bool PartitionEntry::operator==(const PartitionEntry& other) const {
+    if (this == &other) {
+        return true;
+    }
+    return partition_ == other.partition_ && record_count_ == other.record_count_ &&
+           file_size_in_bytes_ == other.file_size_in_bytes_ && file_count_ == other.file_count_ &&
+           last_file_creation_time_ == other.last_file_creation_time_ &&
+           total_buckets_ == other.total_buckets_;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/manifest/partition_entry.h
+++ b/src/paimon/core/manifest/partition_entry.h
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/binary_row_partition_computer.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/partition/partition_statistics.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class FileKind;
+struct DataFileMeta;
+class BinaryRowPartitionComputer;
+
+class PartitionEntry {
+ public:
+    PartitionEntry(const BinaryRow& partition, int64_t record_count, int64_t file_size_in_bytes,
+                   int64_t file_count, int64_t last_file_creation_time, int32_t total_buckets);
+
+    const BinaryRow& Partition() const {
+        return partition_;
+    }
+    int64_t RecordCount() const {
+        return record_count_;
+    }
+    int64_t FileSizeInBytes() const {
+        return file_size_in_bytes_;
+    }
+    int64_t FileCount() const {
+        return file_count_;
+    }
+
+    // supposed to return UTC time
+    int64_t LastFileCreationTime() const {
+        return last_file_creation_time_;
+    }
+    int32_t TotalBuckets() const {
+        return total_buckets_;
+    }
+    PartitionEntry Merge(const PartitionEntry& entry) const;
+
+    static Result<PartitionEntry> FromManifestEntry(const ManifestEntry& entry) {
+        return FromDataFile(entry.Partition(), entry.Kind(), entry.File(), entry.TotalBuckets());
+    }
+
+    static Result<PartitionEntry> FromDataFile(const BinaryRow& partition, const FileKind& kind,
+                                               const std::shared_ptr<DataFileMeta>& file,
+                                               int32_t total_buckets);
+
+    Result<PartitionStatistics> ToPartitionStatistics(
+        const BinaryRowPartitionComputer* partition_computer) const;
+
+    static Status Merge(const std::vector<ManifestEntry>& from,
+                        std::unordered_map<BinaryRow, PartitionEntry>* to);
+
+    bool operator==(const PartitionEntry& other) const;
+
+ private:
+    BinaryRow partition_;
+    int64_t record_count_;
+    int64_t file_size_in_bytes_;
+    int64_t file_count_;
+    int64_t last_file_creation_time_;
+    int32_t total_buckets_;
+};
+}  // namespace paimon

--- a/src/paimon/core/manifest/partition_entry_test.cpp
+++ b/src/paimon/core/manifest/partition_entry_test.cpp
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/manifest/partition_entry.h"
+
+#include <optional>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
+
+#include "gtest/gtest.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+#include "paimon/testing/utils/timezone_guard.h"
+
+namespace paimon::test {
+
+class PartitionEntryTest : public testing::Test {
+    std::shared_ptr<DataFileMeta> GetDataFileMeta(const Timestamp& ts) const {
+        return std::make_shared<DataFileMeta>(
+            "file_name", /*file_size=*/10, /*row_count=*/5, DataFileMeta::EmptyMinKey(),
+            DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+            /*min_seq_no=*/16,
+            /*max_seq_no=*/32,
+            /*schema_id=*/1, /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            ts,
+            /*delete_row_count=*/2,
+            /*embedded_index=*/nullptr, /*file_source=*/std::nullopt,
+            /*value_stats_cols=*/std::nullopt,
+            /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt);
+    }
+};
+
+TEST_F(PartitionEntryTest, TestSimple) {
+    TimezoneGuard guard("Asia/Shanghai");
+    {
+        ASSERT_OK_AND_ASSIGN(auto partition_entry1, PartitionEntry::FromManifestEntry(ManifestEntry(
+                                                        FileKind::Add(), BinaryRow::EmptyRow(),
+                                                        /*bucket=*/0, /*total_buckets=*/2,
+                                                        GetDataFileMeta(Timestamp(500, 123)))));
+
+        ASSERT_OK_AND_ASSIGN(auto partition_entry2,
+                             PartitionEntry::FromManifestEntry(ManifestEntry(
+                                 FileKind::Add(), BinaryRow::EmptyRow(), /*bucket=*/1,
+                                 /*total_buckets=*/2, GetDataFileMeta(Timestamp(1500, 123)))));
+
+        auto res = partition_entry1.Merge(partition_entry2);
+        auto expected_partition_entry =
+            PartitionEntry(BinaryRow::EmptyRow(), /*record_count=*/10,
+                           /*file_size_in_bytes=*/20, /*file_count=*/2,
+                           /*last_file_creation_time=*/-28798500, /*total_buckets=*/2);
+        ASSERT_EQ(res, expected_partition_entry);
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(auto partition_entry1, PartitionEntry::FromManifestEntry(ManifestEntry(
+                                                        FileKind::Add(), BinaryRow::EmptyRow(),
+                                                        /*bucket=*/0, /*total_buckets=*/2,
+                                                        GetDataFileMeta(Timestamp(500, 123)))));
+
+        ASSERT_OK_AND_ASSIGN(auto partition_entry2,
+                             PartitionEntry::FromManifestEntry(ManifestEntry(
+                                 FileKind::Delete(), BinaryRow::EmptyRow(), /*bucket=*/1,
+                                 /*total_buckets=*/2, GetDataFileMeta(Timestamp(1500, 123)))));
+
+        auto res = partition_entry1.Merge(partition_entry2);
+        auto expected_partition_entry =
+            PartitionEntry(BinaryRow::EmptyRow(), /*record_count=*/0,
+                           /*file_size_in_bytes=*/0, /*file_count=*/0,
+                           /*last_file_creation_time=*/-28798500, /*total_buckets=*/2);
+        ASSERT_EQ(res, expected_partition_entry);
+    }
+}
+
+TEST_F(PartitionEntryTest, TestMerge) {
+    TimezoneGuard guard("Asia/Shanghai");
+    BinaryRow partition0 = BinaryRowGenerator::GenerateRow({0}, GetDefaultPool().get());
+    BinaryRow partition1 = BinaryRowGenerator::GenerateRow({1}, GetDefaultPool().get());
+
+    auto entry1 =
+        ManifestEntry(FileKind::Add(), partition0,
+                      /*bucket=*/0, /*total_buckets=*/2, GetDataFileMeta(Timestamp(500, 123)));
+
+    auto entry2 = ManifestEntry(FileKind::Add(), partition0, /*bucket=*/1,
+                                /*total_buckets=*/2, GetDataFileMeta(Timestamp(1500, 123)));
+
+    auto entry3 = ManifestEntry(FileKind::Add(), partition1, /*bucket=*/0, /*total_buckets=*/2,
+                                GetDataFileMeta(Timestamp(0, 123)));
+
+    std::unordered_map<BinaryRow, PartitionEntry> to;
+    ASSERT_OK(PartitionEntry::Merge({entry1, entry2, entry3}, &to));
+    std::unordered_map<BinaryRow, PartitionEntry> expected_partition_entry;
+    expected_partition_entry.emplace(
+        std::piecewise_construct, std::forward_as_tuple(partition0),
+        std::forward_as_tuple(PartitionEntry(partition0, 10, 20, 2, -28798500, 2)));
+    expected_partition_entry.emplace(
+        std::piecewise_construct, std::forward_as_tuple(partition1),
+        std::forward_as_tuple(PartitionEntry(partition1, 5, 10, 1, -28800000, 2)));
+    ASSERT_EQ(to, expected_partition_entry);
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
### Purpose

Linked issue: No linked issue

This change adds manifest and index manifest support for Paimon C++.

Included changes:

- **Manifest core**:
  - Adds `ManifestFile`, `ManifestList`, `ManifestCommittable`, and `PartitionEntry` classes for managing table manifests and partition metadata.
  - Adds test coverage for manifest file operations, manifest list handling, committable serialization, and partition entry logic.

- **Index manifest**:
  - Adds `IndexManifestEntry`, `IndexManifestEntrySerializer`, `IndexManifestFile`, and `IndexManifestFileHandler` for index file tracking and serialization.
  - Adds test coverage for index manifest entry serialization, index manifest file I/O, and handler workflows.

### Tests

Not run. Local compile, CMake, and gtest environment checks are not part of this PR description.

Test coverage included in this change:

- `ManifestFileTest`
- `ManifestListTest`
- `ManifestCommittableTest`
- `PartitionEntryTest`
- `IndexManifestEntrySerializerTest`
- `IndexManifestFileHandlerTest`

### API and Format

This change adds public API in `src/paimon/core/manifest/`.

No storage format or protocol changes.

### Documentation

No documentation changes required.

### Generative AI tooling

Migrate-by: Aone Copilot (Qwen-3.7-Max)
