### PR TITLE
feat: implement TableRead and FallbackDataSplit

### DIFF
--- a/src/paimon/core/table/source/data_split_test.cpp
+++ b/src/paimon/core/table/source/data_split_test.cpp
@@ -1,0 +1,1124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/table/source/data_split.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <variant>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/data_define.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/core/table/source/deletion_file.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(DataSplitTest, TestDeserializeVersion8WithWriteColsAndExternalPath) {
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/orc/pk_dv_index_in_data_with_external.db/"
+                            "pk_dv_index_in_data_with_external/data_splits/"
+                            "data_split-02";
+    auto file_system = std::make_unique<LocalFileSystem>();
+
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-72b62a5f-d698-4db5-b51a-04c0dc027702-0.orc", /*file_size=*/961, /*row_count=*/5,
+        /*min_key=*/BinaryRowGenerator::GenerateRow({std::string("Alex"), 0}, pool.get()),
+        /*max_key=*/BinaryRowGenerator::GenerateRow({std::string("Tony"), 0}, pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 0}, {std::string("Tony"), 0},
+                                          {
+                                              0,
+                                              0,
+                                          },
+                                          pool.get()),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 10, 0, 12.1},
+                                          {std::string("Tony"), 10, 0, 17.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/4, /*schema_id=*/0,
+        /*level=*/5, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1757354415711ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/
+        "FILE:/tmp/external/f1=10/bucket-1/data-72b62a5f-d698-4db5-b51a-04c0dc027702-0.orc",
+        /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/1, /*bucket_path=*/
+        "data/orc/pk_dv_index_in_data_with_external.db/pk_dv_index_in_data_with_external/f1=10/"
+        "bucket-1",
+        {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(4)
+            .WithTotalBuckets(2)
+            .IsStreaming(false)
+            .RawConvertible(true)
+            .WithDataDeletionFiles({DeletionFile(
+                "FILE:/tmp/external/f1=10/bucket-1/index-419e7c6b-9cad-49e8-9cd2-6187471df954-1",
+                /*offset=*/1,
+                /*length=*/22, /*cardinality=*/1)})
+            .Build()
+            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split) << result_data_split->ToString();
+    ASSERT_OK_AND_ASSIGN(std::string serialize_bytes, Split::Serialize(result_data_split, pool));
+    ASSERT_EQ(serialize_bytes, std::string(split_bytes.data(), split_bytes.size()));
+}
+
+TEST(DataSplitTest, TestDeserializeVersion8WithWriteCols) {
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/orc/pk_dv_index_not_in_data_no_external.db/"
+                            "pk_dv_index_not_in_data_no_external/data_splits/"
+                            "data_split-02";
+    auto file_system = std::make_unique<LocalFileSystem>();
+
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-aa87291d-2a90-4846-b106-1bb4c76d74db-0.orc", /*file_size=*/961, /*row_count=*/5,
+        /*min_key=*/BinaryRowGenerator::GenerateRow({std::string("Alex"), 0}, pool.get()),
+        /*max_key=*/BinaryRowGenerator::GenerateRow({std::string("Tony"), 0}, pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 0}, {std::string("Tony"), 0},
+                                          {
+                                              0,
+                                              0,
+                                          },
+                                          pool.get()),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 10, 0, 12.1},
+                                          {std::string("Tony"), 10, 0, 17.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/4, /*schema_id=*/0,
+        /*level=*/5, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1757349273246ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/1, /*bucket_path=*/
+        "data/orc/pk_dv_index_not_in_data_no_external.db/pk_dv_index_not_in_data_no_external/f1=10/"
+        "bucket-1",
+        {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(4)
+            .WithTotalBuckets(2)
+            .IsStreaming(false)
+            .RawConvertible(true)
+            .WithDataDeletionFiles({DeletionFile("data/orc/pk_dv_index_not_in_data_no_external.db/"
+                                                 "pk_dv_index_not_in_data_no_external/index/"
+                                                 "index-aa60193d-d7cd-434f-bc1a-c1adb210e1f7-1",
+                                                 /*offset=*/1,
+                                                 /*length=*/22, /*cardinality=*/1)})
+            .Build()
+            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split) << result_data_split->ToString();
+    ASSERT_OK_AND_ASSIGN(std::string serialize_bytes, Split::Serialize(result_data_split, pool));
+    ASSERT_EQ(serialize_bytes, std::string(split_bytes.data(), split_bytes.size()));
+}
+
+TEST(DataSplitTest, TestDeserializeVersion7WithFirstRowId) {
+    // test data split with version 7
+    std::string file_name =
+        paimon::test::GetDataDir() +
+        "/orc/append_table_with_first_row_id.db/append_table_with_first_row_id/data_splits/"
+        "data_split-02";
+    auto file_system = std::make_unique<LocalFileSystem>();
+
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-92480a4b-ec0b-4585-883a-a99679870c4d-0.orc", /*file_size=*/653, /*row_count=*/5,
+        /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/
+        SimpleStats::EmptyStats(),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 110, 0, 11.1},
+                                          {std::string("Tony"), 110, 1, 16.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/2, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1754073518741ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/5, /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRow::EmptyRow(),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/append_table_with_support_first_row_id.db/append_table_with_support_first_row_id/"
+        "bucket-0",
+        {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(builder.WithSnapshot(2)
+                                                                            .WithTotalBuckets(-1)
+                                                                            .IsStreaming(false)
+                                                                            .RawConvertible(true)
+                                                                            .Build()
+                                                                            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+    ASSERT_OK(Split::Serialize(result_data_split, pool));
+}
+
+TEST(DataSplitTest, TestDeserializeVersion7WithNullFirstRowId) {
+    // test data split with version 7
+    std::string file_name =
+        paimon::test::GetDataDir() +
+        "/orc/append_table_with_first_row_id.db/append_table_with_first_row_id/data_splits/"
+        "data_split-01";
+    auto file_system = std::make_unique<LocalFileSystem>();
+
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-16bd83f7-282a-479a-9968-0868436516b0-0.orc", /*file_size=*/567, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/
+        SimpleStats::EmptyStats(),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 1, 11.1},
+                                          {std::string("Alice"), 10, 1, 11.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1754068646844ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/append_table_with_first_row_id.db/append_table_with_first_row_id/f1=10/bucket-0",
+        {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(builder.WithSnapshot(1)
+                                                                            .WithTotalBuckets(2)
+                                                                            .IsStreaming(false)
+                                                                            .RawConvertible(true)
+                                                                            .Build()
+                                                                            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+    ASSERT_OK(Split::Serialize(result_data_split, pool));
+}
+
+TEST(DataSplitTest, TestDeserializeVersion6PkWithTotalBuckets) {
+    // test data split with version 6
+    std::string file_name =
+        paimon::test::GetDataDir() +
+        "/orc/pk_table_with_total_buckets.db/pk_table_with_total_buckets/data_splits/"
+        "data_split-01";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-d7725088-6bd4-4e70-9ce6-714ae93b47cc-0.orc", /*file_size=*/863, /*row_count=*/1,
+        /*min_key=*/BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool.get()),
+        /*max_key=*/BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 1}, {std::string("Alice"), 1},
+                                          {0, 0}, pool.get()),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 1, 11.1},
+                                          {std::string("Alice"), 10, 1, 11.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1743525392885ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/pk_table_with_total_buckets.db/pk_table_with_total_buckets/f1=10/bucket-0",
+        {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(builder.WithSnapshot(1)
+                                                                            .WithTotalBuckets(2)
+                                                                            .IsStreaming(false)
+                                                                            .RawConvertible(true)
+                                                                            .Build()
+                                                                            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+    ASSERT_OK(Split::Serialize(result_data_split, pool));
+}
+
+TEST(DataSplitTest, TestDeserializeVersion5PkWithExternalPath) {
+    // test data split with version 5
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/orc/append_10_external_path.db/append_10_external_path/data_splits/"
+                            "data_split-02";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-80110e15-97b5-4bcf-ac09-6ca2659a4950-0.orc", /*file_size=*/645, /*row_count=*/5,
+        BinaryRow::EmptyRow(), BinaryRow::EmptyRow(), SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 0, 11.1},
+                                          {std::string("Tony"), 20, 1, 14.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/4, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1737111915429ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/"file:/tmp/bucket-0/data-80110e15-97b5-4bcf-ac09-6ca2659a4950-0.orc",
+        /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRow::EmptyRow(),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/append_10_external_path2.db/append_10_external_path2/bucket-0", {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build().value());
+
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+
+    std::vector<DataSplit::SimpleDataFileMeta> file_list = {DataSplit::SimpleDataFileMeta(
+        {"file:/tmp/bucket-0/data-80110e15-97b5-4bcf-ac09-6ca2659a4950-0.orc",
+         /*file_size=*/645, /*row_count=*/5, /*min_sequence_number=*/0,
+         /*max_sequence_number=*/4, /*schema_id=*/0, /*level=*/0,
+         /*creation_time=*/Timestamp(1737111915429ll, 0), /*delete_row_count=*/0})};
+    ASSERT_EQ(file_list, result_data_split->GetFileList());
+
+    ASSERT_OK(Split::Serialize(result_data_split, pool));
+}
+
+TEST(DataSplitTest, TestDeserializeVersion5PkWithEmptyExternalPath) {
+    // test data split with version 5
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/orc/append_10_external_path.db/append_10_external_path/data_splits/"
+                            "data_split-01";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-64d93fc3-eaf2-4253-9cff-a9faa701e207-0.orc", /*file_size=*/645, /*row_count=*/5,
+        BinaryRow::EmptyRow(), BinaryRow::EmptyRow(), SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 0, 11.1},
+                                          {std::string("Tony"), 20, 1, 14.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/4, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1737052260143ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRow::EmptyRow(),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/append_10_external_path.db/append_10_external_path/bucket-0", {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build().value());
+
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+    ASSERT_EQ(5, expected_data_split->PartialMergedRowCount());
+
+    ASSERT_OK(Split::Serialize(result_data_split, pool));
+}
+
+TEST(DataSplitTest, TestDeserializeVersion4PkWithSnapshot4WithDvCardinality) {
+    // test data split with version 4
+    std::string file_name =
+        paimon::test::GetDataDir() +
+        "/orc/pk_table_with_dv_cardinality.db/pk_table_with_dv_cardinality/data_splits/"
+        "data_split-01";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-2ffe7ae9-2cf7-41e9-944b-2065585cde31-0.orc", /*file_size=*/1318, /*row_count=*/7,
+        /*min_key=*/BinaryRowGenerator::GenerateRow({std::string("Alex"), 0}, pool.get()),
+        /*max_key=*/
+        BinaryRowGenerator::GenerateRow(
+            {std::string("Whether I shall turn out to be the hero of my own life."), 0},
+            pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats(
+            {std::string("Alex"), 0},
+            {std::string("Whether I shall turn out to be the hero of my own life."), 0}, {0, 0},
+            pool.get()),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 10, 0},
+                                          {std::string("Whether I shall!"), 10, 0}, {0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/6, /*schema_id=*/0,
+        /*level=*/5, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1734707235578ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::optional<std::vector<std::string>>({"f0", "f1", "f2"}),
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/1, /*bucket_path=*/
+        "data/pk_table_with_dv_cardinality.db/pk_table_with_dv_cardinality/f1=10/bucket-1",
+        {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(4)
+            .WithDataDeletionFiles(
+                {DeletionFile("data/pk_table_with_dv_cardinality.db/pk_table_with_dv_cardinality/"
+                              "index/index-86356766-3238-46e6-990b-656cd7409eaa-1",
+                              /*offset=*/1, /*length=*/24, /*cardinality=*/2)})
+            .IsStreaming(false)
+            .RawConvertible(true)
+            .Build()
+            .value());
+
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+    ASSERT_EQ(5, expected_data_split->PartialMergedRowCount());
+}
+
+TEST(DataSplitTest, TestDeserializeVersion3AppendWithSnapshot1) {
+    // test data split with version 3
+    std::string file_name =
+        paimon::test::GetDataDir() + "/orc/append_10.db/append_10/data_splits/data_split-01";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-de4e972f-5cc8-49b1-844e-374191534c68-0.orc", /*file_size=*/575, /*row_count=*/3,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Bob"), 10, 0, 12.1},
+                                          {std::string("Tony"), 10, 0, 14.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1731404403198ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    DataSplitImpl::Builder builder(/*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+                                   /*bucket=*/1, /*bucket_path=*/
+                                   "data/append_10.db/append_10/f1=10/bucket-1", {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build().value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+}
+
+TEST(DataSplitTest, TestDeserializeVersion3AppendWithSnapshot1WithStatsDenseStore) {
+    // test data split with version 3
+    std::string file_name =
+        paimon::test::GetDataDir() +
+        "/orc/append_10_stats_dense_store.db/append_10_stats_dense_store/data_splits/"
+        "data_split-01";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-c2613568-0412-4cd9-a0c4-1eae8e4ca89b-0.orc", /*file_size=*/575, /*row_count=*/3,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Bob"), 10, 0}, {std::string("Tony"), 10, 0},
+                                          {0, 0, 0}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1731412938891ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::optional<std::vector<std::string>>({"f0", "f1", "f2"}),
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/1, /*bucket_path=*/
+        "data/append_10_stats_dense_store.db/append_10_stats_dense_store/f1=10/bucket-1",
+        {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build().value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+}
+
+TEST(DataSplitTest, TestDeserializeAppendWithSnapshot1) {
+    // test multiple rows in one data file
+    std::string file_name =
+        paimon::test::GetDataDir() + "/orc/append_09.db/append_09/data_splits/data_split-01";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-4e30d6c0-f109-4300-a010-4ba03047dd9d-0.orc", /*file_size=*/575, /*row_count=*/3,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Bob"), 10, 0, 12.1},
+                                          {std::string("Tony"), 10, 0, 14.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643142456ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/1, /*bucket_path=*/
+        "data/append_09.db/append_09/f1=10/bucket-1", {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build().value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+}
+
+TEST(DataSplitTest, TestDeserializeAppendWithSnapshot3) {
+    // test with null value & multiple DataFileMeta
+    std::string file_name =
+        paimon::test::GetDataDir() + "/orc/append_09.db/append_09/data_splits/data_split-02";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-db2b44c0-0d73-449d-82a0-4075bd2cb6e3-0.orc", /*file_size=*/541, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Lucy"), 20, 1, 14.1},
+                                          {std::string("Lucy"), 20, 1, 14.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643142472ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-b913a160-a4d1-4084-af2a-18333c35668e-0.orc", /*file_size=*/506, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Paul"), 20, 1, NullType()},
+                                          {std::string("Paul"), 20, 1, NullType()}, {0, 0, 0, 1},
+                                          pool.get()),
+        /*min_sequence_number=*/1, /*max_sequence_number=*/1, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643267404ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({20}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/append_09.db/append_09/f1=20/bucket-0", {file_meta1, file_meta2});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(3).IsStreaming(false).RawConvertible(true).Build().value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+
+    std::vector<DataSplit::SimpleDataFileMeta> file_list = {
+        DataSplit::SimpleDataFileMeta(
+            {"data/append_09.db/append_09/f1=20/bucket-0/"
+             "data-db2b44c0-0d73-449d-82a0-4075bd2cb6e3-0.orc",
+             /*file_size=*/541, /*row_count=*/1, /*min_sequence_number=*/0,
+             /*max_sequence_number=*/0, /*schema_id=*/0, /*level=*/0,
+             /*creation_time=*/Timestamp(1721643142472ll, 0), /*delete_row_count=*/0}),
+        DataSplit::SimpleDataFileMeta({"data/append_09.db/append_09/f1=20/bucket-0/"
+                                       "data-b913a160-a4d1-4084-af2a-18333c35668e-0.orc",
+                                       /*file_size=*/506, /*row_count=*/1,
+                                       /*min_sequence_number=*/1,
+                                       /*max_sequence_number=*/1, /*schema_id=*/0, /*level=*/0,
+                                       /*creation_time=*/Timestamp(1721643267404ll, 0),
+                                       /*delete_row_count=*/0})};
+
+    ASSERT_EQ(file_list, result_data_split->GetFileList());
+}
+
+TEST(DataSplitTest, TestDeserializeAppendWithSnapshot5) {
+    // test with full compaction & multiple DataFileMetas
+    std::string file_name =
+        paimon::test::GetDataDir() + "/orc/append_09.db/append_09/data_splits/data_split-03";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-b9e7c41f-66e8-4dad-b25a-e6e1963becc4-0.orc", /*file_size=*/640, /*row_count=*/8,
+        /*min_key=*/BinaryRow::EmptyRow(), /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/SimpleStats::EmptyStats(),
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 10, 0, 12.1},
+                                          {std::string("Tony"), 10, 0, 17.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/7, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1721643834472ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Compact(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/1, /*bucket_path=*/
+        "data/append_09.db/append_09/f1=10/bucket-1", {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(5).IsStreaming(false).RawConvertible(true).Build().value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+}
+
+TEST(DataSplitTest, TestDeserializePkWithSnapshot2) {
+    // test only one file in datasplit
+    std::string file_name =
+        paimon::test::GetDataDir() + "/orc/pk_09.db/pk_09/data_splits/data_split-01";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-980e82b4-2345-4976-bc1d-ea989fcdbffa-0.orc", /*file_size=*/1397, /*row_count=*/2,
+        /*min_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow(
+            {std::string("Two roads diverged in a wood, and I took the one less traveled by, And "
+                         "that has made all the difference."),
+             1},
+            pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 1},
+                                          {std::string("Two roads diverh"), 1}, {0, 0},
+                                          pool.get()), /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 1, 11.0},
+                                          {std::string("Two roads diverh"), 10, 1, 11.1},
+                                          {0, 0, 0, 0}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/1, /*schema_id=*/0,
+        /*level=*/5, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562946338ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/pk_09.db/pk_09/f1=10/bucket-0", {file_meta});
+
+    auto expected_data_split =
+        std::dynamic_pointer_cast<DataSplitImpl>(builder.WithSnapshot(2)
+                                                     .WithDataDeletionFiles({std::nullopt})
+                                                     .IsStreaming(false)
+                                                     .RawConvertible(true)
+                                                     .Build()
+                                                     .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+}
+
+TEST(DataSplitTest, TestDeserializePkWithSnapshot6OfSingleFile) {
+    // test data split with deletion vector info
+    std::string file_name =
+        paimon::test::GetDataDir() + "/orc/pk_09.db/pk_09/data_splits/data_split-02";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-6871b960-edd9-40fc-9859-aaca9ea205cf-0.orc", /*file_size=*/887, /*row_count=*/5,
+        /*min_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Alex"), 0}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Tony"), 0}, pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 0}, {std::string("Tony"), 0},
+                                          {0, 0}, pool.get()), /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alex"), 10, 0, 12.1},
+                                          {std::string("Tony"), 10, 0, 17.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/4, /*schema_id=*/0,
+        /*level=*/5, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562946453ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    DataSplitImpl::Builder builder(/*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+                                   /*bucket=*/1, /*bucket_path=*/
+                                   "data/pk_09.db/pk_09/f1=10/bucket-1", {file_meta});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(6)
+            .WithDataDeletionFiles({DeletionFile(
+                "data/pk_09.db/pk_09/index/index-7badd250-6c0b-49e9-8e40-2449ae9a2539-1",
+                /*offset=*/1, /*length=*/22, /*cardinality=*/std::nullopt)})
+            .IsStreaming(false)
+            .RawConvertible(true)
+            .Build()
+            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+    ASSERT_EQ(0, expected_data_split->PartialMergedRowCount());
+}
+
+TEST(DataSplitTest, TestDeserializePkWithSnapshot6OfMultiFiles) {
+    // test multiple files in data splits (a deletion file contains multiple bitmaps)
+    std::string file_name =
+        paimon::test::GetDataDir() + "/orc/pk_09.db/pk_09/data_splits/data_split-03";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-980e82b4-2345-4976-bc1d-ea989fcdbffa-0.orc", /*file_size=*/1397, /*row_count=*/2,
+        /*min_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow(
+            {std::string("Two roads diverged in a wood, and I took the one less traveled by, And "
+                         "that has made all the difference."),
+             1},
+            pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 1},
+                                          {std::string("Two roads diverh"), 1}, {0, 0},
+                                          pool.get()), /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 1, 11.0},
+                                          {std::string("Two roads diverh"), 10, 1, 11.1},
+                                          {0, 0, 0, 0}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/1, /*schema_id=*/0,
+        /*level=*/5, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562946338ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-1c7a85f1-55bd-424f-b503-34a33be0fb96-0.orc", /*file_size=*/1148, /*row_count=*/2,
+        /*min_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Lily"), 1}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow(
+            {std::string("Whether I shall turn out to be the hero of my own life."), 1},
+            pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Lily"), 1},
+                                          {std::string("Whether I shall!"), 1}, {0, 0},
+                                          pool.get()), /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Lily"), 10, 1, 19.1},
+                                          {std::string("Whether I shall!"), 10, 1, 20.1},
+                                          {0, 0, 0, 0}, pool.get()),
+        /*min_sequence_number=*/2, /*max_sequence_number=*/3, /*schema_id=*/0,
+        /*level=*/4, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725563027164ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+
+    auto file_meta3 = std::make_shared<DataFileMeta>(
+        "data-8cdb8b8d-5830-4b3b-aa94-8a30c449277a-0.orc", /*file_size=*/810, /*row_count=*/1,
+        /*min_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 1}, {std::string("Alice"), 1},
+                                          {0, 0}, pool.get()), /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 1, 19.1},
+                                          {std::string("Alice"), 10, 1, 19.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/4, /*max_sequence_number=*/4, /*schema_id=*/0,
+        /*level=*/3, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725563103281ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Compact(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/pk_09.db/pk_09/f1=10/bucket-0", {file_meta1, file_meta2, file_meta3});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(6)
+            .WithDataDeletionFiles(
+                {DeletionFile(
+                     "data/pk_09.db/pk_09/index/index-7badd250-6c0b-49e9-8e40-2449ae9a2539-0",
+                     /*offset=*/31, /*length=*/22, /*cardinality=*/std::nullopt),
+                 DeletionFile(
+                     "data/pk_09.db/pk_09/index/index-7badd250-6c0b-49e9-8e40-2449ae9a2539-0",
+                     /*offset=*/1, /*length=*/22, /*cardinality=*/std::nullopt),
+                 std::nullopt})
+            .IsStreaming(false)
+            .RawConvertible(true)
+            .Build()
+            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+}
+
+TEST(DataSplitTest, TestDeserializePkWithSnapshot8) {
+    // test the data split of merged data file
+    std::string file_name =
+        paimon::test::GetDataDir() + "/orc/pk_09.db/pk_09/data_splits/data_split-04";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-79413425-25fd-426f-a8a3-618d57f0e9a9-0.orc", /*file_size=*/1295, /*row_count=*/3,
+        /*min_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow(
+            {std::string("Whether I shall turn out to be the hero of my own life."), 1},
+            pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 1},
+                                          {std::string("Whether I shall!"), 1}, {0, 0},
+                                          pool.get()), /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 1, 11.0},
+                                          {std::string("Whether I shall!"), 10, 1, 21.1},
+                                          {0, 0, 0, 0}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/5, /*schema_id=*/0,
+        /*level=*/5, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725629198650ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Compact(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    DataSplitImpl::Builder builder(/*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+                                   /*bucket=*/0, /*bucket_path=*/
+                                   "data/pk_09.db/pk_09/f1=10/bucket-0", {file_meta});
+
+    auto expected_data_split =
+        std::dynamic_pointer_cast<DataSplitImpl>(builder.WithSnapshot(8)
+                                                     .WithDataDeletionFiles({std::nullopt})
+                                                     .IsStreaming(false)
+                                                     .RawConvertible(true)
+                                                     .Build()
+                                                     .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+}
+
+TEST(DataSplitTest, TestDeserializePk10WithSnapshot6) {
+    // test serialize and deserialize datasplit with deletion file and dense_stats
+    std::string file_name =
+        paimon::test::GetDataDir() +
+        "/orc/pk_table_with_alter_table.db/pk_table_with_alter_table/data_splits/"
+        "data_split-01";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    ASSERT_TRUE(input_stream);
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(result);
+
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-3842c1d6-6b34-4b2c-a648-9e95b4fb941b-0.orc", /*file_size=*/1165, /*row_count=*/7,
+        /*min_key=*/BinaryRowGenerator::GenerateRow({22}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow({82}, pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({22}, {82}, {0}, pool.get()),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats(
+            {1, 1, 22, 23, 24, 25, 26, std::string("Alex")},
+            {1, 1, 82, 83, 84, 85, 86, std::string("Whether I shall!")}, {0, 0, 0, 0, 0, 0, 0, 0},
+            pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/6, /*schema_id=*/0,
+        /*level=*/5, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1730544332215ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-d6d370f3-242b-45c9-8739-44bf31b2b449-0.orc", /*file_size=*/924, /*row_count=*/1,
+        /*min_key=*/BinaryRowGenerator::GenerateRow({52}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow({52}, pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({52}, {52}, {0}, pool.get()),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({1, std::string("Alex"), 52, 514, 518, 516, 1, 519},
+                                          {1, std::string("Alex"), 52, 514, 518, 516, 1, 519},
+                                          {0, 0, 0, 0, 0, 0, 0, 0}, pool.get()),
+        /*min_sequence_number=*/7, /*max_sequence_number=*/7, /*schema_id=*/1,
+        /*level=*/4, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1730547649721ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({1, 1}, pool.get()), /*bucket=*/0,
+        /*bucket_path=*/
+        "data/pk_table_with_alter_table.db/pk_table_with_alter_table/key0=1/key1=1/bucket-0",
+        {file_meta1, file_meta2});
+
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(6)
+            .WithDataDeletionFiles(
+                {DeletionFile("data/pk_table_with_alter_table.db/pk_table_with_alter_table/index/"
+                              "index-51804749-ed6c-4e7b-b3e9-337cfe38499c-1",
+                              /*offset=*/1, /*length=*/26, /*cardinality=*/std::nullopt),
+                 std::nullopt})
+            .IsStreaming(false)
+            .RawConvertible(true)
+            .Build()
+            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split);
+}
+
+TEST(DataSplitTest, TestPartialMergedRowCount) {
+    auto pool = GetDefaultPool();
+    auto file_meta = std::make_shared<DataFileMeta>(
+        "data-0.orc", /*file_size=*/100, /*row_count=*/2,
+        /*min_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Alice"), 1}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("David"), 1}, pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 1}, {std::string("David"), 1},
+                                          {0, 0}, pool.get()), /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Alice"), 10, 1, 11.0},
+                                          {std::string("David"), 10, 1, 11.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/1, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562946338ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-1.orc", /*file_size=*/100, /*row_count=*/2,
+        /*min_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("Bob"), 1}, pool.get()), /*max_key=*/
+        BinaryRowGenerator::GenerateRow({std::string("David"), 1}, pool.get()),
+        /*key_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Bob"), 1}, {std::string("David"), 1},
+                                          {0, 0}, pool.get()), /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({std::string("Bob"), 10, 1, 11.0},
+                                          {std::string("David"), 10, 1, 11.1}, {0, 0, 0, 0},
+                                          pool.get()),
+        /*min_sequence_number=*/2, /*max_sequence_number=*/3, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562947338ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/std::nullopt,
+        /*write_cols=*/std::nullopt);
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/
+        "fake_table/f1=10/bucket-0", {file_meta, file_meta2});
+
+    auto expected_data_split =
+        std::dynamic_pointer_cast<DataSplitImpl>(builder.WithSnapshot(1)
+                                                     .WithDataDeletionFiles({std::nullopt})
+                                                     .IsStreaming(false)
+                                                     .RawConvertible(false)
+                                                     .Build()
+                                                     .value());
+    ASSERT_EQ(0, expected_data_split->PartialMergedRowCount());
+
+    ASSERT_EQ(4, expected_data_split->RowCount());
+    ASSERT_OK_AND_ASSIGN(auto latest_epoch, expected_data_split->LatestFileCreationEpochMillis());
+    ASSERT_TRUE(latest_epoch.has_value());
+    ASSERT_EQ(file_meta2->CreationTimeEpochMillis().value(), latest_epoch.value());
+}
+
+TEST(DataSplitTest, TestRowCountAndLatestFileCreationEpochMillisEmpty) {
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRow::EmptyRow(),
+        /*bucket=*/0, /*bucket_path=*/
+        "fake_table/bucket-0", std::vector<std::shared_ptr<DataFileMeta>>({}));
+
+    auto data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1).IsStreaming(false).RawConvertible(true).Build().value());
+
+    // Empty data_files: RowCount should be 0, LatestFileCreationEpochMillis should be nullopt
+    ASSERT_EQ(0, data_split->RowCount());
+    ASSERT_OK_AND_ASSIGN(auto latest_epoch, data_split->LatestFileCreationEpochMillis());
+    ASSERT_FALSE(latest_epoch.has_value());
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/table/source/fallback_data_split.h
+++ b/src/paimon/core/table/source/fallback_data_split.h
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "paimon/table/source/data_split.h"
+
+namespace paimon {
+class FallbackDataSplit : public DataSplit {
+ public:
+    FallbackDataSplit(const std::shared_ptr<DataSplit>& split, bool is_fallback)
+        : is_fallback_(is_fallback), split_(split) {}
+
+    std::vector<SimpleDataFileMeta> GetFileList() const override {
+        return split_->GetFileList();
+    }
+
+    bool IsFallback() const {
+        return is_fallback_;
+    }
+
+    const std::shared_ptr<DataSplit>& GetSplit() const {
+        return split_;
+    }
+
+ private:
+    bool is_fallback_ = false;
+    std::shared_ptr<DataSplit> split_;
+};
+}  // namespace paimon

--- a/src/paimon/core/table/source/fallback_data_split_test.cpp
+++ b/src/paimon/core/table/source/fallback_data_split_test.cpp
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/table/source/fallback_data_split.h"
+
+#include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <variant>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/binary_row_generator.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(FallbackDataSplitTest, TestDeserialize) {
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/parquet/append_table_with_append_pt_branch.db/"
+                            "append_table_with_append_pt_branch/data-splits/"
+                            "data_split-0";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto fallback_data_split = std::dynamic_pointer_cast<FallbackDataSplit>(result);
+    ASSERT_TRUE(fallback_data_split);
+    // not fallback branch
+    ASSERT_FALSE(fallback_data_split->IsFallback());
+
+    auto result_data_split =
+        std::dynamic_pointer_cast<DataSplitImpl>(fallback_data_split->GetSplit());
+    ASSERT_TRUE(result_data_split);
+
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-eefbe5f2-f015-487c-b2ab-141b2b2cffd7-0.parquet", /*file_size=*/619, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/
+        SimpleStats::EmptyStats(),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({1, 110}, {1, 110}, {0, 0}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1755880762233ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-43880011-d066-4255-ad65-891d79cde23b-0.parquet", /*file_size=*/891, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/
+        SimpleStats::EmptyStats(),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({1, 120, 1200}, {1, 120, 1200}, {0, 0, 0}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/2,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1755884315482ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({1}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/parquet/append_table_with_append_pt_branch.db/append_table_with_append_pt_branch/"
+        "pt=1/bucket-0",
+        {file_meta1, file_meta2});
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(builder.WithSnapshot(2)
+                                                                            .WithTotalBuckets(-1)
+                                                                            .IsStreaming(false)
+                                                                            .RawConvertible(true)
+                                                                            .Build()
+                                                                            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split)
+        << result_data_split->ToString() << std::endl
+        << expected_data_split->ToString();
+}
+
+TEST(FallbackDataSplitTest, TestDeserialize2) {
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/parquet/append_table_with_append_pt_branch.db/"
+                            "append_table_with_append_pt_branch/data-splits/"
+                            "data_split-1";
+    auto file_system = std::make_unique<LocalFileSystem>();
+    ASSERT_OK_AND_ASSIGN(auto input_stream, file_system->Open(file_name));
+    std::vector<char> split_bytes(input_stream->Length().value_or(0), 0);
+    ASSERT_OK(input_stream->Read(split_bytes.data(), split_bytes.size()));
+    ASSERT_OK(input_stream->Close());
+
+    auto pool = GetDefaultPool();
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<Split> result,
+        Split::Deserialize(reinterpret_cast<char*>(split_bytes.data()), split_bytes.size(), pool));
+    auto fallback_data_split = std::dynamic_pointer_cast<FallbackDataSplit>(result);
+    ASSERT_TRUE(fallback_data_split);
+    // is fallback branch
+    ASSERT_TRUE(fallback_data_split->IsFallback());
+
+    auto result_data_split =
+        std::dynamic_pointer_cast<DataSplitImpl>(fallback_data_split->GetSplit());
+    ASSERT_TRUE(result_data_split);
+
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-39204ff8-55b2-497b-8e87-a1c736799eab-0.parquet", /*file_size=*/619, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/
+        SimpleStats::EmptyStats(),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({2, 210}, {2, 210}, {0, 0}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1755880762585ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-625b3277-84d3-4320-80b9-89a5075bf5fd-0.parquet", /*file_size=*/891, /*row_count=*/1,
+        /*min_key=*/BinaryRow::EmptyRow(),
+        /*max_key=*/BinaryRow::EmptyRow(),
+        /*key_stats=*/
+        SimpleStats::EmptyStats(),
+        /*value_stats=*/
+        BinaryRowGenerator::GenerateStats({2, 220, 2200}, {2, 220, 2200}, {0, 0, 0}, pool.get()),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/0, /*schema_id=*/1,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1755884315889ll, 0),
+        /*delete_row_count=*/0, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt,
+        /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);
+
+    std::vector<DataSplit::SimpleDataFileMeta> file_list;
+    file_list.emplace_back(
+        "data/parquet/append_table_with_append_pt_branch.db/append_table_with_append_pt_branch/"
+        "pt=2/bucket-0/data-39204ff8-55b2-497b-8e87-a1c736799eab-0.parquet",
+        619, 1, /*min_sequence_number=*/0,
+        /*max_sequence_number=*/0, /*schema_id=*/0, /*level=*/0, Timestamp(1755880762585ll, 0),
+        /*delete_row_count=*/0);
+    file_list.emplace_back(
+        "data/parquet/append_table_with_append_pt_branch.db/append_table_with_append_pt_branch/"
+        "pt=2/bucket-0/data-625b3277-84d3-4320-80b9-89a5075bf5fd-0.parquet",
+        891, 1, /*min_sequence_number=*/0,
+        /*max_sequence_number=*/0, /*schema_id=*/1, /*level=*/0, Timestamp(1755884315889ll, 0),
+        /*delete_row_count=*/0);
+    ASSERT_EQ(fallback_data_split->GetFileList(), file_list);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({2}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/
+        "data/parquet/append_table_with_append_pt_branch.db/append_table_with_append_pt_branch/"
+        "pt=2/bucket-0",
+        {file_meta1, file_meta2});
+    auto expected_data_split = std::dynamic_pointer_cast<DataSplitImpl>(builder.WithSnapshot(2)
+                                                                            .WithTotalBuckets(-1)
+                                                                            .IsStreaming(false)
+                                                                            .RawConvertible(true)
+                                                                            .Build()
+                                                                            .value());
+    ASSERT_EQ(*result_data_split, *expected_data_split)
+        << result_data_split->ToString() << std::endl
+        << expected_data_split->ToString();
+}
+}  // namespace paimon::test

--- a/src/paimon/core/table/source/table_read.cpp
+++ b/src/paimon/core/table/source/table_read.cpp
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/table/source/table_read.h"
+
+#include <cassert>
+#include <map>
+#include <optional>
+#include <string>
+#include <utility>
+
+#include "fmt/format.h"
+#include "paimon/common/reader/concat_batch_reader.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/operation/internal_read_context.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/table/source/append_only_table_read.h"
+#include "paimon/core/table/source/fallback_table_read.h"
+#include "paimon/core/table/source/key_value_table_read.h"
+#include "paimon/core/table/system/system_table.h"
+#include "paimon/core/utils/branch_manager.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/defs.h"
+#include "paimon/format/file_format.h"
+#include "paimon/read_context.h"
+#include "paimon/status.h"
+
+namespace paimon {
+class DataSplit;
+class Executor;
+class MemoryPool;
+
+namespace {
+
+Result<std::unique_ptr<InternalReadContext>> CreateInternalReadContext(
+    const std::shared_ptr<ReadContext>& context, const std::string& branch) {
+    std::map<std::string, std::string> tmp_options = context->GetOptions();
+    std::shared_ptr<TableSchema> table_schema;
+    const auto& specific_table_schema = context->GetSpecificTableSchema();
+    if (branch == BranchManager::DEFAULT_MAIN_BRANCH && specific_table_schema) {
+        PAIMON_ASSIGN_OR_RAISE(table_schema,
+                               TableSchema::CreateFromJson(specific_table_schema.value()));
+    } else {
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions tmp_core_options,
+                               CoreOptions::FromMap(tmp_options, context->GetSpecificFileSystem(),
+                                                    context->GetFileSystemSchemeToIdentifierMap()));
+        SchemaManager schema_manager(tmp_core_options.GetFileSystem(), context->GetPath(), branch);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::shared_ptr<TableSchema>> latest_schema,
+                               schema_manager.Latest());
+        if (!latest_schema) {
+            return Status::Invalid(fmt::format("schema file not found in path {}, branch {}",
+                                               context->GetPath(), branch));
+        }
+        table_schema = latest_schema.value();
+    }
+    assert(table_schema);
+
+    // merge options
+    auto options = table_schema->Options();
+    for (const auto& [key, value] : tmp_options) {
+        options[key] = value;
+    }
+    if (branch != BranchManager::DEFAULT_MAIN_BRANCH) {
+        options[Options::BRANCH] = branch;
+    }
+    return InternalReadContext::Create(context, table_schema, options);
+}
+
+Result<std::unique_ptr<TableRead>> CreateTableRead(
+    const std::shared_ptr<InternalReadContext>& internal_context,
+    const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor) {
+    const auto& core_options = internal_context->GetCoreOptions();
+    const auto& table_schema = internal_context->GetTableSchema();
+    auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> external_paths,
+                           core_options.CreateExternalPaths());
+    PAIMON_ASSIGN_OR_RAISE(std::optional<std::string> global_index_external_path,
+                           core_options.CreateGlobalIndexExternalPath());
+
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<FileStorePathFactory> path_factory,
+        FileStorePathFactory::Create(
+            internal_context->GetPath(), arrow_schema, table_schema->PartitionKeys(),
+            core_options.GetPartitionDefaultName(), core_options.GetFileFormat()->Identifier(),
+            core_options.DataFilePrefix(), core_options.LegacyPartitionNameEnabled(),
+            external_paths, global_index_external_path, core_options.IndexFileInDataFileDir(),
+            memory_pool));
+
+    if (internal_context->GetPrimaryKeys().empty()) {
+        return std::make_unique<AppendOnlyTableRead>(path_factory, internal_context, memory_pool,
+                                                     executor);
+    }
+    return KeyValueTableRead::Create(path_factory, internal_context, memory_pool, executor);
+}
+
+Result<std::unique_ptr<TableRead>> NewDataTableRead(const std::shared_ptr<ReadContext>& context) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InternalReadContext> internal_context,
+                           CreateInternalReadContext(context, context->GetBranch()));
+
+    PAIMON_ASSIGN_OR_RAISE(
+        std::unique_ptr<TableRead> table_read,
+        CreateTableRead(internal_context, context->GetMemoryPool(), context->GetExecutor()));
+
+    std::optional<std::string> scan_fallback_branch =
+        internal_context->GetCoreOptions().GetScanFallbackBranch();
+    if (!scan_fallback_branch ||
+        StringUtils::IsNullOrWhitespaceOnly(scan_fallback_branch.value())) {
+        return std::move(table_read);
+    }
+
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<InternalReadContext> fallback_context,
+        CreateInternalReadContext(context, /*branch=*/scan_fallback_branch.value()));
+
+    PAIMON_ASSIGN_OR_RAISE(
+        std::unique_ptr<TableRead> fallback_table_read,
+        CreateTableRead(fallback_context, context->GetMemoryPool(), context->GetExecutor()));
+    return std::make_unique<FallbackTableRead>(
+        std::move(table_read), std::move(fallback_table_read), context->GetMemoryPool());
+}
+
+}  // namespace
+
+TableRead::TableRead(const std::shared_ptr<MemoryPool>& memory_pool) : pool_(memory_pool) {}
+
+Result<std::unique_ptr<TableRead>> TableRead::Create(std::unique_ptr<ReadContext> ctx) {
+    std::shared_ptr<ReadContext> context = std::move(ctx);
+    if (context == nullptr) {
+        return Status::Invalid("read context is null pointer");
+    }
+    if (context->GetMemoryPool() == nullptr) {
+        return Status::Invalid("memory pool is null pointer");
+    }
+    if (context->GetExecutor() == nullptr) {
+        return Status::Invalid("executor is null pointer");
+    }
+    PAIMON_ASSIGN_OR_RAISE(
+        CoreOptions tmp_core_options,
+        CoreOptions::FromMap(context->GetOptions(), context->GetSpecificFileSystem(),
+                             context->GetFileSystemSchemeToIdentifierMap()));
+    PAIMON_ASSIGN_OR_RAISE(std::optional<SystemTablePath> system_table_path,
+                           SystemTableLoader::TryParsePath(context->GetPath()));
+    if (system_table_path) {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<SystemTable> system_table,
+            SystemTableLoader::LoadFromPath(tmp_core_options.GetFileSystem(), context->GetPath(),
+                                            context->GetOptions()));
+        return system_table->NewRead(context);
+    }
+
+    return NewDataTableRead(context);
+}
+
+Result<std::unique_ptr<BatchReader>> TableRead::CreateReader(
+    const std::vector<std::shared_ptr<Split>>& splits) {
+    std::vector<std::unique_ptr<BatchReader>> batch_readers;
+    batch_readers.reserve(splits.size());
+    for (const auto& split : splits) {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> reader, CreateReader(split));
+        batch_readers.emplace_back(std::move(reader));
+    }
+    return std::make_unique<ConcatBatchReader>(std::move(batch_readers), pool_);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/table/source/table_read_test.cpp
+++ b/src/paimon/core/table/source/table_read_test.cpp
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/table/source/table_read.h"
+
+#include <map>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/operation/abstract_split_read.h"
+#include "paimon/core/operation/split_read.h"
+#include "paimon/core/table/source/append_only_table_read.h"
+#include "paimon/core/table/source/key_value_table_read.h"
+#include "paimon/defs.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/read_context.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+TEST(TableReadTest, TestReadWithInvalidContext) {
+    std::string path = paimon::test::GetDataDir() + "/orc/append_10.db/append_10/";
+    {
+        // read with non-exist field
+        ReadContextBuilder context_builder(path);
+        context_builder.SetReadSchema({"f0", "f1", "non-exist"});
+        ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+        ASSERT_NOK_WITH_MSG(TableRead::Create(std::move(read_context)),
+                            "Get field non-exist failed: not exist in table schema");
+    }
+    {
+        // field type and literal type mismatch
+        auto predicate = PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                                 FieldType::DOUBLE, Literal(15l));
+        ReadContextBuilder context_builder(path);
+        context_builder.SetPredicate(predicate);
+        ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+        ASSERT_NOK_WITH_MSG(
+            TableRead::Create(std::move(read_context)),
+            "field f3 has field type BIGINT in literal, mismatch field type DOUBLE in predicate");
+    }
+    {
+        // field type in predicate mismatch schema
+        auto predicate = PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                                 FieldType::BIGINT, Literal(15l));
+        ReadContextBuilder context_builder(path);
+        context_builder.SetPredicate(predicate);
+        ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+        ASSERT_NOK_WITH_MSG(TableRead::Create(std::move(read_context)),
+                            "schema type double mismatches predicate field type BIGINT");
+    }
+    {
+        // field idx in predicate mismatch in schema
+        auto predicate = PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f3",
+                                                 FieldType::DOUBLE, Literal(15.0));
+        ReadContextBuilder context_builder(path);
+        context_builder.SetReadSchema({"f3", "f0", "f1"});
+        context_builder.SetPredicate(predicate);
+        ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+        ASSERT_NOK_WITH_MSG(
+            TableRead::Create(std::move(read_context)),
+            "field f3 has field idx 0 in input schema, mismatch field idx 2 in predicate");
+    }
+    {
+        // literal cannot be null
+        auto predicate = PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                                 FieldType::DOUBLE, Literal(FieldType::DOUBLE));
+        ReadContextBuilder context_builder(path);
+        context_builder.SetPredicate(predicate);
+        ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+        ASSERT_NOK_WITH_MSG(TableRead::Create(std::move(read_context)),
+                            "literal cannot be null in predicate, field name f3");
+    }
+    {
+        // schema with duplicate field f3
+        ReadContextBuilder context_builder(path);
+        context_builder.SetReadSchema({"f3", "f1", "f3"});
+        ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+        ASSERT_NOK_WITH_MSG(TableRead::Create(std::move(read_context)),
+                            "validate schema failed: read schema has duplicate field f3");
+    }
+}
+
+TEST(TableReadTest, TestReadWithSpecifiedInvalidSchema) {
+    std::string path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    ReadContextBuilder context_builder(path);
+    context_builder.SetReadSchema({"field_no_exist"});
+    ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+    ASSERT_NOK_WITH_MSG(TableRead::Create(std::move(read_context)),
+                        "Get field field_no_exist failed: not exist in table schema");
+}
+
+TEST(TableReadTest, TestCreateKeyValueTableRead) {
+    std::string path = paimon::test::GetDataDir() +
+                       "/orc/pk_table_with_dv_cardinality.db/pk_table_with_dv_cardinality/";
+    ReadContextBuilder context_builder(path);
+    context_builder.SetReadSchema({"f0", "f1", "f2", "f3"});
+    context_builder.AddOption("read.batch-size", "2");
+    context_builder.AddOption("orc.read.enable-lazy-decoding", "true");
+    ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto table_read, TableRead::Create(std::move(read_context)));
+    auto key_value_table_read = dynamic_cast<KeyValueTableRead*>(table_read.get());
+    ASSERT_TRUE(key_value_table_read);
+}
+
+TEST(TableReadTest, TestCreateAppendOnlyTableRead) {
+    std::string path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    ReadContextBuilder context_builder(path);
+    context_builder.SetReadSchema({"f0", "f1", "f2", "f3"});
+    context_builder.AddOption("read.batch-size", "2");
+    context_builder.AddOption("orc.read.enable-lazy-decoding", "true");
+    ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto table_read, TableRead::Create(std::move(read_context)));
+    auto append_only_table_read = dynamic_cast<AppendOnlyTableRead*>(table_read.get());
+    ASSERT_TRUE(append_only_table_read);
+}
+
+TEST(TableReadTest, TestMergeOptions) {
+    std::string path = paimon::test::GetDataDir() + "/orc/append_09.db/append_09";
+    ReadContextBuilder context_builder(path);
+    context_builder.SetReadSchema({"f0", "f1", "f2", "f3"});
+    context_builder.AddOption("read.batch-size", "2");
+    context_builder.AddOption("orc.read.enable-lazy-decoding", "true");
+    context_builder.AddOption("bucket", "10");
+    context_builder.AddOption("bucket-key", "f3");
+    ASSERT_OK_AND_ASSIGN(auto read_context, context_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(auto table_read, TableRead::Create(std::move(read_context)));
+    auto append_only_table_read = dynamic_cast<AppendOnlyTableRead*>(table_read.get());
+    ASSERT_TRUE(append_only_table_read);
+    auto* typed_split_read =
+        dynamic_cast<AbstractSplitRead*>(append_only_table_read->split_reads_[0].get());
+    ASSERT_TRUE(typed_split_read);
+    const auto& core_options = typed_split_read->options_;
+    std::map<std::string, std::string> expected_options = {
+        {"read.batch-size", "2"},   {"orc.read.enable-lazy-decoding", "true"},
+        {"bucket", "10"},           {"bucket-key", "f3"},
+        {"manifest.format", "orc"}, {"file.format", "orc"}};
+    ASSERT_EQ(expected_options, core_options.ToMap());
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
## Implement TableRead and FallbackDataSplit for Table Source Module

### Summary

Add the implementation of `TableRead` and introduce `FallbackDataSplit` to support reading data from Paimon tables, including fallback branch reading capabilities.

### New Classes

**`TableRead` (table_read.cpp)** — The core entry point for reading data from a Paimon table. `TableRead::Create` constructs the appropriate table reader based on the `ReadContext`:
- Resolves the table schema from the schema manager or from a user-provided specific schema.
- Merges user options with table schema options.
- Dispatches to `AppendOnlyTableRead` for append-only tables or `KeyValueTableRead` for primary-key tables.
- Supports fallback branch reading: when `scan-fallback-branch` is configured, creates a `FallbackTableRead` that wraps both the primary and fallback branch readers.
- Supports system table reading by detecting and delegating to the appropriate `SystemTable` implementation.
- `CreateReader` concatenates readers from multiple splits into a single `ConcatBatchReader`.

**`FallbackDataSplit`** — A decorator over `DataSplit` that marks whether a split originates from the fallback branch. Wraps an existing `DataSplit` and exposes `IsFallback()` to indicate its origin, enabling the read layer to apply branch-specific read logic.

### Tests

- `data_split_test.cpp`
- `fallback_data_split_test.cpp`
- `table_read_test.cpp`