### PR TITLE
feat(orc): introduce ORC format infrastructure for statistics extraction, predicate pushdown, and read range generation

### DIFF
--- a/src/paimon/format/orc/orc_stats_extractor.cpp
+++ b/src/paimon/format/orc/orc_stats_extractor.cpp
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/format/orc/orc_stats_extractor.h"
+
+#include <cassert>
+#include <exception>
+
+#include "arrow/type_fwd.h"
+#include "fmt/format.h"
+#include "orc/Int128.hh"
+#include "orc/OrcFile.hh"
+#include "orc/Reader.hh"
+#include "orc/Statistics.hh"
+#include "orc/Type.hh"
+#include "orc/Vector.hh"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/core/casting/decimal_to_decimal_cast_executor.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/format/column_stats.h"
+#include "paimon/format/orc/orc_format_defs.h"
+#include "paimon/format/orc/orc_input_stream_impl.h"
+#include "paimon/format/orc/orc_memory_pool.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/status.h"
+
+namespace arrow {
+class DataType;
+}  // namespace arrow
+namespace paimon {
+class MemoryPool;
+}  // namespace paimon
+
+namespace paimon::orc {
+Result<std::pair<ColumnStatsVector, FormatStatsExtractor::FileInfo>>
+OrcStatsExtractor::ExtractWithFileInfo(const std::shared_ptr<FileSystem>& file_system,
+                                       const std::string& path,
+                                       const std::shared_ptr<MemoryPool>& pool) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InputStream> input_stream, file_system->Open(path));
+    assert(input_stream);
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<OrcInputStreamImpl> orc_input_stream,
+                           OrcInputStreamImpl::Create(input_stream, DEFAULT_NATURAL_READ_SIZE));
+    try {
+        ::orc::ReaderOptions reader_options;
+        auto orc_pool = std::make_shared<OrcMemoryPool>(pool);
+        reader_options.setMemoryPool(*orc_pool);
+        std::unique_ptr<::orc::Reader> reader =
+            ::orc::createReader(std::move(orc_input_stream), reader_options);
+        assert(reader);
+        row_count_ = reader->getNumberOfRows();
+        if (reader->getNumberOfStripeStatistics() == 0) {
+            return Status::Invalid(fmt::format("statistics is disabled in {}", path));
+        }
+        auto statistics = reader->getStatistics();
+        auto num_columns = statistics->getNumberOfColumns();
+        auto sub_type_count = reader->getType().getSubtypeCount();
+        if (reader->getType().getSubtype(sub_type_count - 1)->getMaximumColumnId() + 1 !=
+            num_columns) {
+            // flatten sub type count {reader->getType().getSubtype(sub_type_count -
+            // 1)->getMaximumColumnId() + 1} mismatch number columns {num_columns} of statistics
+            return Status::Invalid(
+                fmt::format("sub type count {} mismatch number columns {} of statistics",
+                            sub_type_count, num_columns));
+        }
+        ColumnStatsVector result_stats;
+        result_stats.reserve(sub_type_count);
+        for (uint32_t i = 0; i < sub_type_count; i++) {
+            PAIMON_ASSIGN_OR_RAISE(
+                std::unique_ptr<ColumnStats> stats,
+                FetchColumnStatistics(
+                    statistics->getColumnStatistics(reader->getType().getSubtype(i)->getColumnId()),
+                    reader->getType().getSubtype(i), write_schema_->field(i)->type()));
+            result_stats.push_back(std::move(stats));
+        }
+        return std::make_pair(result_stats, FileInfo(row_count_));
+    } catch (const std::exception& e) {
+        return Status::Invalid(
+            fmt::format("extract file info failed for file {}, with {} error", path, e.what()));
+    } catch (...) {
+        return Status::UnknownError(
+            fmt::format("extract file info failed for file {}, with unknown error", path));
+    }
+}
+
+Result<std::unique_ptr<ColumnStats>> OrcStatsExtractor::FetchColumnStatistics(
+    const ::orc::ColumnStatistics* column_stats, const ::orc::Type* type,
+    const std::shared_ptr<arrow::DataType>& write_type) const {
+    if (column_stats == nullptr || type == nullptr) {
+        return Status::Invalid("column stats is null or orc type is null");
+    }
+    int64_t null_count = row_count_ - column_stats->getNumberOfValues();
+    bool all_null = (null_count == row_count_);
+    if (null_count > 0 && !column_stats->hasNull()) {
+        return Status::Invalid(
+            "invalid column statistics, null count greater than zero while has no null value");
+    }
+    ::orc::TypeKind kind = type->getKind();
+    switch (kind) {
+        case ::orc::BOOLEAN: {
+            auto typed_stats = dynamic_cast<const ::orc::BooleanColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid(
+                    "cannot cast to BooleanColumnStatistics for orc::BOOLEAN type");
+            }
+            if (all_null || !typed_stats->hasCount()) {
+                return ColumnStats::CreateBooleanColumnStats(std::nullopt, std::nullopt,
+                                                             null_count);
+            }
+            return ColumnStats::CreateBooleanColumnStats(
+                typed_stats->getFalseCount() == 0, typed_stats->getTrueCount() != 0, null_count);
+        }
+        case ::orc::BYTE: {
+            auto typed_stats = dynamic_cast<const ::orc::IntegerColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid("cannot cast to IntegerColumnStatistics for orc::BYTE type");
+            }
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateTinyIntColumnStats(std::nullopt, std::nullopt,
+                                                             null_count);
+            }
+            return ColumnStats::CreateTinyIntColumnStats(
+                static_cast<int8_t>(typed_stats->getMinimum()),
+                static_cast<int8_t>(typed_stats->getMaximum()), null_count);
+        }
+        case ::orc::SHORT: {
+            auto typed_stats = dynamic_cast<const ::orc::IntegerColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid(
+                    "cannot cast to IntegerColumnStatistics for orc::SHORT type");
+            }
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateSmallIntColumnStats(std::nullopt, std::nullopt,
+                                                              null_count);
+            }
+            return ColumnStats::CreateSmallIntColumnStats(
+                static_cast<int16_t>(typed_stats->getMinimum()),
+                static_cast<int16_t>(typed_stats->getMaximum()), null_count);
+        }
+        case ::orc::INT: {
+            auto typed_stats = dynamic_cast<const ::orc::IntegerColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid("cannot cast to IntegerColumnStatistics for orc::INT type");
+            }
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateIntColumnStats(std::nullopt, std::nullopt, null_count);
+            }
+            return ColumnStats::CreateIntColumnStats(
+                static_cast<int32_t>(typed_stats->getMinimum()),
+                static_cast<int32_t>(typed_stats->getMaximum()), null_count);
+        }
+        case ::orc::LONG: {
+            auto typed_stats = dynamic_cast<const ::orc::IntegerColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid("cannot cast to IntegerColumnStatistics for orc::Long type");
+            }
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateBigIntColumnStats(std::nullopt, std::nullopt, null_count);
+            }
+            return ColumnStats::CreateBigIntColumnStats(typed_stats->getMinimum(),
+                                                        typed_stats->getMaximum(), null_count);
+        }
+        case ::orc::FLOAT: {
+            auto typed_stats = dynamic_cast<const ::orc::DoubleColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid("cannot cast to DoubleColumnStatistics for orc::FLOAT type");
+            }
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateFloatColumnStats(std::nullopt, std::nullopt, null_count);
+            }
+            return ColumnStats::CreateFloatColumnStats(
+                static_cast<float>(typed_stats->getMinimum()),
+                static_cast<float>(typed_stats->getMaximum()), null_count);
+        }
+        case ::orc::DOUBLE: {
+            auto typed_stats = dynamic_cast<const ::orc::DoubleColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid(
+                    "cannot cast to DoubleColumnStatistics for orc::DOUBLE type");
+            }
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateDoubleColumnStats(std::nullopt, std::nullopt, null_count);
+            }
+            return ColumnStats::CreateDoubleColumnStats(typed_stats->getMinimum(),
+                                                        typed_stats->getMaximum(), null_count);
+        }
+        case ::orc::CHAR:
+        case ::orc::VARCHAR:
+        case ::orc::STRING: {
+            auto typed_stats = dynamic_cast<const ::orc::StringColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid(
+                    "cannot cast to StringColumnStatistics for orc::CHAR/VARCHAR/STRING type");
+            }
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateStringColumnStats(std::nullopt, std::nullopt, null_count);
+            }
+            return ColumnStats::CreateStringColumnStats(typed_stats->getMinimum(),
+                                                        typed_stats->getMaximum(), null_count);
+        }
+        case ::orc::BINARY:
+            return ColumnStats::CreateStringColumnStats(std::nullopt, std::nullopt, null_count);
+        case ::orc::TIMESTAMP:
+        case ::orc::TIMESTAMP_INSTANT: {
+            auto typed_stats = dynamic_cast<const ::orc::TimestampColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid(
+                    "cannot cast to TimestampColumnStatistics for orc::TIMESTAMP/TIMESTAMP_INSTANT "
+                    "type");
+            }
+            auto write_ts_type =
+                arrow::internal::checked_pointer_cast<::arrow::TimestampType>(write_type);
+            int32_t precision = DateTimeUtils::GetPrecisionFromType(write_ts_type);
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateTimestampColumnStats(std::nullopt, std::nullopt,
+                                                               null_count, precision);
+            }
+            int64_t min_ms = typed_stats->getMinimum();
+            int64_t max_ms = typed_stats->getMaximum();
+            int32_t min_ns = typed_stats->getMinimumNanos();
+            int32_t max_ns = typed_stats->getMaximumNanos();
+            return ColumnStats::CreateTimestampColumnStats(
+                Timestamp(min_ms, min_ns), Timestamp(max_ms, max_ns), null_count, precision);
+        }
+        case ::orc::DATE: {
+            auto typed_stats = dynamic_cast<const ::orc::DateColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid(
+                    "cannot cast to DateColumnStatistics for orc::Date "
+                    "type");
+            }
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateDateColumnStats(std::nullopt, std::nullopt, null_count);
+            }
+            return ColumnStats::CreateDateColumnStats(typed_stats->getMinimum(),
+                                                      typed_stats->getMaximum(), null_count);
+        }
+        case ::orc::DECIMAL: {
+            auto typed_stats = dynamic_cast<const ::orc::DecimalColumnStatistics*>(column_stats);
+            if (typed_stats == nullptr) {
+                return Status::Invalid(
+                    "cannot cast to DecimalColumnStatistics for orc::DECIMAL "
+                    "type");
+            }
+            int32_t precision = type->getPrecision();
+            int32_t scale = type->getScale();
+            if (all_null || !typed_stats->hasMinimum()) {
+                return ColumnStats::CreateDecimalColumnStats(std::nullopt, std::nullopt, null_count,
+                                                             precision, scale);
+            }
+            auto min_decimal = typed_stats->getMinimum();
+            Decimal min_value(precision, min_decimal.scale,
+                              static_cast<Decimal::int128_t>(
+                                  static_cast<Decimal::uint128_t>(
+                                      static_cast<uint64_t>(min_decimal.value.getHighBits()))
+                                      << 64 |
+                                  min_decimal.value.getLowBits()));
+            std::shared_ptr<arrow::DataType> target_type = arrow::decimal128(precision, scale);
+            auto cast_executor = std::make_shared<DecimalToDecimalCastExecutor>();
+            if (min_decimal.scale != scale) {
+                // need casting
+                PAIMON_ASSIGN_OR_RAISE(Literal converted_min_value,
+                                       cast_executor->Cast(Literal(min_value), target_type));
+                min_value = converted_min_value.GetValue<Decimal>();
+            }
+            auto max_decimal = typed_stats->getMaximum();
+            Decimal max_value(precision, max_decimal.scale,
+                              static_cast<Decimal::int128_t>(
+                                  static_cast<Decimal::uint128_t>(
+                                      static_cast<uint64_t>(max_decimal.value.getHighBits()))
+                                      << 64 |
+                                  max_decimal.value.getLowBits()));
+            if (max_decimal.scale != scale) {
+                // need casting
+                PAIMON_ASSIGN_OR_RAISE(Literal converted_max_value,
+                                       cast_executor->Cast(Literal(max_value), target_type));
+                max_value = converted_max_value.GetValue<Decimal>();
+            }
+            return ColumnStats::CreateDecimalColumnStats(min_value, max_value, null_count,
+                                                         precision, scale);
+        }
+        case ::orc::LIST:
+            return ColumnStats::CreateNestedColumnStats(FieldType::ARRAY, null_count);
+        case ::orc::MAP:
+            return ColumnStats::CreateNestedColumnStats(FieldType::MAP, null_count);
+        case ::orc::STRUCT:
+            return ColumnStats::CreateNestedColumnStats(FieldType::STRUCT, null_count);
+        default:
+            return Status::Invalid(
+                fmt::format("cannot fetch statistics, invalid type {}", type->toString()));
+    }
+    return Status::Invalid(
+        fmt::format("cannot fetch statistics, invalid type {}", type->toString()));
+}
+}  // namespace paimon::orc

--- a/src/paimon/format/orc/orc_stats_extractor.h
+++ b/src/paimon/format/orc/orc_stats_extractor.h
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "arrow/api.h"
+#include "orc/Common.hh"
+#include "orc/Statistics.hh"
+#include "orc/Type.hh"
+#include "paimon/format/column_stats.h"
+#include "paimon/format/format_stats_extractor.h"
+#include "paimon/result.h"
+#include "paimon/type_fwd.h"
+
+namespace arrow {
+class DataType;
+class Schema;
+}  // namespace arrow
+
+namespace orc {
+class ColumnStatistics;
+class Type;
+}  // namespace orc
+
+namespace paimon {
+class FileSystem;
+class MemoryPool;
+}  // namespace paimon
+
+namespace paimon::orc {
+class OrcStatsExtractor : public FormatStatsExtractor {
+ public:
+    explicit OrcStatsExtractor(const std::shared_ptr<arrow::Schema>& write_schema)
+        : write_schema_(write_schema) {}
+    Result<ColumnStatsVector> Extract(const std::shared_ptr<FileSystem>& file_system,
+                                      const std::string& path,
+                                      const std::shared_ptr<MemoryPool>& pool) override {
+        PAIMON_ASSIGN_OR_RAISE(auto result, ExtractWithFileInfo(file_system, path, pool));
+        return result.first;
+    }
+
+    Result<std::pair<ColumnStatsVector, FileInfo>> ExtractWithFileInfo(
+        const std::shared_ptr<FileSystem>& file_system, const std::string& path,
+        const std::shared_ptr<MemoryPool>& pool) override;
+
+ private:
+    Result<std::unique_ptr<ColumnStats>> FetchColumnStatistics(
+        const ::orc::ColumnStatistics* column_stats, const ::orc::Type* type,
+        const std::shared_ptr<arrow::DataType>& write_type) const;
+
+ private:
+    int64_t row_count_ = -1;
+    std::shared_ptr<arrow::Schema> write_schema_;
+};
+
+}  // namespace paimon::orc

--- a/src/paimon/format/orc/orc_stats_extractor_test.cpp
+++ b/src/paimon/format/orc/orc_stats_extractor_test.cpp
@@ -1,0 +1,523 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/format/orc/orc_stats_extractor.h"
+
+#include <cstddef>
+#include <map>
+#include <tuple>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/array/array_base.h"
+#include "arrow/array/array_nested.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "arrow/ipc/json_simple.h"
+#include "gtest/gtest.h"
+#include "orc/Int128.hh"
+#include "orc/MemoryPool.hh"
+#include "orc/OrcFile.hh"
+#include "orc/Type.hh"
+#include "orc/Vector.hh"
+#include "orc/Writer.hh"
+#include "paimon/common/data/binary_array.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_string.h"
+#include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/decimal_utils.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/stats/simple_stats_converter.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/format/orc/orc_adapter.h"
+#include "paimon/format/orc/orc_format_writer.h"
+#include "paimon/format/orc/orc_output_stream_impl.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::orc::test {
+
+class OrcStatsExtractorTest : public ::testing::Test {
+ public:
+    void SetUp() override {
+        dir_ = paimon::test::UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir_);
+        test_root_ = dir_->Str();
+        file_system_ = std::make_shared<LocalFileSystem>();
+        file_name_ = test_root_ + "/test.orc";
+        pool_ = GetDefaultPool();
+    }
+    void TearDown() override {
+        dir_.reset();
+        file_system_.reset();
+        pool_.reset();
+    }
+
+    void CheckStats(const arrow::FieldVector& fields, const std::string& input,
+                    const std::vector<std::string>& expected_stats,
+                    int64_t expect_row_count) const {
+        auto schema = std::make_shared<arrow::Schema>(fields);
+        auto struct_type = arrow::struct_(fields);
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> out,
+                             file_system_->Create(file_name_, /*overwrite=*/true));
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<OrcOutputStreamImpl> out_stream,
+                             OrcOutputStreamImpl::Create(out));
+        ASSERT_OK_AND_ASSIGN(
+            auto format_writer,
+            OrcFormatWriter::Create(std::move(out_stream), *schema,
+                                    {{"orc.timestamp-ltz.legacy.type", "false"}}, "zstd",
+                                    /*batch_size=*/10, pool_));
+        auto src_array = arrow::ipc::internal::json::ArrayFromJSON(struct_type, input).ValueOrDie();
+        ArrowArray c_array;
+        ASSERT_TRUE(arrow::ExportArray(*src_array, &c_array).ok());
+        ASSERT_OK(format_writer->AddBatch(&c_array));
+        ASSERT_OK(format_writer->Flush());
+        ASSERT_OK(format_writer->Finish());
+        ASSERT_OK(out->Close());
+
+        auto extractor = std::make_shared<OrcStatsExtractor>(schema);
+        ASSERT_OK_AND_ASSIGN(auto result,
+                             extractor->ExtractWithFileInfo(file_system_, file_name_, pool_));
+        auto& col_stats_vec = result.first;
+        ASSERT_EQ(fields.size(), col_stats_vec.size());
+        ASSERT_EQ(col_stats_vec.size(), expected_stats.size());
+        for (size_t i = 0; i < expected_stats.size(); i++) {
+            ASSERT_EQ(expected_stats[i], col_stats_vec[i]->ToString());
+        }
+        auto row_count = result.second.GetRowCount();
+        ASSERT_EQ(row_count, expect_row_count);
+    }
+
+ private:
+    std::unique_ptr<paimon::test::UniqueTestDirectory> dir_;
+    std::string test_root_;
+    std::string file_name_;
+    std::shared_ptr<FileSystem> file_system_;
+    std::shared_ptr<MemoryPool> pool_;
+};
+
+TEST_F(OrcStatsExtractorTest, TestSimpleProcess) {
+    // generate orc file
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> out,
+                         file_system_->Create(file_name_, /*overwrite=*/false));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<OrcOutputStreamImpl> out_stream,
+                         OrcOutputStreamImpl::Create(out));
+    ::orc::WriterOptions writer_options;
+    writer_options.setUseTightNumericVector(true);
+    std::string orc_schema =
+        "struct<col1:boolean,col2:tinyint,col3:smallint,col4:int,col5:bigint,col6:float,col7:"
+        "double,col8:string>";
+    std::unique_ptr<::orc::Type> type = ::orc::Type::buildTypeFromString(orc_schema);
+    ASSERT_OK_AND_ASSIGN(auto arrow_type, OrcAdapter::GetArrowType(type.get()));
+    std::unique_ptr<::orc::Writer> writer =
+        ::orc::createWriter(*type, out_stream.get(), writer_options);
+    size_t batch_size = 10;
+    auto batch = writer->createRowBatch(batch_size);
+    auto* struct_batch = dynamic_cast<::orc::StructVectorBatch*>(batch.get());
+    ASSERT_TRUE(struct_batch);
+    auto* bool_batch = dynamic_cast<::orc::ByteVectorBatch*>(struct_batch->fields[0]);
+    ASSERT_TRUE(bool_batch);
+    auto* tiny_int_batch = dynamic_cast<::orc::ByteVectorBatch*>(struct_batch->fields[1]);
+    ASSERT_TRUE(tiny_int_batch);
+    auto* small_int_batch = dynamic_cast<::orc::ShortVectorBatch*>(struct_batch->fields[2]);
+    ASSERT_TRUE(small_int_batch);
+    auto* int_batch = dynamic_cast<::orc::IntVectorBatch*>(struct_batch->fields[3]);
+    ASSERT_TRUE(int_batch);
+    auto* big_int_batch = dynamic_cast<::orc::LongVectorBatch*>(struct_batch->fields[4]);
+    ASSERT_TRUE(big_int_batch);
+    auto* float_batch = dynamic_cast<::orc::FloatVectorBatch*>(struct_batch->fields[5]);
+    ASSERT_TRUE(float_batch);
+    auto* double_batch = dynamic_cast<::orc::DoubleVectorBatch*>(struct_batch->fields[6]);
+    ASSERT_TRUE(double_batch);
+    auto* string_batch = dynamic_cast<::orc::StringVectorBatch*>(struct_batch->fields[7]);
+    ASSERT_TRUE(string_batch);
+
+    std::vector<std::tuple<bool, int16_t, int64_t, double>> raw_data0;
+    std::vector<std::tuple<int8_t, int32_t, float, std::string>> raw_data1;
+    raw_data0.reserve(batch_size);
+    raw_data1.reserve(batch_size);
+    for (size_t i = 0; i < batch_size; i++) {
+        raw_data0.emplace_back(i != 0, static_cast<int16_t>(i), static_cast<int64_t>(i),
+                               static_cast<double>(i + 0.1));
+    }
+    for (size_t i = 0; i < batch_size; i++) {
+        raw_data1.emplace_back(
+            static_cast<int8_t>(batch_size - i), static_cast<int32_t>(batch_size - i),
+            static_cast<float>(batch_size - i + 0.1), "str_" + std::to_string(batch_size - i));
+    }
+
+    for (size_t i = 0; i < batch_size; i++) {
+        const auto& [bvalue, int16_value, int64_value, dvalue] = raw_data0[i];
+        bool_batch->data[i] = bvalue;
+        small_int_batch->data[i] = int16_value;
+        big_int_batch->data[i] = int64_value;
+        double_batch->data[i] = dvalue;
+    }
+
+    for (size_t i = 0; i < batch_size; i++) {
+        const auto& [int8_value, int32_value, fvalue, svalue] = raw_data1[i];
+        tiny_int_batch->data[i] = int8_value;
+        int_batch->data[i] = int32_value;
+        float_batch->data[i] = fvalue;
+        string_batch->data[i] = const_cast<char*>(svalue.c_str());
+        string_batch->length[i] = static_cast<int32_t>(svalue.length());
+    }
+    struct_batch->numElements = batch_size;
+    struct_batch->fields[0]->numElements = batch_size;
+    struct_batch->fields[1]->numElements = batch_size;
+    struct_batch->fields[2]->numElements = batch_size;
+    struct_batch->fields[3]->numElements = batch_size;
+    struct_batch->fields[4]->numElements = batch_size;
+    struct_batch->fields[5]->numElements = batch_size;
+    struct_batch->fields[6]->numElements = batch_size;
+    struct_batch->fields[7]->numElements = batch_size;
+
+    writer->add(*batch);
+    writer->close();
+    ASSERT_OK(out->Close());
+    ASSERT_TRUE(file_system_->Exists(file_name_).value());
+
+    auto extractor = std::make_shared<OrcStatsExtractor>(arrow::schema(arrow_type->fields()));
+    ASSERT_OK_AND_ASSIGN(auto ret, extractor->ExtractWithFileInfo(file_system_, file_name_, pool_));
+
+    auto column_stats = ret.first;
+    auto file_info = ret.second;
+    ASSERT_EQ(batch_size, file_info.GetRowCount());
+    ASSERT_OK_AND_ASSIGN(auto simple_stats,
+                         SimpleStatsConverter::ToBinary(column_stats, pool_.get()));
+    // check min value
+    auto min_values = simple_stats.MinValues();
+    ASSERT_EQ(min_values.GetFieldCount(), 8);
+    ASSERT_EQ(min_values.GetBoolean(0), false);
+    ASSERT_EQ(min_values.GetByte(1), 1);
+    ASSERT_EQ(min_values.GetShort(2), 0);
+    ASSERT_EQ(min_values.GetInt(3), 1);
+    ASSERT_EQ(min_values.GetLong(4), 0);
+    ASSERT_NEAR(min_values.GetFloat(5), 1.1, 0.0001);
+    ASSERT_NEAR(min_values.GetDouble(6), 0.1, 0.0001);
+    ASSERT_EQ(min_values.GetString(7), BinaryString::FromString("str_1", pool_.get()));
+    // check max value
+    auto max_values = simple_stats.MaxValues();
+    ASSERT_EQ(max_values.GetFieldCount(), 8);
+    ASSERT_EQ(max_values.GetBoolean(0), true);
+    ASSERT_EQ(max_values.GetByte(1), 10);
+    ASSERT_EQ(max_values.GetShort(2), 9);
+    ASSERT_EQ(max_values.GetInt(3), 10);
+    ASSERT_EQ(max_values.GetLong(4), 9);
+    ASSERT_NEAR(max_values.GetFloat(5), 10.1, 0.0001);
+    ASSERT_NEAR(max_values.GetDouble(6), 9.1, 0.0001);
+    ASSERT_EQ(max_values.GetString(7), BinaryString::FromString("str_9", pool_.get()));
+    // check null count
+    auto null_counts = simple_stats.NullCounts();
+    ASSERT_EQ(8, null_counts.Size());
+    for (int32_t i = 0; i < null_counts.Size(); i++) {
+        ASSERT_EQ(0, null_counts.GetLong(i));
+    }
+}
+
+TEST_F(OrcStatsExtractorTest, TestTimestampAndDecimal) {
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> out,
+                         file_system_->Create(file_name_, /*overwrite=*/false));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<OrcOutputStreamImpl> out_stream,
+                         OrcOutputStreamImpl::Create(out));
+
+    ::orc::WriterOptions writer_options;
+    writer_options.setUseTightNumericVector(true);
+    std::string orc_schema =
+        "struct<col1:timestamp,col2:timestamp,col3:date,col4:decimal(7,2),"
+        "col5:decimal(23,5),col6:decimal(30,5)>";
+    std::unique_ptr<::orc::Type> type = ::orc::Type::buildTypeFromString(orc_schema);
+    ASSERT_OK_AND_ASSIGN(auto arrow_type, OrcAdapter::GetArrowType(type.get()));
+    std::unique_ptr<::orc::Writer> writer =
+        ::orc::createWriter(*type, out_stream.get(), writer_options);
+    size_t batch_size = 10;
+    auto batch = writer->createRowBatch(batch_size);
+    auto* struct_batch = dynamic_cast<::orc::StructVectorBatch*>(batch.get());
+    ASSERT_TRUE(struct_batch);
+    auto* timestamp_batch = dynamic_cast<::orc::TimestampVectorBatch*>(struct_batch->fields[0]);
+    ASSERT_TRUE(timestamp_batch);
+    auto* timestamp2_batch = dynamic_cast<::orc::TimestampVectorBatch*>(struct_batch->fields[1]);
+    ASSERT_TRUE(timestamp2_batch);
+    auto* date_batch = dynamic_cast<::orc::LongVectorBatch*>(struct_batch->fields[2]);
+    ASSERT_TRUE(date_batch);
+    auto* decimal_batch = dynamic_cast<::orc::Decimal64VectorBatch*>(struct_batch->fields[3]);
+    ASSERT_TRUE(decimal_batch);
+    auto* decimal128_batch = dynamic_cast<::orc::Decimal128VectorBatch*>(struct_batch->fields[4]);
+    ASSERT_TRUE(decimal128_batch);
+    auto* negative_decimal128_batch =
+        dynamic_cast<::orc::Decimal128VectorBatch*>(struct_batch->fields[5]);
+    ASSERT_TRUE(negative_decimal128_batch);
+
+    Decimal::int128_t decimal = 1234500;
+    ASSERT_OK_AND_ASSIGN(Decimal::int128_t big_integer,
+                         DecimalUtils::StrToInt128("12345678998765432145678"));
+    ASSERT_OK_AND_ASSIGN(Decimal::int128_t negative_big_integer,
+                         DecimalUtils::StrToInt128("-325627385378534568734875523420"));
+    Decimal negative_decimal(30, 5, negative_big_integer);
+    for (size_t i = 0; i < batch_size; i++) {
+        timestamp_batch->data[i] = 1723535710ll + i;
+        timestamp_batch->nanoseconds[i] = i;
+        timestamp2_batch->data[i] = 1723535710ll + 10 + i;
+        timestamp2_batch->nanoseconds[i] = 10 + i;
+        date_batch->data[i] = i;
+
+        decimal_batch->values[i] = static_cast<int64_t>(1234500);
+        decimal128_batch->values[i] = ::orc::Int128(static_cast<int64_t>(big_integer >> 64),
+                                                    big_integer & 0xFFFFFFFFFFFFFFFF);
+        negative_decimal128_batch->values[i] =
+            ::orc::Int128(negative_decimal.HighBits(), negative_decimal.LowBits());
+    }
+    struct_batch->numElements = batch_size;
+    struct_batch->fields[0]->numElements = batch_size;
+    struct_batch->fields[1]->numElements = batch_size;
+    struct_batch->fields[2]->numElements = batch_size;
+    struct_batch->fields[3]->numElements = batch_size;
+    struct_batch->fields[4]->numElements = batch_size;
+    struct_batch->fields[5]->numElements = batch_size;
+    writer->add(*batch);
+    writer->close();
+    ASSERT_OK(out->Close());
+    ASSERT_TRUE(file_system_->Exists(file_name_).value());
+
+    auto extractor = std::make_shared<OrcStatsExtractor>(arrow::schema(arrow_type->fields()));
+    ASSERT_OK_AND_ASSIGN(auto ret, extractor->ExtractWithFileInfo(file_system_, file_name_, pool_));
+
+    auto column_stats = ret.first;
+    ASSERT_OK_AND_ASSIGN(auto simple_stats,
+                         SimpleStatsConverter::ToBinary(column_stats, pool_.get()));
+
+    // check min value
+    auto min_values = simple_stats.MinValues();
+    ASSERT_EQ(min_values.GetFieldCount(), 6);
+    ASSERT_EQ(min_values.GetTimestamp(0, Timestamp::MAX_PRECISION), Timestamp(1723535710000ll, 0));
+    ASSERT_EQ(min_values.GetTimestamp(1, Timestamp::MAX_PRECISION), Timestamp(1723535720000ll, 10));
+    ASSERT_EQ(min_values.GetLong(2), 0);
+    ASSERT_EQ(min_values.GetDecimal(3, 7, 2), Decimal(7, 2, decimal));
+    ASSERT_EQ(min_values.GetDecimal(4, 30, 5), Decimal(30, 5, big_integer));
+    ASSERT_EQ(min_values.GetDecimal(5, 30, 5), Decimal(30, 5, negative_big_integer));
+
+    // check max value
+    auto max_values = simple_stats.MaxValues();
+    ASSERT_EQ(max_values.GetFieldCount(), 6);
+    ASSERT_EQ(max_values.GetTimestamp(0, Timestamp::MAX_PRECISION),
+              Timestamp(1723535719000ll, batch_size - 1));
+    ASSERT_EQ(max_values.GetTimestamp(1, Timestamp::MAX_PRECISION),
+              Timestamp(1723535729000ll, 10 + batch_size - 1));
+    ASSERT_EQ(max_values.GetLong(2), batch_size - 1);
+    ASSERT_EQ(max_values.GetDecimal(3, 7, 2), Decimal(7, 2, decimal));
+    ASSERT_EQ(max_values.GetDecimal(4, 30, 5), Decimal(30, 5, big_integer));
+    ASSERT_EQ(max_values.GetDecimal(5, 30, 5), Decimal(30, 5, negative_big_integer));
+
+    // check null count
+    auto null_counts = simple_stats.NullCounts();
+    ASSERT_EQ(6, null_counts.Size());
+    for (int32_t i = 0; i < null_counts.Size(); i++) {
+        ASSERT_EQ(0, null_counts.GetLong(i));
+    }
+}
+
+TEST_F(OrcStatsExtractorTest, TestEmptyStats) {
+    // generate orc file
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> out,
+                         file_system_->Create(file_name_, /*overwrite=*/false));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<OrcOutputStreamImpl> out_stream,
+                         OrcOutputStreamImpl::Create(out));
+    ::orc::WriterOptions writer_options;
+    writer_options.setUseTightNumericVector(true);
+    std::string orc_schema = "struct<col1:int,col2:struct<inner_col:int>,col3:binary>";
+    std::unique_ptr<::orc::Type> type = ::orc::Type::buildTypeFromString(orc_schema);
+    ASSERT_OK_AND_ASSIGN(auto arrow_type, OrcAdapter::GetArrowType(type.get()));
+    std::unique_ptr<::orc::Writer> writer =
+        ::orc::createWriter(*type, out_stream.get(), writer_options);
+    size_t batch_size = 10;
+    auto batch = writer->createRowBatch(batch_size);
+    auto* struct_batch = dynamic_cast<::orc::StructVectorBatch*>(batch.get());
+    ASSERT_TRUE(struct_batch);
+    auto* int_batch = dynamic_cast<::orc::IntVectorBatch*>(struct_batch->fields[0]);
+    ASSERT_TRUE(int_batch);
+    auto* nested_batch = dynamic_cast<::orc::StructVectorBatch*>(struct_batch->fields[1]);
+    ASSERT_TRUE(nested_batch);
+    auto* inner_batch = dynamic_cast<::orc::IntVectorBatch*>(nested_batch->fields[0]);
+    ASSERT_TRUE(inner_batch);
+    auto* binary_batch = dynamic_cast<::orc::StringVectorBatch*>(struct_batch->fields[2]);
+    ASSERT_TRUE(binary_batch);
+
+    int_batch->hasNulls = true;
+    for (size_t i = 0; i < batch_size; i++) {
+        int_batch->data[i] = i;
+        int_batch->notNull[i] = false;
+        inner_batch->data[i] = i + 100;
+        binary_batch->data[i] = const_cast<char*>("hello");
+        binary_batch->length[i] = static_cast<int32_t>(5);
+    }
+
+    struct_batch->numElements = batch_size;
+    nested_batch->numElements = batch_size;
+    struct_batch->fields[0]->numElements = batch_size;
+    struct_batch->fields[1]->numElements = batch_size;
+    struct_batch->fields[2]->numElements = batch_size;
+    nested_batch->fields[0]->numElements = batch_size;
+
+    writer->add(*batch);
+    writer->close();
+    ASSERT_OK(out->Close());
+    ASSERT_TRUE(file_system_->Exists(file_name_).value());
+
+    auto extractor = std::make_shared<OrcStatsExtractor>(arrow::schema(arrow_type->fields()));
+    ASSERT_OK_AND_ASSIGN(auto ret, extractor->ExtractWithFileInfo(file_system_, file_name_, pool_));
+
+    auto column_stats = ret.first;
+    auto file_info = ret.second;
+    ASSERT_EQ(batch_size, file_info.GetRowCount());
+    ASSERT_OK_AND_ASSIGN(auto simple_stats,
+                         SimpleStatsConverter::ToBinary(column_stats, pool_.get()));
+
+    // check min value
+    auto min_values = simple_stats.MinValues();
+    ASSERT_EQ(min_values.GetFieldCount(), 3);
+    ASSERT_TRUE(min_values.IsNullAt(0));
+    ASSERT_TRUE(min_values.IsNullAt(1));
+    ASSERT_TRUE(min_values.IsNullAt(2));
+    // check max value
+    auto max_values = simple_stats.MaxValues();
+    ASSERT_EQ(max_values.GetFieldCount(), 3);
+    ASSERT_TRUE(max_values.IsNullAt(0));
+    ASSERT_TRUE(max_values.IsNullAt(1));
+    ASSERT_TRUE(max_values.IsNullAt(2));
+    // check null count
+    auto null_counts = simple_stats.NullCounts();
+    ASSERT_EQ(3, null_counts.Size());
+    ASSERT_EQ(batch_size, null_counts.GetLong(0));
+    ASSERT_EQ(0, null_counts.GetLong(1));
+    ASSERT_EQ(0, null_counts.GetLong(2));
+}
+
+TEST_F(OrcStatsExtractorTest, TestNullForAllType) {
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::boolean()),
+        arrow::field("f1", arrow::int8()),
+        arrow::field("f2", arrow::int16()),
+        arrow::field("f3", arrow::int32()),
+        arrow::field("f4", arrow::int64()),
+        arrow::field("f5", arrow::float32()),
+        arrow::field("f6", arrow::float64()),
+        arrow::field("f7", arrow::utf8()),
+        arrow::field("f8", arrow::binary()),
+        arrow::field("f9", arrow::map(arrow::int8(), arrow::int16())),
+        arrow::field("f10", arrow::list(arrow::float32())),
+        arrow::field("f11", arrow::struct_({arrow::field("f0", arrow::boolean()),
+                                            arrow::field("f1", arrow::int64())})),
+        arrow::field("f12", arrow::timestamp(arrow::TimeUnit::NANO)),
+        arrow::field("f13", arrow::date32()),
+        arrow::field("f14", arrow::decimal128(2, 2)),
+        arrow::field("f15", arrow::decimal128(30, 2)),
+        arrow::field("ts_sec", arrow::timestamp(arrow::TimeUnit::SECOND)),
+        arrow::field("ts_milli", arrow::timestamp(arrow::TimeUnit::MILLI)),
+        arrow::field("ts_micro", arrow::timestamp(arrow::TimeUnit::MICRO)),
+        arrow::field("ts_nano", arrow::timestamp(arrow::TimeUnit::NANO)),
+        arrow::field("ts_tz_sec", arrow::timestamp(arrow::TimeUnit::SECOND, timezone)),
+        arrow::field("ts_tz_milli", arrow::timestamp(arrow::TimeUnit::MILLI, timezone)),
+        arrow::field("ts_tz_micro", arrow::timestamp(arrow::TimeUnit::MICRO, timezone)),
+        arrow::field("ts_tz_nano", arrow::timestamp(arrow::TimeUnit::NANO, timezone)),
+    };
+    auto schema = std::make_shared<arrow::Schema>(fields);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> out,
+                         file_system_->Create(file_name_, /*overwrite=*/false));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<OrcOutputStreamImpl> out_stream,
+                         OrcOutputStreamImpl::Create(out));
+    ASSERT_OK_AND_ASSIGN(
+        auto format_writer,
+        OrcFormatWriter::Create(std::move(out_stream), *schema,
+                                {{"orc.timestamp-ltz.legacy.type", "false"}}, "zstd",
+                                /*batch_size=*/10, pool_));
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        [null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null]
+    ])")
+            .ValueOrDie());
+    ArrowArray c_array;
+    ASSERT_TRUE(arrow::ExportArray(*src_array, &c_array).ok());
+    ASSERT_OK(format_writer->AddBatch(&c_array));
+    ASSERT_OK(format_writer->Flush());
+    ASSERT_OK(format_writer->Finish());
+    ASSERT_OK(out->Close());
+
+    auto extractor = std::make_shared<OrcStatsExtractor>(schema);
+    ASSERT_OK_AND_ASSIGN(auto ret, extractor->ExtractWithFileInfo(file_system_, file_name_, pool_));
+
+    auto column_stats = ret.first;
+    auto file_info = ret.second;
+    ASSERT_EQ(src_array->length(), file_info.GetRowCount());
+    ASSERT_OK_AND_ASSIGN(auto stats, SimpleStatsConverter::ToBinary(column_stats, pool_.get()));
+    // test compatible with java
+    ASSERT_EQ(stats.min_values_.HashCode(), 0xf890741a);
+    ASSERT_EQ(stats.max_values_.HashCode(), 0xf890741a);
+    ASSERT_EQ(stats.null_counts_.HashCode(), 0x9299256f);
+}
+
+TEST_F(OrcStatsExtractorTest, TestExtractStatsTimestampType) {
+    auto timezone = DateTimeUtils::GetLocalTimezoneName();
+    arrow::FieldVector fields = {
+        arrow::field("ts_sec", arrow::timestamp(arrow::TimeUnit::SECOND)),
+        arrow::field("ts_milli", arrow::timestamp(arrow::TimeUnit::MILLI)),
+        arrow::field("ts_micro", arrow::timestamp(arrow::TimeUnit::MICRO)),
+        arrow::field("ts_nano", arrow::timestamp(arrow::TimeUnit::NANO)),
+        arrow::field("ts_tz_sec", arrow::timestamp(arrow::TimeUnit::SECOND, timezone)),
+        arrow::field("ts_tz_milli", arrow::timestamp(arrow::TimeUnit::MILLI, timezone)),
+        arrow::field("ts_tz_micro", arrow::timestamp(arrow::TimeUnit::MICRO, timezone)),
+        arrow::field("ts_tz_nano", arrow::timestamp(arrow::TimeUnit::NANO, timezone)),
+    };
+    {
+        std::string data_str = R"([
+["1970-01-01 00:00:01", "1970-01-01 00:00:00.001", "1970-01-01 00:00:00.000001", "1970-01-01 00:00:00.000000001", "1970-01-01 00:00:02", "1970-01-01 00:00:00.002", "1970-01-01 00:00:00.000002", "1970-01-01 00:00:00.000000002"],
+["1970-01-01 00:00:03", "1970-01-01 00:00:00.003", null,                         "1970-01-01 00:00:00.000000003", "1970-01-01 00:00:04", "1970-01-01 00:00:00.004", "1970-01-01 00:00:00.000004", "1970-01-01 00:00:00.000000004"],
+["1970-01-01 00:00:05", "1970-01-01 00:00:00.005", null,                         null,                            "1970-01-01 00:00:06",                     null,  "1970-01-01 00:00:00.000006", null]
+    ])";
+        std::vector<std::string> expected_stats_str = {
+            "min 1970-01-01 00:00:01.000000000, max 1970-01-01 00:00:05.000000000, null count 0",
+            "min 1970-01-01 00:00:00.001000000, max 1970-01-01 00:00:00.005000000, null count 0",
+            "min 1970-01-01 00:00:00.000001000, max 1970-01-01 00:00:00.000001000, null count 2",
+            "min 1970-01-01 00:00:00.000000001, max 1970-01-01 00:00:00.000000003, null count 1",
+            "min 1970-01-01 00:00:02.000000000, max 1970-01-01 00:00:06.000000000, null count 0",
+            "min 1970-01-01 00:00:00.002000000, max 1970-01-01 00:00:00.004000000, null count 1",
+            "min 1970-01-01 00:00:00.000002000, max 1970-01-01 00:00:00.000006000, null count 0",
+            "min 1970-01-01 00:00:00.000000002, max 1970-01-01 00:00:00.000000004, null count 1",
+        };
+        CheckStats(fields, data_str, expected_stats_str, /*expect_row_count=*/3);
+    }
+    {
+        std::string data_str = R"([
+         [null,null,null,null,null,null,null,null]
+    ])";
+        std::vector<std::string> expected_stats_str = {
+            "min null, max null, null count 1", "min null, max null, null count 1",
+            "min null, max null, null count 1", "min null, max null, null count 1",
+            "min null, max null, null count 1", "min null, max null, null count 1",
+            "min null, max null, null count 1", "min null, max null, null count 1",
+        };
+        CheckStats(fields, data_str, expected_stats_str, /*expect_row_count=*/1);
+    }
+}
+
+}  // namespace paimon::orc::test

--- a/src/paimon/format/orc/predicate_converter.cpp
+++ b/src/paimon/format/orc/predicate_converter.cpp
@@ -1,0 +1,391 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/format/orc/predicate_converter.h"
+
+#include <exception>
+#include <utility>
+
+#include "fmt/format.h"
+#include "orc/Int128.hh"
+#include "orc/Type.hh"
+#include "orc/sargs/Literal.hh"
+#include "orc/sargs/SearchArgument.hh"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/predicate/compound_predicate.h"
+#include "paimon/predicate/function.h"
+#include "paimon/predicate/leaf_predicate.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/predicate/predicate_utils.h"
+
+namespace paimon::orc {
+
+Result<std::unique_ptr<::orc::SearchArgument>> PredicateConverter::Convert(
+    const ::orc::Type& orc_type, const std::shared_ptr<Predicate>& predicate) {
+    if (!predicate) {
+        return std::unique_ptr<::orc::SearchArgument>();
+    }
+    std::unordered_map<std::string, uint64_t> name_id_mapping;
+    for (uint64_t i = 0; i < orc_type.getSubtypeCount(); i++) {
+        name_id_mapping[orc_type.getFieldName(i)] = orc_type.getSubtype(i)->getColumnId();
+    }
+    auto split_predicates = PredicateUtils::SplitAnd(predicate);
+    // same as java, if check failed, do not push down to ::orc instead of return invalid
+    // status
+    std::vector<std::shared_ptr<Predicate>> pushable_predicates;
+    pushable_predicates.reserve(split_predicates.size());
+    for (const auto& split_predicate : split_predicates) {
+        PAIMON_ASSIGN_OR_RAISE(bool pushable,
+                               IsPredicatePushable(split_predicate, name_id_mapping));
+        if (pushable) {
+            pushable_predicates.push_back(split_predicate);
+        }
+    }
+    if (!pushable_predicates.empty()) {
+        try {
+            auto builder = ::orc::SearchArgumentFactory::newBuilder();
+            builder->startAnd();
+            for (auto predicate : pushable_predicates) {
+                PAIMON_RETURN_NOT_OK(Convert(predicate, name_id_mapping, builder.get()));
+            }
+            builder->end();
+            return builder->build();
+        } catch (const std::exception& e) {
+            return Status::Invalid(fmt::format(
+                "convert paimon predicate to orc SearchArgument failed, with error: {}", e.what()));
+        } catch (...) {
+            return Status::Invalid(
+                "convert paimon predicate to orc SearchArgument failed, with unknown error");
+        }
+    }
+    return std::unique_ptr<::orc::SearchArgument>();
+}
+
+Status PredicateConverter::ConvertCompound(
+    const std::shared_ptr<CompoundPredicate>& compound_predicate,
+    const std::unordered_map<std::string, uint64_t>& name_id_mapping,
+    ::orc::SearchArgumentBuilder* builder) {
+    const auto& children = compound_predicate->Children();
+    const auto& function = compound_predicate->GetFunction();
+    auto function_type = function.GetType();
+    switch (function_type) {
+        case Function::Type::AND: {
+            builder->startAnd();
+            for (const auto& child : children) {
+                PAIMON_RETURN_NOT_OK(Convert(child, name_id_mapping, builder));
+            }
+            builder->end();
+            break;
+        }
+        case Function::Type::OR: {
+            builder->startOr();
+            for (const auto& child : children) {
+                PAIMON_RETURN_NOT_OK(Convert(child, name_id_mapping, builder));
+            }
+            builder->end();
+            break;
+        }
+        default:
+            return Status::Invalid(
+                fmt::format("invalid predicate type {}", static_cast<int32_t>(function_type)));
+    }
+    return Status::OK();
+}
+
+Status PredicateConverter::ConvertLeaf(
+    const std::shared_ptr<LeafPredicate>& leaf_predicate,
+    const std::unordered_map<std::string, uint64_t>& name_id_mapping,
+    ::orc::SearchArgumentBuilder* builder) {
+    const auto& field_name = leaf_predicate->FieldName();
+    auto iter = name_id_mapping.find(field_name);
+    if (iter == name_id_mapping.end()) {
+        return Status::Invalid(
+            fmt::format("ConvertLeafPredicate failed in PredicateConverter: field {} in predicate "
+                        "not in file schema",
+                        field_name));
+    }
+    auto field_index = iter->second;
+    const auto& literals = leaf_predicate->Literals();
+    const auto& function = leaf_predicate->GetFunction();
+    auto function_type = function.GetType();
+    PAIMON_ASSIGN_OR_RAISE(::orc::PredicateDataType orc_type,
+                           ConvertToOrcPredicateType(leaf_predicate->GetFieldType()));
+    switch (function_type) {
+        case Function::Type::IS_NULL: {
+            builder->isNull(field_index, orc_type);
+            break;
+        }
+        case Function::Type::IS_NOT_NULL: {
+            builder->startNot();
+            builder->isNull(field_index, orc_type);
+            builder->end();
+            break;
+        }
+        case Function::Type::EQUAL: {
+            PAIMON_RETURN_NOT_OK(CheckLiteralNotEmpty(literals, function, field_name));
+            PAIMON_ASSIGN_OR_RAISE(std::vector<::orc::Literal> orc_literals,
+                                   ConvertToOrcLiterals(literals));
+            builder->equals(field_index, orc_type, orc_literals[0]);
+            break;
+        }
+        case Function::Type::NOT_EQUAL: {
+            PAIMON_RETURN_NOT_OK(CheckLiteralNotEmpty(literals, function, field_name));
+            PAIMON_ASSIGN_OR_RAISE(std::vector<::orc::Literal> orc_literals,
+                                   ConvertToOrcLiterals(literals));
+            builder->startNot();
+            builder->equals(field_index, orc_type, orc_literals[0]);
+            builder->end();
+            break;
+        }
+        case Function::Type::GREATER_THAN: {
+            PAIMON_RETURN_NOT_OK(CheckLiteralNotEmpty(literals, function, field_name));
+            PAIMON_ASSIGN_OR_RAISE(std::vector<::orc::Literal> orc_literals,
+                                   ConvertToOrcLiterals(literals));
+            builder->startNot();
+            builder->lessThanEquals(field_index, orc_type, orc_literals[0]);
+            builder->end();
+            break;
+        }
+        case Function::Type::GREATER_OR_EQUAL: {
+            PAIMON_RETURN_NOT_OK(CheckLiteralNotEmpty(literals, function, field_name));
+            PAIMON_ASSIGN_OR_RAISE(std::vector<::orc::Literal> orc_literals,
+                                   ConvertToOrcLiterals(literals));
+            builder->startNot();
+            builder->lessThan(field_index, orc_type, orc_literals[0]);
+            builder->end();
+            break;
+        }
+        case Function::Type::LESS_THAN: {
+            PAIMON_RETURN_NOT_OK(CheckLiteralNotEmpty(literals, function, field_name));
+            PAIMON_ASSIGN_OR_RAISE(std::vector<::orc::Literal> orc_literals,
+                                   ConvertToOrcLiterals(literals));
+            builder->lessThan(field_index, orc_type, orc_literals[0]);
+            break;
+        }
+        case Function::Type::LESS_OR_EQUAL: {
+            PAIMON_RETURN_NOT_OK(CheckLiteralNotEmpty(literals, function, field_name));
+            PAIMON_ASSIGN_OR_RAISE(std::vector<::orc::Literal> orc_literals,
+                                   ConvertToOrcLiterals(literals));
+            builder->lessThanEquals(field_index, orc_type, orc_literals[0]);
+            break;
+        }
+        // Noted that: java paimon don't support pushdown IN and NOT_IN to orc
+        case Function::Type::IN: {
+            PAIMON_RETURN_NOT_OK(CheckLiteralNotEmpty(literals, function, field_name));
+            PAIMON_ASSIGN_OR_RAISE(std::vector<::orc::Literal> orc_literals,
+                                   ConvertToOrcLiterals(literals));
+            builder->in(field_index, orc_type, orc_literals);
+            break;
+        }
+        case Function::Type::NOT_IN: {
+            PAIMON_RETURN_NOT_OK(CheckLiteralNotEmpty(literals, function, field_name));
+            PAIMON_ASSIGN_OR_RAISE(std::vector<::orc::Literal> orc_literals,
+                                   ConvertToOrcLiterals(literals));
+            builder->startNot();
+            builder->in(field_index, orc_type, orc_literals);
+            builder->end();
+            break;
+        }
+        case Function::Type::STARTS_WITH:
+        case Function::Type::ENDS_WITH:
+        case Function::Type::CONTAINS:
+        case Function::Type::LIKE:
+            // SearchArgument does not support predicates including StartsWith, EndsWith, Contains
+            // and Like that should skip.
+            builder->literal(::orc::TruthValue::YES);
+            break;
+        default:
+            return Status::Invalid(
+                fmt::format("invalid predicate type {}", static_cast<int32_t>(function_type)));
+    }
+    return Status::OK();
+}
+
+Result<::orc::PredicateDataType> PredicateConverter::ConvertToOrcPredicateType(
+    const FieldType& field_type) {
+    switch (field_type) {
+        case FieldType::BOOLEAN:
+            return ::orc::PredicateDataType::BOOLEAN;
+        case FieldType::TINYINT:
+        case FieldType::SMALLINT:
+        case FieldType::INT:
+        case FieldType::BIGINT:
+            return ::orc::PredicateDataType::LONG;
+        case FieldType::FLOAT:
+        case FieldType::DOUBLE:
+            return ::orc::PredicateDataType::FLOAT;
+        case FieldType::STRING:
+            return ::orc::PredicateDataType::STRING;
+        case FieldType::TIMESTAMP:
+            return ::orc::PredicateDataType::TIMESTAMP;
+        case FieldType::DECIMAL:
+            return ::orc::PredicateDataType::DECIMAL;
+        case FieldType::DATE:
+            return ::orc::PredicateDataType::DATE;
+        default:
+            return Status::Invalid(fmt::format("invalid field type {} in PredicateConverter",
+                                               FieldTypeUtils::FieldTypeToString(field_type)));
+    }
+}
+
+Result<std::vector<::orc::Literal>> PredicateConverter::ConvertToOrcLiterals(
+    const std::vector<Literal>& literals) {
+    std::vector<::orc::Literal> orc_literals;
+    orc_literals.reserve(literals.size());
+    for (const auto& literal : literals) {
+        auto literal_type = literal.GetType();
+        PAIMON_ASSIGN_OR_RAISE(::orc::PredicateDataType orc_type,
+                               ConvertToOrcPredicateType(literal_type));
+        if (literal.IsNull()) {
+            orc_literals.emplace_back(orc_type);
+            continue;
+        }
+        switch (literal_type) {
+            case FieldType::BOOLEAN:
+                orc_literals.emplace_back(literal.GetValue<bool>());
+                break;
+            case FieldType::TINYINT:
+                orc_literals.emplace_back(static_cast<int64_t>(literal.GetValue<int8_t>()));
+                break;
+            case FieldType::SMALLINT:
+                orc_literals.emplace_back(static_cast<int64_t>(literal.GetValue<int16_t>()));
+                break;
+            case FieldType::INT:
+                orc_literals.emplace_back(static_cast<int64_t>(literal.GetValue<int32_t>()));
+                break;
+            case FieldType::BIGINT:
+                orc_literals.emplace_back(literal.GetValue<int64_t>());
+                break;
+            case FieldType::FLOAT:
+                orc_literals.emplace_back(static_cast<double>(literal.GetValue<float>()));
+                break;
+            case FieldType::DOUBLE:
+                orc_literals.emplace_back(literal.GetValue<double>());
+                break;
+            case FieldType::STRING: {
+                auto str = literal.GetValue<std::string>();
+                orc_literals.emplace_back(str.data(), str.length());
+                break;
+            }
+            case FieldType::TIMESTAMP: {
+                auto timestamp = literal.GetValue<Timestamp>();
+                // orc literal is different with paimon literal,
+                // if timestamp < 1970-01-01 00:00:00, nanosecond in orc literal is negative
+                const int64_t conversion_factor_from_second = 1000;
+                const int64_t conversion_factor_from_nanosecond = 1000000;
+                orc_literals.emplace_back(
+                    timestamp.GetMillisecond() / conversion_factor_from_second,
+                    (timestamp.GetMillisecond() % conversion_factor_from_second) *
+                            conversion_factor_from_nanosecond +
+                        timestamp.GetNanoOfMillisecond());
+                break;
+            }
+            case FieldType::DECIMAL: {
+                auto decimal = literal.GetValue<Decimal>();
+                orc_literals.emplace_back(::orc::Int128(decimal.HighBits(), decimal.LowBits()),
+                                          decimal.Precision(), decimal.Scale());
+                break;
+            }
+            case FieldType::DATE:
+                orc_literals.emplace_back(orc_type,
+                                          static_cast<int64_t>(literal.GetValue<int32_t>()));
+                break;
+            default:
+                return Status::Invalid(
+                    fmt::format("invalid literal type {}", static_cast<int32_t>(literal_type)));
+        }
+    }
+    return orc_literals;
+}
+Status PredicateConverter::Convert(const std::shared_ptr<Predicate>& predicate,
+                                   const std::unordered_map<std::string, uint64_t>& name_id_mapping,
+                                   ::orc::SearchArgumentBuilder* builder) {
+    if (auto leaf_predicate = std::dynamic_pointer_cast<LeafPredicate>(predicate)) {
+        return ConvertLeaf(leaf_predicate, name_id_mapping, builder);
+    }
+    if (auto compound_predicate = std::dynamic_pointer_cast<CompoundPredicate>(predicate)) {
+        return ConvertCompound(compound_predicate, name_id_mapping, builder);
+    }
+    return Status::Invalid("invalid predicate, must be leaf or compound");
+}
+
+Status PredicateConverter::CheckLiteralNotEmpty(const std::vector<Literal>& literals,
+                                                const Function& function,
+                                                const std::string& field_name) {
+    if (literals.empty()) {
+        return Status::Invalid(fmt::format("predicate [{}] need literal on field {}",
+                                           function.ToString(), field_name));
+    }
+    return Status::OK();
+}
+
+Result<bool> PredicateConverter::IsPredicatePushable(
+    const std::shared_ptr<Predicate>& predicate,
+    const std::unordered_map<std::string, uint64_t>& name_id_mapping) {
+    if (auto leaf_predicate = std::dynamic_pointer_cast<LeafPredicate>(predicate)) {
+        return IsLeafPredicatePushable(leaf_predicate, name_id_mapping);
+    }
+    if (auto compound_predicate = std::dynamic_pointer_cast<CompoundPredicate>(predicate)) {
+        return IsCompoundPredicatePushable(compound_predicate, name_id_mapping);
+    }
+    return Status::Invalid("invalid predicate, must be leaf or compound");
+}
+
+Result<bool> PredicateConverter::IsCompoundPredicatePushable(
+    const std::shared_ptr<CompoundPredicate>& compound_predicate,
+    const std::unordered_map<std::string, uint64_t>& name_id_mapping) {
+    const auto& children = compound_predicate->Children();
+    const auto& function = compound_predicate->GetFunction();
+    auto function_type = function.GetType();
+    switch (function_type) {
+        case Function::Type::AND:
+        case Function::Type::OR: {
+            for (const auto& child : children) {
+                PAIMON_ASSIGN_OR_RAISE(bool pushable, IsPredicatePushable(child, name_id_mapping));
+                if (!pushable) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        default:
+            return Status::Invalid(
+                fmt::format("invalid predicate type {}", static_cast<int32_t>(function_type)));
+    }
+}
+
+Result<bool> PredicateConverter::IsLeafPredicatePushable(
+    const std::shared_ptr<LeafPredicate>& leaf_predicate,
+    const std::unordered_map<std::string, uint64_t>& name_id_mapping) {
+    const auto& field_name = leaf_predicate->FieldName();
+    auto iter = name_id_mapping.find(field_name);
+    if (iter == name_id_mapping.end()) {
+        return Status::Invalid(fmt::format("field {} is not exist in data file", field_name));
+    }
+    if (leaf_predicate->GetFieldType() == FieldType::BINARY) {
+        return false;
+    }
+    return true;
+}
+
+}  // namespace paimon::orc

--- a/src/paimon/format/orc/predicate_converter.h
+++ b/src/paimon/format/orc/predicate_converter.h
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "orc/Type.hh"
+#include "orc/sargs/Literal.hh"
+#include "orc/sargs/SearchArgument.hh"
+#include "paimon/predicate/compound_predicate.h"
+#include "paimon/predicate/leaf_predicate.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+
+namespace orc {
+class Type;
+}  // namespace orc
+
+namespace paimon {
+class CompoundPredicate;
+class Function;
+class LeafPredicate;
+class Literal;
+class Predicate;
+enum class FieldType;
+}  // namespace paimon
+
+namespace paimon::orc {
+
+class PredicateConverter {
+ public:
+    PredicateConverter() = delete;
+    ~PredicateConverter() = delete;
+
+    // convert paimon predicate to orc SearchArgument
+    static Result<std::unique_ptr<::orc::SearchArgument>> Convert(
+        const ::orc::Type& orc_type, const std::shared_ptr<Predicate>& predicate);
+
+ private:
+    static Status ConvertCompound(const std::shared_ptr<CompoundPredicate>& compound_predicate,
+                                  const std::unordered_map<std::string, uint64_t>& name_id_mapping,
+                                  ::orc::SearchArgumentBuilder* builder);
+
+    static Status ConvertLeaf(const std::shared_ptr<LeafPredicate>& leaf_predicate,
+                              const std::unordered_map<std::string, uint64_t>& name_id_mapping,
+                              ::orc::SearchArgumentBuilder* builder);
+
+    static Status Convert(const std::shared_ptr<Predicate>& predicate,
+                          const std::unordered_map<std::string, uint64_t>& name_id_mapping,
+                          ::orc::SearchArgumentBuilder* builder);
+
+    static Result<bool> IsPredicatePushable(
+        const std::shared_ptr<Predicate>& predicate,
+        const std::unordered_map<std::string, uint64_t>& name_id_mapping);
+
+    static Result<bool> IsCompoundPredicatePushable(
+        const std::shared_ptr<CompoundPredicate>& compound_predicate,
+        const std::unordered_map<std::string, uint64_t>& name_id_mapping);
+
+    static Result<bool> IsLeafPredicatePushable(
+        const std::shared_ptr<LeafPredicate>& leaf_predicate,
+        const std::unordered_map<std::string, uint64_t>& name_id_mapping);
+
+    static Status CheckLiteralNotEmpty(const std::vector<Literal>& literals,
+                                       const Function& function, const std::string& field_name);
+
+    static Result<::orc::PredicateDataType> ConvertToOrcPredicateType(const FieldType& field_type);
+
+    static Result<std::vector<::orc::Literal>> ConvertToOrcLiterals(
+        const std::vector<Literal>& literals);
+};
+
+}  // namespace paimon::orc

--- a/src/paimon/format/orc/predicate_converter_test.cpp
+++ b/src/paimon/format/orc/predicate_converter_test.cpp
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/format/orc/predicate_converter.h"
+
+#include <utility>
+
+#include "gtest/gtest.h"
+#include "orc/Type.hh"
+#include "orc/sargs/SearchArgument.hh"
+#include "paimon/data/decimal.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::orc::test {
+
+TEST(PredicateConverterTest, TestSimple) {
+    std::string orc_schema =
+        "struct<f0:bigint,f1:double,f2:string,f3:int,f4:tinyint,f5:decimal(6,2)>";
+    std::unique_ptr<::orc::Type> orc_type = ::orc::Type::buildTypeFromString(orc_schema);
+    {
+        auto predicate =
+            PredicateBuilder::IsNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT);
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) is null), expr = leaf-0", search_arg->toString());
+    }
+    {
+        auto predicate =
+            PredicateBuilder::IsNotNull(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT);
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) is null), expr = (not leaf-0)", search_arg->toString());
+    }
+    {
+        auto predicate = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                 FieldType::BIGINT, Literal(5l));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) = 5), expr = leaf-0", search_arg->toString());
+    }
+    {
+        auto predicate = PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                                 FieldType::INT, Literal(10));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=4) = 10), expr = leaf-0", search_arg->toString());
+    }
+    {
+        // Noted: equal null convert to is null in orc, which is different from java paimon,
+        // where any field value equal/not equal null return false
+        // therefore, we disable literal in predicate to be null (see PredicateValidator)
+        auto predicate = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                                 FieldType::BIGINT, Literal(FieldType::BIGINT));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) is null), expr = leaf-0", search_arg->toString());
+    }
+    {
+        auto predicate = PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                    FieldType::BIGINT, Literal(5l));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) = 5), expr = (not leaf-0)", search_arg->toString());
+    }
+    {
+        auto predicate = PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                       FieldType::BIGINT, Literal(5l));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) <= 5), expr = (not leaf-0)", search_arg->toString());
+    }
+    {
+        auto predicate = PredicateBuilder::GreaterOrEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                          FieldType::BIGINT, Literal(5l));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) < 5), expr = (not leaf-0)", search_arg->toString());
+    }
+    {
+        auto predicate = PredicateBuilder::GreaterOrEqual(
+            /*field_index=*/4, /*field_name=*/"f4", FieldType::TINYINT,
+            Literal(static_cast<int8_t>(16)));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=5) < 16), expr = (not leaf-0)", search_arg->toString());
+    }
+    {
+        auto predicate = PredicateBuilder::LessThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                    FieldType::BIGINT, Literal(5l));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) < 5), expr = leaf-0", search_arg->toString());
+    }
+    {
+        auto predicate = PredicateBuilder::LessOrEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                       FieldType::BIGINT, Literal(5l));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) <= 5), expr = leaf-0", search_arg->toString());
+    }
+    {
+        auto predicate =
+            PredicateBuilder::In(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                 {Literal(1l), Literal(3l), Literal(5l)});
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) in [1, 3, 5]), expr = leaf-0", search_arg->toString());
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            const auto predicate,
+            PredicateBuilder::StartsWith(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                         Literal(FieldType::STRING, "aab", 3)));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("expr = YES", search_arg->toString());
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            const auto predicate,
+            PredicateBuilder::EndsWith(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                       Literal(FieldType::STRING, "bcc", 3)));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("expr = YES", search_arg->toString());
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            const auto predicate,
+            PredicateBuilder::Contains(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                       Literal(FieldType::STRING, "abc", 3)));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("expr = YES", search_arg->toString());
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            const auto predicate,
+            PredicateBuilder::Like(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                   Literal(FieldType::STRING, "abc", 3)));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("expr = YES", search_arg->toString());
+    }
+    {
+        auto predicate =
+            PredicateBuilder::NotIn(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                    {Literal(1l), Literal(3l), Literal(5l)});
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) in [1, 3, 5]), expr = (not leaf-0)",
+                  search_arg->toString());
+    }
+    {
+        // orc format do not support only one decimal for In Predicate
+        auto predicate = PredicateBuilder::In(/*field_index=*/5, /*field_name=*/"f5",
+                                              FieldType::DECIMAL, {Literal(Decimal(6, 2, 12345))});
+        ASSERT_NOK_WITH_MSG(PredicateConverter::Convert(*orc_type, predicate),
+                            "At least two literals are required!");
+    }
+    {
+        // test idx mismatches in orc type
+        auto predicate =
+            PredicateBuilder::IsNull(/*field_index=*/3, /*field_name=*/"f0", FieldType::BIGINT);
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=1) is null), expr = leaf-0", search_arg->toString());
+    }
+    {
+        // support decimal precision and scale mismatches between literal and data
+        auto predicate =
+            PredicateBuilder::In(/*field_index=*/5, /*field_name=*/"f5", FieldType::DECIMAL,
+                                 {Literal(Decimal(5, 1, 12345)), Literal(Decimal(5, 1, 54321))});
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ("leaf-0 = (column(id=6) in [1234.5, 5432.1]), expr = leaf-0",
+                  search_arg->toString());
+    }
+}
+
+TEST(PredicateConverterTest, TestCompound) {
+    std::string orc_schema =
+        "struct<f0:bigint,f1:float,f2:string,f3:boolean,f4:date,f5:timestamp,f6:decimal(6,2),f7:"
+        "binary>";
+    std::unique_ptr<::orc::Type> orc_type = ::orc::Type::buildTypeFromString(orc_schema);
+    {
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::And({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.0))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, "apple", 5)),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+                PredicateBuilder::Equal(/*field_index=*/4, /*field_name=*/"f4", FieldType::DATE,
+                                        Literal(FieldType::DATE, 3)),
+                PredicateBuilder::Equal(/*field_index=*/5, /*field_name=*/"f5",
+                                        FieldType::TIMESTAMP,
+                                        Literal(Timestamp(1725875365442l, 12000))),
+                PredicateBuilder::Equal(/*field_index=*/6, /*field_name=*/"f6", FieldType::DECIMAL,
+                                        Literal(Decimal(6, 2, 123456))),
+                PredicateBuilder::Equal(/*field_index=*/7, /*field_name=*/"f7", FieldType::BINARY,
+                                        Literal(FieldType::BINARY, "add", 3)),
+            }));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ(
+            "leaf-0 = (column(id=1) = 3), "
+            "leaf-1 = (column(id=2) = 5), "
+            "leaf-2 = (column(id=3) = apple), "
+            "leaf-3 = (column(id=4) = true), "
+            "leaf-4 = (column(id=5) = 3), "
+            "leaf-5 = (column(id=6) = 1725875365.442012000), "
+            "leaf-6 = (column(id=7) = 1234.56), "
+            "expr = (and leaf-0 leaf-1 leaf-2 leaf-3 leaf-4 leaf-5 leaf-6)",
+            search_arg->toString());
+    }
+    {
+        ASSERT_OK_AND_ASSIGN(
+            auto predicate,
+            PredicateBuilder::Or({
+                PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
+                                        Literal(3l)),
+                PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
+                                        Literal(static_cast<float>(5.0))),
+                PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
+                                        Literal(FieldType::STRING, "apple", 5)),
+                PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
+                                        Literal(true)),
+            }));
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ(
+            "leaf-0 = (column(id=1) = 3), "
+            "leaf-1 = (column(id=2) = 5), "
+            "leaf-2 = (column(id=3) = apple), "
+            "leaf-3 = (column(id=4) = true), "
+            "expr = (or leaf-0 leaf-1 leaf-2 leaf-3)",
+            search_arg->toString());
+    }
+    {
+        auto predicate =
+            PredicateBuilder::Or(
+                {PredicateBuilder::And(
+                     {PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                              FieldType::BOOLEAN, Literal(true)),
+                      PredicateBuilder::LessThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                 FieldType::BIGINT, Literal(3l))})
+                     .value(),
+                 PredicateBuilder::And(
+                     {PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                              FieldType::BOOLEAN, Literal(false)),
+                      PredicateBuilder::LessThan(/*field_index=*/1, /*field_name=*/"f1",
+                                                 FieldType::FLOAT,
+                                                 Literal(static_cast<float>(3.1)))})
+                     .value()})
+                .value();
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ(
+            "leaf-0 = (column(id=4) = true), "
+            "leaf-1 = (column(id=4) = false), "
+            "leaf-2 = (column(id=1) < 3), "
+            "leaf-3 = (column(id=2) < 3.1), "
+            "expr = (and (or leaf-0 leaf-1) (or leaf-2 leaf-1) "
+            "(or leaf-0 leaf-3) (or leaf-2 leaf-3))",
+            search_arg->toString());
+    }
+    {
+        // predicate nodes containing binary type will not be pushed down
+        auto predicate = PredicateBuilder::And(
+                             {PredicateBuilder::Or(
+                                  {PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                                           FieldType::BOOLEAN, Literal(true)),
+                                   PredicateBuilder::LessThan(
+                                       /*field_index=*/7, /*field_name=*/"f7", FieldType::BINARY,
+                                       Literal(FieldType::BINARY, "add", 3))})
+                                  .value(),
+                              PredicateBuilder::Or(
+                                  {PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                                           FieldType::BOOLEAN, Literal(false)),
+                                   PredicateBuilder::LessThan(/*field_index=*/1,
+                                                              /*field_name=*/"f1", FieldType::FLOAT,
+                                                              Literal(static_cast<float>(3.1)))})
+                                  .value()})
+                             .value();
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_EQ(
+            "leaf-0 = (column(id=4) = false), "
+            "leaf-1 = (column(id=2) < 3.1), "
+            "expr = (or leaf-0 leaf-1)",
+            search_arg->toString());
+    }
+    {
+        // predicate nodes containing binary type will not be pushed down with OR Predicate
+        auto predicate =
+            PredicateBuilder::Or(
+                {PredicateBuilder::Or(
+                     {PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
+                                              FieldType::BOOLEAN, Literal(true)),
+                      PredicateBuilder::LessThan(
+                          /*field_index=*/7, /*field_name=*/"f7", FieldType::BINARY,
+                          Literal(FieldType::BINARY, "add", 3))})
+                     .value(),
+                 PredicateBuilder::Or(
+                     {PredicateBuilder::Equal(/*field_index=*/4, /*field_name=*/"f4",
+                                              FieldType::DATE, Literal(FieldType::DATE, 3)),
+                      PredicateBuilder::LessThan(/*field_index=*/1, /*field_name=*/"f1",
+                                                 FieldType::FLOAT,
+                                                 Literal(static_cast<float>(3.1)))})
+                     .value()})
+                .value();
+        ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, predicate));
+        ASSERT_FALSE(search_arg);
+    }
+}
+
+TEST(PredicateConverterTest, TestWithoutPredicate) {
+    std::string orc_schema = "struct<f0:int,f1:double,f2:string>";
+    std::unique_ptr<::orc::Type> orc_type = ::orc::Type::buildTypeFromString(orc_schema);
+    ASSERT_OK_AND_ASSIGN(auto search_arg, PredicateConverter::Convert(*orc_type, nullptr));
+    ASSERT_FALSE(search_arg);
+}
+
+TEST(PredicateConverterTest, TestInvalidCase) {
+    std::string orc_schema = "struct<f0:int,f1:double,f2:string>";
+    std::unique_ptr<::orc::Type> orc_type = ::orc::Type::buildTypeFromString(orc_schema);
+    {
+        auto predicate =
+            PredicateBuilder::In(/*field_index=*/0, /*field_name=*/"f0", FieldType::INT, {});
+        ASSERT_NOK_WITH_MSG(PredicateConverter::Convert(*orc_type, predicate),
+                            "predicate [In] need literal on field f0");
+    }
+    {
+        auto predicate = PredicateBuilder::In(/*field_index=*/4, /*field_name=*/"f3",
+                                              FieldType::INT, {Literal(3)});
+        ASSERT_NOK_WITH_MSG(PredicateConverter::Convert(*orc_type, predicate),
+                            "field f3 is not exist in data file");
+    }
+}
+
+}  // namespace paimon::orc::test

--- a/src/paimon/format/orc/read_range_generator.cpp
+++ b/src/paimon/format/orc/read_range_generator.cpp
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/format/orc/read_range_generator.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <exception>
+#include <limits>
+#include <unordered_set>
+
+#include "fmt/format.h"
+#include "orc/Common.hh"
+#include "orc/Reader.hh"
+#include "orc/orc-config.hh"
+#include "paimon/common/utils/options_utils.h"
+#include "paimon/format/orc/orc_format_defs.h"
+#include "paimon/status.h"
+
+namespace paimon::orc {
+
+Result<std::unique_ptr<ReadRangeGenerator>> ReadRangeGenerator::Create(
+    const ::orc::Reader* reader, uint64_t natural_read_size,
+    const std::map<std::string, std::string>& options) {
+    try {
+        if (reader == nullptr) {
+            return Status::Invalid("create read range generator failed, orc reader is nullptr.");
+        }
+        std::map<uint64_t, std::map<::orc::StreamKind, uint64_t>> column_length_map;
+        uint64_t stripe_num = reader->getNumberOfStripes();
+        std::vector<std::unique_ptr<::orc::StripeInformation>> stripe_infos;
+        stripe_infos.reserve(stripe_num);
+        for (uint64_t i = 0; i < stripe_num; i++) {
+            stripe_infos.emplace_back(reader->getStripe(i));
+        }
+        if (stripe_num > 0) {
+            const auto& stripe = stripe_infos[0].get();
+            for (uint64_t s = 0; s < stripe->getNumberOfStreams(); ++s) {
+                std::unique_ptr<::orc::StreamInformation> stream = stripe->getStreamInformation(s);
+                uint64_t column_id = stream->getColumnId();
+                uint64_t length = stream->getLength();
+                column_length_map[column_id][stream->getKind()] = length;
+            }
+        }
+        return std::unique_ptr<ReadRangeGenerator>(new ReadRangeGenerator(
+            reader, natural_read_size, std::move(stripe_infos), column_length_map, options));
+    } catch (const std::exception& e) {
+        return Status::Invalid(
+            fmt::format("create read range generator failed, with {} error", e.what()));
+    } catch (...) {
+        return Status::UnknownError("create read range generator failed, with unknown error");
+    }
+}
+
+Result<std::vector<std::pair<uint64_t, uint64_t>>> ReadRangeGenerator::GenReadRanges(
+    const std::vector<uint64_t>& target_column_ids, uint64_t begin_row_num, uint64_t end_row_num,
+    bool* need_prefetch) const {
+    try {
+        *need_prefetch = false;
+        uint64_t stripe_num = reader_->getNumberOfStripes();
+        if (stripe_num == 0) {
+            return std::vector<std::pair<uint64_t, uint64_t>>();
+        }
+        ReadRangeGenerator::ReaderMeta reader_meta = GetReaderMeta();
+        uint32_t suggest_row_count = static_cast<uint32_t>(
+            std::min(SuggestRowCount(target_column_ids),
+                     static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())));
+        auto ranges = DoGenReadRanges(begin_row_num, end_row_num, suggest_row_count, reader_meta);
+
+        uint64_t target_read_length = 0;
+        for (const auto& column_id : target_column_ids) {
+            target_read_length += CompressedLength(column_id, std::nullopt);
+        }
+        target_read_length *= reader_->getNumberOfStripes();
+        PAIMON_ASSIGN_OR_RAISE(
+            uint64_t enable_prefetch_read_size_threshold,
+            OptionsUtils::GetValueFromMap<uint64_t>(options_, ENABLE_PREFETCH_READ_SIZE_THRESHOLD,
+                                                    DEFAULT_ENABLE_PREFETCH_READ_SIZE_THRESHOLD));
+        if (target_read_length > enable_prefetch_read_size_threshold) {
+            *need_prefetch = true;
+        }
+
+        return ranges;
+    } catch (const std::exception& e) {
+        return Status::Invalid(fmt::format("gen read ranges failed, with {} error", e.what()));
+    } catch (...) {
+        return Status::UnknownError("gen read ranges failed, with unknown error");
+    }
+}
+
+std::vector<std::pair<uint64_t, uint64_t>> ReadRangeGenerator::DoGenReadRanges(
+    uint64_t begin_row_num, uint64_t end_row_num, uint32_t range_size,
+    const ReaderMeta& reader_meta) {
+    std::vector<std::pair<uint64_t, uint64_t>> read_ranges;
+    auto calculate_range_size = [range_size](uint64_t pos, uint64_t stripe_end) -> uint64_t {
+        uint64_t min_right_bound = std::min({pos + range_size, stripe_end});
+        return min_right_bound - pos;
+    };
+
+    uint64_t current_row = begin_row_num;
+    uint64_t next_range_size = range_size;
+    while (current_row < end_row_num) {
+        uint64_t curr_stripe_begin = 0;
+        for (auto stripe_row_count : reader_meta.rows_per_stripes) {
+            if (current_row >= curr_stripe_begin &&
+                current_row < curr_stripe_begin + stripe_row_count) {
+                next_range_size =
+                    calculate_range_size(current_row - curr_stripe_begin, stripe_row_count);
+                break;
+            } else {
+                curr_stripe_begin += stripe_row_count;
+            }
+        }
+        read_ranges.emplace_back(current_row, std::min(current_row + next_range_size, end_row_num));
+        current_row += next_range_size;
+    }
+    return read_ranges;
+}
+
+uint64_t ReadRangeGenerator::SuggestRowCount(const std::vector<uint64_t>& target_column_ids) const {
+    double bytes_per_group = BytesPerGroup(target_column_ids);
+    uint64_t expect_row_group_count =
+        std::ceil(static_cast<double>(natural_read_size_) / bytes_per_group);
+    expect_row_group_count =
+        std::max(expect_row_group_count, MIN_ROW_GROUP_COUNT_IN_ONE_NATURAL_READ);
+    return std::min(expect_row_group_count * reader_->getRowIndexStride(), MaxRowCountInStripe());
+}
+
+double ReadRangeGenerator::BytesPerGroup(const std::vector<uint64_t>& column_ids) const {
+    if (reader_->getNumberOfRows() == 0) {
+        return 1;
+    }
+    uint64_t max_column_id = std::numeric_limits<uint64_t>::max();
+    uint64_t max_length = 0;
+    for (const auto& column_id : column_ids) {
+        uint64_t length = CompressedLength(column_id, std::nullopt);
+        if (length > max_length) {
+            max_length = length;
+            max_column_id = column_id;
+        }
+    }
+    if (max_column_id == std::numeric_limits<uint64_t>::max()) {
+        return 1;
+    }
+    uint64_t stripe_row_count = stripe_infos_[0]->getNumberOfRows();
+    if (stripe_row_count == 0) {
+        return 1;
+    }
+    double avg_len_per_row = static_cast<double>(max_length) / stripe_row_count;
+    double bytes_per_group = avg_len_per_row * reader_->getRowIndexStride();
+    if (bytes_per_group < 1) {
+        return 1;
+    }
+    return bytes_per_group;
+}
+
+ReadRangeGenerator::ReaderMeta ReadRangeGenerator::GetReaderMeta() const {
+    ReaderMeta reader_meta;
+    reader_meta.rows_per_group = reader_->getRowIndexStride();
+    uint64_t stripe_num = reader_->getNumberOfStripes();
+    for (uint64_t i = 0; i < stripe_num; i++) {
+        auto stripe_row_num = stripe_infos_[i]->getNumberOfRows();
+        reader_meta.rows_per_stripes.push_back(stripe_row_num);
+    }
+    return reader_meta;
+}
+
+uint64_t ReadRangeGenerator::MaxRowCountInStripe() const {
+    uint64_t max_row_num_per_stripe = 0;
+    uint64_t stripe_num = reader_->getNumberOfStripes();
+    if (stripe_num == 0) {
+        return 0;
+    }
+    for (uint64_t i = 0; i < stripe_num; i++) {
+        auto stripe_row_num = stripe_infos_[i]->getNumberOfRows();
+        max_row_num_per_stripe = std::max(max_row_num_per_stripe, stripe_row_num);
+    }
+    return max_row_num_per_stripe;
+}
+
+uint64_t ReadRangeGenerator::CompressedLength(uint32_t col_id,
+                                              std::optional<::orc::StreamKind> stream_kind) const {
+    uint64_t length = 0;
+    auto iter = column_length_map_.find(col_id);
+    if (iter != column_length_map_.end()) {
+        auto& kind_and_length = iter->second;
+        if (stream_kind) {
+            auto it = kind_and_length.find(stream_kind.value());
+            if (it != kind_and_length.end()) {
+                length = it->second;
+            } else {
+                assert(false);
+            }
+        } else {
+            for (const auto& [_, len] : kind_and_length) {
+                length += len;
+            }
+        }
+    } else {
+        assert(false);
+    }
+    return length;
+}
+
+ReadRangeGenerator::ReadRangeGenerator(
+    const ::orc::Reader* reader, uint64_t natural_read_size,
+    std::vector<std::unique_ptr<::orc::StripeInformation>>&& stripe_infos,
+    const std::map<uint64_t, std::map<::orc::StreamKind, uint64_t>>& column_length_map,
+    const std::map<std::string, std::string>& options)
+    : reader_(reader),
+      natural_read_size_(natural_read_size),
+      stripe_infos_(std::move(stripe_infos)),
+      column_length_map_(column_length_map),
+      options_(options) {}
+
+}  // namespace paimon::orc

--- a/src/paimon/format/orc/read_range_generator.h
+++ b/src/paimon/format/orc/read_range_generator.h
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "orc/Common.hh"
+#include "orc/Reader.hh"
+#include "orc/orc-config.hh"
+#include "paimon/common/utils/options_utils.h"
+#include "paimon/data/decimal.h"
+#include "paimon/format/orc/orc_format_defs.h"
+#include "paimon/result.h"
+
+namespace orc {
+class Reader;
+}  // namespace orc
+
+namespace paimon::orc {
+
+class ReadRangeGenerator {
+ public:
+    static Result<std::unique_ptr<ReadRangeGenerator>> Create(
+        const ::orc::Reader* reader, uint64_t natural_read_size,
+        const std::map<std::string, std::string>& options);
+
+    Result<std::vector<std::pair<uint64_t, uint64_t>>> GenReadRanges(
+        const std::vector<uint64_t>& target_column_ids, uint64_t begin_row_num,
+        uint64_t end_row_num, bool* need_prefetch) const;
+
+ private:
+    struct ReaderMeta {
+        uint64_t rows_per_group;
+        std::vector<uint64_t> rows_per_stripes;
+    };
+
+    static std::vector<std::pair<uint64_t, uint64_t>> DoGenReadRanges(
+        uint64_t begin_row_num, uint64_t end_row_num, uint32_t range_size,
+        const ReaderMeta& reader_meta);
+
+    ReadRangeGenerator(
+        const ::orc::Reader* reader, uint64_t natural_read_size,
+        std::vector<std::unique_ptr<::orc::StripeInformation>>&& stripe_infos,
+        const std::map<uint64_t, std::map<::orc::StreamKind, uint64_t>>& column_length_map,
+        const std::map<std::string, std::string>& options);
+
+    uint64_t SuggestRowCount(const std::vector<uint64_t>& target_column_ids) const;
+    double BytesPerGroup(const std::vector<uint64_t>& column_ids) const;
+    ReaderMeta GetReaderMeta() const;
+    uint64_t MaxRowCountInStripe() const;
+    uint64_t CompressedLength(uint32_t col_id, std::optional<::orc::StreamKind> stream_kind) const;
+
+    const ::orc::Reader* reader_;
+    const uint64_t natural_read_size_;
+    const std::vector<std::unique_ptr<::orc::StripeInformation>> stripe_infos_;
+    const std::map<uint64_t, std::map<::orc::StreamKind, uint64_t>> column_length_map_;
+    const std::map<std::string, std::string> options_;
+};
+
+}  // namespace paimon::orc

--- a/src/paimon/format/orc/read_range_generator_test.cpp
+++ b/src/paimon/format/orc/read_range_generator_test.cpp
@@ -1,0 +1,293 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/format/orc/read_range_generator.h"
+
+#include <cstddef>
+#include <iostream>
+#include <sstream>
+
+#include "gtest/gtest.h"
+#include "orc/MemoryPool.hh"
+#include "orc/OrcFile.hh"
+#include "orc/Reader.hh"
+#include "orc/Type.hh"
+#include "orc/Vector.hh"
+#include "orc/Writer.hh"
+#include "orc/orc-config.hh"
+#include "paimon/format/orc/orc_format_defs.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::orc::test {
+
+class ReadRangeGeneratorTest : public ::testing::Test {
+ public:
+    bool CheckEqual(const std::vector<std::pair<uint64_t, uint64_t>>& expected,
+                    const std::vector<std::pair<uint64_t, uint64_t>>& actual) const {
+        if (expected.size() != actual.size()) {
+            std::cout << "expected: " << ToString(expected) << std::endl;
+            std::cout << "actual: " << ToString(actual) << std::endl;
+            return false;
+        }
+        for (size_t i = 0; i < expected.size(); i++) {
+            if (expected[i] != actual[i]) {
+                std::cout << "expected: " << ToString(expected) << std::endl;
+                std::cout << "actual: " << ToString(actual) << std::endl;
+                return false;
+            }
+        }
+        return true;
+    }
+
+    std::string ToString(const std::vector<std::pair<uint64_t, uint64_t>>& ranges) const {
+        std::stringstream ss;
+        for (size_t i = 0; i < ranges.size(); i++) {
+            ss << "[ " << ranges[i].first << "," << ranges[i].second << " ] ";
+            if (i % 5 == 0 && i != 0) {
+                ss << std::endl;
+            }
+        }
+        ss << std::endl;
+        return ss.str();
+    }
+};
+
+TEST_F(ReadRangeGeneratorTest, EmptyFile) {
+    auto dir = paimon::test::UniqueTestDirectory::Create();
+    std::string file_path = dir->Str() + "/empty_file.orc";
+    std::unique_ptr<::orc::Type> schema = ::orc::createStructType();
+    schema->addStructField("id", ::orc::createPrimitiveType(::orc::TypeKind::INT));
+    schema->addStructField("name", ::orc::createPrimitiveType(::orc::TypeKind::STRING));
+    schema->addStructField("is_active", ::orc::createPrimitiveType(::orc::TypeKind::BOOLEAN));
+    schema->addStructField("value", ::orc::createPrimitiveType(::orc::TypeKind::DOUBLE));
+    ::orc::WriterOptions options;
+    ORC_UNIQUE_PTR<::orc::OutputStream> output_stream = ::orc::writeLocalFile(file_path);
+    std::unique_ptr<::orc::Writer> writer =
+        ::orc::createWriter(*schema, output_stream.get(), options);
+    writer->close();
+    auto input_stream = ::orc::readLocalFile(file_path);
+    auto reader = createReader(std::move(input_stream), ::orc::ReaderOptions());
+    ASSERT_OK_AND_ASSIGN(auto range_generator,
+                         ReadRangeGenerator::Create(reader.get(), 1024 * 1024, {}));
+    bool need_prefetch = false;
+    ASSERT_OK_AND_ASSIGN(auto read_ranges, range_generator->GenReadRanges(
+                                               /*target_column_ids=*/{1, 2}, /*begin_row_num=*/0,
+                                               /*end_row_num=*/100, &need_prefetch));
+    ASSERT_FALSE(need_prefetch);
+    std::vector<std::pair<uint64_t, uint64_t>> empty_ranges;
+    ASSERT_EQ(read_ranges, empty_ranges);
+}
+
+TEST_F(ReadRangeGeneratorTest, Simple) {
+    /*
+{ "name": "/tmp/paimon_test_a6daa513-04df-423f-98d1-7eebc52510ae/simple.orc",
+  "type": "struct<name:string,id:bigint>",
+  "attributes": {},
+  "rows": 300000,
+  "stripe count": 1,
+  "format": "0.12", "writer version": "ORC-135", "software version": "ORC C++ 2.1.1",
+  "compression": "zstd", "compression block": 65536,
+  "file length": 3763,
+  "content": 3528, "stripe stats": 64, "footer": 143, "postscript": 24,
+  "row index stride": 10000,
+  "user metadata": {
+  },
+  "stripes": [
+    { "stripe": 0, "rows": 300000,
+      "offset": 3, "length": 3528,
+      "index": 929, "data": 2512, "footer": 87,
+      "encodings": [
+         { "column": 0, "encoding": "direct" },
+         { "column": 1, "encoding": "dictionary rle2", "count": 100 },
+         { "column": 2, "encoding": "direct rle2" }
+      ],
+      "streams": [
+        { "id": 0, "column": 0, "kind": "index", "offset": 3, "length": 29 },
+        { "id": 1, "column": 1, "kind": "index", "offset": 32, "length": 291 },
+        { "id": 2, "column": 2, "kind": "index", "offset": 323, "length": 609 },
+        { "id": 3, "column": 1, "kind": "data", "offset": 932, "length": 1682 },
+        { "id": 4, "column": 1, "kind": "dictionary", "offset": 2614, "length": 251 },
+        { "id": 5, "column": 1, "kind": "length", "offset": 2865, "length": 26 },
+        { "id": 6, "column": 2, "kind": "data", "offset": 2891, "length": 553 }
+      ],
+      "timezone": "GMT"
+    }
+  ]
+}
+     */
+    auto dir = paimon::test::UniqueTestDirectory::Create();
+    std::string file_path = dir->Str() + "/simple.orc";
+    std::unique_ptr<::orc::Type> schema = ::orc::createStructType();
+    schema->addStructField("name", ::orc::createPrimitiveType(::orc::TypeKind::STRING));
+    schema->addStructField("id", ::orc::createPrimitiveType(::orc::TypeKind::LONG));
+    ::orc::WriterOptions options;
+    options.setDictionaryKeySizeThreshold(1);
+    ORC_UNIQUE_PTR<::orc::OutputStream> output_stream = ::orc::writeLocalFile(file_path);
+    std::unique_ptr<::orc::Writer> writer =
+        ::orc::createWriter(*schema, output_stream.get(), options);
+    const int64_t num_rows = 300000;
+    for (int64_t i = 0; i < num_rows; ++i) {
+        auto batch = writer->createRowBatch(1);
+        auto struct_batch = dynamic_cast<::orc::StructVectorBatch*>(batch.get());
+        auto* string_batch = dynamic_cast<::orc::StringVectorBatch*>(struct_batch->fields[0]);
+        auto* int64_batch = dynamic_cast<::orc::LongVectorBatch*>(struct_batch->fields[1]);
+        std::string str = "Row" + std::to_string(i % 100);
+        string_batch->data[0] = str.data();
+        string_batch->length[0] = str.size();
+        int64_batch->data[0] = i;
+        batch->numElements = 1;
+        writer->add(*struct_batch);
+    }
+    writer->close();
+    auto input_stream = ::orc::readLocalFile(file_path);
+    auto reader = createReader(std::move(input_stream), ::orc::ReaderOptions());
+    ASSERT_OK_AND_ASSIGN(auto range_generator,
+                         ReadRangeGenerator::Create(reader.get(), /*natural_read_size=*/1024,
+                                                    {{ENABLE_PREFETCH_READ_SIZE_THRESHOLD, "0"}}));
+    bool need_prefetch = false;
+    ASSERT_OK_AND_ASSIGN(auto read_ranges,
+                         range_generator->GenReadRanges(
+                             /*target_column_ids=*/{1, 2}, /*begin_row_num=*/0,
+                             /*end_row_num=*/reader->getNumberOfRows(), &need_prefetch));
+    ASSERT_TRUE(need_prefetch);
+    std::vector<std::pair<uint64_t, uint64_t>> expect_ranges = {
+        {0, 140000}, {140000, 280000}, {280000, 300000}};
+    EXPECT_EQ(read_ranges, expect_ranges);
+    EXPECT_EQ(140000, range_generator->SuggestRowCount({1}));
+    EXPECT_EQ(140000, range_generator->SuggestRowCount({1, 2}));
+    EXPECT_EQ(270000, range_generator->SuggestRowCount({2}));
+}
+
+TEST_F(ReadRangeGeneratorTest, SuggestRowCountWithFewRows) {
+    // struct<f0:string,f1:int,f2:int,f3:double>
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/orc/append_09.db/append_09/f1=10/bucket-1/"
+                            "data-b9e7c41f-66e8-4dad-b25a-e6e1963becc4-0.orc";
+    auto input_stream = ::orc::readLocalFile(file_name);
+    auto reader = createReader(std::move(input_stream), ::orc::ReaderOptions());
+    ASSERT_OK_AND_ASSIGN(auto range_generator,
+                         ReadRangeGenerator::Create(reader.get(), 1024 * 1024, {}));
+    EXPECT_EQ(8, range_generator->SuggestRowCount({1}));
+    EXPECT_EQ(8, range_generator->SuggestRowCount({4}));
+}
+
+TEST_F(ReadRangeGeneratorTest, TestBytesPerGroup) {
+    std::string file_name = paimon::test::GetDataDir() +
+                            "/orc/append_09.db/append_09/f1=10/bucket-1/"
+                            "data-b9e7c41f-66e8-4dad-b25a-e6e1963becc4-0.orc";
+
+    std::unique_ptr<::orc::Reader> reader =
+        ::orc::createReader(::orc::readLocalFile(file_name), ::orc::ReaderOptions());
+    ASSERT_OK_AND_ASSIGN(auto range_generator,
+                         ReadRangeGenerator::Create(reader.get(), 1024 * 1024, {}));
+    EXPECT_EQ(37500, range_generator->BytesPerGroup({2}));
+    EXPECT_EQ(96250, range_generator->BytesPerGroup({1, 2}));
+    EXPECT_EQ(96250, range_generator->BytesPerGroup({1}));
+}
+
+TEST_F(ReadRangeGeneratorTest, TestGenReadRanges) {
+    ReadRangeGenerator::ReaderMeta meta;
+    meta.rows_per_group = 10000;
+    meta.rows_per_stripes = {20480, 20480, 20480, 20480, 2080};
+    auto read_ranges_vec = ReadRangeGenerator::DoGenReadRanges(
+        /*begin_row_num=*/0, /*end_row_num=*/84000, /*range_size=*/10000, meta);
+    ASSERT_TRUE(CheckEqual({{0, 10000},
+                            {10000, 20000},
+                            {20000, 20480},
+                            {20480, 30480},
+                            {30480, 40480},
+                            {40480, 40960},
+                            {40960, 50960},
+                            {50960, 60960},
+                            {60960, 61440},
+                            {61440, 71440},
+                            {71440, 81440},
+                            {81440, 81920},
+                            {81920, 84000}},
+                           read_ranges_vec));
+}
+
+TEST_F(ReadRangeGeneratorTest, TestGenReadRangesBasic) {
+    ReadRangeGenerator::ReaderMeta meta;
+    meta.rows_per_group = 3;
+    meta.rows_per_stripes = {4, 6};
+    auto read_ranges_vec = ReadRangeGenerator::DoGenReadRanges(
+        /*begin_row_num=*/0, /*end_row_num=*/10, /*range_size=*/3, meta);
+    ASSERT_TRUE(CheckEqual({{0, 3}, {3, 4}, {4, 7}, {7, 10}}, read_ranges_vec));
+}
+
+TEST_F(ReadRangeGeneratorTest, TestGenReadRangesMultiStripes) {
+    ReadRangeGenerator::ReaderMeta meta;
+    meta.rows_per_group = 4;
+    meta.rows_per_stripes = {10, 15};
+    auto read_ranges_vec = ReadRangeGenerator::DoGenReadRanges(
+        /*begin_row_num=*/5, /*end_row_num=*/25, /*range_size=*/5, meta);
+    ASSERT_TRUE(CheckEqual({{5, 10}, {10, 15}, {15, 20}, {20, 25}}, read_ranges_vec));
+}
+
+TEST_F(ReadRangeGeneratorTest, TestGenReadRangesInvalid) {
+    ReadRangeGenerator::ReaderMeta meta;
+    meta.rows_per_group = 4;
+    meta.rows_per_stripes = {10, 15};
+    auto read_ranges_vec = ReadRangeGenerator::DoGenReadRanges(
+        /*begin_row_num=*/3, /*end_row_num=*/2, /*range_size=*/5, meta);
+    ASSERT_TRUE(CheckEqual({}, read_ranges_vec));
+}
+
+TEST_F(ReadRangeGeneratorTest, TestGenReadRangesStripeBound) {
+    ReadRangeGenerator::ReaderMeta meta;
+    meta.rows_per_group = 5;
+    meta.rows_per_stripes = {10, 10};
+    auto read_ranges_vec = ReadRangeGenerator::DoGenReadRanges(
+        /*begin_row_num=*/3, /*end_row_num=*/18, /*range_size=*/5, meta);
+    ASSERT_TRUE(CheckEqual({{3, 8}, {8, 10}, {10, 15}, {15, 18}}, read_ranges_vec));
+}
+
+TEST_F(ReadRangeGeneratorTest, TestGenReadRangesNotMatch) {
+    ReadRangeGenerator::ReaderMeta meta;
+    meta.rows_per_group = 2;
+    meta.rows_per_stripes = {4, 6};
+    auto read_ranges_vec = ReadRangeGenerator::DoGenReadRanges(
+        /*begin_row_num=*/10, /*end_row_num=*/10, /*range_size=*/2, meta);
+    ASSERT_TRUE(CheckEqual({}, read_ranges_vec));
+}
+
+TEST_F(ReadRangeGeneratorTest, CreateWithNullReader) {
+    ASSERT_NOK(ReadRangeGenerator::Create(nullptr, 1024 * 1024, {}));
+}
+
+TEST_F(ReadRangeGeneratorTest, BytesPerGroupWithEmptyColumns) {
+    auto dir = paimon::test::UniqueTestDirectory::Create();
+    std::string file_path = dir->Str() + "/empty_columns.orc";
+    std::unique_ptr<::orc::Type> schema = ::orc::createStructType();
+    schema->addStructField("id", ::orc::createPrimitiveType(::orc::TypeKind::INT));
+    ::orc::WriterOptions options;
+    ORC_UNIQUE_PTR<::orc::OutputStream> output_stream = ::orc::writeLocalFile(file_path);
+    std::unique_ptr<::orc::Writer> writer =
+        ::orc::createWriter(*schema, output_stream.get(), options);
+    writer->close();
+    auto input_stream = ::orc::readLocalFile(file_path);
+    auto reader = createReader(std::move(input_stream), ::orc::ReaderOptions());
+    ASSERT_OK_AND_ASSIGN(auto range_generator,
+                         ReadRangeGenerator::Create(reader.get(), 1024 * 1024, {}));
+    EXPECT_EQ(1, range_generator->BytesPerGroup({}));
+}
+
+}  // namespace paimon::orc::test


### PR DESCRIPTION

<!-- Please specify the module before the PR name: feat: ... or fix: ... -->

### Purpose
Introduce ORC format infrastructure for statistics extraction, predicate pushdown, and read range generation. These components enable efficient ORC file reading with column statistics collection, filter pushdown via ORC SearchArgument, and optimized I/O range planning based on stripe metadata.

#### New Classes
- OrcStatsExtractor: Extracts column-level statistics from ORC files by reading ORC column statistics and converting them to Paimon's ColumnStats format. Supports extracting both column stats and file info (e.g., row count) for use in query optimization and data validation.
- PredicateConverter: Converts Paimon predicates (LeafPredicate, CompoundPredicate) into ORC SearchArgument for predicate pushdown. Validates predicate pushability, maps field types to ORC predicate types, and converts literals to ORC literal format to enable server-side filtering during ORC reads.
- ReadRangeGenerator: Generates optimized byte ranges for reading specific columns and row ranges from ORC files. Analyzes stripe metadata and column stream lengths to suggest appropriate row counts per read, minimizing I/O while respecting natural read size constraints.

### Tests
- OrcStatsExtractorTest
- PredicateConverterTest
- ReadRangeGeneratorTest