### PR TITLE
feat(mergetree): add compact manager, task abstractions and file rewr…

### DIFF
--- a/src/paimon/core/mergetree/compact/file_rewrite_compact_task.h
+++ b/src/paimon/core/mergetree/compact/file_rewrite_compact_task.h
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "paimon/core/compact/compact_task.h"
+#include "paimon/core/compact/compact_unit.h"
+#include "paimon/core/mergetree/compact/compact_rewriter.h"
+#include "paimon/core/mergetree/sorted_run.h"
+
+namespace paimon {
+
+/// Compact task for file rewrite compaction.
+class FileRewriteCompactTask : public CompactTask {
+ public:
+    FileRewriteCompactTask(const std::shared_ptr<CompactRewriter>& rewriter,
+                           const CompactUnit& unit, bool drop_delete,
+                           const std::shared_ptr<CompactionMetrics::Reporter>& metrics_reporter)
+        : CompactTask(metrics_reporter),
+          rewriter_(rewriter),
+          output_level_(unit.output_level),
+          files_(unit.files),
+          drop_delete_(drop_delete) {}
+
+ protected:
+    Result<std::shared_ptr<CompactResult>> DoCompact() override {
+        auto result = std::make_shared<CompactResult>();
+        for (const auto& file : files_) {
+            PAIMON_RETURN_NOT_OK(RewriteFile(file, result.get()));
+        }
+        return result;
+    }
+
+ private:
+    Status RewriteFile(const std::shared_ptr<DataFileMeta>& file, CompactResult* to_update) {
+        std::vector<std::vector<SortedRun>> candidate = {{SortedRun::FromSingle(file)}};
+        PAIMON_ASSIGN_OR_RAISE(CompactResult rewritten,
+                               rewriter_->Rewrite(output_level_, drop_delete_, candidate));
+        return to_update->Merge(rewritten);
+    }
+
+    std::shared_ptr<CompactRewriter> rewriter_;
+    int32_t output_level_;
+    std::vector<std::shared_ptr<DataFileMeta>> files_;
+    bool drop_delete_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/file_rewrite_compact_task_test.cpp
+++ b/src/paimon/core/mergetree/compact/file_rewrite_compact_task_test.cpp
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/file_rewrite_compact_task.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+namespace {
+
+class SpyCompactRewriter final : public CompactRewriter {
+ public:
+    Result<CompactResult> Rewrite(int32_t output_level, bool drop_delete,
+                                  const std::vector<std::vector<SortedRun>>& sections) override {
+        output_levels.push_back(output_level);
+        drop_deletes.push_back(drop_delete);
+
+        EXPECT_EQ(sections.size(), 1);
+        EXPECT_EQ(sections[0].size(), 1);
+        EXPECT_EQ(sections[0][0].Files().size(), 1);
+
+        auto input = sections[0][0].Files()[0];
+        rewritten_files.push_back(input);
+
+        PAIMON_ASSIGN_OR_RAISE(auto upgraded, input->Upgrade(output_level));
+        return CompactResult({input}, {upgraded});
+    }
+
+    Result<CompactResult> Upgrade(int32_t, const std::shared_ptr<DataFileMeta>&) override {
+        return Status::Invalid("Upgrade should not be called by FileRewriteCompactTask");
+    }
+
+    Status Close() override {
+        return Status::OK();
+    }
+
+    std::vector<int32_t> output_levels;
+    std::vector<bool> drop_deletes;
+    std::vector<std::shared_ptr<DataFileMeta>> rewritten_files;
+};
+
+class FailingCompactRewriter final : public CompactRewriter {
+ public:
+    explicit FailingCompactRewriter(size_t fail_on_call) : fail_on_call_(fail_on_call) {}
+
+    Result<CompactResult> Rewrite(int32_t, bool,
+                                  const std::vector<std::vector<SortedRun>>& sections) override {
+        EXPECT_EQ(sections.size(), 1);
+        EXPECT_EQ(sections[0].size(), 1);
+        EXPECT_EQ(sections[0][0].Files().size(), 1);
+
+        rewritten_files.push_back(sections[0][0].Files()[0]);
+        ++call_count_;
+        if (call_count_ == fail_on_call_) {
+            return Status::Invalid("injected rewrite failure");
+        }
+
+        auto input = sections[0][0].Files()[0];
+        PAIMON_ASSIGN_OR_RAISE(auto upgraded, input->Upgrade(/*new_level=*/1));
+        return CompactResult({input}, {upgraded});
+    }
+
+    Result<CompactResult> Upgrade(int32_t, const std::shared_ptr<DataFileMeta>&) override {
+        return Status::Invalid("Upgrade should not be called by FileRewriteCompactTask");
+    }
+
+    Status Close() override {
+        return Status::OK();
+    }
+
+    size_t call_count() const {
+        return call_count_;
+    }
+
+    std::vector<std::shared_ptr<DataFileMeta>> rewritten_files;
+
+ private:
+    size_t fail_on_call_;
+    size_t call_count_ = 0;
+};
+
+std::shared_ptr<DataFileMeta> NewAppendFile(const std::string& file_name, int64_t row_count,
+                                            int64_t min_sequence_number,
+                                            int64_t max_sequence_number) {
+    return DataFileMeta::ForAppend(file_name, /*file_size=*/row_count, row_count,
+                                   SimpleStats::EmptyStats(), min_sequence_number,
+                                   max_sequence_number, /*schema_id=*/0, FileSource::Append(),
+                                   std::nullopt, std::nullopt, std::nullopt, std::nullopt)
+        .value();
+}
+
+}  // namespace
+
+TEST(FileRewriteCompactTaskTest, TestRewriteEachFileAndMergeResults) {
+    auto file1 = NewAppendFile("file-1", /*row_count=*/10, /*min_sequence_number=*/0,
+                               /*max_sequence_number=*/9);
+    auto file2 = NewAppendFile("file-2", /*row_count=*/20, /*min_sequence_number=*/10,
+                               /*max_sequence_number=*/29);
+    CompactUnit unit(/*output_level=*/2, {file1, file2}, /*file_rewrite=*/true);
+
+    auto rewriter = std::make_shared<SpyCompactRewriter>();
+    FileRewriteCompactTask task(rewriter, unit, /*drop_delete=*/true, /*metrics_reporter=*/nullptr);
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<CompactResult> result, task.Execute());
+
+    ASSERT_EQ(rewriter->output_levels, std::vector<int32_t>({2, 2}));
+    ASSERT_EQ(rewriter->drop_deletes, std::vector<bool>({true, true}));
+    ASSERT_EQ(rewriter->rewritten_files.size(), 2);
+    EXPECT_EQ(rewriter->rewritten_files[0], file1);
+    EXPECT_EQ(rewriter->rewritten_files[1], file2);
+
+    ASSERT_EQ(result->Before().size(), 2);
+    EXPECT_EQ(result->Before()[0], file1);
+    EXPECT_EQ(result->Before()[1], file2);
+
+    ASSERT_EQ(result->After().size(), 2);
+    EXPECT_EQ(result->After()[0]->file_name, file1->file_name);
+    EXPECT_EQ(result->After()[1]->file_name, file2->file_name);
+    EXPECT_EQ(result->After()[0]->level, 2);
+    EXPECT_EQ(result->After()[1]->level, 2);
+}
+
+TEST(FileRewriteCompactTaskTest, TestStopOnRewriteFailure) {
+    auto file1 = NewAppendFile("file-1", /*row_count=*/10, /*min_sequence_number=*/0,
+                               /*max_sequence_number=*/9);
+    auto file2 = NewAppendFile("file-2", /*row_count=*/20, /*min_sequence_number=*/10,
+                               /*max_sequence_number=*/29);
+    auto file3 = NewAppendFile("file-3", /*row_count=*/30, /*min_sequence_number=*/30,
+                               /*max_sequence_number=*/59);
+    CompactUnit unit(/*output_level=*/2, {file1, file2, file3}, /*file_rewrite=*/true);
+
+    auto rewriter = std::make_shared<FailingCompactRewriter>(/*fail_on_call=*/2);
+    FileRewriteCompactTask task(rewriter, unit, /*drop_delete=*/false,
+                                /*metrics_reporter=*/nullptr);
+
+    ASSERT_NOK_WITH_MSG(task.Execute(), "injected rewrite failure");
+    ASSERT_EQ(rewriter->call_count(), 2);
+    ASSERT_EQ(rewriter->rewritten_files.size(), 2);
+    EXPECT_EQ(rewriter->rewritten_files[0], file1);
+    EXPECT_EQ(rewriter->rewritten_files[1], file2);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager.cpp
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/merge_tree_compact_manager.h"
+
+#include <cassert>
+#include <iterator>
+
+#include "fmt/format.h"
+#include "paimon/common/executor/future.h"
+#include "paimon/core/compact/compact_deletion_file.h"
+#include "paimon/core/compact/compact_task.h"
+#include "paimon/core/mergetree/compact/file_rewrite_compact_task.h"
+#include "paimon/core/mergetree/compact/interval_partition.h"
+#include "paimon/core/mergetree/compact/merge_tree_compact_task.h"
+
+namespace paimon {
+
+std::string FilesToString(const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+    fmt::memory_buffer buffer;
+    bool first = true;
+    for (const auto& file : files) {
+        if (!first) {
+            fmt::format_to(std::back_inserter(buffer), ", ");
+        }
+        fmt::format_to(std::back_inserter(buffer), "({}, {}, {})", file->file_name, file->level,
+                       file->file_size);
+        first = false;
+    }
+    return fmt::to_string(buffer);
+}
+
+std::string FilesToString(const std::vector<LevelSortedRun>& runs) {
+    fmt::memory_buffer buffer;
+    bool first = true;
+    for (const auto& level_sorted_run : runs) {
+        auto files = FilesToString(level_sorted_run.run.Files());
+        if (files.empty()) {
+            continue;
+        }
+        if (!first) {
+            fmt::format_to(std::back_inserter(buffer), ", ");
+        }
+        fmt::format_to(std::back_inserter(buffer), "{}", files);
+        first = false;
+    }
+    return fmt::to_string(buffer);
+}
+
+MergeTreeCompactManager::MergeTreeCompactManager(
+    const std::shared_ptr<Levels>& levels, const std::shared_ptr<CompactStrategy>& strategy,
+    const std::shared_ptr<FieldsComparator>& key_comparator, int64_t compaction_file_size,
+    int32_t num_sorted_run_stop_trigger, const std::shared_ptr<CompactRewriter>& rewriter,
+    const std::shared_ptr<CompactionMetrics::Reporter>& metrics_reporter,
+    const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, bool lazy_gen_deletion_file,
+    bool need_lookup, bool force_rewrite_all_files, bool force_keep_delete,
+    const std::shared_ptr<CancellationController>& cancellation_controller,
+    const std::shared_ptr<Executor>& executor)
+    : executor_(executor),
+      levels_(levels),
+      strategy_(strategy),
+      key_comparator_(key_comparator),
+      compaction_file_size_(compaction_file_size),
+      num_sorted_run_stop_trigger_(num_sorted_run_stop_trigger),
+      rewriter_(rewriter),
+      metrics_reporter_(metrics_reporter),
+      dv_maintainer_(dv_maintainer),
+      lazy_gen_deletion_file_(lazy_gen_deletion_file),
+      need_lookup_(need_lookup),
+      force_rewrite_all_files_(force_rewrite_all_files),
+      force_keep_delete_(force_keep_delete),
+      cancellation_controller_(cancellation_controller),
+      logger_(Logger::GetLogger("MergeTreeCompactManager")) {
+    assert(cancellation_controller_ != nullptr);
+    ReportMetrics();
+}
+
+bool MergeTreeCompactManager::ShouldWaitForLatestCompaction() const {
+    return levels_->NumberOfSortedRuns() > num_sorted_run_stop_trigger_;
+}
+
+bool MergeTreeCompactManager::ShouldWaitForPreparingCheckpoint() const {
+    // cast to long to avoid Numeric overflow
+    return levels_->NumberOfSortedRuns() > (static_cast<int64_t>(num_sorted_run_stop_trigger_) + 1);
+}
+
+Status MergeTreeCompactManager::AddNewFile(const std::shared_ptr<DataFileMeta>& file) {
+    // if overwrite an empty partition, the snapshot will be changed to APPEND, then its files
+    // might be upgraded to high level, thus we should use #update
+    PAIMON_RETURN_NOT_OK(levels_->Update(/*before=*/{}, /*after=*/{file}));
+    ReportMetrics();
+    return Status::OK();
+}
+
+std::vector<std::shared_ptr<DataFileMeta>> MergeTreeCompactManager::AllFiles() const {
+    return levels_->AllFiles();
+}
+
+Status MergeTreeCompactManager::TriggerCompaction(bool full_compaction) {
+    std::optional<CompactUnit> optional_unit;
+    std::vector<LevelSortedRun> runs = levels_->LevelSortedRuns();
+
+    if (full_compaction) {
+        if (task_future_.valid()) {
+            return Status::Invalid(
+                "A compaction task is still running while the user forces a new compaction. This "
+                "is unexpected.");
+        }
+
+        PAIMON_LOG_DEBUG(logger_, "Trigger forced full compaction. Picking from runs:\n%s",
+                         StringUtils::VectorToString(runs).c_str());
+        optional_unit = CompactStrategy::PickFullCompaction(
+            levels_->NumberOfLevels(), runs, dv_maintainer_, force_rewrite_all_files_);
+    } else {
+        if (task_future_.valid()) {
+            return Status::OK();
+        }
+
+        PAIMON_LOG_DEBUG(logger_, "Trigger normal compaction. Picking from the following runs:\n%s",
+                         StringUtils::VectorToString(runs).c_str());
+
+        PAIMON_ASSIGN_OR_RAISE(std::optional<CompactUnit> picked,
+                               strategy_->Pick(levels_->NumberOfLevels(), runs));
+        if (picked && !picked->files.empty() &&
+            (picked->files.size() > 1 || picked->files[0]->level != picked->output_level)) {
+            optional_unit = picked;
+        }
+    }
+
+    if (!optional_unit) {
+        return Status::OK();
+    }
+
+    // As long as there is no older data, We can drop the deletion.
+    // If the output level is 0, there may be older data not involved in compaction.
+    // If the output level is bigger than 0, as long as there is no older data in
+    // the current levels, the output is the oldest, so we can drop the deletion.
+    // See CompactStrategy::Pick.
+    const CompactUnit& unit = optional_unit.value();
+    bool drop_delete =
+        !force_keep_delete_ && unit.output_level != 0 &&
+        (unit.output_level >= levels_->NonEmptyHighestLevel() || dv_maintainer_ != nullptr);
+
+    PAIMON_LOG_DEBUG(logger_, "Submit compaction with files (name, level, size): %s",
+                     StringUtils::VectorToString(levels_->LevelSortedRuns()).c_str());
+    return SubmitCompaction(unit, drop_delete);
+}
+
+void MergeTreeCompactManager::RequestCancelCompaction() {
+    cancellation_controller_->Cancel();
+}
+
+Status MergeTreeCompactManager::SubmitCompaction(const CompactUnit& unit, bool drop_delete) {
+    cancellation_controller_->Reset();
+    const char* task_name = unit.file_rewrite ? "FileRewriteCompactTask" : "MergeTreeCompactTask";
+    if (unit.file_rewrite) {
+        auto task = std::make_shared<FileRewriteCompactTask>(rewriter_, unit, drop_delete,
+                                                             metrics_reporter_);
+        task_future_ = Via(executor_.get(), [task]() -> Result<std::shared_ptr<CompactResult>> {
+            return task->Execute();
+        });
+    } else {
+        MergeTreeCompactTask::DeletionFileSupplier compact_df_supplier =
+            []() -> Result<std::shared_ptr<CompactDeletionFile>> {
+            return std::shared_ptr<CompactDeletionFile>();
+        };
+        if (dv_maintainer_ != nullptr) {
+            if (lazy_gen_deletion_file_) {
+                compact_df_supplier = [dv = dv_maintainer_]() {
+                    return CompactDeletionFile::LazyGeneration(dv);
+                };
+            } else {
+                compact_df_supplier = [dv = dv_maintainer_]() {
+                    return CompactDeletionFile::GenerateFiles(dv);
+                };
+            }
+        }
+
+        auto task = std::make_shared<MergeTreeCompactTask>(
+            key_comparator_, compaction_file_size_, rewriter_, unit, drop_delete,
+            levels_->MaxLevel(), metrics_reporter_, compact_df_supplier, force_rewrite_all_files_);
+        task_future_ = Via(executor_.get(), [task]() -> Result<std::shared_ptr<CompactResult>> {
+            return task->Execute();
+        });
+    }
+
+    PAIMON_LOG_DEBUG(logger_, "Pick these files (name, level, size) for %s compaction: %s",
+                     task_name, FilesToString(unit.files).c_str());
+
+    if (metrics_reporter_) {
+        metrics_reporter_->IncreaseCompactionsQueuedCount();
+        metrics_reporter_->IncreaseCompactionsTotalCount();
+    }
+    return Status::OK();
+}
+
+Result<std::optional<std::shared_ptr<CompactResult>>> MergeTreeCompactManager::GetCompactionResult(
+    bool blocking) {
+    PAIMON_ASSIGN_OR_RAISE(std::optional<std::shared_ptr<CompactResult>> result,
+                           InnerGetCompactionResult(blocking));
+    if (result) {
+        const auto& compact_result = result.value();
+        PAIMON_RETURN_NOT_OK(levels_->Update(compact_result->Before(), compact_result->After()));
+        ReportMetrics();
+        PAIMON_LOG_DEBUG(logger_, "Levels in compact manager updated. Current runs are\n%s",
+                         StringUtils::VectorToString(levels_->LevelSortedRuns()).c_str());
+    }
+    return result;
+}
+
+bool MergeTreeCompactManager::CompactNotCompleted() const {
+    // If it is a lookup compaction, we should ensure that all level 0 files are consumed, so
+    // here we need to make the outside think that we still need to do unfinished compact
+    // working
+    return CompactFutureManager::CompactNotCompleted() ||
+           (need_lookup_ && !levels_->GetLevel0().empty());
+}
+
+Status MergeTreeCompactManager::Close() {
+    PAIMON_RETURN_NOT_OK(rewriter_->Close());
+    if (metrics_reporter_) {
+        metrics_reporter_->Unregister();
+        metrics_reporter_.reset();
+    }
+    return Status::OK();
+}
+
+void MergeTreeCompactManager::ReportMetrics() const {
+    if (metrics_reporter_) {
+        metrics_reporter_->ReportLevel0FileCount(levels_->GetLevel0().size());
+        metrics_reporter_->ReportTotalFileSize(levels_->TotalFileSize());
+    }
+}
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager.h
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager.h
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/compact/cancellation_controller.h"
+#include "paimon/core/compact/compact_future_manager.h"
+#include "paimon/core/deletionvectors/bucketed_dv_maintainer.h"
+#include "paimon/core/mergetree/compact/compact_rewriter.h"
+#include "paimon/core/mergetree/compact/compact_strategy.h"
+#include "paimon/core/mergetree/levels.h"
+#include "paimon/core/operation/metrics/compaction_metrics.h"
+#include "paimon/executor.h"
+#include "paimon/logging.h"
+
+namespace paimon {
+
+/// Compact manager for key value tables.
+class MergeTreeCompactManager : public CompactFutureManager {
+ public:
+    MergeTreeCompactManager(const std::shared_ptr<Levels>& levels,
+                            const std::shared_ptr<CompactStrategy>& strategy,
+                            const std::shared_ptr<FieldsComparator>& key_comparator,
+                            int64_t compaction_file_size, int32_t num_sorted_run_stop_trigger,
+                            const std::shared_ptr<CompactRewriter>& rewriter,
+                            const std::shared_ptr<CompactionMetrics::Reporter>& metrics_reporter,
+                            const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer,
+                            bool lazy_gen_deletion_file, bool need_lookup,
+                            bool force_rewrite_all_files, bool force_keep_delete,
+                            const std::shared_ptr<CancellationController>& cancellation_controller,
+                            const std::shared_ptr<Executor>& executor);
+
+    ~MergeTreeCompactManager() override = default;
+
+    bool ShouldWaitForLatestCompaction() const override;
+
+    bool ShouldWaitForPreparingCheckpoint() const override;
+
+    Status AddNewFile(const std::shared_ptr<DataFileMeta>& file) override;
+
+    std::vector<std::shared_ptr<DataFileMeta>> AllFiles() const override;
+
+    Status TriggerCompaction(bool full_compaction) override;
+
+    void RequestCancelCompaction() override;
+
+    Result<std::optional<std::shared_ptr<CompactResult>>> GetCompactionResult(
+        bool blocking) override;
+
+    bool CompactNotCompleted() const override;
+
+    Status Close() override;
+
+    std::shared_ptr<Levels> GetLevels() const {
+        return levels_;
+    }
+
+    std::shared_ptr<CompactStrategy> GetStrategy() const {
+        return strategy_;
+    }
+
+ private:
+    Status SubmitCompaction(const CompactUnit& unit, bool drop_delete);
+
+    void ReportMetrics() const;
+
+    std::shared_ptr<Executor> executor_;
+    std::shared_ptr<Levels> levels_;
+    std::shared_ptr<CompactStrategy> strategy_;
+    std::shared_ptr<FieldsComparator> key_comparator_;
+    int64_t compaction_file_size_;
+    int32_t num_sorted_run_stop_trigger_;
+    std::shared_ptr<CompactRewriter> rewriter_;
+    std::shared_ptr<CompactionMetrics::Reporter> metrics_reporter_;
+    std::shared_ptr<BucketedDvMaintainer> dv_maintainer_;
+    bool lazy_gen_deletion_file_;
+    bool need_lookup_;
+    bool force_rewrite_all_files_;
+    bool force_keep_delete_;
+    std::shared_ptr<CancellationController> cancellation_controller_;
+    std::unique_ptr<Logger> logger_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.cpp
@@ -1,0 +1,360 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/merge_tree_compact_manager_factory.h"
+
+#include <vector>
+
+#include "paimon/common/data/serializer/row_compacted_serializer.h"
+#include "paimon/core/compact/noop_compact_manager.h"
+#include "paimon/core/mergetree/compact/aggregate/aggregate_merge_function.h"
+#include "paimon/core/mergetree/compact/early_full_compaction.h"
+#include "paimon/core/mergetree/compact/force_up_level0_compaction.h"
+#include "paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter.h"
+#include "paimon/core/mergetree/compact/merge_tree_compact_manager.h"
+#include "paimon/core/mergetree/compact/merge_tree_compact_rewriter.h"
+#include "paimon/core/mergetree/compact/off_peak_hours.h"
+#include "paimon/core/mergetree/compact/universal_compaction.h"
+#include "paimon/core/mergetree/lookup/default_lookup_serializer_factory.h"
+#include "paimon/core/mergetree/lookup/persist_empty_processor.h"
+#include "paimon/core/mergetree/lookup/persist_position_processor.h"
+#include "paimon/core/mergetree/lookup/persist_value_and_pos_processor.h"
+#include "paimon/core/mergetree/lookup/persist_value_processor.h"
+#include "paimon/core/mergetree/lookup/positioned_key_value.h"
+#include "paimon/core/mergetree/lookup_levels.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/core/utils/file_store_path_factory_cache.h"
+#include "paimon/core/utils/primary_key_table_utils.h"
+
+namespace arrow {
+class Schema;
+}
+
+namespace paimon {
+
+namespace {
+
+template <typename T>
+Result<std::unique_ptr<LookupLevels<T>>> CreateLookupLevelsInternal(
+    const CoreOptions& options, const std::shared_ptr<SchemaManager>& schema_manager,
+    const std::shared_ptr<IOManager>& io_manager,
+    const std::shared_ptr<CacheManager>& cache_manager,
+    const std::shared_ptr<FileStorePathFactory>& file_store_path_factory,
+    const std::shared_ptr<TableSchema>& table_schema, const BinaryRow& partition, int32_t bucket,
+    const std::shared_ptr<Levels>& levels,
+    const std::shared_ptr<typename PersistProcessor<T>::Factory>& processor_factory,
+    const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer,
+    const std::shared_ptr<LookupFile::LookupFileCache>& lookup_file_cache,
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager,
+    const std::shared_ptr<MemoryPool>& pool) {
+    if (io_manager == nullptr) {
+        return Status::Invalid("Can not use lookup, there is no temp disk directory to use.");
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Schema> key_schema,
+                           table_schema->TrimmedPrimaryKeySchema());
+    PAIMON_ASSIGN_OR_RAISE(MemorySlice::SliceComparator lookup_key_comparator,
+                           RowCompactedSerializer::CreateSliceComparator(key_schema, pool));
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<LookupStoreFactory> lookup_store_factory,
+        LookupStoreFactory::Create(lookup_key_comparator, cache_manager, options));
+    auto dv_factory = DeletionVector::CreateFactory(dv_maintainer);
+    auto serializer_factory = std::make_shared<DefaultLookupSerializerFactory>();
+    return LookupLevels<T>::Create(options.GetFileSystem(), partition, bucket, options,
+                                   schema_manager, io_manager, file_store_path_factory,
+                                   table_schema, levels, dv_factory, processor_factory,
+                                   serializer_factory, lookup_store_factory, lookup_file_cache,
+                                   remote_lookup_file_manager, pool);
+}
+
+}  // namespace
+
+std::shared_ptr<CompactStrategy> MergeTreeCompactManagerFactory::CreateCompactStrategy() const {
+    auto universal = std::make_shared<UniversalCompaction>(
+        options_.GetCompactionMaxSizeAmplificationPercent(), options_.GetCompactionSizeRatio(),
+        options_.GetNumSortedRunsCompactionTrigger(), EarlyFullCompaction::Create(options_),
+        OffPeakHours::Create(options_));
+
+    if (options_.NeedLookup()) {
+        std::optional<int32_t> compact_max_interval = std::nullopt;
+        switch (options_.GetLookupCompactMode()) {
+            case LookupCompactMode::GENTLE:
+                compact_max_interval = options_.GetLookupCompactMaxInterval();
+                break;
+            case LookupCompactMode::RADICAL:
+                break;
+        }
+        return std::make_shared<ForceUpLevel0Compaction>(universal, compact_max_interval);
+    }
+
+    if (options_.CompactionForceUpLevel0()) {
+        return std::make_shared<ForceUpLevel0Compaction>(universal,
+                                                         /*max_compact_interval=*/std::nullopt);
+    }
+    return universal;
+}
+
+Result<std::shared_ptr<CompactManager>> MergeTreeCompactManagerFactory::CreateCompactManager(
+    const BinaryRow& partition, int32_t bucket,
+    const std::shared_ptr<CompactStrategy>& compact_strategy,
+    const std::shared_ptr<Executor>& compact_executor, const std::shared_ptr<Levels>& levels,
+    const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer) {
+    if (options_.WriteOnly()) {
+        return std::make_shared<NoopCompactManager>();
+    }
+
+    auto cancellation_controller = std::make_shared<CancellationController>();
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<CompactRewriter> rewriter,
+        CreateRewriter(partition, bucket, levels, dv_maintainer, cancellation_controller));
+    auto metrics_reporter = CreateCompactionMetricsReporter(partition, bucket);
+
+    return std::make_shared<MergeTreeCompactManager>(
+        levels, compact_strategy, key_comparator_,
+        options_.GetCompactionFileSize(/*has_primary_key=*/true),
+        options_.GetNumSortedRunsStopTrigger(), rewriter, metrics_reporter, dv_maintainer,
+        options_.PrepareCommitWaitCompaction(), options_.NeedLookup(),
+        options_.CompactionForceRewriteAllFiles(),
+        /*force_keep_delete=*/false, cancellation_controller, compact_executor);
+}
+
+std::shared_ptr<CompactionMetrics::Reporter>
+MergeTreeCompactManagerFactory::CreateCompactionMetricsReporter(const BinaryRow& partition,
+                                                                int32_t bucket) const {
+    return compaction_metrics_ ? compaction_metrics_->CreateReporter(partition, bucket) : nullptr;
+}
+
+Result<std::shared_ptr<CompactRewriter>> MergeTreeCompactManagerFactory::CreateRewriter(
+    const BinaryRow& partition, int32_t bucket, const std::shared_ptr<Levels>& levels,
+    const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer,
+    const std::shared_ptr<CancellationController>& cancellation_controller) {
+    auto path_factory_cache =
+        std::make_shared<FileStorePathFactoryCache>(root_path_, table_schema_, options_, pool_);
+    if (options_.GetChangelogProducer() == ChangelogProducer::FULL_COMPACTION) {
+        return Status::NotImplemented("not support full changelog merge tree compact rewriter");
+    }
+    if (options_.NeedLookup()) {
+        // Lazily create the global lookup file cache
+        if (!lookup_file_cache_) {
+            lookup_file_cache_ = LookupFile::CreateLookupFileCache(
+                options_.GetLookupCacheFileRetentionMs(), options_.GetLookupCacheMaxDiskSize());
+        }
+        int32_t max_level = options_.GetNumLevels() - 1;
+        return CreateLookupRewriter(partition, bucket, levels, dv_maintainer, max_level,
+                                    options_.GetLookupStrategy(), path_factory_cache,
+                                    cancellation_controller);
+    }
+
+    auto dv_factory = DeletionVector::CreateFactory(dv_maintainer);
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<MergeTreeCompactRewriter> rewriter,
+                           MergeTreeCompactRewriter::Create(
+                               bucket, partition, table_schema_, dv_factory, path_factory_cache,
+                               options_, cancellation_controller, pool_));
+    return std::shared_ptr<CompactRewriter>(std::move(rewriter));
+}
+
+Result<std::shared_ptr<CompactRewriter>> MergeTreeCompactManagerFactory::CreateLookupRewriter(
+    const BinaryRow& partition, int32_t bucket, const std::shared_ptr<Levels>& levels,
+    const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
+    const LookupStrategy& lookup_strategy,
+    const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
+    const std::shared_ptr<CancellationController>& cancellation_controller) const {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RemoteLookupFileManager> remote_lookup_file_manager,
+                           CreateRemoteLookupFileManager(partition, bucket));
+    if (lookup_strategy.is_first_row) {
+        if (options_.DeletionVectorsEnabled()) {
+            return Status::Invalid(
+                "First row merge engine does not need deletion vectors because there is no "
+                "deletion of old data in this merge engine.");
+        }
+
+        auto processor_factory = std::make_shared<PersistEmptyProcessor::Factory>();
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<LookupLevels<bool>> lookup_levels,
+            CreateLookupLevelsInternal<bool>(
+                options_, schema_manager_, io_manager_, cache_manager_, file_store_path_factory_,
+                table_schema_, partition, bucket, levels, processor_factory, dv_maintainer,
+                lookup_file_cache_, remote_lookup_file_manager, pool_));
+        auto merge_function_wrapper_factory =
+            [lookup_levels_ptr = lookup_levels.get(), ignore_delete = options_.IgnoreDelete()](
+                int32_t output_level) -> Result<std::shared_ptr<MergeFunctionWrapper<KeyValue>>> {
+            std::shared_ptr<MergeFunctionWrapper<KeyValue>> merge_function_wrapper =
+                LookupMergeTreeCompactRewriter<bool>::CreateFirstRowMergeFunctionWrapper(
+                    std::make_unique<FirstRowMergeFunction>(ignore_delete), output_level,
+                    lookup_levels_ptr);
+            return merge_function_wrapper;
+        };
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<LookupMergeTreeCompactRewriter<bool>> rewriter,
+                               LookupMergeTreeCompactRewriter<bool>::Create(
+                                   max_level, std::move(lookup_levels), dv_maintainer,
+                                   std::move(merge_function_wrapper_factory), bucket, partition,
+                                   table_schema_, path_factory_cache, options_,
+                                   cancellation_controller, remote_lookup_file_manager, pool_));
+        return std::shared_ptr<CompactRewriter>(std::move(rewriter));
+    }
+
+    if (lookup_strategy.deletion_vector) {
+        return CreateLookupRewriterWithDeletionVector(
+            partition, bucket, levels, dv_maintainer, max_level, lookup_strategy,
+            path_factory_cache, cancellation_controller, remote_lookup_file_manager);
+    }
+
+    return CreateLookupRewriterWithoutDeletionVector(
+        partition, bucket, levels, dv_maintainer, max_level, lookup_strategy, path_factory_cache,
+        cancellation_controller, remote_lookup_file_manager);
+}
+
+Result<std::shared_ptr<CompactRewriter>>
+MergeTreeCompactManagerFactory::CreateLookupRewriterWithDeletionVector(
+    const BinaryRow& partition, int32_t bucket, const std::shared_ptr<Levels>& levels,
+    const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
+    const LookupStrategy& lookup_strategy,
+    const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
+    const std::shared_ptr<CancellationController>& cancellation_controller,
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager) const {
+    auto merge_engine = options_.GetMergeEngine();
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> trimmed_primary_keys,
+                           table_schema_->TrimmedPrimaryKeys());
+    if (lookup_strategy.produce_changelog || merge_engine != MergeEngine::DEDUPLICATE ||
+        !options_.GetSequenceField().empty()) {
+        auto processor_factory = std::make_shared<PersistValueAndPosProcessor::Factory>(schema_);
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<LookupLevels<PositionedKeyValue>> lookup_levels,
+            CreateLookupLevelsInternal<PositionedKeyValue>(
+                options_, schema_manager_, io_manager_, cache_manager_, file_store_path_factory_,
+                table_schema_, partition, bucket, levels, processor_factory, dv_maintainer,
+                lookup_file_cache_, remote_lookup_file_manager, pool_));
+        auto merge_function_wrapper_factory =
+            [data_schema = schema_, options = options_, trimmed_primary_keys,
+             lookup_levels_ptr = lookup_levels.get(), lookup_strategy,
+             dv_maintainer_ptr = dv_maintainer,
+             user_defined_seq_comparator = user_defined_seq_comparator_](
+                int32_t output_level) -> Result<std::shared_ptr<MergeFunctionWrapper<KeyValue>>> {
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<MergeFunction> merge_func,
+                                   PrimaryKeyTableUtils::CreateMergeFunction(
+                                       data_schema, trimmed_primary_keys, options));
+            PAIMON_ASSIGN_OR_RAISE(
+                std::shared_ptr<MergeFunctionWrapper<KeyValue>> merge_function_wrapper,
+                LookupMergeTreeCompactRewriter<PositionedKeyValue>::
+                    CreateLookupMergeFunctionWrapper(
+                        std::make_unique<LookupMergeFunction>(std::move(merge_func)), output_level,
+                        dv_maintainer_ptr, lookup_strategy, user_defined_seq_comparator,
+                        lookup_levels_ptr));
+            return merge_function_wrapper;
+        };
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<LookupMergeTreeCompactRewriter<PositionedKeyValue>> rewriter,
+            LookupMergeTreeCompactRewriter<PositionedKeyValue>::Create(
+                max_level, std::move(lookup_levels), dv_maintainer,
+                std::move(merge_function_wrapper_factory), bucket, partition, table_schema_,
+                path_factory_cache, options_, cancellation_controller, remote_lookup_file_manager,
+                pool_));
+        return std::shared_ptr<CompactRewriter>(std::move(rewriter));
+    }
+    auto processor_factory = std::make_shared<PersistPositionProcessor::Factory>();
+    PAIMON_ASSIGN_OR_RAISE(
+        std::unique_ptr<LookupLevels<FilePosition>> lookup_levels,
+        CreateLookupLevelsInternal<FilePosition>(
+            options_, schema_manager_, io_manager_, cache_manager_, file_store_path_factory_,
+            table_schema_, partition, bucket, levels, processor_factory, dv_maintainer,
+            lookup_file_cache_, remote_lookup_file_manager, pool_));
+    auto merge_function_wrapper_factory =
+        [data_schema = schema_, options = options_, trimmed_primary_keys,
+         lookup_levels_ptr = lookup_levels.get(), lookup_strategy,
+         dv_maintainer_ptr = dv_maintainer,
+         user_defined_seq_comparator = user_defined_seq_comparator_](
+            int32_t output_level) -> Result<std::shared_ptr<MergeFunctionWrapper<KeyValue>>> {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<MergeFunction> merge_func,
+            PrimaryKeyTableUtils::CreateMergeFunction(data_schema, trimmed_primary_keys, options));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<MergeFunctionWrapper<KeyValue>> merge_function_wrapper,
+            LookupMergeTreeCompactRewriter<FilePosition>::CreateLookupMergeFunctionWrapper(
+                std::make_unique<LookupMergeFunction>(std::move(merge_func)), output_level,
+                dv_maintainer_ptr, lookup_strategy, user_defined_seq_comparator,
+                lookup_levels_ptr));
+        return merge_function_wrapper;
+    };
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<LookupMergeTreeCompactRewriter<FilePosition>> rewriter,
+                           LookupMergeTreeCompactRewriter<FilePosition>::Create(
+                               max_level, std::move(lookup_levels), dv_maintainer,
+                               std::move(merge_function_wrapper_factory), bucket, partition,
+                               table_schema_, path_factory_cache, options_, cancellation_controller,
+                               remote_lookup_file_manager, pool_));
+    return std::shared_ptr<CompactRewriter>(std::move(rewriter));
+}
+
+Result<std::shared_ptr<CompactRewriter>>
+MergeTreeCompactManagerFactory::CreateLookupRewriterWithoutDeletionVector(
+    const BinaryRow& partition, int32_t bucket, const std::shared_ptr<Levels>& levels,
+    const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
+    const LookupStrategy& lookup_strategy,
+    const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
+    const std::shared_ptr<CancellationController>& cancellation_controller,
+    const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager) const {
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> trimmed_primary_keys,
+                           table_schema_->TrimmedPrimaryKeys());
+    auto processor_factory = std::make_shared<PersistValueProcessor::Factory>(schema_);
+    PAIMON_ASSIGN_OR_RAISE(
+        std::unique_ptr<LookupLevels<KeyValue>> lookup_levels,
+        CreateLookupLevelsInternal<KeyValue>(
+            options_, schema_manager_, io_manager_, cache_manager_, file_store_path_factory_,
+            table_schema_, partition, bucket, levels, processor_factory, dv_maintainer,
+            lookup_file_cache_, remote_lookup_file_manager, pool_));
+    auto merge_function_wrapper_factory =
+        [data_schema = schema_, options = options_, trimmed_primary_keys,
+         lookup_levels_ptr = lookup_levels.get(), lookup_strategy,
+         dv_maintainer_ptr = dv_maintainer,
+         user_defined_seq_comparator = user_defined_seq_comparator_](
+            int32_t output_level) -> Result<std::shared_ptr<MergeFunctionWrapper<KeyValue>>> {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<MergeFunction> merge_func,
+            PrimaryKeyTableUtils::CreateMergeFunction(data_schema, trimmed_primary_keys, options));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<MergeFunctionWrapper<KeyValue>> merge_function_wrapper,
+            LookupMergeTreeCompactRewriter<KeyValue>::CreateLookupMergeFunctionWrapper(
+                std::make_unique<LookupMergeFunction>(std::move(merge_func)), output_level,
+                dv_maintainer_ptr, lookup_strategy, user_defined_seq_comparator,
+                lookup_levels_ptr));
+        return merge_function_wrapper;
+    };
+
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<LookupMergeTreeCompactRewriter<KeyValue>> rewriter,
+                           LookupMergeTreeCompactRewriter<KeyValue>::Create(
+                               max_level, std::move(lookup_levels), dv_maintainer,
+                               std::move(merge_function_wrapper_factory), bucket, partition,
+                               table_schema_, path_factory_cache, options_, cancellation_controller,
+                               remote_lookup_file_manager, pool_));
+    return std::shared_ptr<CompactRewriter>(std::move(rewriter));
+}
+
+Result<std::shared_ptr<RemoteLookupFileManager>>
+MergeTreeCompactManagerFactory::CreateRemoteLookupFileManager(const BinaryRow& partition,
+                                                              int32_t bucket) const {
+    if (options_.LookupRemoteFileEnabled()) {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<DataFilePathFactory> data_path_factory,
+            file_store_path_factory_->CreateDataFilePathFactory(partition, bucket));
+        return std::make_shared<RemoteLookupFileManager>(options_.GetLookupRemoteLevelThreshold(),
+                                                         data_path_factory,
+                                                         options_.GetFileSystem(), pool_);
+    }
+    return std::shared_ptr<RemoteLookupFileManager>();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.h
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory.h
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "paimon/common/io/cache/cache_manager.h"
+#include "paimon/core/compact/cancellation_controller.h"
+#include "paimon/core/compact/compact_manager.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/mergetree/compact/compact_rewriter.h"
+#include "paimon/core/mergetree/compact/compact_strategy.h"
+#include "paimon/core/mergetree/lookup/remote_lookup_file_manager.h"
+#include "paimon/core/mergetree/lookup_file.h"
+#include "paimon/core/operation/metrics/compaction_metrics.h"
+#include "paimon/result.h"
+namespace arrow {
+class Schema;
+}
+
+namespace paimon {
+
+class BinaryRow;
+class BucketedDvMaintainer;
+class Executor;
+class FieldsComparator;
+class FileStorePathFactory;
+class FileStorePathFactoryCache;
+class IOManager;
+class Levels;
+class SchemaManager;
+class TableSchema;
+class MemoryPool;
+class LookupStoreFactory;
+template <typename T>
+class LookupLevels;
+template <typename T>
+class PersistProcessor;
+struct KeyValue;
+template <typename T>
+class MergeFunctionWrapper;
+
+/// Factory for creating merge-tree compact strategy and compact manager.
+class MergeTreeCompactManagerFactory {
+ public:
+    MergeTreeCompactManagerFactory(
+        const CoreOptions& options, const std::shared_ptr<FieldsComparator>& key_comparator,
+        const std::shared_ptr<FieldsComparator>& user_defined_seq_comparator,
+        const std::shared_ptr<CompactionMetrics>& compaction_metrics,
+        const std::shared_ptr<TableSchema>& table_schema,
+        const std::shared_ptr<arrow::Schema>& schema,
+        const std::shared_ptr<SchemaManager>& schema_manager,
+        const std::shared_ptr<IOManager>& io_manager,
+        const std::shared_ptr<CacheManager>& cache_manager,
+        const std::shared_ptr<FileStorePathFactory>& file_store_path_factory,
+        const std::string& root_path, const std::shared_ptr<MemoryPool>& pool)
+        : options_(options),
+          pool_(pool),
+          key_comparator_(key_comparator),
+          user_defined_seq_comparator_(user_defined_seq_comparator),
+          compaction_metrics_(compaction_metrics),
+          table_schema_(table_schema),
+          schema_(schema),
+          schema_manager_(schema_manager),
+          io_manager_(io_manager),
+          cache_manager_(cache_manager),
+          file_store_path_factory_(file_store_path_factory),
+          root_path_(root_path) {}
+
+    std::shared_ptr<CompactStrategy> CreateCompactStrategy() const;
+
+    Result<std::shared_ptr<CompactManager>> CreateCompactManager(
+        const BinaryRow& partition, int32_t bucket,
+        const std::shared_ptr<CompactStrategy>& compact_strategy,
+        const std::shared_ptr<Executor>& compact_executor, const std::shared_ptr<Levels>& levels,
+        const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer);
+
+    void Close() {
+        if (lookup_file_cache_) {
+            lookup_file_cache_->InvalidateAll();
+        }
+    }
+
+ private:
+    std::shared_ptr<CompactionMetrics::Reporter> CreateCompactionMetricsReporter(
+        const BinaryRow& partition, int32_t bucket) const;
+
+    Result<std::shared_ptr<CompactRewriter>> CreateRewriter(
+        const BinaryRow& partition, int32_t bucket, const std::shared_ptr<Levels>& levels,
+        const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer,
+        const std::shared_ptr<CancellationController>& cancellation_controller);
+
+    Result<std::shared_ptr<CompactRewriter>> CreateLookupRewriter(
+        const BinaryRow& partition, int32_t bucket, const std::shared_ptr<Levels>& levels,
+        const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
+        const LookupStrategy& lookup_strategy,
+        const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
+        const std::shared_ptr<CancellationController>& cancellation_controller) const;
+
+    Result<std::shared_ptr<CompactRewriter>> CreateLookupRewriterWithDeletionVector(
+        const BinaryRow& partition, int32_t bucket, const std::shared_ptr<Levels>& levels,
+        const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
+        const LookupStrategy& lookup_strategy,
+        const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
+        const std::shared_ptr<CancellationController>& cancellation_controller,
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager) const;
+
+    Result<std::shared_ptr<CompactRewriter>> CreateLookupRewriterWithoutDeletionVector(
+        const BinaryRow& partition, int32_t bucket, const std::shared_ptr<Levels>& levels,
+        const std::shared_ptr<BucketedDvMaintainer>& dv_maintainer, int32_t max_level,
+        const LookupStrategy& lookup_strategy,
+        const std::shared_ptr<FileStorePathFactoryCache>& path_factory_cache,
+        const std::shared_ptr<CancellationController>& cancellation_controller,
+        const std::shared_ptr<RemoteLookupFileManager>& remote_lookup_file_manager) const;
+
+    Result<std::shared_ptr<RemoteLookupFileManager>> CreateRemoteLookupFileManager(
+        const BinaryRow& partition, int32_t bucket) const;
+
+    CoreOptions options_;
+    std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<FieldsComparator> key_comparator_;
+    std::shared_ptr<FieldsComparator> user_defined_seq_comparator_;
+    std::shared_ptr<CompactionMetrics> compaction_metrics_;
+    std::shared_ptr<TableSchema> table_schema_;
+    std::shared_ptr<arrow::Schema> schema_;
+    std::shared_ptr<SchemaManager> schema_manager_;
+    std::shared_ptr<IOManager> io_manager_;
+    std::shared_ptr<CacheManager> cache_manager_;
+    std::shared_ptr<FileStorePathFactory> file_store_path_factory_;
+    std::string root_path_;
+    std::shared_ptr<LookupFile::LookupFileCache> lookup_file_cache_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory_test.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager_factory_test.cpp
@@ -1,0 +1,388 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/merge_tree_compact_manager_factory.h"
+
+#include <map>
+
+#include "arrow/array/array_base.h"
+#include "arrow/array/builder_binary.h"
+#include "arrow/array/builder_nested.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "arrow/c/helpers.h"
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/catalog/catalog.h"
+#include "paimon/catalog/identifier.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/compact/noop_compact_manager.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/mergetree/compact/force_up_level0_compaction.h"
+#include "paimon/core/mergetree/compact/universal_compaction.h"
+#include "paimon/file_store_write.h"
+#include "paimon/record_batch.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+#include "paimon/write_context.h"
+
+namespace paimon::test {
+
+namespace {
+
+class MergeTreeCompactManagerFactoryStrategyTest : public ::testing::Test {
+ protected:
+    LevelSortedRun CreateLevelSortedRun(int32_t level, int64_t size) const {
+        auto file_meta = std::make_shared<DataFileMeta>(
+            "factory-direct.data", /*file_size=*/size, /*row_count=*/1,
+            /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+            /*key_stats=*/SimpleStats::EmptyStats(), /*value_stats=*/SimpleStats::EmptyStats(),
+            /*min_sequence_number=*/0, /*max_sequence_number=*/1, /*schema_id=*/0,
+            /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*creation_time=*/Timestamp(0ll, 0), /*delete_row_count=*/0,
+            /*embedded_index=*/nullptr, FileSource::Append(),
+            /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+            /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+        return {level, SortedRun::FromSingle(file_meta)};
+    }
+
+    std::vector<LevelSortedRun> CreateRuns(const std::vector<int32_t>& levels,
+                                           const std::vector<int64_t>& sizes) const {
+        std::vector<LevelSortedRun> runs;
+        for (size_t i = 0; i < levels.size(); ++i) {
+            runs.push_back(CreateLevelSortedRun(levels[i], sizes[i]));
+        }
+        return runs;
+    }
+
+    Result<MergeTreeCompactManagerFactory> CreateFactory(
+        const std::map<std::string, std::string>& options_map) const {
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options, CoreOptions::FromMap(options_map));
+        return MergeTreeCompactManagerFactory(options,
+                                              /*key_comparator=*/nullptr,
+                                              /*user_defined_seq_comparator=*/nullptr,
+                                              /*compaction_metrics=*/nullptr,
+                                              /*table_schema=*/nullptr,
+                                              /*schema=*/nullptr,
+                                              /*schema_manager=*/nullptr,
+                                              /*io_manager=*/nullptr,
+                                              /*cache_manager=*/nullptr,
+                                              /*file_store_path_factory=*/nullptr,
+                                              /*root_path=*/"",
+                                              /*pool=*/nullptr);
+    }
+};
+
+class MergeTreeCompactManagerFactoryWriteTest : public ::testing::Test {
+ protected:
+    Result<std::unique_ptr<FileStoreWrite>> CreateFileStoreWrite(
+        const std::vector<std::shared_ptr<arrow::Field>>& fields,
+        const std::vector<std::string>& primary_keys,
+        const std::map<std::string, std::string>& table_options, bool with_io_manager,
+        const std::map<std::string, std::string>& context_options = {}) {
+        arrow::Schema typed_schema(fields);
+        ::ArrowSchema schema;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportSchema(typed_schema, &schema));
+
+        auto dir = UniqueTestDirectory::Create();
+        if (!dir) {
+            return Status::Invalid("failed to create test directory");
+        }
+        PAIMON_ASSIGN_OR_RAISE(auto catalog, Catalog::Create(dir->Str(), {}));
+        PAIMON_RETURN_NOT_OK(catalog->CreateDatabase("foo", {}, /*ignore_if_exists=*/false));
+        PAIMON_RETURN_NOT_OK(catalog->CreateTable(Identifier("foo", "bar"), &schema,
+                                                  /*partition_keys=*/{}, primary_keys,
+                                                  table_options,
+                                                  /*ignore_if_exists=*/false));
+
+        WriteContextBuilder context_builder(PathUtil::JoinPath(dir->Str(), "foo.db/bar"), "test");
+        if (!context_options.empty()) {
+            context_builder.SetOptions(context_options);
+        }
+        if (with_io_manager) {
+            context_builder.WithTempDirectory(dir->Str());
+        }
+
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<WriteContext> write_context,
+                               context_builder.Finish());
+        return FileStoreWrite::Create(std::move(write_context));
+    }
+
+    Result<std::unique_ptr<FileStoreWrite>> CreateSingleStringFileStoreWrite(
+        const std::map<std::string, std::string>& table_options, bool with_io_manager,
+        const std::map<std::string, std::string>& context_options = {}) {
+        return CreateFileStoreWrite({arrow::field("f0", arrow::utf8(), /*nullable=*/false)},
+                                    /*primary_keys=*/{"f0"}, table_options, with_io_manager,
+                                    context_options);
+    }
+
+    Result<std::unique_ptr<FileStoreWrite>> CreateStringAndInt64FileStoreWrite(
+        const std::map<std::string, std::string>& table_options, bool with_io_manager,
+        const std::map<std::string, std::string>& context_options = {}) {
+        return CreateFileStoreWrite({arrow::field("f0", arrow::utf8(), /*nullable=*/false),
+                                     arrow::field("f1", arrow::int64())},
+                                    /*primary_keys=*/{"f0"}, table_options, with_io_manager,
+                                    context_options);
+    }
+
+    Status WriteSingleStringRow(FileStoreWrite* file_store_write, int32_t bucket,
+                                const std::string& value) const {
+        auto fields = {arrow::field("f0", arrow::utf8(), /*nullable=*/false)};
+        auto struct_type = arrow::struct_(fields);
+        arrow::StructBuilder struct_builder(struct_type, arrow::default_memory_pool(),
+                                            {std::make_shared<arrow::StringBuilder>()});
+        auto string_builder = static_cast<arrow::StringBuilder*>(struct_builder.field_builder(0));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(struct_builder.Append());
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(string_builder->Append(value));
+
+        std::shared_ptr<arrow::Array> array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(struct_builder.Finish(&array));
+        ::ArrowArray arrow_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*array, &arrow_array));
+
+        RecordBatchBuilder batch_builder(&arrow_array);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<RecordBatch> batch,
+                               batch_builder.SetBucket(bucket).Finish());
+        Status write_status = file_store_write->Write(std::move(batch));
+        if (!ArrowArrayIsReleased(&arrow_array)) {
+            ArrowArrayRelease(&arrow_array);
+        }
+        return write_status;
+    }
+
+    Status WriteStringAndInt64Row(FileStoreWrite* file_store_write, int32_t bucket,
+                                  const std::string& key, int64_t sequence) const {
+        auto fields = {arrow::field("f0", arrow::utf8(), /*nullable=*/false),
+                       arrow::field("f1", arrow::int64())};
+        auto struct_type = arrow::struct_(fields);
+        arrow::StructBuilder struct_builder(
+            struct_type, arrow::default_memory_pool(),
+            {std::make_shared<arrow::StringBuilder>(), std::make_shared<arrow::Int64Builder>()});
+        auto string_builder = static_cast<arrow::StringBuilder*>(struct_builder.field_builder(0));
+        auto int64_builder = static_cast<arrow::Int64Builder*>(struct_builder.field_builder(1));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(struct_builder.Append());
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(string_builder->Append(key));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(int64_builder->Append(sequence));
+
+        std::shared_ptr<arrow::Array> array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(struct_builder.Finish(&array));
+        ::ArrowArray arrow_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*array, &arrow_array));
+
+        RecordBatchBuilder batch_builder(&arrow_array);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<RecordBatch> batch,
+                               batch_builder.SetBucket(bucket).Finish());
+        Status write_status = file_store_write->Write(std::move(batch));
+        if (!ArrowArrayIsReleased(&arrow_array)) {
+            ArrowArrayRelease(&arrow_array);
+        }
+        return write_status;
+    }
+};
+
+}  // namespace
+
+TEST_F(MergeTreeCompactManagerFactoryStrategyTest, TestCreateCompactStrategyDefaultUniversal) {
+    ASSERT_OK_AND_ASSIGN(auto factory, CreateFactory({}));
+    auto strategy = factory.CreateCompactStrategy();
+    ASSERT_NE(strategy, nullptr);
+    ASSERT_NE(std::dynamic_pointer_cast<UniversalCompaction>(strategy), nullptr);
+    ASSERT_EQ(std::dynamic_pointer_cast<ForceUpLevel0Compaction>(strategy), nullptr);
+}
+
+TEST_F(MergeTreeCompactManagerFactoryStrategyTest,
+       TestCreateCompactStrategyLookupShouldForceUpLevel0) {
+    ASSERT_OK_AND_ASSIGN(auto factory,
+                         CreateFactory({{Options::FORCE_LOOKUP, "true"}, {Options::BUCKET, "1"}}));
+    auto strategy = factory.CreateCompactStrategy();
+    ASSERT_NE(strategy, nullptr);
+    ASSERT_NE(std::dynamic_pointer_cast<ForceUpLevel0Compaction>(strategy), nullptr);
+}
+
+TEST_F(MergeTreeCompactManagerFactoryStrategyTest,
+       TestCreateCompactStrategyLookupRadicalShouldNotSetMaxInterval) {
+    ASSERT_OK_AND_ASSIGN(auto factory, CreateFactory({{Options::FORCE_LOOKUP, "true"},
+                                                      {Options::LOOKUP_COMPACT, "radical"},
+                                                      {Options::LOOKUP_COMPACT_MAX_INTERVAL, "7"},
+                                                      {Options::BUCKET, "1"}}));
+    auto strategy = factory.CreateCompactStrategy();
+    ASSERT_NE(strategy, nullptr);
+    auto force_strategy = std::dynamic_pointer_cast<ForceUpLevel0Compaction>(strategy);
+    ASSERT_NE(force_strategy, nullptr);
+    ASSERT_EQ(force_strategy->MaxCompactInterval(), std::nullopt);
+}
+
+TEST_F(MergeTreeCompactManagerFactoryStrategyTest,
+       TestCreateCompactStrategyLookupGentleShouldSetMaxInterval) {
+    ASSERT_OK_AND_ASSIGN(auto factory, CreateFactory({{Options::FORCE_LOOKUP, "true"},
+                                                      {Options::LOOKUP_COMPACT, "gentle"},
+                                                      {Options::LOOKUP_COMPACT_MAX_INTERVAL, "7"},
+                                                      {Options::BUCKET, "1"}}));
+    auto strategy = factory.CreateCompactStrategy();
+    ASSERT_NE(strategy, nullptr);
+    auto force_strategy = std::dynamic_pointer_cast<ForceUpLevel0Compaction>(strategy);
+    ASSERT_NE(force_strategy, nullptr);
+    ASSERT_EQ(force_strategy->MaxCompactInterval(), 7);
+}
+
+TEST_F(MergeTreeCompactManagerFactoryStrategyTest,
+       TestCreateCompactStrategyLookupGentleBehaviorShouldForceAfterThreshold) {
+    ASSERT_OK_AND_ASSIGN(auto factory, CreateFactory({{Options::FORCE_LOOKUP, "true"},
+                                                      {Options::LOOKUP_COMPACT, "gentle"},
+                                                      {Options::LOOKUP_COMPACT_MAX_INTERVAL, "7"},
+                                                      {Options::BUCKET, "1"}}));
+    auto strategy = factory.CreateCompactStrategy();
+    ASSERT_NE(strategy, nullptr);
+
+    auto runs = CreateRuns({0, 0}, {1, 1});
+    std::optional<CompactUnit> unit;
+    for (int32_t i = 0; i < 6; ++i) {
+        ASSERT_OK_AND_ASSIGN(unit, strategy->Pick(/*num_levels=*/3, runs));
+        ASSERT_FALSE(unit);
+    }
+
+    ASSERT_OK_AND_ASSIGN(unit, strategy->Pick(/*num_levels=*/3, runs));
+    ASSERT_TRUE(unit);
+    ASSERT_EQ(unit->output_level, 2);
+}
+
+TEST_F(MergeTreeCompactManagerFactoryStrategyTest,
+       TestCreateCompactStrategyLookupRadicalBehaviorShouldForceImmediately) {
+    ASSERT_OK_AND_ASSIGN(auto factory, CreateFactory({{Options::FORCE_LOOKUP, "true"},
+                                                      {Options::LOOKUP_COMPACT, "radical"},
+                                                      {Options::BUCKET, "1"}}));
+    auto strategy = factory.CreateCompactStrategy();
+    ASSERT_NE(strategy, nullptr);
+
+    auto runs = CreateRuns({0, 0}, {1, 1});
+    ASSERT_OK_AND_ASSIGN(auto unit, strategy->Pick(/*num_levels=*/3, runs));
+    ASSERT_TRUE(unit);
+    ASSERT_EQ(unit->output_level, 2);
+}
+
+TEST_F(MergeTreeCompactManagerFactoryStrategyTest,
+       TestCreateCompactStrategyForceUpLevel0OptionShouldTakeEffect) {
+    ASSERT_OK_AND_ASSIGN(
+        auto factory,
+        CreateFactory({{Options::COMPACTION_FORCE_UP_LEVEL_0, "true"}, {Options::BUCKET, "1"}}));
+    auto strategy = factory.CreateCompactStrategy();
+    ASSERT_NE(strategy, nullptr);
+    ASSERT_NE(std::dynamic_pointer_cast<ForceUpLevel0Compaction>(strategy), nullptr);
+}
+
+TEST_F(MergeTreeCompactManagerFactoryStrategyTest,
+       TestCreateCompactManagerWriteOnlyShouldReturnNoopCompactManager) {
+    ASSERT_OK_AND_ASSIGN(auto factory,
+                         CreateFactory({{Options::WRITE_ONLY, "true"}, {Options::BUCKET, "1"}}));
+
+    BinaryRow partition;
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<CompactManager> manager,
+                         factory.CreateCompactManager(partition, /*bucket=*/0,
+                                                      /*compact_strategy=*/nullptr,
+                                                      /*compact_executor=*/nullptr,
+                                                      /*levels=*/nullptr,
+                                                      /*dv_maintainer=*/nullptr));
+    ASSERT_NE(manager, nullptr);
+    ASSERT_NE(std::dynamic_pointer_cast<NoopCompactManager>(manager), nullptr);
+}
+
+TEST_F(MergeTreeCompactManagerFactoryWriteTest,
+       TestWriteShouldFailWhenLookupEnabledButIOManagerMissing) {
+    ASSERT_OK_AND_ASSIGN(
+        auto file_store_write,
+        CreateSingleStringFileStoreWrite({{"bucket", "1"}, {Options::FORCE_LOOKUP, "true"}},
+                                         /*with_io_manager=*/false));
+
+    ASSERT_NOK_WITH_MSG(WriteSingleStringRow(file_store_write.get(), /*bucket=*/0, "k1"),
+                        "Can not use lookup, there is no temp disk directory to use");
+}
+
+TEST_F(MergeTreeCompactManagerFactoryWriteTest,
+       TestCompactShouldUseNoopCompactManagerWhenWriteOnly) {
+    ASSERT_OK_AND_ASSIGN(
+        auto file_store_write,
+        CreateSingleStringFileStoreWrite({{"bucket", "1"}, {Options::WRITE_ONLY, "true"}},
+                                         /*with_io_manager=*/false));
+
+    ASSERT_NOK_WITH_MSG(file_store_write->Compact(/*partition=*/{}, /*bucket=*/0,
+                                                  /*full_compaction=*/true),
+                        "NoopCompactManager does not support user triggered compaction");
+}
+
+TEST_F(MergeTreeCompactManagerFactoryWriteTest,
+       TestCreateFileStoreWriteShouldFailWhenFullCompactionChangelogConfigured) {
+    ASSERT_NOK_WITH_MSG(CreateSingleStringFileStoreWrite(
+                            {{"bucket", "1"}, {Options::CHANGELOG_PRODUCER, "full-compaction"}},
+                            /*with_io_manager=*/false),
+                        "C++ Paimon does not support changelog-producer yet");
+}
+
+TEST_F(MergeTreeCompactManagerFactoryWriteTest,
+       TestPrepareCommitShouldSucceedWhenLookupDeletionVectorsTakeNoEffectInWriteProcess) {
+    ASSERT_OK_AND_ASSIGN(auto file_store_write, CreateSingleStringFileStoreWrite(
+                                                    {{"bucket", "1"},
+                                                     {Options::FORCE_LOOKUP, "true"},
+                                                     {Options::DELETION_VECTORS_ENABLED, "true"}},
+                                                    /*with_io_manager=*/true));
+
+    ASSERT_OK(WriteSingleStringRow(file_store_write.get(), /*bucket=*/0, "k1"));
+    ASSERT_OK(file_store_write->PrepareCommit(/*wait_compaction=*/true).status());
+}
+
+TEST_F(MergeTreeCompactManagerFactoryWriteTest,
+       TestWriteShouldFailWhenFirstRowWithDeletionVectors) {
+    ASSERT_OK_AND_ASSIGN(
+        auto file_store_write,
+        CreateSingleStringFileStoreWrite({{"bucket", "1"}, {Options::MERGE_ENGINE, "first-row"}},
+                                         /*with_io_manager=*/false,
+                                         {{Options::BUCKET, "1"},
+                                          {Options::MERGE_ENGINE, "first-row"},
+                                          {Options::DELETION_VECTORS_ENABLED, "true"}}));
+
+    ASSERT_NOK_WITH_MSG(WriteSingleStringRow(file_store_write.get(), /*bucket=*/0, "k1"),
+                        "First row merge engine does not need deletion vectors because there "
+                        "is no deletion of old "
+                        "data in this merge engine");
+}
+
+TEST_F(MergeTreeCompactManagerFactoryWriteTest,
+       TestPrepareCommitShouldSucceedWhenLookupDeletionVectorEnabledWithSequenceField) {
+    ASSERT_OK_AND_ASSIGN(auto file_store_write, CreateStringAndInt64FileStoreWrite(
+                                                    {{"bucket", "1"},
+                                                     {Options::FORCE_LOOKUP, "true"},
+                                                     {Options::DELETION_VECTORS_ENABLED, "true"},
+                                                     {Options::SEQUENCE_FIELD, "f1"}},
+                                                    /*with_io_manager=*/true));
+
+    ASSERT_OK(WriteStringAndInt64Row(file_store_write.get(), /*bucket=*/0, "k1", 1));
+    ASSERT_OK(file_store_write->PrepareCommit(/*wait_compaction=*/true).status());
+}
+
+TEST_F(MergeTreeCompactManagerFactoryWriteTest,
+       TestCreateFileStoreWriteShouldFailWhenLookupChangelogConfigured) {
+    ASSERT_NOK_WITH_MSG(
+        CreateSingleStringFileStoreWrite({{"bucket", "1"},
+                                          {Options::DELETION_VECTORS_ENABLED, "true"},
+                                          {Options::CHANGELOG_PRODUCER, "lookup"}},
+                                         /*with_io_manager=*/true),
+        "C++ Paimon does not support changelog-producer yet");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_manager_test.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_manager_test.cpp
@@ -1,0 +1,439 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/merge_tree_compact_manager.h"
+
+#include <algorithm>
+#include <functional>
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "gtest/gtest.h"
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/mergetree/level_sorted_run.h"
+#include "paimon/core/mergetree/levels.h"
+#include "paimon/core/mergetree/sorted_run.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+namespace {
+
+class InlineExecutor final : public Executor {
+ public:
+    void Add(std::function<void()> func) override {
+        func();
+    }
+
+    void ShutdownNow() override {}
+};
+
+class QueuedExecutor final : public Executor {
+ public:
+    void Add(std::function<void()> func) override {
+        tasks_.push_back(std::move(func));
+    }
+
+    void ShutdownNow() override {}
+
+    void RunAll() {
+        for (auto& task : tasks_) {
+            task();
+        }
+        tasks_.clear();
+    }
+
+ private:
+    std::vector<std::function<void()>> tasks_;
+};
+
+class FunctionalCompactStrategy final : public CompactStrategy {
+ public:
+    using PickFunc =
+        std::function<std::optional<CompactUnit>(int32_t, const std::vector<LevelSortedRun>&)>;
+
+    explicit FunctionalCompactStrategy(PickFunc func) : func_(std::move(func)) {}
+
+    Result<std::optional<CompactUnit>> Pick(int32_t num_levels,
+                                            const std::vector<LevelSortedRun>& runs) override {
+        return func_(num_levels, runs);
+    }
+
+ private:
+    PickFunc func_;
+};
+
+class TestRewriter final : public CompactRewriter {
+ public:
+    explicit TestRewriter(bool expected_drop_delete)
+        : expected_drop_delete_(expected_drop_delete) {}
+
+    Result<CompactResult> Rewrite(int32_t output_level, bool drop_delete,
+                                  const std::vector<std::vector<SortedRun>>& sections) override {
+        EXPECT_EQ(drop_delete, expected_drop_delete_);
+
+        int32_t min_key = std::numeric_limits<int32_t>::max();
+        int32_t max_key = std::numeric_limits<int32_t>::min();
+        int64_t min_sequence = std::numeric_limits<int64_t>::max();
+        int64_t max_sequence = 0;
+        std::vector<std::shared_ptr<DataFileMeta>> before;
+
+        for (const auto& section : sections) {
+            for (const auto& run : section) {
+                for (const auto& file : run.Files()) {
+                    before.push_back(file);
+                    min_key = std::min(min_key, file->min_key.GetInt(0));
+                    max_key = std::max(max_key, file->max_key.GetInt(0));
+                    min_sequence = std::min(min_sequence, file->min_sequence_number);
+                    max_sequence = std::max(max_sequence, file->max_sequence_number);
+                }
+            }
+        }
+
+        if (before.empty()) {
+            return CompactResult({}, {});
+        }
+
+        auto after = std::make_shared<DataFileMeta>(
+            "rewrite-" + std::to_string(rewrite_id_++),
+            /*file_size=*/max_key - min_key + 1,
+            /*row_count=*/0, BinaryRowGenerator::GenerateRow({min_key}, pool_.get()),
+            BinaryRowGenerator::GenerateRow({max_key}, pool_.get()), SimpleStats::EmptyStats(),
+            SimpleStats::EmptyStats(),
+            /*min_sequence_number=*/min_sequence,
+            /*max_sequence_number=*/max_sequence,
+            /*schema_id=*/0, output_level, std::vector<std::optional<std::string>>(),
+            Timestamp(1, 0), std::nullopt, nullptr, FileSource::Append(), std::nullopt,
+            std::nullopt, std::nullopt, std::nullopt);
+
+        return CompactResult(before, {after});
+    }
+
+    Result<CompactResult> Upgrade(int32_t output_level,
+                                  const std::shared_ptr<DataFileMeta>& file) override {
+        PAIMON_ASSIGN_OR_RAISE(auto upgraded, file->Upgrade(output_level));
+        return CompactResult({file}, {upgraded});
+    }
+
+    Status Close() override {
+        return Status::OK();
+    }
+
+ private:
+    bool expected_drop_delete_;
+    mutable int64_t rewrite_id_ = 0;
+    std::shared_ptr<MemoryPool> pool_ = GetDefaultPool();
+};
+
+struct LevelMinMax {
+    int32_t level;
+    int32_t min;
+    int32_t max;
+
+    LevelMinMax(int32_t level_value, int32_t min_value, int32_t max_value)
+        : level(level_value), min(min_value), max(max_value) {}
+
+    explicit LevelMinMax(const std::shared_ptr<DataFileMeta>& file)
+        : level(file->level), min(file->min_key.GetInt(0)), max(file->max_key.GetInt(0)) {}
+
+    bool operator==(const LevelMinMax& other) const {
+        return level == other.level && min == other.min && max == other.max;
+    }
+};
+
+}  // namespace
+
+class MergeTreeCompactManagerTest : public testing::Test {
+ protected:
+    using StrategyFn =
+        std::function<std::optional<CompactUnit>(int32_t, const std::vector<LevelSortedRun>&)>;
+
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+        std::vector<DataField> data_fields;
+        data_fields.emplace_back(/*id=*/0, arrow::field("f0", arrow::int32()));
+        ASSERT_OK_AND_ASSIGN(auto comparator,
+                             FieldsComparator::Create(data_fields, /*is_ascending_order=*/true));
+        comparator_ = std::shared_ptr<FieldsComparator>(std::move(comparator));
+        file_id_ = 0;
+    }
+
+    std::shared_ptr<DataFileMeta> ToFile(const LevelMinMax& minmax, int64_t max_sequence) {
+        const int64_t file_size = minmax.max - minmax.min + 1;
+        return std::make_shared<DataFileMeta>(
+            "f-" + std::to_string(file_id_++),
+            /*file_size=*/file_size,
+            /*row_count=*/0, BinaryRowGenerator::GenerateRow({minmax.min}, pool_.get()),
+            BinaryRowGenerator::GenerateRow({minmax.max}, pool_.get()), SimpleStats::EmptyStats(),
+            SimpleStats::EmptyStats(),
+            /*min_sequence_number=*/minmax.min,
+            /*max_sequence_number=*/max_sequence,
+            /*schema_id=*/0, minmax.level, std::vector<std::optional<std::string>>(),
+            Timestamp(1, 0), std::nullopt, nullptr, FileSource::Append(), std::nullopt,
+            std::nullopt, std::nullopt, std::nullopt);
+    }
+
+    StrategyFn TestStrategy() {
+        return [](int32_t num_levels,
+                  const std::vector<LevelSortedRun>& runs) -> std::optional<CompactUnit> {
+            return CompactUnit::FromLevelRuns(num_levels - 1, runs);
+        };
+    }
+
+    Result<std::shared_ptr<Levels>> CreateLevels(
+        const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+        PAIMON_ASSIGN_OR_RAISE(auto levels, Levels::Create(comparator_, files, /*num_levels=*/3));
+        return std::shared_ptr<Levels>(std::move(levels));
+    }
+
+    void InnerTest(const std::vector<LevelMinMax>& inputs,
+                   const std::vector<LevelMinMax>& expected) {
+        InnerTest(inputs, expected, TestStrategy(), /*expected_drop_delete=*/true);
+    }
+
+    void InnerTest(const std::vector<LevelMinMax>& inputs, const std::vector<LevelMinMax>& expected,
+                   const StrategyFn& strategy, bool expected_drop_delete) {
+        std::vector<std::shared_ptr<DataFileMeta>> files;
+        files.reserve(inputs.size());
+        for (size_t i = 0; i < inputs.size(); ++i) {
+            files.push_back(ToFile(inputs[i], static_cast<int64_t>(i)));
+        }
+
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<Levels> levels, CreateLevels(files));
+
+        auto manager = std::make_shared<MergeTreeCompactManager>(
+            levels, std::make_shared<FunctionalCompactStrategy>(strategy), comparator_,
+            /*compaction_file_size=*/2,
+            /*num_sorted_run_stop_trigger=*/std::numeric_limits<int32_t>::max(),
+            std::make_shared<TestRewriter>(expected_drop_delete),
+            /*metrics_reporter=*/nullptr,
+            /*dv_maintainer=*/nullptr,
+            /*lazy_gen_deletion_file=*/false,
+            /*need_lookup=*/false,
+            /*force_rewrite_all_files=*/false,
+            /*force_keep_delete=*/false, std::make_shared<CancellationController>(),
+            std::make_shared<InlineExecutor>());
+
+        ASSERT_OK(manager->TriggerCompaction(/*full_compaction=*/false));
+        ASSERT_OK_AND_ASSIGN(auto compact_result, manager->GetCompactionResult(/*blocking=*/true));
+        (void)compact_result;
+
+        std::vector<LevelMinMax> outputs;
+        for (const auto& file : levels->AllFiles()) {
+            outputs.emplace_back(file);
+        }
+
+        ASSERT_EQ(outputs.size(), expected.size());
+        EXPECT_EQ(outputs, expected);
+    }
+
+    std::shared_ptr<MemoryPool> pool_;
+    std::shared_ptr<FieldsComparator> comparator_;
+    int64_t file_id_ = 0;
+};
+
+TEST_F(MergeTreeCompactManagerTest, TestOutputToZeroLevel) {
+    InnerTest(
+        {LevelMinMax(0, 1, 3), LevelMinMax(0, 1, 5), LevelMinMax(0, 1, 8)},
+        {LevelMinMax(0, 1, 8), LevelMinMax(0, 1, 3)},
+        [](int32_t, const std::vector<LevelSortedRun>& runs) -> std::optional<CompactUnit> {
+            return CompactUnit::FromLevelRuns(0, {runs[0], runs[1]});
+        },
+        /*expected_drop_delete=*/false);
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestCompactToPenultimateLayer) {
+    InnerTest(
+        {LevelMinMax(0, 1, 3), LevelMinMax(0, 1, 5), LevelMinMax(2, 1, 7)},
+        {LevelMinMax(1, 1, 5), LevelMinMax(2, 1, 7)},
+        [](int32_t, const std::vector<LevelSortedRun>& runs) -> std::optional<CompactUnit> {
+            return CompactUnit::FromLevelRuns(1, {runs[0], runs[1]});
+        },
+        /*expected_drop_delete=*/false);
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestNoCompaction) {
+    InnerTest(
+        {LevelMinMax(3, 1, 3)}, {LevelMinMax(3, 1, 3)},
+        [](int32_t, const std::vector<LevelSortedRun>&) -> std::optional<CompactUnit> {
+            return std::nullopt;
+        },
+        /*expected_drop_delete=*/true);
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestNormal) {
+    InnerTest({LevelMinMax(0, 1, 3), LevelMinMax(1, 1, 5), LevelMinMax(1, 6, 7)},
+              {LevelMinMax(2, 1, 5), LevelMinMax(2, 6, 7)});
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestUpgrade) {
+    InnerTest({LevelMinMax(0, 1, 3), LevelMinMax(0, 1, 5), LevelMinMax(0, 6, 8)},
+              {LevelMinMax(2, 1, 5), LevelMinMax(2, 6, 8)});
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestSmallFiles) {
+    InnerTest({LevelMinMax(0, 1, 1), LevelMinMax(0, 2, 2)}, {LevelMinMax(2, 1, 2)});
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestSmallFilesNoCompact) {
+    InnerTest(
+        {LevelMinMax(0, 1, 5), LevelMinMax(0, 6, 6), LevelMinMax(1, 7, 8), LevelMinMax(1, 9, 10)},
+        {LevelMinMax(2, 1, 5), LevelMinMax(2, 6, 6), LevelMinMax(2, 7, 8), LevelMinMax(2, 9, 10)});
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestSmallFilesCrossLevel) {
+    InnerTest(
+        {LevelMinMax(0, 1, 5), LevelMinMax(0, 6, 6), LevelMinMax(1, 7, 7), LevelMinMax(1, 9, 10)},
+        {LevelMinMax(2, 1, 5), LevelMinMax(2, 6, 7), LevelMinMax(2, 9, 10)});
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestComplex) {
+    InnerTest(
+        {LevelMinMax(0, 1, 5), LevelMinMax(0, 6, 6), LevelMinMax(1, 1, 4), LevelMinMax(1, 6, 8),
+         LevelMinMax(1, 10, 11), LevelMinMax(2, 1, 3), LevelMinMax(2, 4, 6)},
+        {LevelMinMax(2, 1, 8), LevelMinMax(2, 10, 11)});
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestSmallInComplex) {
+    InnerTest(
+        {LevelMinMax(0, 1, 5), LevelMinMax(0, 6, 6), LevelMinMax(1, 1, 4), LevelMinMax(1, 6, 8),
+         LevelMinMax(1, 10, 10), LevelMinMax(2, 1, 3), LevelMinMax(2, 4, 6)},
+        {LevelMinMax(2, 1, 10)});
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestIsCompacting) {
+    std::vector<LevelMinMax> inputs = {LevelMinMax(0, 1, 3), LevelMinMax(1, 1, 5),
+                                       LevelMinMax(1, 6, 7)};
+    std::vector<std::shared_ptr<DataFileMeta>> files;
+    files.reserve(inputs.size());
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        files.push_back(ToFile(inputs[i], static_cast<int64_t>(i)));
+    }
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Levels> lookup_levels, CreateLevels(files));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Levels> default_levels, CreateLevels(files));
+
+    auto strategy = std::make_shared<FunctionalCompactStrategy>(TestStrategy());
+
+    auto lookup_manager = std::make_shared<MergeTreeCompactManager>(
+        lookup_levels, strategy, comparator_,
+        /*compaction_file_size=*/2,
+        /*num_sorted_run_stop_trigger=*/std::numeric_limits<int32_t>::max(),
+        std::make_shared<TestRewriter>(/*expected_drop_delete=*/true),
+        /*metrics_reporter=*/nullptr,
+        /*dv_maintainer=*/nullptr,
+        /*lazy_gen_deletion_file=*/false,
+        /*need_lookup=*/true,
+        /*force_rewrite_all_files=*/false,
+        /*force_keep_delete=*/false, std::make_shared<CancellationController>(),
+        std::make_shared<InlineExecutor>());
+
+    auto default_manager = std::make_shared<MergeTreeCompactManager>(
+        default_levels, strategy, comparator_,
+        /*compaction_file_size=*/2,
+        /*num_sorted_run_stop_trigger=*/std::numeric_limits<int32_t>::max(),
+        std::make_shared<TestRewriter>(/*expected_drop_delete=*/true),
+        /*metrics_reporter=*/nullptr,
+        /*dv_maintainer=*/nullptr,
+        /*lazy_gen_deletion_file=*/false,
+        /*need_lookup=*/false,
+        /*force_rewrite_all_files=*/false,
+        /*force_keep_delete=*/false, std::make_shared<CancellationController>(),
+        std::make_shared<InlineExecutor>());
+
+    EXPECT_TRUE(lookup_manager->CompactNotCompleted());
+    EXPECT_FALSE(default_manager->CompactNotCompleted());
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestTriggerFullCompaction) {
+    std::vector<LevelMinMax> inputs = {LevelMinMax(0, 1, 3), LevelMinMax(1, 2, 5),
+                                       LevelMinMax(1, 6, 7)};
+    std::vector<std::shared_ptr<DataFileMeta>> files;
+    files.reserve(inputs.size());
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        files.push_back(ToFile(inputs[i], static_cast<int64_t>(i)));
+    }
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Levels> levels, CreateLevels(files));
+
+    auto manager = std::make_shared<MergeTreeCompactManager>(
+        levels, std::make_shared<FunctionalCompactStrategy>(TestStrategy()), comparator_,
+        /*compaction_file_size=*/2,
+        /*num_sorted_run_stop_trigger=*/std::numeric_limits<int32_t>::max(),
+        std::make_shared<TestRewriter>(/*expected_drop_delete=*/true),
+        /*metrics_reporter=*/nullptr,
+        /*dv_maintainer=*/nullptr,
+        /*lazy_gen_deletion_file=*/false,
+        /*need_lookup=*/false,
+        /*force_rewrite_all_files=*/false,
+        /*force_keep_delete=*/false, std::make_shared<CancellationController>(),
+        std::make_shared<InlineExecutor>());
+
+    ASSERT_OK(manager->TriggerCompaction(/*full_compaction=*/true));
+    ASSERT_OK_AND_ASSIGN(auto compact_result, manager->GetCompactionResult(/*blocking=*/true));
+    ASSERT_TRUE(compact_result.has_value());
+    ASSERT_FALSE(compact_result.value()->Before().empty());
+    ASSERT_FALSE(compact_result.value()->After().empty());
+    for (const auto& after : compact_result.value()->After()) {
+        EXPECT_EQ(after->level, 2);
+    }
+}
+
+TEST_F(MergeTreeCompactManagerTest, TestRejectReentrantFullCompaction) {
+    std::vector<LevelMinMax> inputs = {LevelMinMax(0, 1, 3), LevelMinMax(1, 2, 5),
+                                       LevelMinMax(1, 6, 7)};
+    std::vector<std::shared_ptr<DataFileMeta>> files;
+    files.reserve(inputs.size());
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        files.push_back(ToFile(inputs[i], static_cast<int64_t>(i)));
+    }
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Levels> levels, CreateLevels(files));
+
+    auto queued_executor = std::make_shared<QueuedExecutor>();
+    auto manager = std::make_shared<MergeTreeCompactManager>(
+        levels, std::make_shared<FunctionalCompactStrategy>(TestStrategy()), comparator_,
+        /*compaction_file_size=*/2,
+        /*num_sorted_run_stop_trigger=*/std::numeric_limits<int32_t>::max(),
+        std::make_shared<TestRewriter>(/*expected_drop_delete=*/true),
+        /*metrics_reporter=*/nullptr,
+        /*dv_maintainer=*/nullptr,
+        /*lazy_gen_deletion_file=*/false,
+        /*need_lookup=*/false,
+        /*force_rewrite_all_files=*/false,
+        /*force_keep_delete=*/false, std::make_shared<CancellationController>(), queued_executor);
+
+    ASSERT_OK(manager->TriggerCompaction(/*full_compaction=*/true));
+    ASSERT_NOK_WITH_MSG(
+        manager->TriggerCompaction(/*full_compaction=*/true),
+        "A compaction task is still running while the user forces a new compaction.");
+    queued_executor->RunAll();
+    ASSERT_OK_AND_ASSIGN(auto compact_result, manager->GetCompactionResult(/*blocking=*/true));
+    ASSERT_TRUE(compact_result.has_value());
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_task.cpp
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_task.cpp
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/mergetree/compact/merge_tree_compact_task.h"
+
+namespace paimon {
+
+MergeTreeCompactTask::MergeTreeCompactTask(
+    const std::shared_ptr<FieldsComparator>& key_comparator, int64_t min_file_size,
+    const std::shared_ptr<CompactRewriter>& rewriter, const CompactUnit& unit, bool drop_delete,
+    int32_t max_level, const std::shared_ptr<CompactionMetrics::Reporter>& metrics_reporter,
+    DeletionFileSupplier compact_df_supplier, bool force_rewrite_all_files)
+    : CompactTask(metrics_reporter),
+      min_file_size_(min_file_size),
+      rewriter_(rewriter),
+      output_level_(unit.output_level),
+      compact_df_supplier_(std::move(compact_df_supplier)),
+      partitioned_(IntervalPartition(unit.files, key_comparator).Partition()),
+      drop_delete_(drop_delete),
+      max_level_(max_level),
+      force_rewrite_all_files_(force_rewrite_all_files) {}
+
+Result<std::shared_ptr<CompactResult>> MergeTreeCompactTask::DoCompact() {
+    std::vector<std::vector<SortedRun>> candidate;
+    auto result = std::make_shared<CompactResult>();
+
+    // Checking the order and compacting adjacent and contiguous files
+    // Note: can't skip an intermediate file to compact, this will destroy the overall orderliness
+    for (const auto& section : partitioned_) {
+        if (section.size() > 1) {
+            candidate.push_back(section);
+        } else if (!section.empty()) {
+            const auto& run = section[0];
+            // No overlapping:
+            // We can just upgrade the large file and just change the level instead of rewriting
+            // it. But for small files, we will try to compact it.
+            for (const auto& file : run.Files()) {
+                if (file->file_size < min_file_size_) {
+                    // Smaller files are rewritten along with the previous files.
+                    candidate.push_back({SortedRun::FromSingle(file)});
+                } else {
+                    // Large file appears, rewrite previous and upgrade it.
+                    PAIMON_RETURN_NOT_OK(Rewrite(&candidate, result.get()));
+                    PAIMON_RETURN_NOT_OK(Upgrade(file, result.get()));
+                }
+            }
+        }
+    }
+
+    PAIMON_RETURN_NOT_OK(Rewrite(&candidate, result.get()));
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<CompactDeletionFile> deletion_file,
+                           compact_df_supplier_());
+    result->SetDeletionFile(deletion_file);
+    return result;
+}
+
+Status MergeTreeCompactTask::Upgrade(const std::shared_ptr<DataFileMeta>& file,
+                                     CompactResult* to_update) {
+    // TODO(yonghao.fyh): check expire
+    if ((output_level_ == max_level_ && ContainsDeleteRecords(file)) || force_rewrite_all_files_) {
+        std::vector<std::vector<SortedRun>> candidate = {{SortedRun::FromSingle(file)}};
+        return RewriteImpl(&candidate, to_update);
+    }
+
+    if (file->level != output_level_) {
+        PAIMON_ASSIGN_OR_RAISE(CompactResult upgraded, rewriter_->Upgrade(output_level_, file));
+        PAIMON_RETURN_NOT_OK(to_update->Merge(upgraded));
+        ++upgrade_files_num_;
+    }
+    return Status::OK();
+}
+
+Status MergeTreeCompactTask::Rewrite(std::vector<std::vector<SortedRun>>* candidate,
+                                     CompactResult* to_update) {
+    if (candidate->empty()) {
+        return Status::OK();
+    }
+
+    if (candidate->size() == 1) {
+        const auto& section = (*candidate)[0];
+        if (section.empty()) {
+            return Status::Invalid("invalid section, section cannot be empty in candidate");
+        }
+        if (section.size() == 1) {
+            for (const auto& file : section[0].Files()) {
+                PAIMON_RETURN_NOT_OK(Upgrade(file, to_update));
+            }
+            candidate->clear();
+            return Status::OK();
+        }
+    }
+
+    return RewriteImpl(candidate, to_update);
+}
+
+Status MergeTreeCompactTask::RewriteImpl(std::vector<std::vector<SortedRun>>* candidate,
+                                         CompactResult* to_update) {
+    PAIMON_ASSIGN_OR_RAISE(CompactResult rewritten,
+                           rewriter_->Rewrite(output_level_, drop_delete_, *candidate));
+    PAIMON_RETURN_NOT_OK(to_update->Merge(rewritten));
+    candidate->clear();
+    return Status::OK();
+}
+
+bool MergeTreeCompactTask::ContainsDeleteRecords(const std::shared_ptr<DataFileMeta>& file) {
+    return !file->delete_row_count.has_value() || file->delete_row_count.value() > 0;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/mergetree/compact/merge_tree_compact_task.h
+++ b/src/paimon/core/mergetree/compact/merge_tree_compact_task.h
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "paimon/common/utils/fields_comparator.h"
+#include "paimon/core/compact/compact_deletion_file.h"
+#include "paimon/core/compact/compact_task.h"
+#include "paimon/core/compact/compact_unit.h"
+#include "paimon/core/mergetree/compact/compact_rewriter.h"
+#include "paimon/core/mergetree/compact/interval_partition.h"
+#include "paimon/core/mergetree/sorted_run.h"
+
+namespace paimon {
+
+/// Compact task for merge tree compaction.
+class MergeTreeCompactTask : public CompactTask {
+ public:
+    using DeletionFileSupplier = std::function<Result<std::shared_ptr<CompactDeletionFile>>()>;
+
+    // TODO(yonghao.fyh): Support RecordLevelExpire
+    MergeTreeCompactTask(const std::shared_ptr<FieldsComparator>& key_comparator,
+                         int64_t min_file_size, const std::shared_ptr<CompactRewriter>& rewriter,
+                         const CompactUnit& unit, bool drop_delete, int32_t max_level,
+                         const std::shared_ptr<CompactionMetrics::Reporter>& metrics_reporter,
+                         DeletionFileSupplier compact_df_supplier, bool force_rewrite_all_files);
+
+ protected:
+    Result<std::shared_ptr<CompactResult>> DoCompact() override;
+
+ private:
+    Status Upgrade(const std::shared_ptr<DataFileMeta>& file, CompactResult* to_update);
+
+    Status Rewrite(std::vector<std::vector<SortedRun>>* candidate, CompactResult* to_update);
+
+    Status RewriteImpl(std::vector<std::vector<SortedRun>>* candidate, CompactResult* to_update);
+
+    static bool ContainsDeleteRecords(const std::shared_ptr<DataFileMeta>& file);
+
+    int64_t min_file_size_;
+    std::shared_ptr<CompactRewriter> rewriter_;
+    int32_t output_level_;
+    DeletionFileSupplier compact_df_supplier_;
+    std::vector<std::vector<SortedRun>> partitioned_;
+    bool drop_delete_;
+    int32_t max_level_;
+    bool force_rewrite_all_files_;
+    int32_t upgrade_files_num_ = 0;
+};
+
+}  // namespace paimon


### PR DESCRIPTION
### Purpose

Linked issue: No linked issue

This change adds merge tree compact manager, compact task abstractions, and file rewrite compact task support for the mergetree compaction subsystem.

Included changes:

- **MergeTreeCompactManager**:
  - Adds `merge_tree_compact_manager.h` and `merge_tree_compact_manager.cpp` to orchestrate merge tree compaction workflows.
  - Adds test coverage in `merge_tree_compact_manager_test.cpp`.

- **MergeTreeCompactManagerFactory**:
  - Adds `merge_tree_compact_manager_factory.h` and `merge_tree_compact_manager_factory.cpp` to provide factory-based construction of compact managers.
  - Adds test coverage in `merge_tree_compact_manager_factory_test.cpp`.

- **MergeTreeCompactTask**:
  - Adds `merge_tree_compact_task.h` and `merge_tree_compact_task.cpp` to define the base compact task abstraction for merge tree operations.

- **FileRewriteCompactTask**:
  - Adds `file_rewrite_compact_task.h` to define file-rewrite specific compact task logic.
  - Adds test coverage in `file_rewrite_compact_task_test.cpp`.

### Tests

Not run. Local compile, CMake, and gtest environment checks are not part of this PR description.

Test coverage included in this change:

- `MergeTreeCompactManagerTest`
- `MergeTreeCompactManagerFactoryTest`
- `FileRewriteCompactTaskTest`

### API and Format

No public API, storage format, or protocol changes.

### Documentation

No documentation changes required.

### Generative AI tooling

Migrate-by: Aone Copilot (Qwen-3.7-Max)
