### PR TITLE
feat: introduce type casting executors for Binary, Date, and Timestam…

### DIFF
--- a/src/paimon/core/casting/binary_to_string_cast_executor.cpp
+++ b/src/paimon/core/casting/binary_to_string_cast_executor.cpp
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/binary_to_string_cast_executor.h"
+
+#include <cassert>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/defs.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> BinaryToStringCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::BINARY);
+    PAIMON_ASSIGN_OR_RAISE(FieldType target_field_type,
+                           FieldTypeUtils::ConvertToFieldType(target_type->id()));
+    assert(target_field_type == FieldType::STRING);
+    if (literal.IsNull()) {
+        return Literal(target_field_type);
+    }
+    auto value = literal.GetValue<std::string>();
+    return Literal(FieldType::STRING, value.data(), value.size());
+}
+
+Result<std::shared_ptr<arrow::Array>> BinaryToStringCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    options.allow_invalid_utf8 = true;
+    return CastingUtils::Cast(array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/binary_to_string_cast_executor.h
+++ b/src/paimon/core/casting/binary_to_string_cast_executor.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class BinaryToStringCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/date_to_string_cast_executor.cpp
+++ b/src/paimon/core/casting/date_to_string_cast_executor.cpp
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/date_to_string_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+
+#include "arrow/compute/cast.h"
+#include "arrow/scalar.h"
+#include "arrow/type.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/defs.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> DateToStringCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(target_type->id() == arrow::Type::type::STRING);
+    assert(literal.GetType() == FieldType::DATE);
+    return CastingUtils::Cast<arrow::Date32Scalar, int32_t, arrow::StringScalar, std::string>(
+        literal, arrow::date32(), target_type, arrow::compute::CastOptions::Safe());
+}
+
+Result<std::shared_ptr<arrow::Array>> DateToStringCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    return CastingUtils::Cast(array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/date_to_string_cast_executor.h
+++ b/src/paimon/core/casting/date_to_string_cast_executor.h
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class DateToStringCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/date_to_timestamp_cast_executor.cpp
+++ b/src/paimon/core/casting/date_to_timestamp_cast_executor.cpp
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/date_to_timestamp_cast_executor.h"
+
+#include <cassert>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+
+Result<Literal> DateToTimestampCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    return Status::Invalid("do not support cast literal from date to timestamp");
+}
+
+Result<std::shared_ptr<arrow::Array>> DateToTimestampCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    auto target_ts_type = arrow::internal::checked_pointer_cast<arrow::TimestampType>(target_type);
+    assert(target_ts_type);
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+
+    auto target_ts_type_no_tz = arrow::timestamp(target_ts_type->unit());
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> target_array,
+                           CastingUtils::Cast(array, target_ts_type_no_tz, options, pool));
+    if (target_ts_type->timezone().empty()) {
+        return target_array;
+    }
+    // handle timezone
+    return CastingUtils::TimestampToTimestampWithTimezone(target_array, target_ts_type, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/date_to_timestamp_cast_executor.h
+++ b/src/paimon/core/casting/date_to_timestamp_cast_executor.h
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class DateToTimestampCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    // Noted that: Java Paimon supports date values ranging from 0000-01-01 to 9999-12-31, while C++
+    // Paimon only supports from (min_int64/NANOS_PER_DAY) to (max_int64/NANOS_PER_DAY) while target
+    // type is NANO unit.
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/numeric_primitive_to_timestamp_cast_executor.cpp
+++ b/src/paimon/core/casting/numeric_primitive_to_timestamp_cast_executor.cpp
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/numeric_primitive_to_timestamp_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+#include "arrow/array/array_base.h"
+#include "arrow/array/builder_dict.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/core/casting/timestamp_to_timestamp_cast_executor.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+template <typename TYPE>
+class NumericArray;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> NumericPrimitiveToTimestampCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    return Status::Invalid("do not support cast literal from numeric primitive to timestamp");
+}
+
+Result<std::shared_ptr<arrow::Array>> NumericPrimitiveToTimestampCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    auto src_type = array->type();
+    assert(src_type->id() == arrow::Type::type::INT32 ||
+           src_type->id() == arrow::Type::type::INT64);
+    auto target_array = array;
+    // 1. int32/int64 array to int64 array
+    if (src_type->id() == arrow::Type::type::INT32) {
+        arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+        PAIMON_ASSIGN_OR_RAISE(target_array,
+                               CastingUtils::Cast(target_array, arrow::int64(), options, pool));
+    }
+    // 2. int64 array to timestamp(second, tz) array
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    auto ts_second_tz = arrow::timestamp(arrow::TimeUnit::SECOND, timezone);
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(target_array, target_array->View(ts_second_tz));
+    // 3. timestamp(second, tz) array to target ts array
+    auto timestamp_to_timestamp_cast_executor =
+        std::make_shared<TimestampToTimestampCastExecutor>();
+    PAIMON_ASSIGN_OR_RAISE(
+        target_array, timestamp_to_timestamp_cast_executor->Cast(target_array, target_type, pool));
+    return target_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/numeric_primitive_to_timestamp_cast_executor.h
+++ b/src/paimon/core/casting/numeric_primitive_to_timestamp_cast_executor.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class NumericPrimitiveToTimestampCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    // Noted that: 1.Java Paimon can cast numeric range [min_int64/1000, max_int64/1000]
+    // while C++ Paimon can only cast numeric range [min_int64/1e9, max_int64/1e9]
+    // value while target type is nano, beyond C++ Paimon range will be undefined behavior
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_binary_cast_executor.cpp
+++ b/src/paimon/core/casting/string_to_binary_cast_executor.cpp
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/string_to_binary_cast_executor.h"
+
+#include <cassert>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/defs.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> StringToBinaryCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::STRING);
+    PAIMON_ASSIGN_OR_RAISE(FieldType target_field_type,
+                           FieldTypeUtils::ConvertToFieldType(target_type->id()));
+    assert(target_field_type == FieldType::BINARY);
+    if (literal.IsNull()) {
+        return Literal(target_field_type);
+    }
+    auto value = literal.GetValue<std::string>();
+    return Literal(FieldType::BINARY, value.data(), value.size());
+}
+
+Result<std::shared_ptr<arrow::Array>> StringToBinaryCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    return CastingUtils::Cast(array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_binary_cast_executor.h
+++ b/src/paimon/core/casting/string_to_binary_cast_executor.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class StringToBinaryCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_date_cast_executor.cpp
+++ b/src/paimon/core/casting/string_to_date_cast_executor.cpp
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/string_to_date_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <string>
+#include <utility>
+
+#include "arrow/array/array_binary.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/defs.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> StringToDateCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    assert(literal.GetType() == FieldType::STRING);
+    PAIMON_ASSIGN_OR_RAISE(FieldType target_field_type,
+                           FieldTypeUtils::ConvertToFieldType(target_type->id()));
+    assert(target_field_type == FieldType::DATE);
+    if (literal.IsNull()) {
+        return Literal(target_field_type);
+    }
+    auto value = literal.GetValue<std::string>();
+    PAIMON_ASSIGN_OR_RAISE(int32_t date_value, StringUtils::StringToDate(value));
+    return Literal(FieldType::DATE, date_value);
+}
+
+Result<std::shared_ptr<arrow::Array>> StringToDateCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    auto* string_array = arrow::internal::checked_cast<arrow::StringArray*>(array.get());
+    assert(string_array);
+    auto date_builder = std::make_shared<arrow::Date32Builder>(pool);
+    for (int64_t i = 0; i < string_array->length(); ++i) {
+        if (string_array->IsNull(i)) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(date_builder->AppendNull());
+        } else {
+            PAIMON_ASSIGN_OR_RAISE(int32_t date_value,
+                                   StringUtils::StringToDate(string_array->GetString(i)));
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(date_builder->Append(date_value));
+        }
+    }
+    std::shared_ptr<arrow::Array> casted_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(date_builder->Finish(&casted_array));
+    return casted_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_date_cast_executor.h
+++ b/src/paimon/core/casting/string_to_date_cast_executor.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class StringToDateCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_timestamp_cast_executor.cpp
+++ b/src/paimon/core/casting/string_to_timestamp_cast_executor.cpp
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/string_to_timestamp_cast_executor.h"
+
+#include <cassert>
+#include <string>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+
+Result<Literal> StringToTimestampCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    return Status::Invalid("do not support cast literal from string to timestamp");
+}
+
+Result<std::shared_ptr<arrow::Array>> StringToTimestampCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    auto timestamp_type = arrow::internal::checked_pointer_cast<arrow::TimestampType>(target_type);
+    assert(timestamp_type);
+    auto target_type_no_tz = arrow::timestamp(timestamp_type->unit());
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> target_array,
+                           CastingUtils::Cast(array, target_type_no_tz, options, pool));
+    if (!timestamp_type->timezone().empty()) {
+        PAIMON_ASSIGN_OR_RAISE(target_array, CastingUtils::TimestampToTimestampWithTimezone(
+                                                 target_array, timestamp_type, pool));
+    }
+    return target_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/string_to_timestamp_cast_executor.h
+++ b/src/paimon/core/casting/string_to_timestamp_cast_executor.h
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class StringToTimestampCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    // Noted that: 1.Java Paimon can cast timestamp range [0000-01-01 00:00:00.00000000, 9999-12-31
+    // 23:59:59.999999999] while C++ Paimon can cast timestamp range [min_int64, max_int64] while
+    // target type is nano, ns value beyond C++ Paimon range will be undefined behavior; 2.Java
+    // Paimon supports passing a numeric value in TimestampType while C++ Paimon does not; 3. C++
+    // Paimon supports the format "1970-01-01T00:00:00" while Java paimon does not
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/timestamp_to_date_cast_executor.cpp
+++ b/src/paimon/core/casting/timestamp_to_date_cast_executor.cpp
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/timestamp_to_date_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <utility>
+
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+
+namespace arrow {
+class MemoryPool;
+class Array;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> TimestampToDateCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    return Status::Invalid("do not support cast literal from timestamp to date");
+}
+
+Result<std::shared_ptr<arrow::Array>> TimestampToDateCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    auto target_array = array;
+    auto src_ts_type = arrow::internal::checked_pointer_cast<arrow::TimestampType>(array->type());
+    if (!src_ts_type->timezone().empty()) {
+        auto target_type_no_tz = std::make_shared<arrow::TimestampType>(src_ts_type->unit());
+        PAIMON_ASSIGN_OR_RAISE(target_array, CastingUtils::TimestampWithTimezoneToTimestamp(
+                                                 target_array, target_type_no_tz, pool));
+    }
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    return CastingUtils::Cast(target_array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/timestamp_to_date_cast_executor.h
+++ b/src/paimon/core/casting/timestamp_to_date_cast_executor.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class TimestampToDateCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/timestamp_to_numeric_primitive_cast_executor.cpp
+++ b/src/paimon/core/casting/timestamp_to_numeric_primitive_cast_executor.cpp
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/timestamp_to_numeric_primitive_cast_executor.h"
+
+#include <cassert>
+#include <cstdint>
+#include <utility>
+
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_primitive.h"
+#include "arrow/array/builder_base.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/core/casting/timestamp_to_timestamp_cast_executor.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+template <typename T>
+class NumericBuilder;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> TimestampToNumericPrimitiveCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    return Status::Invalid("do not support cast literal from timestamp to numeric primitive");
+}
+
+Result<std::shared_ptr<arrow::Array>> TimestampToNumericPrimitiveCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    auto timestamp_type =
+        arrow::internal::checked_pointer_cast<arrow::TimestampType>(array->type());
+    assert(timestamp_type);
+    assert(target_type->id() == arrow::Type::type::INT32 ||
+           target_type->id() == arrow::Type::type::INT64);
+    auto timestamp_to_timestamp_cast_executor =
+        std::make_shared<TimestampToTimestampCastExecutor>();
+    auto target_array = array;
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    auto ts_with_sec_tz = arrow::timestamp(arrow::TimeUnit::SECOND, timezone);
+    // 1. timestamp array cast to timestamp(second, tz)
+    PAIMON_ASSIGN_OR_RAISE(target_array, timestamp_to_timestamp_cast_executor->Cast(
+                                             target_array, ts_with_sec_tz, pool));
+    // 2. timestamp(second, tz) array cast to int32/int64 array, as output integer indicates
+    // second
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(target_array, target_array->View(arrow::int64()));
+    if (target_type->id() == arrow::Type::type::INT32) {
+        arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+        options.allow_int_overflow = true;
+        PAIMON_ASSIGN_OR_RAISE(target_array,
+                               CastingUtils::Cast(target_array, target_type, options, pool));
+    }
+    return target_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/timestamp_to_numeric_primitive_cast_executor.h
+++ b/src/paimon/core/casting/timestamp_to_numeric_primitive_cast_executor.h
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class TimestampToNumericPrimitiveCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    // output integer array indicates second, when src array has higher precision (e.g., > 0),
+    // there may be inconsistent with Java Paimon
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/timestamp_to_string_cast_executor.cpp
+++ b/src/paimon/core/casting/timestamp_to_string_cast_executor.cpp
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/timestamp_to_string_cast_executor.h"
+
+#include <string>
+
+#include "arrow/array/array_base.h"
+#include "arrow/compute/cast.h"
+#include "arrow/type.h"
+#include "arrow/util/checked_cast.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+Result<Literal> TimestampToStringCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    return Status::Invalid("do not support cast literal from timestamp to string");
+}
+
+Result<std::shared_ptr<arrow::Array>> TimestampToStringCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    auto target_array = array;
+    auto src_ts_type = arrow::internal::checked_pointer_cast<arrow::TimestampType>(array->type());
+    if (!src_ts_type->timezone().empty()) {
+        auto target_type_no_tz = std::make_shared<arrow::TimestampType>(src_ts_type->unit());
+        PAIMON_ASSIGN_OR_RAISE(target_array, CastingUtils::TimestampWithTimezoneToTimestamp(
+                                                 target_array, target_type_no_tz, pool));
+    }
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    return CastingUtils::Cast(target_array, target_type, options, pool);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/casting/timestamp_to_string_cast_executor.h
+++ b/src/paimon/core/casting/timestamp_to_string_cast_executor.h
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "arrow/array/array_base.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class MemoryPool;
+}  // namespace arrow
+
+namespace paimon {
+class TimestampToStringCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/casting/timestamp_to_timestamp_cast_executor.cpp
+++ b/src/paimon/core/casting/timestamp_to_timestamp_cast_executor.cpp
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/casting/timestamp_to_timestamp_cast_executor.h"
+
+#include <memory>
+
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/core/casting/casting_utils.h"
+
+namespace paimon {
+Result<Literal> TimestampToTimestampCastExecutor::Cast(
+    const Literal& literal, const std::shared_ptr<arrow::DataType>& target_type) const {
+    return Status::Invalid("do not support cast literal from timestamp to timestamp");
+}
+
+Result<std::shared_ptr<arrow::Array>> TimestampToTimestampCastExecutor::Cast(
+    const std::shared_ptr<arrow::Array>& array, const std::shared_ptr<arrow::DataType>& target_type,
+    arrow::MemoryPool* pool) const {
+    arrow::compute::CastOptions options = arrow::compute::CastOptions::Safe();
+    options.allow_time_truncate = true;
+    auto src_ts_type = arrow::internal::checked_pointer_cast<arrow::TimestampType>(array->type());
+    auto target_ts_type = arrow::internal::checked_pointer_cast<arrow::TimestampType>(target_type);
+    assert(src_ts_type && target_ts_type);
+    std::shared_ptr<arrow::Array> target_array = array;
+    // first, handle timezone
+    if (src_ts_type->timezone() != target_ts_type->timezone()) {
+        auto target_type_with_tz =
+            std::make_shared<arrow::TimestampType>(src_ts_type->unit(), target_ts_type->timezone());
+        if (src_ts_type->timezone().empty() && !target_type_with_tz->timezone().empty()) {
+            PAIMON_ASSIGN_OR_RAISE(target_array, CastingUtils::TimestampToTimestampWithTimezone(
+                                                     target_array, target_type_with_tz, pool));
+        } else if (!src_ts_type->timezone().empty() && target_type_with_tz->timezone().empty()) {
+            PAIMON_ASSIGN_OR_RAISE(target_array, CastingUtils::TimestampWithTimezoneToTimestamp(
+                                                     target_array, target_type_with_tz, pool));
+        } else {
+            // src and target have non-empty different timezone
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(target_array,
+                                              target_array->View(target_type_with_tz));
+        }
+    }
+    // second, handle precision
+    if (src_ts_type->unit() != target_ts_type->unit()) {
+        PAIMON_ASSIGN_OR_RAISE(target_array,
+                               CastingUtils::Cast(target_array, target_type, options, pool));
+    }
+    return target_array;
+}
+}  // namespace paimon

--- a/src/paimon/core/casting/timestamp_to_timestamp_cast_executor.h
+++ b/src/paimon/core/casting/timestamp_to_timestamp_cast_executor.h
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "paimon/core/casting/cast_executor.h"
+
+namespace paimon {
+/// support convert between TIMESTAMP and TIMESTAMP_WITH_LOCAL_TIME_ZONE. Check and adjust if there
+/// is the precision changes at the same time.
+class PAIMON_EXPORT TimestampToTimestampCastExecutor : public CastExecutor {
+ public:
+    Result<Literal> Cast(const Literal& literal,
+                         const std::shared_ptr<arrow::DataType>& target_type) const override;
+
+    Result<std::shared_ptr<arrow::Array>> Cast(const std::shared_ptr<arrow::Array>& array,
+                                               const std::shared_ptr<arrow::DataType>& target_type,
+                                               arrow::MemoryPool* pool) const override;
+};
+
+}  // namespace paimon


### PR DESCRIPTION
## Introduce Type Casting Executors for Binary, Date, and Timestamp Types

### Summary

Add a set of `CastExecutor` implementations under `src/paimon/core/casting/` to support type casting between binary, date, timestamp, string, and numeric types. These executors extend the casting framework to cover temporal and binary type conversions required for schema evolution scenarios.

Each executor supports two casting modes:
- **Literal casting**: Converts a single `Literal` value to the target type (used during predicate rewriting).
- **Array casting**: Converts an entire Arrow `Array` to the target type (used during batch data reading).

### New Classes

**`BinaryToStringCastExecutor`** — Casts binary (byte array) values to string type by interpreting the raw bytes as a UTF-8 encoded string.

**`DateToStringCastExecutor`** — Casts date values (days since epoch) to their ISO-8601 string representation (e.g., `"2024-01-15"`).

**`DateToTimestampCastExecutor`** — Casts date values to timestamp types with configurable time unit (seconds, milliseconds, microseconds, nanoseconds). Sets the time component to midnight (00:00:00). Note: C++ Paimon supports a narrower date range than Java Paimon when the target unit is nanoseconds, limited by int64 bounds.

**`NumericPrimitiveToTimestampCastExecutor`** — Casts numeric primitive values (interpreted as seconds since epoch) to timestamp types with the specified precision. Note: When the target type is nanosecond precision, the valid numeric range is narrower than Java Paimon due to int64 overflow constraints.

**`StringToBinaryCastExecutor`** — Casts string values to binary type by encoding the string content as raw bytes.

**`StringToDateCastExecutor`** — Casts string values in date format (e.g., `"2024-01-15"`) to date type (days since epoch).

**`StringToTimestampCastExecutor`** — Casts string values in timestamp format to timestamp types. Supports ISO-8601 formats including `"1970-01-01T00:00:00"`. Note: Differs from Java Paimon in that it does not support passing numeric values as timestamp strings, but additionally supports the `T`-separated format.

**`TimestampToDateCastExecutor`** — Casts timestamp values to date type by truncating the time component and retaining only the date part (days since epoch).

**`TimestampToNumericPrimitiveCastExecutor`** — Casts timestamp values to numeric primitive types by extracting the epoch seconds. When the source timestamp has sub-second precision, the fractional part is truncated.

**`TimestampToStringCastExecutor`** — Casts timestamp values to their ISO-8601 string representation with appropriate precision (e.g., `"2024-01-15 12:30:45.123"`).

**`TimestampToTimestampCastExecutor`** — Converts between `TIMESTAMP` and `TIMESTAMP_WITH_LOCAL_TIME_ZONE` types, handling precision changes (e.g., milliseconds to nanoseconds) by scaling the underlying int64 value accordingly.