### PR TITLE
feat(testing): introduce mock testing utilities

### DIFF
--- a/src/paimon/testing/mock/mock_file_batch_reader.h
+++ b/src/paimon/testing/mock/mock_file_batch_reader.h
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "paimon/common/metrics/metrics_impl.h"
+#include "paimon/common/reader/reader_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/reader/prefetch_file_batch_reader.h"
+namespace paimon::test {
+
+class MockFileBatchReader : public PrefetchFileBatchReader {
+ public:
+    MockFileBatchReader(const std::shared_ptr<arrow::Array>& data,
+                        const std::shared_ptr<arrow::DataType>& file_schema,
+                        int32_t read_batch_size)
+        : data_(data),
+          file_schema_(file_schema),
+          read_schema_(arrow::schema(file_schema->fields())),
+          batch_size_(read_batch_size) {
+        // add all valid bitmap
+        int32_t data_length = data_ ? data_->length() : 0;
+        bitmap_ = RoaringBitmap32();
+        bitmap_.AddRange(0, data_length);
+        read_end_pos_ = data_length;
+        int64_t seed = DateTimeUtils::GetCurrentUTCTimeUs();
+        std::srand(seed);
+    }
+
+    MockFileBatchReader(const std::shared_ptr<arrow::Array>& data,
+                        const std::shared_ptr<arrow::DataType>& schema,
+                        const RoaringBitmap32& bitmap, int32_t read_batch_size)
+        : MockFileBatchReader(data, schema, read_batch_size) {
+        bitmap_ = bitmap;
+    }
+
+    Result<std::unique_ptr<::ArrowSchema>> GetFileSchema() const override {
+        std::unique_ptr<ArrowSchema> c_schema = std::make_unique<ArrowSchema>();
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportType(*file_schema_, c_schema.get()));
+        return c_schema;
+    }
+
+    void SetNextBatchStatus(const Status& status) {
+        next_batch_status_ = status;
+    }
+
+    void EnableRandomizeBatchSize(bool enabled) {
+        enable_randomize_batch_size_ = enabled;
+    }
+
+    Status SetReadSchema(::ArrowSchema* read_schema, const std::shared_ptr<Predicate>& predicate,
+                         const std::optional<RoaringBitmap32>& selection_bitmap) override {
+        // Noted that SetReadSchema only change inner read_schema_, but take no effective on
+        // NextBatch
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Schema> arrow_schema,
+                                          arrow::ImportSchema(read_schema));
+        read_schema_ = arrow_schema;
+        return Status::OK();
+    }
+
+    Result<std::vector<std::pair<uint64_t, uint64_t>>> GenReadRanges(
+        bool* need_prefetch) const override {
+        uint64_t begin_row_num = 0;
+        PAIMON_ASSIGN_OR_RAISE(uint64_t end_row_num, GetNumberOfRows());
+        std::vector<std::pair<uint64_t, uint64_t>> read_ranges;
+        for (uint64_t begin = begin_row_num; begin < end_row_num; begin += batch_size_) {
+            uint64_t end = std::min(begin + batch_size_, end_row_num);
+            read_ranges.emplace_back(begin, end);
+        }
+        *need_prefetch = true;
+        return read_ranges;
+    }
+
+    Status SeekToRow(uint64_t row_number) override {
+        current_pos_ = row_number;
+        return Status::OK();
+    }
+
+    Status SetReadRanges(const std::vector<std::pair<uint64_t, uint64_t>>& read_ranges) override {
+        read_ranges_ = read_ranges;
+        return Status::OK();
+    }
+
+    Result<ReadBatch> NextBatch() override {
+        PAIMON_ASSIGN_OR_RAISE(ReadBatchWithBitmap batch_with_bitmap, NextBatchWithBitmap());
+        return ReaderUtils::ApplyBitmapToReadBatch(std::move(batch_with_bitmap),
+                                                   arrow::default_memory_pool());
+    }
+
+    Result<ReadBatchWithBitmap> NextBatchWithBitmap() override {
+        while (true) {
+            PAIMON_RETURN_NOT_OK(next_batch_status_);
+            if (current_pos_ >= read_end_pos_) {
+                previous_batch_first_row_num_ = current_pos_;
+                return BatchReader::MakeEofBatchWithBitmap();
+            }
+            int32_t actual_batch_size = batch_size_;
+            if (enable_randomize_batch_size_) {
+                actual_batch_size = std::rand() % batch_size_ + 1;
+            }
+            int32_t batch_end_pos = std::min(read_end_pos_, current_pos_ + actual_batch_size);
+            auto slice = data_->Slice(current_pos_, batch_end_pos - current_pos_);
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                std::shared_ptr<arrow::Array> concat_slice,
+                arrow::Concatenate({slice}, arrow::default_memory_pool()));
+            RoaringBitmap32 bitmap;
+            for (auto iter = bitmap_.EqualOrLarger(current_pos_);
+                 iter != bitmap_.End() && *iter < batch_end_pos; ++iter) {
+                bitmap.Add(*iter - current_pos_);
+            }
+            previous_batch_first_row_num_ = current_pos_;
+            current_pos_ = batch_end_pos;
+            if (bitmap.IsEmpty()) {
+                continue;
+            }
+            std::unique_ptr<ArrowArray> c_array = std::make_unique<ArrowArray>();
+            std::unique_ptr<ArrowSchema> c_schema = std::make_unique<ArrowSchema>();
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                arrow::ExportArray(*concat_slice, c_array.get(), c_schema.get()));
+            return std::make_pair(std::make_pair(std::move(c_array), std::move(c_schema)),
+                                  std::move(bitmap));
+        }
+    }
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        auto metrics = std::make_shared<MetricsImpl>();
+        metrics->SetCounter("mock.number.of.rows", GetNumberOfRows().value_or(-1));
+        return metrics;
+    }
+
+    Result<uint64_t> GetPreviousBatchFirstRowNumber() const override {
+        return previous_batch_first_row_num_;
+    }
+
+    Result<uint64_t> GetNumberOfRows() const override {
+        return data_ ? data_->length() : 0;
+    }
+    uint64_t GetNextRowToRead() const override {
+        return current_pos_;
+    }
+    void Close() override {}
+
+    std::vector<std::pair<uint64_t, uint64_t>> GetReadRanges() const {
+        return read_ranges_;
+    }
+
+    bool SupportPreciseBitmapSelection() const override {
+        return false;
+    }
+
+ private:
+    std::shared_ptr<arrow::Array> data_;
+    std::shared_ptr<arrow::DataType> file_schema_;
+    std::shared_ptr<arrow::Schema> read_schema_;
+    RoaringBitmap32 bitmap_;
+    int32_t batch_size_ = 0;
+    int32_t current_pos_ = 0;
+    int32_t read_end_pos_ = 0;
+    int32_t previous_batch_first_row_num_ = -1;
+    Status next_batch_status_;
+    bool enable_randomize_batch_size_ = true;
+    std::vector<std::pair<uint64_t, uint64_t>> read_ranges_;
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_file_format.cpp
+++ b/src/paimon/testing/mock/mock_file_format.cpp
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/testing/mock/mock_file_format.h"
+
+#include <utility>
+
+#include "arrow/c/helpers.h"
+#include "paimon/status.h"
+#include "paimon/testing/mock/mock_format_writer_builder.h"
+#include "paimon/testing/mock/mock_stats_extractor.h"
+
+namespace paimon::test {
+Result<std::unique_ptr<ReaderBuilder>> MockFileFormat::CreateReaderBuilder(
+    int32_t batch_size) const {
+    return Status::NotImplemented("");
+}
+Result<std::unique_ptr<WriterBuilder>> MockFileFormat::CreateWriterBuilder(
+    ::ArrowSchema* schema, int32_t batch_size) const {
+    ArrowSchemaRelease(schema);
+    return std::make_unique<MockFormatWriterBuilder>();
+}
+
+Result<std::unique_ptr<FormatStatsExtractor>> MockFileFormat::CreateStatsExtractor(
+    ::ArrowSchema* schema) const {
+    ArrowSchemaRelease(schema);
+    return std::make_unique<MockStatsExtractor>();
+}
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_file_format.h
+++ b/src/paimon/testing/mock/mock_file_format.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "paimon/format/file_format.h"
+#include "paimon/format/format_stats_extractor.h"
+#include "paimon/format/reader_builder.h"
+#include "paimon/format/writer_builder.h"
+#include "paimon/result.h"
+
+struct ArrowSchema;
+
+namespace paimon::test {
+
+class MockFileFormat : public FileFormat {
+ public:
+    MockFileFormat() : identifier_("mock_format") {}
+
+    const std::string& Identifier() const override {
+        return identifier_;
+    }
+    Result<std::unique_ptr<ReaderBuilder>> CreateReaderBuilder(int32_t batch_size) const override;
+    Result<std::unique_ptr<WriterBuilder>> CreateWriterBuilder(::ArrowSchema* schema,
+                                                               int32_t batch_size) const override;
+    Result<std::unique_ptr<FormatStatsExtractor>> CreateStatsExtractor(
+        ::ArrowSchema* schema) const override;
+
+ private:
+    const std::string identifier_;
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_file_format_factory.cpp
+++ b/src/paimon/testing/mock/mock_file_format_factory.cpp
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/testing/mock/mock_file_format_factory.h"
+
+#include <utility>
+
+#include "paimon/factories/factory.h"
+#include "paimon/testing/mock/mock_file_format.h"
+
+namespace paimon::test {
+
+const char MockFileFormatFactory::IDENTIFIER[] = "mock_format";
+
+Result<std::unique_ptr<FileFormat>> MockFileFormatFactory::Create(
+    const std::map<std::string, std::string>& options) const {
+    return std::make_unique<MockFileFormat>();
+}
+
+REGISTER_PAIMON_FACTORY(MockFileFormatFactory);
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_file_format_factory.h
+++ b/src/paimon/testing/mock/mock_file_format_factory.h
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "paimon/format/file_format.h"
+#include "paimon/format/file_format_factory.h"
+#include "paimon/result.h"
+
+namespace paimon::test {
+
+class MockFileFormatFactory : public FileFormatFactory {
+ public:
+    static const char IDENTIFIER[];
+
+    const char* Identifier() const override {
+        return IDENTIFIER;
+    }
+
+    Result<std::unique_ptr<FileFormat>> Create(
+        const std::map<std::string, std::string>& options) const override;
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_file_system.h
+++ b/src/paimon/testing/mock/mock_file_system.h
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/fs/file_system.h"
+
+namespace paimon::test {
+
+class MockInputStream : public InputStream {
+ public:
+    MockInputStream() = default;
+    ~MockInputStream() override = default;
+
+    Status Seek(int64_t offset, SeekOrigin origin) override {
+        return Status::OK();
+    }
+    Result<int64_t> GetPos() const override {
+        return 0;
+    }
+    Result<int32_t> Read(char* buffer, uint32_t size) override {
+        return 0;
+    }
+    Result<int32_t> Read(char* buffer, uint32_t size, uint64_t offset) override {
+        return 0;
+    }
+    void ReadAsync(char* buffer, uint32_t size, uint64_t offset,
+                   std::function<void(Status)>&& callback) override {}
+
+    Status Close() override {
+        return Status::OK();
+    }
+    Result<std::string> GetUri() const override {
+        return std::string();
+    }
+    Result<uint64_t> Length() const override {
+        return 0;
+    }
+};
+
+class MockOutputStream : public OutputStream {
+ public:
+    MockOutputStream() = default;
+    ~MockOutputStream() override = default;
+
+    Result<int64_t> GetPos() const override {
+        return 0;
+    }
+    Result<int32_t> Write(const char* buffer, uint32_t size) override {
+        return 0;
+    }
+    Status Flush() override {
+        return Status::OK();
+    }
+    Status Close() override {
+        return Status::OK();
+    }
+    Result<std::string> GetUri() const override {
+        return std::string();
+    }
+};
+
+class MockFileStatus : public FileStatus {
+ public:
+    MockFileStatus() = default;
+    ~MockFileStatus() override = default;
+
+    std::string GetPath() const override {
+        return "";
+    }
+    uint64_t GetLen() const override {
+        return 0;
+    }
+    int64_t GetModificationTime() const override {
+        return 0;
+    }
+    bool IsDir() const override {
+        return false;
+    }
+};
+
+class MockFileSystem : public FileSystem {
+ public:
+    MockFileSystem() = default;
+    ~MockFileSystem() override = default;
+
+    Result<std::unique_ptr<InputStream>> Open(const std::string& path) const override {
+        return std::make_unique<MockInputStream>();
+    }
+    Result<std::unique_ptr<OutputStream>> Create(const std::string& path,
+                                                 bool overwrite) const override {
+        return std::make_unique<MockOutputStream>();
+    }
+    Status Mkdirs(const std::string& path) const override {
+        return Status::OK();
+    }
+    Status Rename(const std::string& src, const std::string& dst) const override {
+        return Status::OK();
+    }
+    Status Delete(const std::string& path, bool recursive = true) const override {
+        return Status::OK();
+    }
+    Result<std::unique_ptr<FileStatus>> GetFileStatus(const std::string& path) const override {
+        return std::make_unique<MockFileStatus>();
+    }
+    Status ListDir(const std::string& directory,
+                   std::vector<std::unique_ptr<BasicFileStatus>>* status_list) const override {
+        return Status::OK();
+    }
+    Status ListFileStatus(const std::string& path,
+                          std::vector<std::unique_ptr<FileStatus>>* status_list) const override {
+        return Status::OK();
+    }
+    Result<bool> Exists(const std::string& path) const override {
+        return true;
+    }
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_file_system_factory.cpp
+++ b/src/paimon/testing/mock/mock_file_system_factory.cpp
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/testing/mock/mock_file_system_factory.h"
+
+#include "paimon/factories/factory.h"
+
+namespace paimon::test {
+
+const char MockFileSystemFactory::IDENTIFIER[] = "mock_fs";
+
+REGISTER_PAIMON_FACTORY(MockFileSystemFactory);
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_file_system_factory.h
+++ b/src/paimon/testing/mock/mock_file_system_factory.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "paimon/fs/file_system_factory.h"
+#include "paimon/result.h"
+#include "paimon/testing/mock/mock_file_system.h"
+
+namespace paimon {
+class FileSystem;
+}  // namespace paimon
+
+namespace paimon::test {
+class MockFileSystemFactory : public FileSystemFactory {
+ public:
+    static const char IDENTIFIER[];
+
+    const char* Identifier() const override {
+        return IDENTIFIER;
+    }
+
+    Result<std::unique_ptr<FileSystem>> Create(
+        const std::string& path, const std::map<std::string, std::string>& options) const override {
+        return std::make_unique<MockFileSystem>();
+    }
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_format_reader_builder.h
+++ b/src/paimon/testing/mock/mock_format_reader_builder.h
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "arrow/type.h"
+#include "paimon/format/reader_builder.h"
+#include "paimon/testing/mock/mock_file_batch_reader.h"
+#include "paimon/type_fwd.h"
+
+namespace paimon::test {
+
+class MockFormatReaderBuilder : public ReaderBuilder {
+ public:
+    MockFormatReaderBuilder(const std::shared_ptr<arrow::Array>& data,
+                            const std::shared_ptr<arrow::DataType>& schema, int32_t read_batch_size)
+        : MockFormatReaderBuilder(data, schema, std::nullopt, read_batch_size) {}
+
+    MockFormatReaderBuilder(const std::shared_ptr<arrow::Array>& data,
+                            const std::shared_ptr<arrow::DataType>& schema,
+                            const std::optional<RoaringBitmap32>& bitmap, int32_t read_batch_size)
+        : data_(data), schema_(schema), bitmap_(bitmap), read_batch_size_(read_batch_size) {}
+
+    ~MockFormatReaderBuilder() override = default;
+
+    ReaderBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool) override {
+        return this;
+    }
+
+    Result<std::unique_ptr<FileBatchReader>> Build(
+        const std::shared_ptr<InputStream>& path) const override {
+        if (bitmap_) {
+            return std::make_unique<MockFileBatchReader>(data_, schema_, bitmap_.value(),
+                                                         read_batch_size_);
+        }
+        return std::make_unique<MockFileBatchReader>(data_, schema_, read_batch_size_);
+    }
+
+    Result<std::unique_ptr<FileBatchReader>> Build(const std::string& path) const override {
+        return Status::Invalid("do not support build reader with path in mock format");
+    }
+
+ private:
+    std::shared_ptr<arrow::Array> data_;
+    std::shared_ptr<arrow::DataType> schema_;
+    std::optional<RoaringBitmap32> bitmap_;
+    int32_t read_batch_size_;
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_format_writer.cpp
+++ b/src/paimon/testing/mock/mock_format_writer.cpp
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/testing/mock/mock_format_writer.h"
+
+#include <string>
+#include <utility>
+
+#include "arrow/c/helpers.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/result.h"
+
+struct ArrowArray;
+
+namespace paimon {
+class MemoryPool;
+}  // namespace paimon
+
+namespace paimon::test {
+MockFormatWriter::MockFormatWriter(const std::shared_ptr<OutputStream>& out,
+                                   const std::shared_ptr<MemoryPool>& pool)
+    : FormatWriter(), out_(std::move(out)), pool_(pool) {}
+
+Status MockFormatWriter::AddBatch(ArrowArray* batch) {
+    ArrowArrayRelease(batch);
+    std::string str = std::to_string(DateTimeUtils::GetCurrentUTCTimeUs()) + "\n";
+    PAIMON_ASSIGN_OR_RAISE(int32_t res, out_->Write(str.data(), str.size()));
+    if (res != static_cast<int32_t>(str.size())) {
+        return Status::IOError("write size does not match");
+    }
+    counter_++;
+    return Status::OK();
+}
+Status MockFormatWriter::Flush() {
+    return out_->Flush();
+}
+Status MockFormatWriter::Finish() {
+    return Flush();
+}
+Result<bool> MockFormatWriter::ReachTargetSize(bool suggested_check, int64_t target_size) const {
+    if (counter_ >= target_size) {
+        return true;
+    }
+    return false;
+}
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_format_writer.h
+++ b/src/paimon/testing/mock/mock_format_writer.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+
+#include "paimon/format/format_writer.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+struct ArrowArray;
+
+namespace paimon {
+class MemoryPool;
+class Metrics;
+class OutputStream;
+}  // namespace paimon
+
+namespace paimon::test {
+class MockFormatWriter : public FormatWriter {
+ public:
+    MockFormatWriter(const std::shared_ptr<OutputStream>& out,
+                     const std::shared_ptr<MemoryPool>& pool);
+
+    Status AddBatch(ArrowArray* batch) override;
+    Status Flush() override;
+    Status Finish() override;
+    Result<bool> ReachTargetSize(bool suggested_check, int64_t target_size) const override;
+    std::shared_ptr<Metrics> GetWriterMetrics() const override {
+        return nullptr;
+    }
+
+ private:
+    int64_t counter_ = 0;
+    std::shared_ptr<OutputStream> out_;
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_format_writer_builder.cpp
+++ b/src/paimon/testing/mock/mock_format_writer_builder.cpp
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/testing/mock/mock_format_writer_builder.h"
+
+#include <utility>
+
+#include "paimon/testing/mock/mock_format_writer.h"
+
+namespace paimon {
+class MemoryPool;
+class OutputStream;
+}  // namespace paimon
+
+namespace paimon::test {
+MockFormatWriterBuilder::MockFormatWriterBuilder() = default;
+
+WriterBuilder* MockFormatWriterBuilder::WithMemoryPool(const std::shared_ptr<MemoryPool>& pool) {
+    memory_pool_ = pool;
+    return this;
+}
+
+Result<std::unique_ptr<FormatWriter>> MockFormatWriterBuilder::Build(
+    const std::shared_ptr<OutputStream>& out, const std::string& compression) {
+    return std::make_unique<MockFormatWriter>(out, memory_pool_);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_format_writer_builder.h
+++ b/src/paimon/testing/mock/mock_format_writer_builder.h
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "paimon/format/format_writer.h"
+#include "paimon/format/writer_builder.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/type_fwd.h"
+
+namespace paimon {
+class MemoryPool;
+class OutputStream;
+}  // namespace paimon
+
+namespace paimon::test {
+class MockFormatWriterBuilder : public WriterBuilder {
+ public:
+    MockFormatWriterBuilder();
+    ~MockFormatWriterBuilder() override = default;
+
+    WriterBuilder* WithMemoryPool(const std::shared_ptr<MemoryPool>& pool) override;
+
+    Result<std::unique_ptr<FormatWriter>> Build(const std::shared_ptr<OutputStream>& out,
+                                                const std::string& compression) override;
+
+ private:
+    Status Prepare();
+
+    std::shared_ptr<MemoryPool> memory_pool_;
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_index_path_factory.h
+++ b/src/paimon/testing/mock/mock_index_path_factory.h
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/index/index_path_factory.h"
+
+namespace paimon::test {
+
+class MockIndexPathFactory : public IndexPathFactory {
+ public:
+    explicit MockIndexPathFactory(const std::string& index_path) : index_path_(index_path) {}
+
+    std::string NewPath() const override {
+        return PathUtil::JoinPath(index_path_, std::string(IndexPathFactory::INDEX_PREFIX) +
+                                                   std::to_string(index_file_count_->fetch_add(1)));
+    }
+    std::string ToPath(const std::string& file_name) const override {
+        return PathUtil::JoinPath(index_path_, file_name);
+    }
+    std::string ToPath(const std::shared_ptr<IndexFileMeta>& file) const override {
+        return PathUtil::JoinPath(index_path_, file->FileName());
+    }
+    bool IsExternalPath() const override {
+        return external_;
+    }
+    void SetExternal(bool v) {
+        external_ = v;
+    }
+
+ private:
+    std::string index_path_;
+    bool external_ = false;
+    std::shared_ptr<std::atomic<int32_t>> index_file_count_ =
+        std::make_shared<std::atomic<int32_t>>(0);
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_key_value_data_file_record_reader.h
+++ b/src/paimon/testing/mock/mock_key_value_data_file_record_reader.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include "paimon/common/data/columnar/columnar_batch_context.h"
+#include "paimon/core/io/key_value_data_file_record_reader.h"
+namespace paimon::test {
+// mock reader hold data array
+class MockKeyValueDataFileRecordReader : public KeyValueDataFileRecordReader {
+ public:
+    MockKeyValueDataFileRecordReader(std::unique_ptr<FileBatchReader>&& reader,
+                                     const std::shared_ptr<arrow::Schema>& key_schema,
+                                     const std::shared_ptr<arrow::Schema>& value_schema,
+                                     int32_t level, const std::shared_ptr<MemoryPool>& pool)
+        : KeyValueDataFileRecordReader(std::move(reader), key_schema, value_schema, level, pool) {}
+
+    void Reset() override {
+        if (key_ctx_) {
+            for (const auto& field : key_ctx_->array_vec) {
+                data_holder_.push_back(field);
+            }
+        }
+        if (value_ctx_) {
+            for (const auto& field : value_ctx_->array_vec) {
+                data_holder_.push_back(field);
+            }
+        }
+        KeyValueDataFileRecordReader::Reset();
+    }
+
+ private:
+    arrow::ArrayVector data_holder_;
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_stats_extractor.cpp
+++ b/src/paimon/testing/mock/mock_stats_extractor.cpp
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/testing/mock/mock_stats_extractor.h"
+
+#include <optional>
+
+#include "paimon/format/column_stats.h"
+
+namespace paimon {
+class FileSystem;
+class MemoryPool;
+}  // namespace paimon
+
+namespace paimon::test {
+Result<std::vector<std::shared_ptr<ColumnStats>>> MockStatsExtractor::Extract(
+    const std::shared_ptr<FileSystem>& file_system, const std::string& path,
+    const std::shared_ptr<MemoryPool>& pool) {
+    PAIMON_ASSIGN_OR_RAISE(auto result, ExtractWithFileInfo(file_system, path, pool));
+    return result.first;
+}
+
+Result<std::pair<std::vector<std::shared_ptr<ColumnStats>>, FormatStatsExtractor::FileInfo>>
+MockStatsExtractor::ExtractWithFileInfo(const std::shared_ptr<FileSystem>& file_system,
+                                        const std::string& path,
+                                        const std::shared_ptr<MemoryPool>& pool) {
+    FormatStatsExtractor::FileInfo file_info(1000);
+    std::shared_ptr<ColumnStats> col0 = ColumnStats::CreateIntColumnStats(0, 100, 10);
+    std::shared_ptr<ColumnStats> col1 = ColumnStats::CreateDoubleColumnStats(0.1, 100.1, 10);
+    std::shared_ptr<ColumnStats> col2 = ColumnStats::CreateStringColumnStats("abc", "def", 10);
+    std::vector<std::shared_ptr<ColumnStats>> stats = {col0, col1, col2};
+    return std::make_pair(stats, file_info);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/testing/mock/mock_stats_extractor.h
+++ b/src/paimon/testing/mock/mock_stats_extractor.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "paimon/format/column_stats.h"
+#include "paimon/format/format_stats_extractor.h"
+#include "paimon/result.h"
+
+namespace paimon {
+class FileSystem;
+class MemoryPool;
+}  // namespace paimon
+
+namespace paimon::test {
+class MockStatsExtractor : public FormatStatsExtractor {
+ public:
+    Result<std::vector<std::shared_ptr<ColumnStats>>> Extract(
+        const std::shared_ptr<FileSystem>& file_system, const std::string& path,
+        const std::shared_ptr<MemoryPool>& pool) override;
+
+    Result<std::pair<std::vector<std::shared_ptr<ColumnStats>>, FileInfo>> ExtractWithFileInfo(
+        const std::shared_ptr<FileSystem>& file_system, const std::string& path,
+        const std::shared_ptr<MemoryPool>& pool) override;
+};
+
+}  // namespace paimon::test


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx

Introduce mock testing utilities from the Alibaba Paimon C++ repository under `src/paimon/testing/mock`.

This migration includes the mock file format, file system, format writer, stats extractor, index path factory, and related testing helpers. The source `src/paimon/testing/mock/CMakeLists.txt` is intentionally not included because this PR follows the requested file scope.

All migrated source files have their Alibaba copyright headers replaced with Apache Software Foundation license headers. No third-party license or NOTICE updates are required for this batch.

External contributor analysis found no external contribution threshold hits, so this PR does not add `Co-authored-by` trailers or require contributor thank-you comments.

### Tests

### API and Format

No public API, storage format, or protocol changes.

### Documentation

No documentation changes.

### Generative AI tooling

Migrated-by: OpenAI Codex
