### PR TITLE
feat(mergetree): add compaction core components and level management

### DIFF
--- a/src/paimon/core/mergetree/compact/compact_rewriter.h
+++ b/src/paimon/core/mergetree/compact/compact_rewriter.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#pragma once
+
+#include "paimon/core/compact/compact_result.h"
+#include "paimon/core/mergetree/sorted_run.h"
+#include "paimon/result.h"
+
+namespace paimon {
+
+/// Rewrite sections to new level.
+class CompactRewriter {
+ public:
+    virtual ~CompactRewriter() = default;
+    /// Rewrite sections to new level
+    ///
+    /// @param output_level new level
+    /// @param drop_delete whether to drop the deletion, see
+    /// `MergeTreeCompactManager::TriggerCompaction`
+    /// @param sections list of sections (section is a list of `SortedRun`s, and key intervals
+    /// between sections do not overlap)
+    /// @return compaction result
+    virtual Result<CompactResult> Rewrite(int32_t output_level, bool drop_delete,
+                                          const std::vector<std::vector<SortedRun>>& sections) = 0;
+
+    /// Upgrade file to new level, usually file data is not rewritten, only the metadata is updated.
+    /// But in some certain scenarios, we must rewrite file too, e.g. `ChangelogMergeTreeRewriter`
+    ///
+    /// @param output_level new level
+    /// @param file file to be updated
+    /// @return compaction result
+    virtual Result<CompactResult> Upgrade(int32_t output_level,
+                                          const std::shared_ptr<DataFileMeta>& file) = 0;
+
+    /// Close rewriter.
+    virtual Status Close() = 0;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/compact_strategy.h
+++ b/src/paimon/core/mergetree/compact/compact_strategy.h
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#pragma once
+
+#include "paimon/core/compact/compact_unit.h"
+#include "paimon/core/deletionvectors/bucketed_dv_maintainer.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/mergetree/level_sorted_run.h"
+namespace paimon {
+/// Compact strategy to decide which files to select for compaction.
+class CompactStrategy {
+ public:
+    virtual ~CompactStrategy() = default;
+
+    /// Pick compaction unit from runs.
+    /// @note Compaction is runs-based, not file-based.
+    ///       Level 0 is special, one run per file; all other levels are one run per level.
+    ///       Compaction is sequential from small level to large level.
+    virtual Result<std::optional<CompactUnit>> Pick(int32_t num_levels,
+                                                    const std::vector<LevelSortedRun>& runs) = 0;
+    /// Pick a compaction unit consisting of all existing files.
+    // TODO(xinyu.lxy): support RecordLevelExpire
+    static std::optional<CompactUnit> PickFullCompaction(
+        int32_t num_levels, const std::vector<LevelSortedRun>& runs,
+        const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, bool force_rewrite_all_files) {
+        int32_t max_level = num_levels - 1;
+        if (runs.empty()) {
+            // no sorted run, no need to compact
+            return std::nullopt;
+        }
+        // only max level files
+        if (runs.size() == 1 && runs[0].level == max_level) {
+            std::vector<std::shared_ptr<DataFileMeta>> files_to_be_compacted;
+            const auto& run = runs[0];
+            for (const auto& file : run.run.Files()) {
+                if (force_rewrite_all_files) {
+                    // add all files when force compacted
+                    files_to_be_compacted.push_back(file);
+                } else if (dv_maintainer && dv_maintainer->DeletionVectorOf(file->file_name)) {
+                    // check deletion vector for large files
+                    files_to_be_compacted.push_back(file);
+                }
+                // TODO(xinyu.lxy): support RecordLevelExpire
+            }
+            if (files_to_be_compacted.empty()) {
+                return std::nullopt;
+            }
+            return CompactUnit::FromFiles(max_level, files_to_be_compacted, /*file_rewrite=*/true);
+        }
+        // full compaction
+        return CompactUnit::FromLevelRuns(max_level, runs);
+    }
+};
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/compact_strategy_test.cpp
+++ b/src/paimon/core/mergetree/compact/compact_strategy_test.cpp
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "paimon/core/mergetree/compact/compact_strategy.h"
+
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+class CompactStrategyTest : public testing::Test {
+ public:
+    LevelSortedRun CreateLevelSortedRun(int32_t level, int64_t total_size) const {
+        auto file_meta = std::make_shared<DataFileMeta>(
+            "fake.data", /*file_size=*/total_size, /*row_count=*/1,
+            /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/
+            BinaryRow::EmptyRow(),
+            /*key_stats=*/
+            SimpleStats::EmptyStats(),
+            /*value_stats=*/
+            SimpleStats::EmptyStats(),
+            /*min_sequence_number=*/0, /*max_sequence_number=*/6, /*schema_id=*/0,
+            /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(0ll, 0),
+            /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+            /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+            /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt);
+        return {level, SortedRun::FromSingle(file_meta)};
+    }
+
+    std::vector<LevelSortedRun> CreateRunsWithLevelAndSize(
+        const std::vector<int32_t>& levels, const std::vector<int64_t>& sizes) const {
+        EXPECT_EQ(levels.size(), sizes.size());
+        std::vector<LevelSortedRun> runs;
+        for (size_t i = 0; i < levels.size(); i++) {
+            runs.push_back(CreateLevelSortedRun(levels[i], sizes[i]));
+        }
+        return runs;
+    }
+};
+
+TEST_F(CompactStrategyTest, TestPickFullCompaction) {
+    {
+        // no sorted run, no need to compact
+        auto runs = CreateRunsWithLevelAndSize({}, {});
+        auto unit =
+            CompactStrategy::PickFullCompaction(/*num_levels=*/3, runs, /*dv_maintainer=*/nullptr,
+                                                /*force_rewrite_all_files=*/false);
+        ASSERT_FALSE(unit);
+    }
+    {
+        // only max level files, not rewrite
+        auto runs = CreateRunsWithLevelAndSize(/*levels=*/{3}, /*sizes*/ {10});
+        auto unit =
+            CompactStrategy::PickFullCompaction(/*num_levels=*/4, runs, /*dv_maintainer=*/nullptr,
+                                                /*force_rewrite_all_files=*/false);
+        ASSERT_FALSE(unit);
+    }
+    {
+        // only max level files, force rewrite
+        auto runs = CreateRunsWithLevelAndSize(/*levels=*/{3}, /*sizes*/ {10});
+        auto unit =
+            CompactStrategy::PickFullCompaction(/*num_levels=*/4, runs, /*dv_maintainer=*/nullptr,
+                                                /*force_rewrite_all_files=*/true);
+        ASSERT_TRUE(unit);
+        ASSERT_EQ(unit.value().output_level, 3);
+        ASSERT_EQ(unit.value().files.size(), 1);
+        ASSERT_TRUE(unit.value().file_rewrite);
+    }
+    {
+        // full compaction
+        auto runs = CreateRunsWithLevelAndSize(/*levels=*/{0, 3}, /*sizes*/ {1, 10});
+        auto unit =
+            CompactStrategy::PickFullCompaction(/*num_levels=*/4, runs, /*dv_maintainer=*/nullptr,
+                                                /*force_rewrite_all_files=*/false);
+        ASSERT_TRUE(unit);
+        ASSERT_EQ(unit.value().output_level, 3);
+        ASSERT_EQ(unit.value().files.size(), 2);
+        ASSERT_FALSE(unit.value().file_rewrite);
+    }
+    {
+        // test with dv maintainer
+        std::map<std::string, std::shared_ptr<DeletionVector>> deletion_vectors = {
+            {"fake.data", std::make_shared<BitmapDeletionVector>(RoaringBitmap32())}};
+
+        auto dv_maintainer = std::make_shared<BucketedDvMaintainer>(
+            std::make_shared<DeletionVectorsIndexFile>(nullptr, nullptr, /*bitmap64=*/false,
+                                                       GetDefaultPool()),
+            deletion_vectors);
+        auto runs = CreateRunsWithLevelAndSize(/*levels=*/{3}, /*sizes*/ {10});
+        auto unit = CompactStrategy::PickFullCompaction(/*num_levels=*/4, runs, dv_maintainer,
+                                                        /*force_rewrite_all_files=*/false);
+        ASSERT_TRUE(unit);
+        ASSERT_EQ(unit.value().output_level, 3);
+        ASSERT_EQ(unit.value().files.size(), 1);
+        ASSERT_TRUE(unit.value().file_rewrite);
+    }
+}
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/interval_partition.cpp
+++ b/src/paimon/core/mergetree/compact/interval_partition.cpp
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "paimon/core/mergetree/compact/interval_partition.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <queue>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/io/data_file_meta.h"
+
+namespace paimon {
+
+IntervalPartition::IntervalPartition(const std::vector<std::shared_ptr<DataFileMeta>>& input_files,
+                                     const std::shared_ptr<FieldsComparator>& key_comparator)
+    : files_(input_files), key_comparator_(key_comparator) {
+    std::stable_sort(
+        files_.begin(), files_.end(),
+        [this](const std::shared_ptr<DataFileMeta>& o1, const std::shared_ptr<DataFileMeta>& o2) {
+            int32_t left_result = key_comparator_->CompareTo(o1->min_key, o2->min_key);
+            if (left_result == 0) {
+                int32_t right_result = key_comparator_->CompareTo(o1->max_key, o2->max_key);
+                return right_result < 0;
+            }
+            return left_result < 0;
+        });
+}
+
+std::vector<std::vector<SortedRun>> IntervalPartition::Partition() const {
+    std::vector<std::vector<SortedRun>> result;
+    std::vector<std::shared_ptr<DataFileMeta>> section;
+    BinaryRow bound = BinaryRow::EmptyRow();
+    for (const auto& meta : files_) {
+        if (!section.empty() && key_comparator_->CompareTo(meta->min_key, bound) > 0) {
+            result.push_back(Partition(section));
+            section.clear();
+            bound = BinaryRow::EmptyRow();
+        }
+        section.push_back(meta);
+        if (bound == BinaryRow::EmptyRow() ||
+            key_comparator_->CompareTo(meta->max_key, bound) > 0) {
+            bound = section.back()->max_key;
+        }
+    }
+
+    if (!section.empty()) {
+        result.push_back(Partition(section));
+    }
+
+    return result;
+}
+
+std::vector<SortedRun> IntervalPartition::Partition(
+    const std::vector<std::shared_ptr<DataFileMeta>>& metas) const {
+    auto comparator = [this](const std::vector<std::shared_ptr<DataFileMeta>>& o1,
+                             const std::vector<std::shared_ptr<DataFileMeta>>& o2) {
+        int32_t right_result = key_comparator_->CompareTo(o1.back()->max_key, o2.back()->max_key);
+        if (right_result == 0) {
+            return key_comparator_->CompareTo(o1.back()->min_key, o2.back()->min_key) > 0;
+        }
+        return right_result > 0;
+    };
+
+    std::priority_queue<std::vector<std::shared_ptr<DataFileMeta>>,
+                        std::vector<std::vector<std::shared_ptr<DataFileMeta>>>,
+                        decltype(comparator)>
+        queue(comparator);
+
+    std::vector<std::shared_ptr<DataFileMeta>> first_run = {metas.front()};
+    queue.push(first_run);
+
+    for (size_t i = 1; i < metas.size(); ++i) {
+        const auto& meta = metas[i];
+        auto top = queue.top();
+        queue.pop();
+
+        if (key_comparator_->CompareTo(meta->min_key, top.back()->max_key) > 0) {
+            top.push_back(meta);
+        } else {
+            std::vector<std::shared_ptr<DataFileMeta>> new_run = {meta};
+            queue.push(new_run);
+        }
+        queue.push(top);
+    }
+
+    std::vector<SortedRun> sorted_runs;
+    while (!queue.empty()) {
+        sorted_runs.emplace_back(SortedRun::FromSorted(queue.top()));
+        queue.pop();
+    }
+    return sorted_runs;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/interval_partition.h
+++ b/src/paimon/core/mergetree/compact/interval_partition.h
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/mergetree/sorted_run.h"
+
+namespace paimon {
+
+/// Algorithm to partition several data files into the minimum number of `SortedRun`s.
+class IntervalPartition {
+ public:
+    IntervalPartition(const std::vector<std::shared_ptr<DataFileMeta>>& input_files,
+                      const std::shared_ptr<FieldsComparator>& key_comparator);
+
+    /// Returns a two-dimensional list of `SortedRun`s.
+    ///
+    /// The elements of the outer list are sections. Key intervals between sections do not
+    /// overlap. This extra layer is to minimize the number of `SortedRun`s dealt at the same
+    /// time.
+    ///
+    /// The elements of the inner list are `SortedRun`s within a section.
+    ///
+    /// Users are expected to use the results by this way:
+    ///
+    /// @code
+    /// for (List<SortedRun> section : algorithm.partition()) {
+    ///     // do some merge sorting within section
+    /// }
+    /// @endcode
+    std::vector<std::vector<SortedRun>> Partition() const;
+
+ private:
+    std::vector<SortedRun> Partition(const std::vector<std::shared_ptr<DataFileMeta>>& metas) const;
+
+ private:
+    std::vector<std::shared_ptr<DataFileMeta>> files_;
+    std::shared_ptr<FieldsComparator> key_comparator_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/interval_partition_test.cpp
+++ b/src/paimon/core/mergetree/compact/interval_partition_test.cpp
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "paimon/core/mergetree/compact/interval_partition.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <regex>
+#include <string>
+
+#include "arrow/type_fwd.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class IntervalPartitionTest : public testing::Test {
+ public:
+    void SetUp() override {
+        ASSERT_OK_AND_ASSIGN(comparator_, FieldsComparator::Create(
+                                              {DataField(0, arrow::field("test", arrow::int32()))},
+                                              /*is_ascending_order=*/true));
+        pool_ = GetDefaultPool();
+    }
+
+ private:
+    void RunTest(const std::string& in, const std::string& expected_str) const {
+        IntervalPartition algorithm(ParseMetas(in), comparator_);
+        std::vector<std::vector<SortedRun>> expected;
+        for (const auto& line : StringUtils::Split(expected_str, "\n")) {
+            expected.push_back(ParseSortedRuns(line));
+        }
+
+        std::vector<std::vector<SortedRun>> actual = algorithm.Partition();
+        for (const auto& section : actual) {
+            for (const auto& sorted_run : section) {
+                ASSERT_TRUE(sorted_run.IsValid(comparator_));
+            }
+        }
+        ASSERT_EQ(expected.size(), actual.size());
+        for (size_t i = 0; i < expected.size(); i++) {
+            auto& expected_sorted_runs = expected[i];
+            auto& actual_sorted_runs = actual[i];
+            ASSERT_EQ(expected_sorted_runs.size(), actual_sorted_runs.size());
+            for (size_t j = 0; j < expected_sorted_runs.size(); j++) {
+                auto& expected_files = expected_sorted_runs[j].Files();
+                auto& actual_files = actual_sorted_runs[j].Files();
+                ASSERT_EQ(expected_files.size(), actual_files.size());
+                for (size_t m = 0; m < expected_files.size(); m++) {
+                    ASSERT_EQ(*expected_files[m], *actual_files[m]);
+                }
+            }
+        }
+    }
+
+    std::vector<SortedRun> ParseSortedRuns(const std::string& in) const {
+        std::vector<SortedRun> sorted_runs;
+        for (const auto& s : StringUtils::Split(in, "|")) {
+            sorted_runs.push_back(SortedRun::FromSorted(ParseMetas(s)));
+        }
+        return sorted_runs;
+    }
+
+    std::vector<std::shared_ptr<DataFileMeta>> ParseMetas(const std::string& in) const {
+        std::vector<std::shared_ptr<DataFileMeta>> metas;
+        std::regex pattern(R"(\[(\d+?), (\d+?)\])");
+        std::smatch matches;
+
+        std::string::const_iterator search_start(in.cbegin());
+        while (std::regex_search(search_start, in.cend(), matches, pattern)) {
+            int32_t start = std::stoi(matches[1].str());
+            int32_t end = std::stoi(matches[2].str());
+            metas.push_back(MakeInterval(start, end));
+
+            // Move to the next position in the string to continue searching
+            search_start = matches.suffix().first;
+        }
+        return metas;
+    }
+
+    std::shared_ptr<DataFileMeta> MakeInterval(int32_t left, int32_t right) const {
+        BinaryRow min_key(1);
+        BinaryRowWriter min_writer(&min_key, /*initial_size=*/20, pool_.get());
+        min_writer.WriteInt(0, left);
+        min_writer.Complete();
+
+        BinaryRow max_key(1);
+        BinaryRowWriter max_writer(&max_key, /*initial_size=*/20, pool_.get());
+        max_writer.WriteInt(0, right);
+        max_writer.Complete();
+
+        return std::make_shared<DataFileMeta>(
+            "DUMMY", /*file_size=*/100, /*row_count=*/25, min_key, max_key,
+            SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+            /*min_sequence_number=*/0, /*max_sequence_number=*/24, /*schema_id=*/0,
+            /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(), Timestamp(0, 0),
+            /*delete_row_count=*/std::nullopt, /*embedded_index=*/nullptr, FileSource::Append(),
+            /*value_stats_cols=*/std::nullopt,
+            /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt);
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<FieldsComparator> comparator_;
+};
+
+TEST_F(IntervalPartitionTest, TestSameMinKey) {
+    RunTest("[100, 200], [100, 400], [100, 300], [100, 500]",
+            "[100, 200] | [100, 300] | [100, 400] | [100, 500]");
+}
+
+TEST_F(IntervalPartitionTest, TestSameMaxKey) {
+    RunTest("[100, 500], [300, 500], [200, 500], [400, 500]",
+            "[100, 500] | [200, 500] | [300, 500] | [400, 500]");
+}
+
+TEST_F(IntervalPartitionTest, TestSectionPartitioning) {
+    // 0    5    10   15   20   25   30
+    // |--------|
+    //      |-|
+    //          |-----|
+    //                 |-----|
+    //                 |-----------|
+    //                         |-------|
+    // 0    5    10   15   20   25   30
+    RunTest("[0, 9], [5, 7], [9, 15], [16, 22], [16, 28], [24, 32]",
+            "[0, 9] | [5, 7], [9, 15]\n[16, 28] | [16, 22], [24, 32]");
+}
+
+TEST_F(IntervalPartitionTest, TestSectionPartitioning2) {
+    // 0    5    10   15   20   25   30
+    // |--------|
+    //      |-|
+    //           |----|
+    //                 |-----|
+    //                 |-----------|
+    //                         |-------|
+    // 0    5    10   15   20   25   30
+    RunTest("[0, 9], [5, 7], [10, 15], [16, 22], [16, 28], [24, 32]",
+            "[5, 7] | [0, 9]\n[10, 15] \n[16, 28] | [16, 22], [24, 32]");
+}
+
+TEST_F(IntervalPartitionTest, TestSectionPartitioning3) {
+    RunTest("[0, 10], [2, 3], [4, 5], [15, 20]", "[2, 3], [4, 5] | [0, 10]\n[15, 20]");
+}
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/off_peak_hours.h
+++ b/src/paimon/core/mergetree/compact/off_peak_hours.h
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#pragma once
+#include "paimon/core/core_options.h"
+namespace paimon {
+/// OffPeakHours to control compaction ratio by hours.
+class OffPeakHours {
+ public:
+    /// @return Pointer to `OffPeakHours` if the options contain OffPeakHours settings; otherwise,
+    /// nullptr.
+    static std::shared_ptr<OffPeakHours> Create(const CoreOptions& options) {
+        return Create(options.GetCompactOffPeakStartHour(), options.GetCompactOffPeakEndHour(),
+                      options.GetCompactOffPeakRatio());
+    }
+
+    static std::shared_ptr<OffPeakHours> Create(int32_t start_hour, int32_t end_hour,
+                                                int32_t compact_off_peak_ratio) {
+        if (start_hour == -1 || end_hour == -1) {
+            return nullptr;
+        }
+        if (start_hour == end_hour) {
+            return nullptr;
+        }
+        return std::shared_ptr<OffPeakHours>(
+            new OffPeakHours(start_hour, end_hour, compact_off_peak_ratio));
+    }
+
+    int32_t CurrentRatio(int32_t target_hour) const {
+        bool is_off_peak;
+        if (start_hour_ <= end_hour_) {
+            is_off_peak = start_hour_ <= target_hour && target_hour < end_hour_;
+        } else {
+            is_off_peak = target_hour < end_hour_ || start_hour_ <= target_hour;
+        }
+        return is_off_peak ? compact_off_peak_ratio_ : 0;
+    }
+
+ private:
+    OffPeakHours(int32_t start_hour, int32_t end_hour, int32_t compact_off_peak_ratio)
+        : start_hour_(start_hour),
+          end_hour_(end_hour),
+          compact_off_peak_ratio_(compact_off_peak_ratio) {}
+
+ private:
+    int32_t start_hour_;
+    int32_t end_hour_;
+    int32_t compact_off_peak_ratio_;
+};
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/off_peak_hours_test.cpp
+++ b/src/paimon/core/mergetree/compact/off_peak_hours_test.cpp
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "paimon/core/mergetree/compact/off_peak_hours.h"
+
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(OffPeakHoursTest, TestCreateFromOptions) {
+    std::map<std::string, std::string> options = {{Options::COMPACT_OFFPEAK_START_HOUR, "22"},
+                                                  {Options::COMPACT_OFFPEAK_END_HOUR, "6"},
+                                                  {Options::COMPACTION_OFFPEAK_RATIO, "10"}};
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options));
+    auto off_peak_hours = OffPeakHours::Create(core_options);
+    ASSERT_TRUE(off_peak_hours);
+    ASSERT_EQ(off_peak_hours->CurrentRatio(23), 10);
+    ASSERT_EQ(off_peak_hours->CurrentRatio(7), 0);
+}
+
+TEST(OffPeakHoursTest, TestCreateFromOptionsWithDefault) {
+    std::map<std::string, std::string> options = {};
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options));
+    auto off_peak_hours = OffPeakHours::Create(core_options);
+    ASSERT_FALSE(off_peak_hours);
+}
+
+TEST(OffPeakHoursTest, TestCreateFromOptionsWithSameHour) {
+    std::map<std::string, std::string> options = {{Options::COMPACT_OFFPEAK_START_HOUR, "5"},
+                                                  {Options::COMPACT_OFFPEAK_END_HOUR, "5"},
+                                                  {Options::COMPACTION_OFFPEAK_RATIO, "10"}};
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options));
+    auto off_peak_hours = OffPeakHours::Create(core_options);
+    ASSERT_FALSE(off_peak_hours);
+}
+
+TEST(OffPeakHoursTest, TestCreateWithInvalidHours) {
+    ASSERT_FALSE(
+        OffPeakHours::Create(/*start_hour=*/-1, /*end_hour=*/-1, /*compact_off_peak_ratio=*/10));
+    ASSERT_FALSE(
+        OffPeakHours::Create(/*start_hour=*/5, /*end_hour=*/5, /*compact_off_peak_ratio=*/10));
+    ASSERT_FALSE(
+        OffPeakHours::Create(/*start_hour=*/2, /*end_hour=*/-1, /*compact_off_peak_ratio=*/10));
+    ASSERT_FALSE(
+        OffPeakHours::Create(/*start_hour=*/-1, /*end_hour=*/2, /*compact_off_peak_ratio=*/10));
+}
+
+TEST(OffPeakHoursTest, TestCurrentRatioNormalHours) {
+    auto off_peak_hours =
+        OffPeakHours::Create(/*start_hour=*/2, /*end_hour=*/8, /*compact_off_peak_ratio=*/10);
+    ASSERT_TRUE(off_peak_hours);
+    // Before start
+    ASSERT_EQ(0, off_peak_hours->CurrentRatio(1));
+    // At start
+    ASSERT_EQ(10, off_peak_hours->CurrentRatio(2));
+    // In between
+    ASSERT_EQ(10, off_peak_hours->CurrentRatio(5));
+    // Before end
+    ASSERT_EQ(10, off_peak_hours->CurrentRatio(7));
+    // At end (exclusive)
+    ASSERT_EQ(0, off_peak_hours->CurrentRatio(8));
+    // After end
+    ASSERT_EQ(0, off_peak_hours->CurrentRatio(9));
+}
+
+TEST(OffPeakHoursTest, TestCurrentRatioOvernightHours) {
+    auto off_peak_hours =
+        OffPeakHours::Create(/*start_hour=*/22, /*end_hour=*/6, /*compact_off_peak_ratio=*/10);
+    ASSERT_TRUE(off_peak_hours);
+    // Before start
+    ASSERT_EQ(0, off_peak_hours->CurrentRatio(21));
+    // At start
+    ASSERT_EQ(10, off_peak_hours->CurrentRatio(22));
+    // After start
+    ASSERT_EQ(10, off_peak_hours->CurrentRatio(23));
+    // After midnight, before end
+    ASSERT_EQ(10, off_peak_hours->CurrentRatio(0));
+    // Before end
+    ASSERT_EQ(10, off_peak_hours->CurrentRatio(5));
+    // At end (exclusive)
+    ASSERT_EQ(0, off_peak_hours->CurrentRatio(6));
+    // After end, before next start"
+    ASSERT_EQ(0, off_peak_hours->CurrentRatio(10));
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/level_sorted_run.h
+++ b/src/paimon/core/mergetree/level_sorted_run.h
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#pragma once
+
+#include "fmt/format.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/mergetree/sorted_run.h"
+namespace paimon {
+/// A `SortedRun` with level.
+struct LevelSortedRun {
+    LevelSortedRun(int32_t _level, const SortedRun& _run) : level(_level), run(_run) {}
+
+    std::string ToString() const {
+        return fmt::format("LevelSortedRun{{ level={}, run={} }}", level, run.ToString());
+    }
+
+    bool operator==(const LevelSortedRun& other) const {
+        if (this == &other) {
+            return true;
+        }
+        return level == other.level && run == other.run;
+    }
+
+    int32_t level;
+    SortedRun run;
+};
+}  // namespace paimon

--- a/src/paimon/core/mergetree/levels.cpp
+++ b/src/paimon/core/mergetree/levels.cpp
@@ -1,0 +1,238 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/levels.h"
+
+#include <algorithm>
+namespace paimon {
+bool Levels::Level0Comparator::operator()(const std::shared_ptr<DataFileMeta>& a,
+                                          const std::shared_ptr<DataFileMeta>& b) const {
+    if (a->max_sequence_number != b->max_sequence_number) {
+        // file with larger sequence number should be in front
+        return a->max_sequence_number > b->max_sequence_number;
+    } else {
+        // When two or more jobs are writing the same merge tree, it is
+        // possible that multiple files have the same maxSequenceNumber. In
+        // this case we have to compare their file names so that files with
+        // same maxSequenceNumber won't be "de-duplicated" by the tree set.
+        int64_t min_seq_a = a->min_sequence_number;
+        int64_t min_seq_b = b->min_sequence_number;
+        if (min_seq_a != min_seq_b) {
+            return min_seq_a < min_seq_b;
+        }
+        // If minSequenceNumber is also the same, use creation time
+        Timestamp time_a = a->creation_time;
+        Timestamp time_b = b->creation_time;
+        if (time_a != time_b) {
+            return time_a < time_b;
+        }
+        // Final fallback: filename (to ensure uniqueness in set)
+        return a->file_name < b->file_name;
+    }
+}
+
+Result<std::unique_ptr<Levels>> Levels::Create(
+    const std::shared_ptr<FieldsComparator>& key_comparator,
+    const std::vector<std::shared_ptr<DataFileMeta>>& input_files, int32_t num_levels) {
+    // in case the num of levels is not specified explicitly
+    int32_t restored_num_levels = -1;
+    for (const auto& file : input_files) {
+        if (file->level > restored_num_levels) {
+            restored_num_levels = file->level;
+        }
+    }
+    restored_num_levels = std::max(restored_num_levels + 1, num_levels);
+    if (restored_num_levels <= 1) {
+        return Status::Invalid("Number of levels must be at least 2.");
+    }
+
+    std::set<std::shared_ptr<DataFileMeta>, Levels::Level0Comparator> level0;
+    std::vector<SortedRun> levels;
+    levels.reserve(restored_num_levels - 1);
+    for (int32_t i = 1; i < restored_num_levels; ++i) {
+        levels.push_back(SortedRun::Empty());
+    }
+    auto level_map = GroupByLevel(input_files);
+    for (auto& [level, files] : level_map) {
+        PAIMON_RETURN_NOT_OK(
+            UpdateLevel(level, /*before=*/{}, /*after=*/files, key_comparator, &levels, &level0));
+    }
+
+    size_t total_file_num = level0.size();
+    for (const auto& run : levels) {
+        total_file_num += run.Files().size();
+    }
+    if (total_file_num != input_files.size()) {
+        return Status::Invalid(
+            "Number of files stored in Levels does not equal to the size of inputFiles. This "
+            "is unexpected.");
+    }
+    return std::unique_ptr<Levels>(new Levels(key_comparator, level0, levels));
+}
+
+int32_t Levels::NumberOfSortedRuns() const {
+    int32_t number_of_runs = level0_.size();
+    for (const auto& run : levels_) {
+        if (!run.IsEmpty()) {
+            number_of_runs++;
+        }
+    }
+    return number_of_runs;
+}
+
+void Levels::AddDropFileCallback(DropFileCallback* callback) {
+    drop_file_callbacks_.push_back(callback);
+}
+
+void Levels::RemoveDropFileCallback(DropFileCallback* callback) {
+    drop_file_callbacks_.erase(
+        std::remove(drop_file_callbacks_.begin(), drop_file_callbacks_.end(), callback),
+        drop_file_callbacks_.end());
+}
+
+Status Levels::AddLevel0File(const std::shared_ptr<DataFileMeta>& file) {
+    if (file->level != 0) {
+        return Status::Invalid("must add level0 file in AddLevel0File");
+    }
+    level0_.insert(file);
+    return Status::OK();
+}
+
+int32_t Levels::NonEmptyHighestLevel() const {
+    for (int32_t i = levels_.size() - 1; i >= 0; i--) {
+        if (!levels_[i].IsEmpty()) {
+            return i + 1;
+        }
+    }
+    return level0_.empty() ? -1 : 0;
+}
+
+int64_t Levels::TotalFileSize() const {
+    int64_t total_size = 0;
+    for (const auto& file : level0_) {
+        total_size += file->file_size;
+    }
+    for (const auto& run : levels_) {
+        total_size += run.TotalSize();
+    }
+    return total_size;
+}
+
+std::vector<std::shared_ptr<DataFileMeta>> Levels::AllFiles() const {
+    std::vector<std::shared_ptr<DataFileMeta>> all_files;
+    auto runs = LevelSortedRuns();
+    for (const auto& run : runs) {
+        all_files.insert(all_files.end(), run.run.Files().begin(), run.run.Files().end());
+    }
+    return all_files;
+}
+
+std::vector<LevelSortedRun> Levels::LevelSortedRuns() const {
+    std::vector<LevelSortedRun> runs;
+    for (const auto& file : level0_) {
+        runs.emplace_back(/*level=*/0, SortedRun::FromSingle(file));
+    }
+    for (int32_t i = 0; i < static_cast<int32_t>(levels_.size()); i++) {
+        const auto& run = levels_[i];
+        if (!run.IsEmpty()) {
+            runs.emplace_back(/*level=*/i + 1, run);
+        }
+    }
+    return runs;
+}
+
+Status Levels::Update(const std::vector<std::shared_ptr<DataFileMeta>>& before,
+                      const std::vector<std::shared_ptr<DataFileMeta>>& after) {
+    auto grouped_before = GroupByLevel(before);
+    auto grouped_after = GroupByLevel(after);
+    int32_t number_of_levels = NumberOfLevels();
+    for (int32_t i = 0; i < number_of_levels; i++) {
+        PAIMON_RETURN_NOT_OK(UpdateLevel(i, grouped_before[i], grouped_after[i], key_comparator_,
+                                         &levels_, &level0_));
+    }
+    if (!drop_file_callbacks_.empty()) {
+        std::set<std::string> dropped_files;
+        for (const auto& file : before) {
+            dropped_files.insert(file->file_name);
+        }
+        // exclude upgrade files
+        for (const auto& file : after) {
+            dropped_files.erase(file->file_name);
+        }
+        for (auto* callback : drop_file_callbacks_) {
+            if (!callback) {
+                continue;
+            }
+            for (const auto& file_name : dropped_files) {
+                callback->NotifyDropFile(file_name);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status Levels::UpdateLevel(int32_t level, const std::vector<std::shared_ptr<DataFileMeta>>& before,
+                           const std::vector<std::shared_ptr<DataFileMeta>>& after,
+                           const std::shared_ptr<FieldsComparator>& key_comparator,
+                           std::vector<SortedRun>* levels,
+                           std::set<std::shared_ptr<DataFileMeta>, Level0Comparator>* level0) {
+    if (before.empty() && after.empty()) {
+        return Status::OK();
+    }
+    if (level == 0) {
+        for (const auto& file : before) {
+            level0->erase(file);
+        }
+        for (const auto& file : after) {
+            level0->insert(file);
+        }
+    } else {
+        PAIMON_ASSIGN_OR_RAISE(SortedRun run, RunOfLevel(level, *levels));
+        std::vector<std::shared_ptr<DataFileMeta>> files = run.Files();
+        for (const auto& before_file : before) {
+            auto iter = std::find_if(files.begin(), files.end(), [&before_file](const auto& cur) {
+                return before_file->file_name == cur->file_name;
+            });
+            if (iter != files.end()) {
+                files.erase(iter);
+            }
+        }
+        files.insert(files.end(), after.begin(), after.end());
+        PAIMON_ASSIGN_OR_RAISE((*levels)[level - 1],
+                               SortedRun::FromUnsorted(files, key_comparator));
+    }
+    return Status::OK();
+}
+
+Result<SortedRun> Levels::RunOfLevel(int32_t level, const std::vector<SortedRun>& levels) {
+    if (level <= 0) {
+        return Status::Invalid("Level0 does not have one single sorted run.");
+    }
+    return levels[level - 1];
+}
+
+std::map<int32_t, std::vector<std::shared_ptr<DataFileMeta>>> Levels::GroupByLevel(
+    const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+    std::map<int32_t, std::vector<std::shared_ptr<DataFileMeta>>> level_map;
+    for (const auto& file : files) {
+        level_map[file->level].push_back(file);
+    }
+    return level_map;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/levels.h
+++ b/src/paimon/core/mergetree/levels.h
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#pragma once
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/mergetree/level_sorted_run.h"
+#include "paimon/core/mergetree/sorted_run.h"
+#include "paimon/result.h"
+namespace paimon {
+/// A class which stores all level files of merge tree.
+class Levels {
+ public:
+    struct Level0Comparator {
+        bool operator()(const std::shared_ptr<DataFileMeta>& a,
+                        const std::shared_ptr<DataFileMeta>& b) const;
+    };
+
+    static Result<std::unique_ptr<Levels>> Create(
+        const std::shared_ptr<FieldsComparator>& key_comparator,
+        const std::vector<std::shared_ptr<DataFileMeta>>& input_files, int32_t num_levels);
+
+    static Result<SortedRun> RunOfLevel(int32_t level, const std::vector<SortedRun>& levels);
+
+    const std::set<std::shared_ptr<DataFileMeta>, Level0Comparator>& GetLevel0() const {
+        return level0_;
+    }
+
+    const std::vector<SortedRun>& GetLevels() const {
+        return levels_;
+    }
+    int32_t NumberOfLevels() const {
+        return levels_.size() + 1;
+    }
+
+    int32_t MaxLevel() const {
+        return levels_.size();
+    }
+
+    int32_t NumberOfSortedRuns() const;
+
+    /// A callback to notify dropping file.
+    class DropFileCallback {
+     public:
+        virtual ~DropFileCallback() = default;
+        virtual void NotifyDropFile(const std::string& file) = 0;
+    };
+
+    void AddDropFileCallback(DropFileCallback* callback);
+
+    void RemoveDropFileCallback(DropFileCallback* callback);
+
+    Status AddLevel0File(const std::shared_ptr<DataFileMeta>& file);
+
+    /// @return the highest non-empty level or -1 if all levels empty.
+    int32_t NonEmptyHighestLevel() const;
+
+    int64_t TotalFileSize() const;
+
+    std::vector<std::shared_ptr<DataFileMeta>> AllFiles() const;
+
+    std::vector<LevelSortedRun> LevelSortedRuns() const;
+
+    Status Update(const std::vector<std::shared_ptr<DataFileMeta>>& before,
+                  const std::vector<std::shared_ptr<DataFileMeta>>& after);
+
+ private:
+    Levels(const std::shared_ptr<FieldsComparator>& key_comparator,
+           const std::set<std::shared_ptr<DataFileMeta>, Level0Comparator>& level0,
+           const std::vector<SortedRun>& levels)
+        : key_comparator_(key_comparator), level0_(level0), levels_(levels) {}
+
+    static Status UpdateLevel(int32_t level,
+                              const std::vector<std::shared_ptr<DataFileMeta>>& before,
+                              const std::vector<std::shared_ptr<DataFileMeta>>& after,
+                              const std::shared_ptr<FieldsComparator>& key_comparator,
+                              std::vector<SortedRun>* levels,
+                              std::set<std::shared_ptr<DataFileMeta>, Level0Comparator>* level0);
+
+    static std::map<int32_t, std::vector<std::shared_ptr<DataFileMeta>>> GroupByLevel(
+        const std::vector<std::shared_ptr<DataFileMeta>>& files);
+
+ private:
+    std::shared_ptr<FieldsComparator> key_comparator_;
+    std::set<std::shared_ptr<DataFileMeta>, Level0Comparator> level0_;
+    std::vector<SortedRun> levels_;
+    std::vector<DropFileCallback*> drop_file_callbacks_;
+};
+}  // namespace paimon

--- a/src/paimon/core/mergetree/levels_test.cpp
+++ b/src/paimon/core/mergetree/levels_test.cpp
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "paimon/core/mergetree/levels.h"
+
+#include "arrow/api.h"
+#include "gtest/gtest.h"
+#include "paimon/common/utils/uuid.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class LevelsTest : public testing::Test {
+ public:
+    std::shared_ptr<DataFileMeta> CreateDataFileMeta(int32_t level, int64_t min_sequence_number,
+                                                     int64_t max_sequence_number,
+                                                     int64_t ts_second) const {
+        std::string uuid;
+        EXPECT_TRUE(UUID::Generate(&uuid));
+        return std::make_shared<DataFileMeta>(
+            /*file_name=*/uuid, /*file_size=*/1,
+            /*row_count=*/max_sequence_number - min_sequence_number + 1,
+            BinaryRowGenerator::GenerateRow({min_sequence_number}, pool_.get()),
+            BinaryRowGenerator::GenerateRow({max_sequence_number}, pool_.get()),
+            SimpleStats::EmptyStats(), SimpleStats::EmptyStats(), min_sequence_number,
+            max_sequence_number,
+            /*schema_id=*/0, level, std::vector<std::optional<std::string>>(),
+            Timestamp(ts_second, 0l), std::nullopt, nullptr, FileSource::Append(), std::nullopt,
+            std::nullopt, std::nullopt, std::nullopt);
+    }
+
+    std::shared_ptr<FieldsComparator> CreateComparator() const {
+        std::vector<DataField> data_fields;
+        data_fields.emplace_back(/*id=*/0, arrow::field("f0", arrow::int32()));
+        EXPECT_OK_AND_ASSIGN(auto cmp,
+                             FieldsComparator::Create(data_fields, /*is_ascending_order=*/true));
+        return cmp;
+    }
+
+ private:
+    std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+};
+
+TEST_F(LevelsTest, TestNonEmptyHighestLevelNo) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files;
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+    ASSERT_EQ(levels->NonEmptyHighestLevel(), -1);
+}
+
+TEST_F(LevelsTest, TestInvalidNumberLevels) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files;
+    ASSERT_NOK_WITH_MSG(Levels::Create(CreateComparator(), input_files, /*num_levels=*/1),
+                        "Number of levels must be at least 2.");
+}
+
+TEST_F(LevelsTest, TestAddLevel0FileInvalid) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {CreateDataFileMeta(0, 0, 1, 0),
+                                                              CreateDataFileMeta(0, 2, 3, 0)};
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+    std::vector<std::shared_ptr<DataFileMeta>> new_files = {CreateDataFileMeta(1, 0, 1, 0)};
+    ASSERT_NOK_WITH_MSG(levels->AddLevel0File(new_files[0]),
+                        "must add level0 file in AddLevel0File");
+}
+
+TEST_F(LevelsTest, TestNonEmptyHighestLevel0) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {CreateDataFileMeta(0, 0, 1, 0),
+                                                              CreateDataFileMeta(0, 2, 3, 0)};
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+    ASSERT_EQ(levels->NonEmptyHighestLevel(), 0);
+}
+
+TEST_F(LevelsTest, TestNonEmptyHighestLevel1) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {CreateDataFileMeta(0, 0, 1, 0),
+                                                              CreateDataFileMeta(1, 2, 3, 0)};
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+    ASSERT_EQ(levels->NonEmptyHighestLevel(), 1);
+    ASSERT_EQ(levels->NumberOfLevels(), 3);
+    ASSERT_EQ(levels->MaxLevel(), 2);
+}
+
+TEST_F(LevelsTest, TestNonEmptyHighestLevel2) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {
+        CreateDataFileMeta(0, 0, 100, 0), CreateDataFileMeta(0, 100, 200, 0),
+        CreateDataFileMeta(0, 0, 200, 0), CreateDataFileMeta(0, 0, 200, 10),
+        CreateDataFileMeta(1, 0, 500, 0), CreateDataFileMeta(2, 0, 1000, 0)};
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+    ASSERT_EQ(levels->NonEmptyHighestLevel(), 2);
+    ASSERT_EQ(levels->TotalFileSize(), 6);
+
+    std::vector<LevelSortedRun> expected_sorted_run = {
+        LevelSortedRun(0, SortedRun::FromSingle(input_files[2])),
+        LevelSortedRun(0, SortedRun::FromSingle(input_files[3])),
+        LevelSortedRun(0, SortedRun::FromSingle(input_files[1])),
+        LevelSortedRun(0, SortedRun::FromSingle(input_files[0])),
+        LevelSortedRun(1, SortedRun::FromSingle(input_files[4])),
+        LevelSortedRun(2, SortedRun::FromSingle(input_files[5])),
+    };
+
+    ASSERT_EQ(levels->LevelSortedRuns(), expected_sorted_run);
+    ASSERT_EQ(levels->NumberOfSortedRuns(), 6);
+
+    std::vector<std::shared_ptr<DataFileMeta>> expected_all_files = {
+        input_files[2], input_files[3], input_files[1],
+        input_files[0], input_files[4], input_files[5]};
+    ASSERT_EQ(levels->AllFiles(), expected_all_files);
+}
+
+TEST_F(LevelsTest, TestAddLevel0File) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {
+        CreateDataFileMeta(0, 100, 200, 0), CreateDataFileMeta(0, 0, 200, 0),
+        CreateDataFileMeta(0, 0, 200, 10), CreateDataFileMeta(1, 0, 500, 0),
+        CreateDataFileMeta(2, 0, 1000, 0)};
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+    ASSERT_EQ(levels->TotalFileSize(), 5);
+
+    auto new_level0 = CreateDataFileMeta(0, 0, 100, 0);
+    ASSERT_OK(levels->AddLevel0File(new_level0));
+    ASSERT_EQ(levels->TotalFileSize(), 6);
+    std::vector<LevelSortedRun> expected_sorted_run = {
+        LevelSortedRun(0, SortedRun::FromSingle(input_files[1])),
+        LevelSortedRun(0, SortedRun::FromSingle(input_files[2])),
+        LevelSortedRun(0, SortedRun::FromSingle(input_files[0])),
+        LevelSortedRun(0, SortedRun::FromSingle(new_level0)),
+        LevelSortedRun(1, SortedRun::FromSingle(input_files[3])),
+        LevelSortedRun(2, SortedRun::FromSingle(input_files[4])),
+    };
+
+    ASSERT_EQ(levels->LevelSortedRuns(), expected_sorted_run);
+    ASSERT_EQ(levels->NumberOfSortedRuns(), 6);
+}
+
+TEST_F(LevelsTest, TestUpdate) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {
+        CreateDataFileMeta(0, 100, 200, 0), CreateDataFileMeta(0, 0, 200, 0),
+        CreateDataFileMeta(0, 0, 200, 10), CreateDataFileMeta(1, 0, 500, 0),
+        CreateDataFileMeta(1, 600, 1000, 0)};
+
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+    ASSERT_EQ(levels->TotalFileSize(), 5);
+    ASSERT_EQ(levels->NumberOfSortedRuns(), 4);
+
+    std::vector<std::shared_ptr<DataFileMeta>> before = {
+        input_files[1],
+        input_files[3],
+    };
+
+    std::vector<std::shared_ptr<DataFileMeta>> after = {CreateDataFileMeta(0, 0, 100, 0),
+                                                        CreateDataFileMeta(1, 0, 550, 0)};
+
+    ASSERT_OK(levels->Update(before, after));
+
+    std::vector<LevelSortedRun> expected_sorted_run = {
+        LevelSortedRun(0, SortedRun::FromSingle(input_files[2])),
+        LevelSortedRun(0, SortedRun::FromSingle(input_files[0])),
+        LevelSortedRun(0, SortedRun::FromSingle(after[0])),
+        LevelSortedRun(1, SortedRun::FromSorted({after[1], input_files[4]})),
+    };
+
+    ASSERT_EQ(levels->LevelSortedRuns(), expected_sorted_run);
+    ASSERT_EQ(levels->NumberOfSortedRuns(), 4);
+}
+
+TEST_F(LevelsTest, TestRunOfLevelInvalidLevel) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {CreateDataFileMeta(2, 0, 1, 0),
+                                                              CreateDataFileMeta(1, 2, 3, 1)};
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+
+    // Test invalid level 0
+    auto result = Levels::RunOfLevel(0, levels->GetLevels());
+    ASSERT_NOK_WITH_MSG(result, "Level0 does not have one single sorted run.");
+
+    // Test invalid negative level
+    auto result_neg = Levels::RunOfLevel(-1, levels->GetLevels());
+    ASSERT_NOK_WITH_MSG(result_neg, "Level0 does not have one single sorted run.");
+}
+
+/// A simple test callback that records dropped file names.
+class TestDropFileCallback : public Levels::DropFileCallback {
+ public:
+    void NotifyDropFile(const std::string& file) override {
+        dropped_files.push_back(file);
+    }
+    std::vector<std::string> dropped_files;
+};
+
+TEST_F(LevelsTest, TestUpdateDropFileCallback) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {
+        CreateDataFileMeta(0, 100, 200, 0), CreateDataFileMeta(0, 0, 200, 0),
+        CreateDataFileMeta(1, 0, 500, 0), CreateDataFileMeta(1, 600, 1000, 0)};
+
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+
+    TestDropFileCallback callback;
+    levels->AddDropFileCallback(&callback);
+
+    // Remove input_files[0] from level0 and input_files[2] from level1,
+    // add new files to level0 and level1.
+    std::vector<std::shared_ptr<DataFileMeta>> before = {input_files[0], input_files[2]};
+    std::vector<std::shared_ptr<DataFileMeta>> after = {CreateDataFileMeta(0, 0, 100, 0),
+                                                        CreateDataFileMeta(1, 0, 550, 0)};
+    ASSERT_OK(levels->Update(before, after));
+
+    // Both files in before are replaced by new files, so both should be dropped.
+    ASSERT_EQ(callback.dropped_files.size(), 2);
+    std::set<std::string> dropped_set(callback.dropped_files.begin(), callback.dropped_files.end());
+    ASSERT_TRUE(dropped_set.count(input_files[0]->file_name));
+    ASSERT_TRUE(dropped_set.count(input_files[2]->file_name));
+
+    // Remove callback
+    ASSERT_EQ(levels->drop_file_callbacks_.size(), 1);
+    levels->RemoveDropFileCallback(nullptr);
+    ASSERT_EQ(levels->drop_file_callbacks_.size(), 1);
+    levels->RemoveDropFileCallback(&callback);
+    ASSERT_TRUE(levels->drop_file_callbacks_.empty());
+}
+
+TEST_F(LevelsTest, TestUpdateDropFileCallbackExcludesUpgradeFiles) {
+    auto file_level0 = CreateDataFileMeta(0, 0, 100, 0);
+    auto file_level1 = CreateDataFileMeta(1, 200, 300, 0);
+
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {file_level0, file_level1};
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+
+    TestDropFileCallback callback;
+    levels->AddDropFileCallback(&callback);
+
+    // Simulate an upgrade: file_level0 appears in both before and after (same file_name).
+    // Create a new version of the file at level 1 with the same file_name.
+    auto upgraded_file = std::make_shared<DataFileMeta>(
+        /*file_name=*/file_level0->file_name, /*file_size=*/file_level0->file_size,
+        /*row_count=*/file_level0->row_count, file_level0->min_key, file_level0->max_key,
+        file_level0->key_stats, file_level0->value_stats, file_level0->min_sequence_number,
+        file_level0->max_sequence_number, file_level0->schema_id, /*level=*/1,
+        file_level0->extra_files, file_level0->creation_time, std::nullopt, nullptr,
+        FileSource::Append(), std::nullopt, std::nullopt, std::nullopt, std::nullopt);
+
+    std::vector<std::shared_ptr<DataFileMeta>> before = {file_level0};
+    std::vector<std::shared_ptr<DataFileMeta>> after = {upgraded_file};
+    ASSERT_OK(levels->Update(before, after));
+
+    // The file was upgraded (same file_name in before and after), so it should NOT be dropped.
+    ASSERT_TRUE(callback.dropped_files.empty());
+}
+
+TEST_F(LevelsTest, TestUpdateNoCallbackWhenNoDroppedFiles) {
+    std::vector<std::shared_ptr<DataFileMeta>> input_files = {CreateDataFileMeta(0, 0, 100, 0)};
+    ASSERT_OK_AND_ASSIGN(auto levels,
+                         Levels::Create(CreateComparator(), input_files, /*num_levels=*/3));
+
+    TestDropFileCallback callback;
+    levels->AddDropFileCallback(&callback);
+
+    // Update with empty before and after.
+    ASSERT_OK(levels->Update({}, {}));
+    ASSERT_TRUE(callback.dropped_files.empty());
+
+    // Update with only after (adding new files).
+    std::vector<std::shared_ptr<DataFileMeta>> after = {CreateDataFileMeta(0, 200, 300, 0)};
+    ASSERT_OK(levels->Update({}, after));
+    ASSERT_TRUE(callback.dropped_files.empty());
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/sorted_run.h
+++ b/src/paimon/core/mergetree/sorted_run.h
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/io/data_file_meta.h"
+namespace paimon {
+/// A `SortedRun` is a list of files sorted by their keys. The key intervals [minKey, maxKey]
+/// of these files do not overlap.
+class SortedRun {
+ public:
+    static SortedRun Empty() {
+        return SortedRun({});
+    }
+    static SortedRun FromSingle(const std::shared_ptr<DataFileMeta>& meta) {
+        return SortedRun({meta});
+    }
+    static SortedRun FromSorted(const std::vector<std::shared_ptr<DataFileMeta>>& meta) {
+        return SortedRun(meta);
+    }
+    static Result<SortedRun> FromUnsorted(const std::vector<std::shared_ptr<DataFileMeta>>& meta,
+                                          const std::shared_ptr<FieldsComparator>& comparator) {
+        std::vector<std::shared_ptr<DataFileMeta>> unsorted = meta;
+        std::sort(unsorted.begin(), unsorted.end(),
+                  [comparator](const std::shared_ptr<DataFileMeta>& m1,
+                               const std::shared_ptr<DataFileMeta>& m2) {
+                      return comparator->CompareTo(m1->min_key, m2->min_key) < 0;
+                  });
+        SortedRun sorted_run(unsorted);
+        if (!sorted_run.IsValid(comparator)) {
+            return Status::Invalid("from unsorted validate failed");
+        }
+        return sorted_run;
+    }
+
+    bool IsEmpty() const {
+        return files_.empty();
+    }
+
+    const std::vector<std::shared_ptr<DataFileMeta>>& Files() const& {
+        return files_;
+    }
+
+    std::vector<std::shared_ptr<DataFileMeta>>&& Files() && {
+        return std::move(files_);
+    }
+
+    int64_t TotalSize() const {
+        return total_size_;
+    }
+
+    bool IsValid(const std::shared_ptr<FieldsComparator>& comparator) const {
+        for (size_t i = 1; i < files_.size(); ++i) {
+            if (comparator->CompareTo(files_[i]->min_key, files_[i - 1]->max_key) <= 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    bool operator==(const SortedRun& other) const {
+        if (this == &other) {
+            return true;
+        }
+        if (files_.size() != other.Files().size()) {
+            return false;
+        }
+        for (size_t i = 0; i < files_.size(); i++) {
+            if (*files_[i] != *(other.Files()[i])) {
+                return false;
+            }
+        }
+        return total_size_ == other.TotalSize();
+    }
+
+    std::string ToString() const {
+        std::vector<std::string> files_str;
+        files_str.reserve(files_.size());
+        for (const auto& file : files_) {
+            files_str.push_back(file->ToString());
+        }
+        return fmt::format("{}", fmt::join(files_str, ", "));
+    }
+
+ private:
+    explicit SortedRun(const std::vector<std::shared_ptr<DataFileMeta>>& files) : files_(files) {
+        for (const auto& file : files) {
+            total_size_ += file->file_size;
+        }
+    }
+
+ private:
+    int64_t total_size_ = 0;
+    std::vector<std::shared_ptr<DataFileMeta>> files_;
+};
+}  // namespace paimon

--- a/src/paimon/core/mergetree/sorted_run_test.cpp
+++ b/src/paimon/core/mergetree/sorted_run_test.cpp
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "paimon/core/mergetree/sorted_run.h"
+
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "arrow/type_fwd.h"
+#include "gtest/gtest.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/mergetree/level_sorted_run.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+namespace paimon::test {
+class SortedRunTest : public testing::Test {
+ public:
+    std::shared_ptr<DataFileMeta> CreateDataFileMeta(int32_t min_key, int32_t max_key) {
+        auto pool = GetDefaultPool();
+        return std::make_shared<DataFileMeta>(
+            "fake.orc", /*file_size=*/1165, /*row_count=*/1,
+            /*min_key=*/BinaryRowGenerator::GenerateRow({min_key}, pool.get()), /*max_key=*/
+            BinaryRowGenerator::GenerateRow({max_key}, pool.get()),
+            /*key_stats=*/
+            SimpleStats::EmptyStats(),
+            /*value_stats=*/
+            SimpleStats::EmptyStats(),
+            /*min_sequence_number=*/0, /*max_sequence_number=*/6, /*schema_id=*/0,
+            /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(0ll, 0),
+            /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+            /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+            /*first_row_id=*/std::nullopt,
+            /*write_cols=*/std::nullopt);
+    }
+};
+
+TEST_F(SortedRunTest, TestSortedRunIsValid) {
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<FieldsComparator> comparator,
+        FieldsComparator::Create({DataField(0, arrow::field("test", arrow::int32()))},
+                                 /*is_ascending_order=*/true));
+
+    // m1 [10, 20]
+    auto m1 = CreateDataFileMeta(10, 20);
+
+    // m2 [30, 40]
+    auto m2 = CreateDataFileMeta(30, 40);
+
+    // m3 [15, 35]
+    auto m3 = CreateDataFileMeta(15, 35);
+    {
+        auto sorted_run = SortedRun::FromSingle(m1);
+        ASSERT_TRUE(sorted_run.IsValid(comparator));
+    }
+    {
+        auto sorted_run = SortedRun::FromSorted({m1, m2});
+        ASSERT_TRUE(sorted_run.IsValid(comparator));
+    }
+    {
+        auto sorted_run = SortedRun::FromSorted({m1, m3});
+        ASSERT_FALSE(sorted_run.IsValid(comparator));
+    }
+    {
+        auto sorted_run = SortedRun::FromSorted({m3, m2});
+        ASSERT_FALSE(sorted_run.IsValid(comparator));
+    }
+}
+
+TEST_F(SortedRunTest, TestFromUnsorted) {
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<FieldsComparator> comparator,
+        FieldsComparator::Create({DataField(0, arrow::field("test", arrow::int32()))},
+                                 /*is_ascending_order=*/true));
+
+    // m1 [10, 20]
+    auto m1 = CreateDataFileMeta(10, 20);
+
+    // m2 [30, 40]
+    auto m2 = CreateDataFileMeta(30, 40);
+
+    // m3 [15, 35]
+    auto m3 = CreateDataFileMeta(15, 35);
+
+    ASSERT_OK_AND_ASSIGN(auto run1, SortedRun::FromUnsorted({m2, m1}, comparator));
+    auto run2 = SortedRun::FromSorted({m1, m2});
+    ASSERT_EQ(run1, run2);
+
+    ASSERT_NOK_WITH_MSG(SortedRun::FromUnsorted({m2, m1, m3}, comparator),
+                        "from unsorted validate failed");
+}
+
+TEST_F(SortedRunTest, TestEqual) {
+    auto empty = SortedRun::Empty();
+    auto m1 = CreateDataFileMeta(10, 20);
+    auto run1 = SortedRun::FromSingle({m1});
+    auto other_run1 = SortedRun::FromSingle({m1});
+
+    auto m2 = CreateDataFileMeta(100, 200);
+    auto run2 = SortedRun::FromSingle({m2});
+
+    ASSERT_EQ(run1, run1);
+    ASSERT_EQ(run1, other_run1);
+    ASSERT_FALSE(run1 == run2);
+    ASSERT_FALSE(empty == run2);
+}
+
+TEST_F(SortedRunTest, TestSortedRunToString) {
+    auto m1 = CreateDataFileMeta(10, 20);
+    auto m2 = CreateDataFileMeta(30, 40);
+    auto sorted_run = SortedRun::FromSorted({m1, m2});
+    auto sorted_run_str = sorted_run.ToString();
+    LevelSortedRun level_sorted_run(/*level=*/10, sorted_run);
+    auto level_sorted_run_str = level_sorted_run.ToString();
+    ASSERT_TRUE(level_sorted_run_str.find("LevelSortedRun{ level=10, run={fileName:") !=
+                std::string::npos);
+    ASSERT_TRUE(level_sorted_run_str.find(sorted_run_str) != std::string::npos);
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
### Purpose

Linked issue: No linked issue

This change adds mergetree compaction core components and level management support.

Included changes:

- **Mergetree sorted run utilities**:
  - Adds `sorted_run.h` for sorted run data structure
  - Adds test coverage in `sorted_run_test.cpp`

- **Mergetree level management**:
  - Adds `levels.h` and `levels.cpp` for level tracking and management
  - Adds `level_sorted_run.h` for level-sorted run association
  - Adds test coverage in `levels_test.cpp`

- **Compaction strategy and rewriter**:
  - Adds `compact_rewriter.h` for compaction rewrite interface
  - Adds `compact_strategy.h` for compaction strategy definitions
  - Adds test coverage in `compact_strategy_test.cpp`

- **Interval partition utilities**:
  - Adds `interval_partition.h` and `interval_partition.cpp` for interval-based partitioning
  - Adds test coverage in `interval_partition_test.cpp`

- **Off-peak hours scheduling**:
  - Adds `off_peak_hours.h` for off-peak time window configuration
  - Adds test coverage in `off_peak_hours_test.cpp`

### Tests

Test coverage included in this change:

- `SortedRunTest`
- `LevelsTest`
- `CompactStrategyTest`
- `IntervalPartitionTest`
- `OffPeakHoursTest`

### API and Format

No public API, storage format, or protocol changes.

### Documentation

No documentation changes required.

### Generative AI tooling

Migrate-by: Aone Copilot (Qwen-3.7-Max)
