### PR TITLE
feat: introduce type casting executors for schema evolution

### DIFF
--- a/src/paimon/core/casting/boolean_to_decimal_cast_executor.cpp
+++ b/src/paimon/core/casting/boolean_to_decimal_cast_executor.cpp
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/boolean_to_decimal_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+#include "arrow/array/array_primitive.h"
+#include "arrow/array/builder_decimal.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/decimal.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/decimal_utils.h"
+#include "paimon/data/decimal.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+
+Result<Literal> BooleanToDecimalCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::BOOLEAN);
+    PAIMON_RETURN_NOT_OK(DecimalUtils::CheckDecimalType(*target_type));
+    auto* decimal_type = arrow::internal::checked_cast<arrow::DecimalType*>(target_type.get());
+    assert(decimal_type);
+    if (literal.IsNull()) {
+        return Literal(FieldType::DECIMAL);
+    }
+    bool bool_value = literal.GetValue<bool>();
+    auto scaled_decimal = DecimalUtils::RescaleDecimalWithOverflowCheck(
+        arrow::Decimal128(bool_value), /*src_scale=*/0, decimal_type->precision(),
+        decimal_type->scale());
+    if (scaled_decimal == std::nullopt) {
+        return Literal(FieldType::DECIMAL);
+    }
+    return Literal(Decimal(
+        decimal_type->precision(), decimal_type->scale(),
+        static_cast<Decimal::int128_t>(static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           scaled_decimal.value().high_bits()))
+                                           << 64 |
+                                       scaled_decimal.value().low_bits())));
+}
+
+Result<std::shared_ptr<arrow::Array>> BooleanToDecimalCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    PAIMON_RETURN_NOT_OK(DecimalUtils::CheckDecimalType(*target_type));
+    auto* boolean_array = arrow::internal::checked_cast<arrow::BooleanArray*>(array.get());
+    assert(boolean_array);
+    auto* decimal_type = arrow::internal::checked_cast<arrow::DecimalType*>(target_type.get());
+    assert(decimal_type);
+    auto decimal_builder = std::make_shared<arrow::Decimal128Builder>(target_type, pool);
+    for (int64_t i = 0; i < boolean_array->length(); ++i) {
+        if (boolean_array->IsNull(i)) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->AppendNull());
+        } else {
+            bool bool_value = boolean_array->Value(i);
+            auto scaled_decimal = DecimalUtils::RescaleDecimalWithOverflowCheck(
+                arrow::Decimal128(bool_value), /*src_scale=*/0, decimal_type->precision(),
+                decimal_type->scale());
+            if (scaled_decimal == std::nullopt) {
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->AppendNull());
+            } else {
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->Append(scaled_decimal.value()));
+            }
+        }
+    }
+    std::shared_ptr<arrow::Array> casted_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->Finish(&casted_array));
+    return casted_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/boolean_to_decimal_cast_executor.h
+++ b/src/paimon/core/casting/boolean_to_decimal_cast_executor.h
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/data/decimal.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class BooleanToDecimalCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/boolean_to_numeric_cast_executor.cpp
+++ b/src/paimon/core/casting/boolean_to_numeric_cast_executor.cpp
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/boolean_to_numeric_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+BooleanToNumericCastExecutor::BooleanToNumericCastExecutor() {
+    literal_cast_executor_map_ = {
+        {FieldType::TINYINT,
+         [&](const Literal& literal) { return CastLiteral<int8_t>(literal, FieldType::TINYINT); }},
+        {FieldType::SMALLINT,
+         [&](const Literal& literal) {
+             return CastLiteral<int16_t>(literal, FieldType::SMALLINT);
+         }},
+        {FieldType::INT,
+         [&](const Literal& literal) { return CastLiteral<int32_t>(literal, FieldType::INT); }},
+        {FieldType::BIGINT,
+         [&](const Literal& literal) { return CastLiteral<int64_t>(literal, FieldType::BIGINT); }},
+        {FieldType::FLOAT,
+         [&](const Literal& literal) { return CastLiteral<float>(literal, FieldType::FLOAT); }},
+        {FieldType::DOUBLE,
+         [&](const Literal& literal) { return CastLiteral<double>(literal, FieldType::DOUBLE); }}};
+}
+
+Result<Literal> BooleanToNumericCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::BOOLEAN);
+    PAIMON_ASSIGN_OR_RAISE(FieldType target_field_type,
+                           FieldTypeUtils::ConvertToFieldType(target_type->id()));
+    auto iter = literal_cast_executor_map_.find(target_field_type);
+    if (iter == literal_cast_executor_map_.end()) {
+        return Status::Invalid(
+            fmt::format("cast literal in BooleanToNumericCastExecutor failed: cannot find cast "
+                        "function from boolean to {}",
+                        target_type->ToString()));
+    }
+    return iter->second(literal);
+}
+
+Result<std::shared_ptr<arrow::Array>> BooleanToNumericCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    return CastingUtils::Cast(array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/boolean_to_numeric_cast_executor.h
+++ b/src/paimon/core/casting/boolean_to_numeric_cast_executor.h
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <functional>
+#include <map>
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+enum class FieldType;
+
+class BooleanToNumericCastExecutor : public CastExecutor {
+ public:
+    BooleanToNumericCastExecutor();
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+
+ private:
+    template <typename TargetType>
+    static Literal CastLiteral(const Literal& literal, const FieldType& target_type) {
+        if (literal.IsNull()) {
+            return Literal(target_type);
+        }
+        bool value = literal.GetValue<bool>();
+        return Literal(static_cast<TargetType>(value));
+    }
+
+ private:
+    std::map<FieldType, std::function<Literal(const Literal&)>> literal_cast_executor_map_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/boolean_to_string_cast_executor.cpp
+++ b/src/paimon/core/casting/boolean_to_string_cast_executor.cpp
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/boolean_to_string_cast_executor.h"
+
+#include <cassert>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/defs.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> BooleanToStringCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::BOOLEAN);
+    PAIMON_ASSIGN_OR_RAISE(FieldType target_field_type,
+                           FieldTypeUtils::ConvertToFieldType(target_type->id()));
+    assert(target_field_type == FieldType::STRING);
+    static const std::string TRUE = "true";
+    static const std::string FALSE = "false";
+    if (literal.IsNull()) {
+        return Literal(target_field_type);
+    }
+    if (literal.GetValue<bool>()) {
+        return Literal(target_field_type, TRUE.data(), TRUE.size());
+    }
+    return Literal(target_field_type, FALSE.data(), FALSE.size());
+}
+
+Result<std::shared_ptr<arrow::Array>> BooleanToStringCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    return CastingUtils::Cast(array, target_type, options, pool);
+}
+}  // namespace paimon

--- a/src/paimon/core/casting/boolean_to_string_cast_executor.h
+++ b/src/paimon/core/casting/boolean_to_string_cast_executor.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class BooleanToStringCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/decimal_to_decimal_cast_executor.cpp
+++ b/src/paimon/core/casting/decimal_to_decimal_cast_executor.cpp
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/decimal_to_decimal_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_decimal.h"
+#include "arrow/array/builder_decimal.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/decimal.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/decimal_utils.h"
+#include "paimon/data/decimal.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> DecimalToDecimalCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::DECIMAL);
+    PAIMON_RETURN_NOT_OK(DecimalUtils::CheckDecimalType(*target_type));
+    if (literal.IsNull()) {
+        return Literal(FieldType::DECIMAL);
+    }
+    auto* target_decimal_type =
+        arrow::internal::checked_cast<arrow::Decimal128Type*>(target_type.get());
+    assert(target_decimal_type);
+    auto src_value = literal.GetValue<Decimal>();
+    arrow::Decimal128 src_decimal(src_value.HighBits(), src_value.LowBits());
+    auto scaled_decimal = DecimalUtils::RescaleDecimalWithOverflowCheck(
+        src_decimal, src_value.Scale(), target_decimal_type->precision(),
+        target_decimal_type->scale());
+    if (scaled_decimal == std::nullopt) {
+        return Literal(FieldType::DECIMAL);
+    }
+    return Literal(Decimal(
+        target_decimal_type->precision(), target_decimal_type->scale(),
+        static_cast<Decimal::int128_t>(static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           scaled_decimal.value().high_bits()))
+                                           << 64 |
+                                       scaled_decimal.value().low_bits())));
+}
+
+Result<std::shared_ptr<arrow::Array>> DecimalToDecimalCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    PAIMON_RETURN_NOT_OK(DecimalUtils::CheckDecimalType(*target_type));
+    auto* src_array = arrow::internal::checked_cast<arrow::Decimal128Array*>(array.get());
+    assert(src_array);
+    auto* src_decimal_type =
+        arrow::internal::checked_cast<arrow::Decimal128Type*>(array->type().get());
+    assert(src_decimal_type);
+    auto* target_decimal_type =
+        arrow::internal::checked_cast<arrow::Decimal128Type*>(target_type.get());
+    assert(target_decimal_type);
+    auto decimal_builder = std::make_shared<arrow::Decimal128Builder>(target_type, pool);
+    for (int64_t i = 0; i < src_array->length(); ++i) {
+        if (src_array->IsNull(i)) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->AppendNull());
+        } else {
+            arrow::Decimal128 src_value(src_array->GetValue(i));
+            auto scaled_decimal = DecimalUtils::RescaleDecimalWithOverflowCheck(
+                src_value, src_decimal_type->scale(), target_decimal_type->precision(),
+                target_decimal_type->scale());
+            if (scaled_decimal == std::nullopt) {
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->AppendNull());
+            } else {
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->Append(scaled_decimal.value()));
+            }
+        }
+    }
+    std::shared_ptr<arrow::Array> casted_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->Finish(&casted_array));
+    return casted_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/decimal_to_decimal_cast_executor.h
+++ b/src/paimon/core/casting/decimal_to_decimal_cast_executor.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+#include "paimon/visibility.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+
+class PAIMON_EXPORT DecimalToDecimalCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/decimal_to_numeric_primitive_cast_executor.cpp
+++ b/src/paimon/core/casting/decimal_to_numeric_primitive_cast_executor.cpp
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/decimal_to_numeric_primitive_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/scalar.h"
+#include "arrow/type.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/data/decimal.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> DecimalToNumericPrimitiveCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::DECIMAL);
+    PAIMON_ASSIGN_OR_RAISE(FieldType target_field_type,
+                           FieldTypeUtils::ConvertToFieldType(target_type->id()));
+    if (literal.IsNull()) {
+        PAIMON_ASSIGN_OR_RAISE(FieldType type,
+                               FieldTypeUtils::ConvertToFieldType(target_type->id()));
+        return Literal(type);
+    }
+    auto decimal_value = literal.GetValue<Decimal>();
+    auto src_type = arrow::decimal128(decimal_value.Precision(), decimal_value.Scale());
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    options.allow_decimal_truncate = true;
+    options.allow_int_overflow = true;
+    if (target_field_type == FieldType::TINYINT) {
+        return CastingUtils::Cast<arrow::Decimal128Scalar, Decimal,
+                                  arrow::NumericScalar<arrow::Int8Type>, int8_t>(
+            literal, src_type, target_type, options);
+    } else if (target_field_type == FieldType::SMALLINT) {
+        return CastingUtils::Cast<arrow::Decimal128Scalar, Decimal,
+                                  arrow::NumericScalar<arrow::Int16Type>, int16_t>(
+            literal, src_type, target_type, options);
+    } else if (target_field_type == FieldType::INT) {
+        return CastingUtils::Cast<arrow::Decimal128Scalar, Decimal,
+                                  arrow::NumericScalar<arrow::Int32Type>, int32_t>(
+            literal, src_type, target_type, options);
+    } else if (target_field_type == FieldType::BIGINT) {
+        return CastingUtils::Cast<arrow::Decimal128Scalar, Decimal,
+                                  arrow::NumericScalar<arrow::Int64Type>, int64_t>(
+            literal, src_type, target_type, options);
+    } else if (target_field_type == FieldType::FLOAT) {
+        return CastingUtils::Cast<arrow::Decimal128Scalar, Decimal,
+                                  arrow::NumericScalar<arrow::FloatType>, float>(
+            literal, src_type, target_type, options);
+    } else if (target_field_type == FieldType::DOUBLE) {
+        return CastingUtils::Cast<arrow::Decimal128Scalar, Decimal,
+                                  arrow::NumericScalar<arrow::DoubleType>, double>(
+            literal, src_type, target_type, options);
+    }
+    return Status::Invalid(fmt::format(
+        "cast literal in DecimalToNumericPrimitiveCastExecutor failed: cannot find cast "
+        "function from decimal to {}",
+        FieldTypeUtils::FieldTypeToString(target_field_type)));
+}
+
+Result<std::shared_ptr<arrow::Array>> DecimalToNumericPrimitiveCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    options.allow_decimal_truncate = true;
+    options.allow_int_overflow = true;
+    return CastingUtils::Cast(array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/decimal_to_numeric_primitive_cast_executor.h
+++ b/src/paimon/core/casting/decimal_to_numeric_primitive_cast_executor.h
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class DecimalToNumericPrimitiveCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/numeric_primitive_to_decimal_cast_executor.cpp
+++ b/src/paimon/core/casting/numeric_primitive_to_decimal_cast_executor.cpp
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/numeric_primitive_to_decimal_cast_executor.h"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_primitive.h"
+#include "arrow/array/builder_decimal.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/decimal.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/decimal_utils.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/data/decimal.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+
+template <typename SrcType>
+Result<Literal> NumericPrimitiveToDecimalCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) {
+    auto* decimal_type = arrow::internal::checked_cast<arrow::Decimal128Type*>(target_type.get());
+    assert(decimal_type);
+    if (literal.IsNull()) {
+        return Literal(FieldType::DECIMAL);
+    }
+    auto src_value = literal.GetValue<SrcType>();
+    if constexpr (std::is_same_v<SrcType, float> || std::is_same_v<SrcType, double>) {
+        if (src_value == INFINITY || src_value == -INFINITY || std::isnan(src_value)) {
+            return Status::Invalid(fmt::format("Cannot cast {} to decimal", src_value));
+        }
+        auto decimal_result = arrow::Decimal128::FromReal(src_value, decimal_type->precision(),
+                                                          decimal_type->scale());
+        if (decimal_result.ok()) {
+            return Literal{Decimal(decimal_type->precision(), decimal_type->scale(),
+                                   static_cast<Decimal::int128_t>(
+                                       static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           decimal_result.ValueUnsafe().high_bits()))
+                                           << 64 |
+                                       decimal_result.ValueUnsafe().low_bits()))};
+        }
+    } else {
+        auto scaled_decimal = DecimalUtils::RescaleDecimalWithOverflowCheck(
+            arrow::Decimal128(src_value), /*src_scale=*/0, decimal_type->precision(),
+            decimal_type->scale());
+        if (scaled_decimal != std::nullopt) {
+            return Literal(Decimal(decimal_type->precision(), decimal_type->scale(),
+                                   static_cast<Decimal::int128_t>(
+                                       static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           scaled_decimal.value().high_bits()))
+                                           << 64 |
+                                       scaled_decimal.value().low_bits())));
+        }
+    }
+    return Literal(FieldType::DECIMAL);
+}
+
+Result<Literal> NumericPrimitiveToDecimalCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    PAIMON_RETURN_NOT_OK(DecimalUtils::CheckDecimalType(*target_type));
+    FieldType src_type = literal.GetType();
+    if (src_type == FieldType::TINYINT) {
+        return Cast<int8_t>(literal, target_type);
+    } else if (src_type == FieldType::SMALLINT) {
+        return Cast<int16_t>(literal, target_type);
+    } else if (src_type == FieldType::INT) {
+        return Cast<int32_t>(literal, target_type);
+    } else if (src_type == FieldType::BIGINT) {
+        return Cast<int64_t>(literal, target_type);
+    } else if (src_type == FieldType::FLOAT) {
+        return Cast<float>(literal, target_type);
+    } else if (src_type == FieldType::DOUBLE) {
+        return Cast<double>(literal, target_type);
+    }
+    return Status::Invalid(fmt::format(
+        "cast literal in NumericPrimitiveToDecimalCastExecutor failed: cannot find cast "
+        "function from {} to {}",
+        FieldTypeUtils::FieldTypeToString(src_type), target_type->ToString()));
+}
+
+template <typename SrcType>
+Result<std::shared_ptr<arrow::Array>> NumericPrimitiveToDecimalCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) {
+    using SrcValueType = typename arrow::NumericArray<SrcType>::value_type;
+    auto* typed_array = arrow::internal::checked_cast<arrow::NumericArray<SrcType>*>(array.get());
+    assert(typed_array);
+    auto* decimal_type = arrow::internal::checked_cast<arrow::Decimal128Type*>(target_type.get());
+    auto decimal_builder = std::make_shared<arrow::Decimal128Builder>(target_type, pool);
+    for (int64_t i = 0; i < typed_array->length(); ++i) {
+        if (typed_array->IsNull(i)) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->AppendNull());
+        } else {
+            SrcValueType src_value = typed_array->Value(i);
+            if constexpr (std::is_same_v<SrcType, arrow::FloatType> ||
+                          std::is_same_v<SrcType, arrow::DoubleType>) {
+                if (src_value == INFINITY || src_value == -INFINITY || std::isnan(src_value)) {
+                    return Status::Invalid(fmt::format("Cannot cast {} to decimal", src_value));
+                }
+                auto decimal_result = arrow::Decimal128::FromReal(
+                    src_value, decimal_type->precision(), decimal_type->scale());
+                if (!decimal_result.ok()) {
+                    PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->AppendNull());
+                } else {
+                    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                        decimal_builder->Append(decimal_result.ValueUnsafe()));
+                }
+            } else {
+                auto scaled_decimal = DecimalUtils::RescaleDecimalWithOverflowCheck(
+                    arrow::Decimal128(src_value), /*src_scale=*/0, decimal_type->precision(),
+                    decimal_type->scale());
+                if (scaled_decimal == std::nullopt) {
+                    PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->AppendNull());
+                } else {
+                    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                        decimal_builder->Append(scaled_decimal.value()));
+                }
+            }
+        }
+    }
+    std::shared_ptr<arrow::Array> casted_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->Finish(&casted_array));
+    return casted_array;
+}
+
+Result<std::shared_ptr<arrow::Array>> NumericPrimitiveToDecimalCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    PAIMON_RETURN_NOT_OK(DecimalUtils::CheckDecimalType(*target_type));
+    auto src_type_id = array->type()->id();
+    if (src_type_id == arrow::Type::type::INT8) {
+        return Cast<arrow::Int8Type>(array, target_type, pool);
+    } else if (src_type_id == arrow::Type::type::INT16) {
+        return Cast<arrow::Int16Type>(array, target_type, pool);
+    } else if (src_type_id == arrow::Type::type::INT32) {
+        return Cast<arrow::Int32Type>(array, target_type, pool);
+    } else if (src_type_id == arrow::Type::type::INT64) {
+        return Cast<arrow::Int64Type>(array, target_type, pool);
+    } else if (src_type_id == arrow::Type::type::FLOAT) {
+        return Cast<arrow::FloatType>(array, target_type, pool);
+    } else if (src_type_id == arrow::Type::type::DOUBLE) {
+        return Cast<arrow::DoubleType>(array, target_type, pool);
+    }
+    return Status::Invalid(
+        fmt::format("cast array in NumericPrimitiveToDecimalCastExecutor failed: cannot cast "
+                    "from {} to decimal",
+                    array->type()->ToString()));
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/numeric_primitive_to_decimal_cast_executor.h
+++ b/src/paimon/core/casting/numeric_primitive_to_decimal_cast_executor.h
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class NumericPrimitiveToDecimalCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+
+ private:
+    template <typename SrcType>
+    static Result<std::shared_ptr<arrow::Array>> Cast(
+        const std::shared_ptr<arrow::Array>& array,
+        const std::shared_ptr<arrow::DataType>& target_type, arrow::MemoryPool* pool);
+
+    template <typename SrcType>
+    static Result<Literal> Cast(const Literal& literal,
+                                const std::shared_ptr<arrow::DataType>& target_type);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/numeric_to_boolean_cast_executor.cpp
+++ b/src/paimon/core/casting/numeric_to_boolean_cast_executor.cpp
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/numeric_to_boolean_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+NumericToBooleanCastExecutor::NumericToBooleanCastExecutor() {
+    literal_cast_executor_map_ = {
+        {FieldType::TINYINT, [&](const Literal& literal) { return CastLiteral<int8_t>(literal); }},
+        {FieldType::SMALLINT,
+         [&](const Literal& literal) { return CastLiteral<int16_t>(literal); }},
+        {FieldType::INT, [&](const Literal& literal) { return CastLiteral<int32_t>(literal); }},
+        {FieldType::BIGINT, [&](const Literal& literal) { return CastLiteral<int64_t>(literal); }}};
+}
+
+Result<Literal> NumericToBooleanCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(target_type->id() == arrow::Type::type::BOOL);
+    FieldType src_type = literal.GetType();
+    auto iter = literal_cast_executor_map_.find(src_type);
+    if (iter == literal_cast_executor_map_.end()) {
+        return Status::Invalid(
+            fmt::format("cast literal in NumericToBooleanCastExecutor failed: cannot find cast "
+                        "function from {} to boolean",
+                        FieldTypeUtils::FieldTypeToString(src_type)));
+    }
+    return iter->second(literal);
+}
+
+Result<std::shared_ptr<arrow::Array>> NumericToBooleanCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    return CastingUtils::Cast(array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/numeric_to_boolean_cast_executor.h
+++ b/src/paimon/core/casting/numeric_to_boolean_cast_executor.h
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <functional>
+#include <map>
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/defs.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class NumericToBooleanCastExecutor : public CastExecutor {
+ public:
+    NumericToBooleanCastExecutor();
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+
+ private:
+    template <typename SrcType>
+    static Literal CastLiteral(const Literal& literal) {
+        if (literal.IsNull()) {
+            return Literal(FieldType::BOOLEAN);
+        }
+        SrcType value = literal.GetValue<SrcType>();
+        return Literal{static_cast<bool>(value)};
+    }
+
+ private:
+    std::map<FieldType, std::function<Literal(const Literal&)>> literal_cast_executor_map_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/numeric_to_string_cast_executor.cpp
+++ b/src/paimon/core/casting/numeric_to_string_cast_executor.cpp
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/numeric_to_string_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/scalar.h"
+#include "arrow/type.h"
+#include "arrow/util/decimal.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/data/decimal.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+
+NumericToStringCastExecutor::NumericToStringCastExecutor() {
+    literal_cast_executor_map_ = {
+        {FieldType::TINYINT, [&](const Literal& literal) { return CastLiteral<int8_t>(literal); }},
+        {FieldType::SMALLINT,
+         [&](const Literal& literal) { return CastLiteral<int16_t>(literal); }},
+        {FieldType::INT, [&](const Literal& literal) { return CastLiteral<int32_t>(literal); }},
+        {FieldType::BIGINT, [&](const Literal& literal) { return CastLiteral<int64_t>(literal); }},
+        {FieldType::FLOAT, [&](const Literal& literal) { return CastLiteral<float>(literal); }},
+        {FieldType::DOUBLE, [&](const Literal& literal) { return CastLiteral<double>(literal); }},
+        {FieldType::DECIMAL,
+         [&](const Literal& literal) { return CastLiteral<Decimal>(literal); }}};
+}
+
+template <typename SrcType>
+Literal NumericToStringCastExecutor::CastLiteral(const Literal& literal) {
+    if (literal.IsNull()) {
+        return Literal(FieldType::STRING);
+    }
+    auto value = literal.GetValue<SrcType>();
+    if constexpr (std::is_same_v<SrcType, float>) {
+        arrow::FloatScalar scalar(value);
+        std::string string_value = scalar.ToString();
+        return Literal(FieldType::STRING, string_value.data(), string_value.size());
+    } else if constexpr (std::is_same_v<SrcType, double>) {
+        arrow::DoubleScalar scalar(value);
+        std::string string_value = scalar.ToString();
+        return Literal(FieldType::STRING, string_value.data(), string_value.size());
+    } else if constexpr (std::is_same_v<SrcType, Decimal>) {
+        auto src_type = arrow::decimal128(value.Precision(), value.Scale());
+        arrow::Decimal128Scalar scalar(arrow::Decimal128(value.HighBits(), value.LowBits()),
+                                       src_type);
+        std::string string_value = scalar.ToString();
+        return Literal(FieldType::STRING, string_value.data(), string_value.size());
+    } else {
+        std::string string_value = std::to_string(value);
+        return Literal(FieldType::STRING, string_value.data(), string_value.size());
+    }
+}
+
+Result<Literal> NumericToStringCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(target_type->id() == arrow::Type::type::STRING);
+    FieldType src_type = literal.GetType();
+    auto iter = literal_cast_executor_map_.find(src_type);
+    if (iter == literal_cast_executor_map_.end()) {
+        return Status::Invalid(
+            fmt::format("cast literal in NumericToStringCastExecutor failed: cannot find cast "
+                        "function from {} to STRING",
+                        FieldTypeUtils::FieldTypeToString(src_type)));
+    }
+    return iter->second(literal);
+}
+
+Result<std::shared_ptr<arrow::Array>> NumericToStringCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    return CastingUtils::Cast(array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/numeric_to_string_cast_executor.h
+++ b/src/paimon/core/casting/numeric_to_string_cast_executor.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <functional>
+#include <map>
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+enum class FieldType;
+
+class NumericToStringCastExecutor : public CastExecutor {
+ public:
+    NumericToStringCastExecutor();
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+
+ private:
+    template <typename SrcType>
+    static Literal CastLiteral(const Literal& literal);
+
+ private:
+    std::map<FieldType, std::function<Literal(const Literal&)>> literal_cast_executor_map_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_boolean_cast_executor.cpp
+++ b/src/paimon/core/casting/string_to_boolean_cast_executor.cpp
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/string_to_boolean_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "arrow/array/array_binary.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> StringToBooleanCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::STRING);
+    PAIMON_ASSIGN_OR_RAISE(FieldType target_field_type,
+                           FieldTypeUtils::ConvertToFieldType(target_type->id()));
+    assert(target_field_type == FieldType::BOOLEAN);
+    if (literal.IsNull()) {
+        return Literal(target_field_type);
+    }
+    auto value = literal.GetValue<std::string>();
+    std::optional<bool> bool_value = StringUtils::StringToValue<bool>(value);
+    if (bool_value == std::nullopt) {
+        return Status::Invalid(fmt::format(
+            "StringToBooleanCastExecutor cast failed: STRING '{}' cannot cast to BOOLEAN", value));
+    }
+    return Literal(bool_value.value());
+}
+
+Result<std::shared_ptr<arrow::Array>> StringToBooleanCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    auto* string_array = arrow::internal::checked_cast<arrow::StringArray*>(array.get());
+    assert(string_array);
+    auto bool_builder = std::make_shared<arrow::BooleanBuilder>(pool);
+    for (int64_t i = 0; i < string_array->length(); ++i) {
+        if (string_array->IsNull(i)) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(bool_builder->AppendNull());
+        } else {
+            std::optional<bool> bool_value =
+                StringUtils::StringToValue<bool>(string_array->GetString(i));
+            if (bool_value == std::nullopt) {
+                return Status::Invalid(fmt::format(
+                    "StringToBooleanCastExecutor cast failed: STRING '{}' cannot cast to BOOLEAN",
+                    string_array->GetString(i)));
+            }
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(bool_builder->Append(bool_value.value()));
+        }
+    }
+    std::shared_ptr<arrow::Array> casted_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(bool_builder->Finish(&casted_array));
+    return casted_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_boolean_cast_executor.h
+++ b/src/paimon/core/casting/string_to_boolean_cast_executor.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class StringToBooleanCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_decimal_cast_executor.cpp
+++ b/src/paimon/core/casting/string_to_decimal_cast_executor.cpp
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/string_to_decimal_cast_executor.h"
+
+#include <cassert>
+#include <utility>
+
+#include "arrow/array/array_binary.h"
+#include "arrow/array/builder_decimal.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/decimal.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/decimal_utils.h"
+#include "paimon/data/decimal.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+
+Result<std::optional<arrow::Decimal128>> StringToDecimalCastExecutor::StringToDecimal(
+    const std::string& str_value, int32_t target_precision, int32_t target_scale) {
+    int32_t src_precision = 0, src_scale = 0;
+    arrow::Decimal128 src_decimal;
+    // parse invalid string
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        arrow::Decimal128::FromString(str_value, &src_decimal, &src_precision, &src_scale));
+    if (src_precision > Decimal::MAX_PRECISION) {
+        return std::optional<arrow::Decimal128>();
+    }
+    return DecimalUtils::RescaleDecimalWithOverflowCheck(src_decimal, src_scale, target_precision,
+                                                         target_scale);
+}
+
+Result<Literal> StringToDecimalCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::STRING);
+    PAIMON_RETURN_NOT_OK(DecimalUtils::CheckDecimalType(*target_type));
+    auto* decimal_type = arrow::internal::checked_cast<arrow::Decimal128Type*>(target_type.get());
+    assert(decimal_type);
+    if (literal.IsNull()) {
+        return Literal(FieldType::DECIMAL);
+    }
+    auto src_value = literal.GetValue<std::string>();
+    PAIMON_ASSIGN_OR_RAISE(
+        std::optional<arrow::Decimal128> scaled_decimal,
+        StringToDecimal(src_value, decimal_type->precision(), decimal_type->scale()));
+    if (scaled_decimal == std::nullopt) {
+        return Literal(FieldType::DECIMAL);
+    }
+    return Literal(Decimal(
+        decimal_type->precision(), decimal_type->scale(),
+        static_cast<Decimal::int128_t>(static_cast<Decimal::uint128_t>(static_cast<uint64_t>(
+                                           scaled_decimal.value().high_bits()))
+                                           << 64 |
+                                       scaled_decimal.value().low_bits())));
+}
+
+Result<std::shared_ptr<arrow::Array>> StringToDecimalCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    PAIMON_RETURN_NOT_OK(DecimalUtils::CheckDecimalType(*target_type));
+    auto* string_array = arrow::internal::checked_cast<arrow::StringArray*>(array.get());
+    assert(string_array);
+    auto* decimal_type = arrow::internal::checked_cast<arrow::Decimal128Type*>(target_type.get());
+    auto decimal_builder = std::make_shared<arrow::Decimal128Builder>(target_type, pool);
+    for (int64_t i = 0; i < string_array->length(); ++i) {
+        if (string_array->IsNull(i)) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->AppendNull());
+        } else {
+            std::string src_value = string_array->GetString(i);
+            PAIMON_ASSIGN_OR_RAISE(
+                std::optional<arrow::Decimal128> scaled_decimal,
+                StringToDecimal(src_value, decimal_type->precision(), decimal_type->scale()));
+            if (scaled_decimal == std::nullopt) {
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->AppendNull());
+            } else {
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->Append(scaled_decimal.value()));
+            }
+        }
+    }
+    std::shared_ptr<arrow::Array> casted_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(decimal_builder->Finish(&casted_array));
+    return casted_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_decimal_cast_executor.h
+++ b/src/paimon/core/casting/string_to_decimal_cast_executor.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+#include "arrow/array/array_base.h"
+#include "arrow/util/decimal.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class StringToDecimalCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+
+ private:
+    static Result<std::optional<arrow::Decimal128>> StringToDecimal(const std::string& str_value,
+                                                                    int32_t target_precision,
+                                                                    int32_t target_scale);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_numeric_primitive_cast_executor.cpp
+++ b/src/paimon/core/casting/string_to_numeric_primitive_cast_executor.cpp
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/string_to_numeric_primitive_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "arrow/util/value_parsing.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+StringToNumericPrimitiveCastExecutor::StringToNumericPrimitiveCastExecutor() {
+    literal_cast_executor_map_ = {
+        {FieldType::TINYINT,
+         [&](const Literal& literal) { return CastLiteral<int8_t>(literal, FieldType::TINYINT); }},
+        {FieldType::SMALLINT,
+         [&](const Literal& literal) {
+             return CastLiteral<int16_t>(literal, FieldType::SMALLINT);
+         }},
+        {FieldType::INT,
+         [&](const Literal& literal) { return CastLiteral<int32_t>(literal, FieldType::INT); }},
+        {FieldType::BIGINT,
+         [&](const Literal& literal) { return CastLiteral<int64_t>(literal, FieldType::BIGINT); }},
+        {FieldType::FLOAT,
+         [&](const Literal& literal) { return CastLiteral<float>(literal, FieldType::FLOAT); }},
+        {FieldType::DOUBLE,
+         [&](const Literal& literal) { return CastLiteral<double>(literal, FieldType::DOUBLE); }}};
+}
+
+template <typename TargetType>
+Result<Literal> StringToNumericPrimitiveCastExecutor::CastLiteral(const Literal& literal,
+                                                                  const FieldType& target_type) {
+    if (literal.IsNull()) {
+        return Literal(target_type);
+    }
+    auto value = literal.GetValue<std::string>();
+    if constexpr (std::is_same_v<TargetType, float> || std::is_same_v<TargetType, double>) {
+        // use arrow::internal::StringToFloat Func to handle overflow, e.g., 1.7976931348623157e309
+        // is supposed to return infinity
+        TargetType out;
+        bool success = arrow::internal::StringToFloat(value.data(), value.size(), '.', &out);
+        if (!success) {
+            return Status::Invalid(
+                fmt::format("cast literal in StringToNumericPrimitiveCastExecutor failed: cannot "
+                            "cast '{}' from STRING to {}",
+                            value, FieldTypeUtils::FieldTypeToString(target_type)));
+        }
+        return Literal(out);
+    } else {
+        std::optional<TargetType> casted_value = StringUtils::StringToValue<TargetType>(value);
+        if (!casted_value) {
+            return Status::Invalid(
+                fmt::format("cast literal in StringToNumericPrimitiveCastExecutor failed: cannot "
+                            "cast '{}' from STRING to {}",
+                            value, FieldTypeUtils::FieldTypeToString(target_type)));
+        }
+        return Literal(casted_value.value());
+    }
+}
+
+Result<Literal> StringToNumericPrimitiveCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::STRING);
+    PAIMON_ASSIGN_OR_RAISE(FieldType target_field_type,
+                           FieldTypeUtils::ConvertToFieldType(target_type->id()));
+    auto iter = literal_cast_executor_map_.find(target_field_type);
+    if (iter == literal_cast_executor_map_.end()) {
+        return Status::Invalid(fmt::format(
+            "cast literal in StringToNumericPrimitiveCastExecutor failed: cannot find cast "
+            "function from STRING to {}",
+            FieldTypeUtils::FieldTypeToString(target_field_type)));
+    }
+    return iter->second(literal);
+}
+
+Result<std::shared_ptr<arrow::Array>> StringToNumericPrimitiveCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    return CastingUtils::Cast(array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_numeric_primitive_cast_executor.h
+++ b/src/paimon/core/casting/string_to_numeric_primitive_cast_executor.h
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <functional>
+#include <map>
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+enum class FieldType;
+
+class StringToNumericPrimitiveCastExecutor : public CastExecutor {
+ public:
+    StringToNumericPrimitiveCastExecutor();
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+
+ private:
+    template <typename TargetType>
+    static Result<Literal> CastLiteral(const Literal& literal, const FieldType& target_type);
+
+ private:
+    std::map<FieldType, std::function<Result<Literal>(const Literal&)>> literal_cast_executor_map_;
+};
+}  // namespace paimon


### PR DESCRIPTION
## Introduce Type Casting Executors for Schema Evolution

### Summary

Add a set of `CastExecutor` implementations under `src/paimon/core/casting/` to support type casting between boolean, numeric, decimal, and string types. These executors are essential for schema evolution scenarios where column types change across table versions, enabling predicate pushdown and data reading to work correctly across different schemas.

Each executor supports two casting modes:
- **Literal casting**: Converts a single `Literal` value to the target type (used during predicate rewriting).
- **Array casting**: Converts an entire Arrow `Array` to the target type (used during batch data reading).

### New Classes

**`BooleanToDecimalCastExecutor`** — Casts boolean values to decimal types. Converts `true` to `Decimal128(1)` and `false` to `Decimal128(0)` with the specified target precision and scale.

**`BooleanToNumericCastExecutor`** — Casts boolean values to numeric primitive types (int8, int16, int32, int64, float, double). Uses a dispatch map to route casting logic per target `FieldType`, mapping `true` to `1` and `false` to `0`.

**`BooleanToStringCastExecutor`** — Casts boolean values to string type. Converts `true` to `"true"` and `false` to `"false"`.

**`DecimalToDecimalCastExecutor`** — Casts decimal values between different precision/scale decimal types. Handles rescaling by adjusting the underlying `Decimal128` representation to match the target precision and scale, with overflow detection.

**`DecimalToNumericPrimitiveCastExecutor`** — Casts decimal values to numeric primitive types. Truncates the decimal value to the target integer or floating-point type by dividing out the scale factor.

**`NumericPrimitiveToDecimalCastExecutor`** — Casts numeric primitive values (int8 through double) to decimal types. Employs templated dispatch to handle each source type, scaling the input value to the target decimal precision and scale.

**`NumericToBooleanCastExecutor`** — Casts numeric values to boolean type. Uses a dispatch map per source `FieldType`, converting zero values to `false` and non-zero values to `true`.

**`NumericToStringCastExecutor`** — Casts numeric values to string type. Uses a dispatch map per source `FieldType`, converting each numeric value to its string representation.

**`StringToBooleanCastExecutor`** — Casts string values to boolean type. Recognizes `"true"`/`"TRUE"` as `true` and `"false"`/`"FALSE"` as `false`, returning an error for unrecognized string values.

**`StringToDecimalCastExecutor`** — Casts string values to decimal types. Parses the string into an `arrow::Decimal128` value with the specified target precision and scale, with support for null propagation when parsing fails.

**`StringToNumericPrimitiveCastExecutor`** — Casts string values to numeric primitive types (int8 through double). Uses a templated dispatch map per target `FieldType`, parsing the string representation into the corresponding numeric value.