### PR TITLE
feat: introduce FieldMapping and FieldMappingBuilder

### DIFF
--- a/src/paimon/core/utils/field_mapping.cpp
+++ b/src/paimon/core/utils/field_mapping.cpp
@@ -1,0 +1,349 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/utils/field_mapping.h"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <set>
+
+#include "arrow/type.h"
+#include "fmt/format.h"
+#include "paimon/common/predicate/compound_predicate_impl.h"
+#include "paimon/common/predicate/leaf_predicate_impl.h"
+#include "paimon/common/utils/field_type_utils.h"
+#include "paimon/common/utils/object_utils.h"
+#include "paimon/core/casting/cast_executor_factory.h"
+#include "paimon/core/casting/casting_utils.h"
+#include "paimon/defs.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/predicate/predicate_utils.h"
+#include "paimon/status.h"
+
+namespace paimon {
+
+Result<std::shared_ptr<arrow::Schema>> FieldMapping::GetPartitionSchema(
+    const std::shared_ptr<arrow::Schema>& schema, const std::vector<std::string>& partition_keys) {
+    arrow::FieldVector partition_fields;
+    partition_fields.reserve(partition_keys.size());
+    for (const auto& partition_key : partition_keys) {
+        auto field = schema->GetFieldByName(partition_key);
+        if (!field) {
+            return Status::Invalid(
+                fmt::format("get partition schema failed, cannot find partition key {} in schema",
+                            partition_key));
+        }
+        partition_fields.push_back(field);
+    }
+    return arrow::schema(partition_fields);
+}
+
+Result<std::unique_ptr<FieldMappingBuilder>> FieldMappingBuilder::Create(
+    const std::shared_ptr<arrow::Schema>& read_schema,
+    const std::vector<std::string>& partition_keys, const std::shared_ptr<Predicate>& predicate) {
+    PAIMON_ASSIGN_OR_RAISE(std::vector<DataField> read_fields,
+                           DataField::ConvertArrowSchemaToDataFields(read_schema));
+    return std::unique_ptr<FieldMappingBuilder>(
+        new FieldMappingBuilder(read_fields, partition_keys, predicate));
+}
+
+Result<std::unique_ptr<FieldMapping>> FieldMappingBuilder::CreateFieldMapping(
+    const std::shared_ptr<arrow::Schema>& data_schema) const {
+    PAIMON_ASSIGN_OR_RAISE(std::vector<DataField> data_fields,
+                           DataField::ConvertArrowSchemaToDataFields(data_schema));
+    return CreateFieldMapping(data_fields);
+}
+
+Result<std::unique_ptr<FieldMapping>> FieldMappingBuilder::CreateFieldMapping(
+    const std::vector<DataField>& data_fields) const {
+    // generate non-exist field info
+    std::optional<NonExistFieldInfo> non_exist_field_info = CreateNonExistFieldInfo(data_fields);
+
+    // generate exist field info
+    ExistFieldInfo exist_field_info = CreateExistFieldInfo(data_fields);
+
+    // key: partition key, value: partition idx
+    std::map<std::string, int32_t> partition_key_to_idx =
+        ObjectUtils::CreateIdentifierToIndexMap(partition_keys_);
+
+    PAIMON_ASSIGN_OR_RAISE(
+        NonPartitionInfo non_partition_info,
+        CreateNonPartitionInfo(data_fields, exist_field_info, partition_key_to_idx));
+    PAIMON_ASSIGN_OR_RAISE(std::optional<PartitionInfo> partition_info,
+                           CreatePartitionInfo(exist_field_info, partition_key_to_idx));
+    return std::make_unique<FieldMapping>(partition_info, non_partition_info, non_exist_field_info);
+}
+
+ExistFieldInfo FieldMappingBuilder::CreateExistFieldInfo(
+    const std::vector<DataField>& data_fields) const {
+    // key:field id, value: {target_idx, read field}
+    std::map<int32_t, std::pair<int32_t, DataField>> field_id_to_read_fields;
+    for (size_t i = 0; i < read_fields_.size(); i++) {
+        const auto& read_field = read_fields_[i];
+        field_id_to_read_fields.emplace(read_field.Id(), std::make_pair(i, read_field));
+    }
+
+    ExistFieldInfo exist_field_info;
+    for (const auto& data_field : data_fields) {
+        auto iter = field_id_to_read_fields.find(data_field.Id());
+        if (iter != field_id_to_read_fields.end()) {
+            const auto& [target_idx, read_field] = iter->second;
+            exist_field_info.exist_read_schema.push_back(read_field);
+            exist_field_info.exist_data_schema.push_back(data_field);
+            exist_field_info.idx_in_target_read_schema.push_back(target_idx);
+        }
+    }
+    return exist_field_info;
+}
+
+std::optional<NonExistFieldInfo> FieldMappingBuilder::CreateNonExistFieldInfo(
+    const std::vector<DataField>& data_fields) const {
+    // key: field id, value: data field
+    std::map<int32_t, DataField> field_id_to_data_fields;
+    for (const auto& data_field : data_fields) {
+        field_id_to_data_fields.emplace(data_field.Id(), data_field);
+    }
+
+    NonExistFieldInfo non_exist_field_info;
+    for (size_t i = 0; i < read_fields_.size(); i++) {
+        const auto& read_field = read_fields_[i];
+        auto iter = field_id_to_data_fields.find(read_field.Id());
+        if (iter == field_id_to_data_fields.end()) {
+            non_exist_field_info.non_exist_read_schema.push_back(read_field);
+            non_exist_field_info.idx_in_target_read_schema.push_back(i);
+        }
+    }
+    if (non_exist_field_info.idx_in_target_read_schema.empty()) {
+        return std::nullopt;
+    }
+    return non_exist_field_info;
+}
+
+Result<std::vector<std::shared_ptr<CastExecutor>>> FieldMappingBuilder::CreateDataCastExecutors(
+    const std::vector<DataField>& read_fields, const std::vector<DataField>& data_fields) {
+    assert(read_fields.size() == data_fields.size());
+    std::vector<std::shared_ptr<CastExecutor>> cast_executors;
+    cast_executors.reserve(read_fields.size());
+    for (size_t i = 0; i < read_fields.size(); i++) {
+        PAIMON_ASSIGN_OR_RAISE(FieldType read_type,
+                               FieldTypeUtils::ConvertToFieldType(read_fields[i].Type()->id()));
+        PAIMON_ASSIGN_OR_RAISE(FieldType data_type,
+                               FieldTypeUtils::ConvertToFieldType(data_fields[i].Type()->id()));
+
+        if (!read_fields[i].Type()->Equals(data_fields[i].Type())) {
+            if (read_type == FieldType::MAP || read_type == FieldType::ARRAY ||
+                read_type == FieldType::STRUCT) {
+                return Status::Invalid("Only support column type evolution in atomic data type.");
+            }
+            auto executor_factory = CastExecutorFactory::GetCastExecutorFactory();
+            auto cast_executor =
+                executor_factory->GetCastExecutor(/*src=*/data_type, /*target=*/read_type);
+            if (!cast_executor) {
+                return Status::Invalid(
+                    fmt::format("CreateDataCastExecutors failed: cannot find cast "
+                                "executor for field {} from type {} to {}",
+                                read_fields[i].Name(), FieldTypeUtils::FieldTypeToString(data_type),
+                                FieldTypeUtils::FieldTypeToString(read_type)));
+            }
+            cast_executors.push_back(cast_executor);
+        } else {
+            cast_executors.push_back(nullptr);
+        }
+    }
+    return cast_executors;
+}
+
+Result<NonPartitionInfo> FieldMappingBuilder::CreateNonPartitionInfo(
+    const std::vector<DataField>& data_fields, const ExistFieldInfo& exist_field_info,
+    const std::map<std::string, int32_t>& partition_keys) const {
+    NonPartitionInfo non_partition_info;
+    for (size_t i = 0; i < exist_field_info.exist_data_schema.size(); i++) {
+        const auto& data_field = exist_field_info.exist_data_schema[i];
+        const auto& read_field = exist_field_info.exist_read_schema[i];
+        auto iter = partition_keys.find(read_field.Name());
+        if (iter == partition_keys.end()) {
+            non_partition_info.non_partition_read_schema.push_back(read_field);
+            non_partition_info.non_partition_data_schema.push_back(data_field);
+            non_partition_info.idx_in_target_read_schema.push_back(
+                exist_field_info.idx_in_target_read_schema[i]);
+        }
+    }
+    PAIMON_ASSIGN_OR_RAISE(non_partition_info.cast_executors,
+                           CreateDataCastExecutors(non_partition_info.non_partition_read_schema,
+                                                   non_partition_info.non_partition_data_schema));
+    // prepare predicate: exclude the push down predicate with partition key and non-exist fields
+    PAIMON_ASSIGN_OR_RAISE(non_partition_info.non_partition_filter, CreateDataFilters(data_fields));
+    return non_partition_info;
+}
+
+Result<std::shared_ptr<Predicate>> FieldMappingBuilder::CreateDataFilters(
+    const std::vector<DataField>& data_fields) const {
+    if (!predicate_) {
+        return predicate_;
+    }
+    // data schema mapping: id -> {data field idx, data field}
+    std::map<int32_t, std::pair<int32_t, DataField>> field_id_to_data_fields;
+    for (size_t i = 0; i < data_fields.size(); i++) {
+        const auto& data_field = data_fields[i];
+        field_id_to_data_fields.emplace(data_field.Id(), std::make_pair(i, data_field));
+    }
+    // table schema mapping: name -> read field
+    std::map<std::string, DataField> field_name_to_read_fields;
+    for (const auto& read_field : read_fields_) {
+        field_name_to_read_fields.emplace(read_field.Name(), read_field);
+    }
+    // reconstruct predicate (e.g., modify field idx, cast literal)
+    auto split_predicates = PredicateUtils::SplitAnd(predicate_);
+    std::vector<std::shared_ptr<Predicate>> converted_predicates;
+    converted_predicates.reserve(split_predicates.size());
+    for (const auto& predicate : split_predicates) {
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::shared_ptr<Predicate>> converted,
+                               ReconstructPredicateWithDataFields(
+                                   predicate, field_name_to_read_fields, field_id_to_data_fields));
+        if (converted != std::nullopt) {
+            converted_predicates.push_back(converted.value());
+        }
+    }
+    // exclude partition fields in predicate
+    std::set<std::string> partition_key_field_name_set(partition_keys_.begin(),
+                                                       partition_keys_.end());
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<Predicate>> remain_predicates,
+                           PredicateUtils::ExcludePredicateWithFields(
+                               converted_predicates, partition_key_field_name_set));
+    if (remain_predicates.empty()) {
+        return std::shared_ptr<Predicate>();
+    }
+    return PredicateBuilder::And(remain_predicates);
+}
+
+Result<std::optional<std::shared_ptr<Predicate>>> FieldMappingBuilder::ReconstructLeafPredicate(
+    const std::shared_ptr<LeafPredicateImpl>& leaf_predicate,
+    const std::map<std::string, DataField>& field_name_to_read_fields,
+    const std::map<int32_t, std::pair<int32_t, DataField>>& field_id_to_data_fields) {
+    auto read_field_iter = field_name_to_read_fields.find(leaf_predicate->FieldName());
+    if (read_field_iter == field_name_to_read_fields.end()) {
+        return Status::Invalid(
+            fmt::format("invalid predicate, cannot find field {}", leaf_predicate->FieldName()));
+    }
+    auto data_field_iter = field_id_to_data_fields.find(read_field_iter->second.Id());
+    if (data_field_iter == field_id_to_data_fields.end()) {
+        return std::optional<std::shared_ptr<Predicate>>();
+    }
+    std::vector<Literal> new_literals;
+    PAIMON_ASSIGN_OR_RAISE(FieldType read_type, FieldTypeUtils::ConvertToFieldType(
+                                                    read_field_iter->second.Type()->id()));
+    PAIMON_ASSIGN_OR_RAISE(FieldType data_type, FieldTypeUtils::ConvertToFieldType(
+                                                    data_field_iter->second.second.Type()->id()));
+    if (read_type != data_type ||
+        (!read_field_iter->second.Type()->Equals(data_field_iter->second.second.Type()))) {
+        // read type and data type are different, only push down integer predicates
+        if (FieldTypeUtils::IsIntegerNumeric(read_type) &&
+            FieldTypeUtils::IsIntegerNumeric(data_type) &&
+            FieldTypeUtils::IntegerScaleLargerThan(read_type, data_type)) {
+            auto executor_factory = CastExecutorFactory::GetCastExecutorFactory();
+            auto cast_executor =
+                executor_factory->GetCastExecutor(/*src=*/read_type, /*target=*/data_type);
+            if (!cast_executor) {
+                return Status::Invalid(fmt::format(
+                    "ReconstructLeafPredicate failed: cannot find cast "
+                    "executor for field {} from type {} to {}",
+                    read_field_iter->second.Name(), FieldTypeUtils::FieldTypeToString(read_type),
+                    FieldTypeUtils::FieldTypeToString(data_type)));
+            }
+            new_literals.reserve(leaf_predicate->Literals().size());
+            for (const auto& literal : leaf_predicate->Literals()) {
+                PAIMON_ASSIGN_OR_RAISE(
+                    Literal casted,
+                    cast_executor->Cast(literal, data_field_iter->second.second.Type()));
+                // ignore if any literal is overflowed.
+                if (CastingUtils::IsIntegerLiteralCastedOverflow(literal, casted)) {
+                    return std::optional<std::shared_ptr<Predicate>>();
+                }
+                new_literals.push_back(casted);
+            }
+        } else {
+            return std::optional<std::shared_ptr<Predicate>>();
+        }
+    } else {
+        new_literals = leaf_predicate->Literals();
+    }
+
+    const auto& [data_field_idx, data_field] = data_field_iter->second;
+    return std::optional<std::shared_ptr<Predicate>>(std::make_shared<LeafPredicateImpl>(
+        leaf_predicate->GetLeafFunction(), /*data field idx*/ data_field_idx,
+        /*data field name*/ data_field.Name(),
+        /*data field type*/ data_type, new_literals));
+}
+
+Result<std::optional<std::shared_ptr<Predicate>>>
+FieldMappingBuilder::ReconstructPredicateWithDataFields(
+    const std::shared_ptr<Predicate>& predicate,
+    const std::map<std::string, DataField>& field_name_to_read_fields,
+    const std::map<int32_t, std::pair<int32_t, DataField>>& field_id_to_data_fields) {
+    if (auto leaf_predicate = std::dynamic_pointer_cast<LeafPredicateImpl>(predicate)) {
+        return ReconstructLeafPredicate(leaf_predicate, field_name_to_read_fields,
+                                        field_id_to_data_fields);
+    } else if (auto compound_predicate =
+                   std::dynamic_pointer_cast<CompoundPredicateImpl>(predicate)) {
+        std::vector<std::shared_ptr<Predicate>> converted_children;
+        for (const auto& child : compound_predicate->Children()) {
+            PAIMON_ASSIGN_OR_RAISE(std::optional<std::shared_ptr<Predicate>> converted_child,
+                                   ReconstructPredicateWithDataFields(
+                                       child, field_name_to_read_fields, field_id_to_data_fields));
+            if (converted_child == std::nullopt) {
+                return std::optional<std::shared_ptr<Predicate>>();
+            }
+            assert(converted_child.value());
+            converted_children.push_back(converted_child.value());
+        }
+        return std::optional<std::shared_ptr<Predicate>>(
+            compound_predicate->NewCompoundPredicate(converted_children));
+    }
+    return Status::Invalid(
+        "invalid predicate, cannot convert to leaf predicate or compound predicate");
+}
+
+Result<std::optional<PartitionInfo>> FieldMappingBuilder::CreatePartitionInfo(
+    const ExistFieldInfo& exist_field_info,
+    const std::map<std::string, int32_t>& partition_keys) const {
+    if (partition_keys.empty()) {
+        return std::optional<PartitionInfo>();
+    }
+    PartitionInfo partition_info;
+    for (size_t i = 0; i < exist_field_info.exist_read_schema.size(); i++) {
+        const auto& read_field = exist_field_info.exist_read_schema[i];
+        auto iter = partition_keys.find(read_field.Name());
+        if (iter != partition_keys.end()) {
+            partition_info.partition_read_schema.push_back(read_field);
+            partition_info.idx_in_target_read_schema.push_back(
+                exist_field_info.idx_in_target_read_schema[i]);
+            partition_info.idx_in_partition.push_back(iter->second);
+        }
+    }
+    if (partition_info.idx_in_target_read_schema.empty()) {
+        return std::optional<PartitionInfo>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(partition_info.partition_filter,
+                           PredicateUtils::CreatePickedFieldFilter(predicate_, partition_keys));
+    return std::optional<PartitionInfo>(partition_info);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/utils/field_mapping.h
+++ b/src/paimon/core/utils/field_mapping.h
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/type.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/core/casting/cast_executor.h"
+#include "paimon/core/partition/partition_info.h"
+#include "paimon/predicate/predicate.h"
+#include "paimon/result.h"
+
+namespace paimon {
+struct FieldMapping {
+    FieldMapping(const std::optional<PartitionInfo>& _partition_info,
+                 const NonPartitionInfo& _non_partition_info,
+                 const std::optional<NonExistFieldInfo>& _non_exist_field_info)
+        : partition_info(_partition_info),
+          non_partition_info(_non_partition_info),
+          non_exist_field_info(_non_exist_field_info) {}
+
+    static Result<std::shared_ptr<arrow::Schema>> GetPartitionSchema(
+        const std::shared_ptr<arrow::Schema>& schema,
+        const std::vector<std::string>& partition_keys);
+
+    std::optional<PartitionInfo> partition_info = std::nullopt;
+    NonPartitionInfo non_partition_info;
+    std::optional<NonExistFieldInfo> non_exist_field_info = std::nullopt;
+};
+class LeafPredicateImpl;
+
+class FieldMappingBuilder {
+ public:
+    static Result<std::unique_ptr<FieldMappingBuilder>> Create(
+        const std::shared_ptr<arrow::Schema>& read_schema,
+        const std::vector<std::string>& partition_keys,
+        const std::shared_ptr<Predicate>& predicate);
+
+    Result<std::unique_ptr<FieldMapping>> CreateFieldMapping(
+        const std::vector<DataField>& data_fields) const;
+    Result<std::unique_ptr<FieldMapping>> CreateFieldMapping(
+        const std::shared_ptr<arrow::Schema>& data_schema) const;
+
+    int32_t GetReadFieldCount() const {
+        return read_fields_.size();
+    }
+
+    static Result<std::vector<std::shared_ptr<CastExecutor>>> CreateDataCastExecutors(
+        const std::vector<DataField>& read_fields, const std::vector<DataField>& data_fields);
+
+    static Result<std::optional<std::shared_ptr<Predicate>>> ReconstructPredicateWithDataFields(
+        const std::shared_ptr<Predicate>& predicate,
+        const std::map<std::string, DataField>& field_name_to_read_fields,
+        const std::map<int32_t, std::pair<int32_t, DataField>>& field_id_to_data_fields);
+
+ private:
+    FieldMappingBuilder(const std::vector<DataField>& read_fields,
+                        const std::vector<std::string>& partition_keys,
+                        const std::shared_ptr<Predicate>& predicate)
+        : read_fields_(read_fields), partition_keys_(partition_keys), predicate_(predicate) {}
+
+    std::optional<NonExistFieldInfo> CreateNonExistFieldInfo(
+        const std::vector<DataField>& data_fields) const;
+    ExistFieldInfo CreateExistFieldInfo(const std::vector<DataField>& data_fields) const;
+
+    Result<NonPartitionInfo> CreateNonPartitionInfo(
+        const std::vector<DataField>& data_fields, const ExistFieldInfo& exist_field_info,
+        const std::map<std::string, int32_t>& partition_keys) const;
+    Result<std::shared_ptr<Predicate>> CreateDataFilters(
+        const std::vector<DataField>& data_fields) const;
+
+    static Result<std::optional<std::shared_ptr<Predicate>>> ReconstructLeafPredicate(
+        const std::shared_ptr<LeafPredicateImpl>& leaf_predicate,
+        const std::map<std::string, DataField>& field_name_to_read_fields,
+        const std::map<int32_t, std::pair<int32_t, DataField>>& field_id_to_data_fields);
+
+    Result<std::optional<PartitionInfo>> CreatePartitionInfo(
+        const ExistFieldInfo& exist_field_info,
+        const std::map<std::string, int32_t>& partition_keys) const;
+
+ private:
+    std::vector<DataField> read_fields_;
+    std::vector<std::string> partition_keys_;
+    std::shared_ptr<Predicate> predicate_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/utils/field_mapping_test.cpp
+++ b/src/paimon/core/utils/field_mapping_test.cpp
@@ -1,0 +1,647 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/utils/field_mapping.h"
+
+#include <algorithm>
+
+#include "arrow/type_fwd.h"
+#include "gtest/gtest.h"
+#include "paimon/common/predicate/leaf_predicate_impl.h"
+#include "paimon/common/predicate/predicate_filter.h"
+#include "paimon/data/decimal.h"
+#include "paimon/defs.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/status.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon::test {
+class FieldMappingTest : public ::testing::Test {
+ public:
+    void SetUp() override {}
+    void TearDown() override {}
+    void CheckPartitionInfo(const PartitionInfo& result, const PartitionInfo& expected) const {
+        ASSERT_EQ(result.partition_read_schema, expected.partition_read_schema);
+        ASSERT_EQ(result.idx_in_target_read_schema, expected.idx_in_target_read_schema);
+        ASSERT_EQ(result.idx_in_partition, expected.idx_in_partition);
+        if (expected.partition_filter == nullptr) {
+            ASSERT_FALSE(result.partition_filter);
+        } else {
+            ASSERT_TRUE(result.partition_filter);
+            ASSERT_EQ(*result.partition_filter, *expected.partition_filter);
+        }
+    }
+
+    void CheckNonPartitionInfo(const NonPartitionInfo& result,
+                               const NonPartitionInfo& expected) const {
+        ASSERT_EQ(result.non_partition_read_schema, expected.non_partition_read_schema);
+        ASSERT_EQ(result.non_partition_data_schema, expected.non_partition_data_schema);
+        ASSERT_EQ(result.idx_in_target_read_schema, expected.idx_in_target_read_schema);
+        if (expected.non_partition_filter == nullptr) {
+            ASSERT_FALSE(result.non_partition_filter);
+        } else {
+            ASSERT_TRUE(result.non_partition_filter);
+            ASSERT_EQ(result.non_partition_filter->ToString(),
+                      expected.non_partition_filter->ToString());
+            ASSERT_EQ(*result.non_partition_filter, *expected.non_partition_filter);
+        }
+    }
+    void CheckNonExistFieldInfo(const NonExistFieldInfo& result,
+                                const NonExistFieldInfo& expected) const {
+        ASSERT_EQ(result.non_exist_read_schema, expected.non_exist_read_schema);
+        ASSERT_EQ(result.idx_in_target_read_schema, expected.idx_in_target_read_schema);
+    }
+
+ private:
+    std::vector<DataField> fields_ = {DataField(0, arrow::field("f0", arrow::utf8())),
+                                      DataField(1, arrow::field("f1", arrow::int32())),
+                                      DataField(2, arrow::field("f2", arrow::int32())),
+                                      DataField(3, arrow::field("f3", arrow::float64()))};
+    std::shared_ptr<arrow::Schema> schema_ = DataField::ConvertDataFieldsToArrowSchema(fields_);
+};
+
+TEST_F(FieldMappingTest, TestEmptyPartitionKeys) {
+    // test no partition keys in schema
+    std::string val("hello");
+    auto equal = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                         Literal(FieldType::STRING, val.data(), val.size()));
+    auto not_equal = PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                FieldType::INT, Literal(20));
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({equal, not_equal}));
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(
+                             schema_, /*partition_keys=*/std::vector<std::string>(), predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(schema_));
+
+    ASSERT_EQ(mapping->partition_info, std::nullopt);
+    ASSERT_EQ(mapping->non_exist_field_info, std::nullopt);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = fields_;
+    expected_non_part_info.non_partition_data_schema = fields_;
+    expected_non_part_info.idx_in_target_read_schema = {0, 1, 2, 3};
+    expected_non_part_info.non_partition_filter =
+        std::dynamic_pointer_cast<PredicateFilter>(predicate);
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+}
+
+TEST_F(FieldMappingTest, TestCompoundPartitionPredicate) {
+    // test partition fields equals schema fields
+    std::string val("hello");
+    auto equal = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                         Literal(FieldType::STRING, val.data(), val.size()));
+    auto not_equal = PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                FieldType::INT, Literal(20));
+    ASSERT_OK_AND_ASSIGN(auto and_predicate, PredicateBuilder::And({equal, not_equal}));
+    auto greater_than = PredicateBuilder::GreaterThan(/*field_index=*/2, /*field_name=*/"f2",
+                                                      FieldType::INT, Literal(30));
+    auto less_than = PredicateBuilder::LessThan(/*field_index=*/3, /*field_name=*/"f3",
+                                                FieldType::DOUBLE, Literal(20.1));
+    ASSERT_OK_AND_ASSIGN(auto or_predicate, PredicateBuilder::Or({greater_than, less_than}));
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({and_predicate, or_predicate}));
+
+    std::vector<std::string> partition_keys = {"f0", "f1", "f2"};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(schema_, partition_keys, predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(schema_));
+
+    PartitionInfo expected_part_info;
+    expected_part_info.partition_read_schema = {fields_[0], fields_[1], fields_[2]};
+    expected_part_info.idx_in_target_read_schema = {0, 1, 2};
+    expected_part_info.idx_in_partition = {0, 1, 2};
+    // less_than predicate includes non-partition-field, therefore, or_predicate is removed from
+    // partition_filter
+    expected_part_info.partition_filter = std::dynamic_pointer_cast<PredicateFilter>(and_predicate);
+    CheckPartitionInfo(mapping->partition_info.value(), expected_part_info);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = {fields_[3]};
+    expected_non_part_info.non_partition_data_schema = {fields_[3]};
+    expected_non_part_info.idx_in_target_read_schema = {3};
+    // or_predicate and and_predicate both include partition fields, therefore, non_partition_filter
+    // is null
+    expected_non_part_info.non_partition_filter = nullptr;
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+}
+
+TEST_F(FieldMappingTest, TestPartitionKeysEqualSchema) {
+    // test partition fields equals schema fields
+    std::string val("hello");
+    auto equal = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                         Literal(FieldType::STRING, val.data(), val.size()));
+    auto not_equal = PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                FieldType::INT, Literal(20));
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({equal, not_equal}));
+
+    std::vector<std::string> partition_keys = {"f0", "f1", "f2", "f3"};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(schema_, partition_keys, predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(schema_));
+
+    PartitionInfo expected_part_info;
+    expected_part_info.partition_read_schema = fields_;
+    expected_part_info.idx_in_target_read_schema = {0, 1, 2, 3};
+    expected_part_info.idx_in_partition = {0, 1, 2, 3};
+    expected_part_info.partition_filter = std::dynamic_pointer_cast<PredicateFilter>(predicate);
+    CheckPartitionInfo(mapping->partition_info.value(), expected_part_info);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = {};
+    expected_non_part_info.idx_in_target_read_schema = {};
+    expected_non_part_info.non_partition_filter = nullptr;
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+}
+
+TEST_F(FieldMappingTest, TestAllPartitionKeysInSchema) {
+    // test all partition keys in schema, with no predicate in partition keys
+    std::string val("hello");
+    auto predicate =
+        PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                Literal(FieldType::STRING, val.data(), val.size()));
+
+    std::vector<std::string> partition_keys = {"f1", "f2"};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(schema_, partition_keys, predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(schema_));
+
+    PartitionInfo expected_part_info;
+    expected_part_info.partition_read_schema = {fields_[1], fields_[2]};
+    expected_part_info.idx_in_target_read_schema = {1, 2};
+    expected_part_info.idx_in_partition = {0, 1};
+    expected_part_info.partition_filter = nullptr;
+    CheckPartitionInfo(mapping->partition_info.value(), expected_part_info);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.non_partition_data_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.idx_in_target_read_schema = {0, 3};
+    expected_non_part_info.non_partition_filter = predicate;
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+}
+
+TEST_F(FieldMappingTest, TestAllPartitionKeysInSchema2) {
+    // test all partition keys in schema, with all predicates in partition field
+    std::string val("hello");
+    auto predicate = PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                FieldType::INT, Literal(20));
+
+    std::vector<std::string> partition_keys = {"f1", "f2"};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(schema_, partition_keys, predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(schema_));
+
+    PartitionInfo expected_part_info;
+    expected_part_info.partition_read_schema = {fields_[1], fields_[2]};
+    expected_part_info.idx_in_target_read_schema = {1, 2};
+    expected_part_info.idx_in_partition = {0, 1};
+    auto new_predicate = PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f1",
+                                                    FieldType::INT, Literal(20));
+    expected_part_info.partition_filter = new_predicate;
+    CheckPartitionInfo(mapping->partition_info.value(), expected_part_info);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_data_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.non_partition_read_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.idx_in_target_read_schema = {0, 3};
+    expected_non_part_info.non_partition_filter = nullptr;
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+}
+
+TEST_F(FieldMappingTest, TestAllPartitionKeysInSchema3) {
+    // test all partition keys in schema, with predicates both in partition field and
+    // non-partition field
+    std::string val("hello");
+    auto equal = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                         Literal(FieldType::STRING, val.data(), val.size()));
+    auto not_equal = PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1",
+                                                FieldType::INT, Literal(20));
+    auto greater_than = PredicateBuilder::GreaterThan(/*field_index=*/2, /*field_name=*/"f2",
+                                                      FieldType::INT, Literal(30));
+    auto less_than = PredicateBuilder::LessThan(/*field_index=*/3, /*field_name=*/"f3",
+                                                FieldType::DOUBLE, Literal(10.4));
+    ASSERT_OK_AND_ASSIGN(auto predicate,
+                         PredicateBuilder::And({equal, not_equal, greater_than, less_than}));
+
+    std::vector<std::string> partition_keys = {"f1", "f2"};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(schema_, partition_keys, predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(schema_));
+
+    PartitionInfo expected_part_info;
+    expected_part_info.partition_read_schema = {fields_[1], fields_[2]};
+    expected_part_info.idx_in_target_read_schema = {1, 2};
+    expected_part_info.idx_in_partition = {0, 1};
+    auto not_equal_new = PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f1",
+                                                    FieldType::INT, Literal(20));
+    auto greater_than_new = PredicateBuilder::GreaterThan(/*field_index=*/1, /*field_name=*/"f2",
+                                                          FieldType::INT, Literal(30));
+    expected_part_info.partition_filter =
+        PredicateBuilder::And({not_equal_new, greater_than_new}).value_or(nullptr);
+    CheckPartitionInfo(mapping->partition_info.value(), expected_part_info);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.non_partition_data_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.idx_in_target_read_schema = {0, 3};
+    expected_non_part_info.non_partition_filter =
+        PredicateBuilder::And({equal, less_than}).value_or(nullptr);
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+}
+
+TEST_F(FieldMappingTest, TestPartialPartitionKeysInSchema) {
+    // test partial partition keys in schema, with predicates both in partition field and
+    // non-partition field
+    std::vector<DataField> fields = {DataField(2, arrow::field("f2", arrow::int32())),
+                                     DataField(3, arrow::field("f3", arrow::float64())),
+                                     DataField(0, arrow::field("f0", arrow::utf8()))};
+    std::shared_ptr<arrow::Schema> read_schema = DataField::ConvertDataFieldsToArrowSchema(fields);
+
+    std::string val("hello");
+    auto equal = PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f0", FieldType::STRING,
+                                         Literal(FieldType::STRING, val.data(), val.size()));
+    auto greater_than = PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"f2",
+                                                      FieldType::INT, Literal(30));
+    auto less_than = PredicateBuilder::LessThan(/*field_index=*/1, /*field_name=*/"f3",
+                                                FieldType::DOUBLE, Literal(10.4));
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({equal, greater_than, less_than}));
+
+    std::vector<std::string> partition_keys = {"f1", "f2"};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(read_schema, partition_keys, predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(schema_));
+
+    PartitionInfo expected_part_info;
+    expected_part_info.partition_read_schema = {fields_[2]};
+    expected_part_info.idx_in_target_read_schema = {0};
+    expected_part_info.idx_in_partition = {1};
+    expected_part_info.partition_filter = PredicateBuilder::GreaterThan(
+        /*field_index=*/1, /*field_name=*/"f2", FieldType::INT, Literal(30));
+    CheckPartitionInfo(mapping->partition_info.value(), expected_part_info);
+    ASSERT_EQ(std::dynamic_pointer_cast<LeafPredicateImpl>(
+                  mapping->partition_info.value().partition_filter)
+                  ->FieldIndex(),
+              1);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.non_partition_data_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.idx_in_target_read_schema = {2, 1};
+    auto equal_new =
+        PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                Literal(FieldType::STRING, val.data(), val.size()));
+    auto less_than_new = PredicateBuilder::LessThan(/*field_index=*/3, /*field_name=*/"f3",
+                                                    FieldType::DOUBLE, Literal(10.4));
+    expected_non_part_info.non_partition_filter =
+        PredicateBuilder::And({equal_new, less_than_new}).value_or(nullptr);
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+}
+
+TEST_F(FieldMappingTest, TestNoPartitionKeysInReadSchema) {
+    // test no partition keys in read schema, with predicates in non-partition field
+    std::vector<DataField> fields = {DataField(3, arrow::field("f3", arrow::float64())),
+                                     DataField(0, arrow::field("f0", arrow::utf8()))};
+    std::shared_ptr<arrow::Schema> read_schema = DataField::ConvertDataFieldsToArrowSchema(fields);
+
+    std::string val("hello");
+    auto equal = PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f0", FieldType::STRING,
+                                         Literal(FieldType::STRING, val.data(), val.size()));
+    auto less_than = PredicateBuilder::LessThan(/*field_index=*/1, /*field_name=*/"f3",
+                                                FieldType::DOUBLE, Literal(10.4));
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({equal, less_than}));
+
+    std::vector<std::string> partition_keys = {"f1", "f2"};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(read_schema, partition_keys, predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(schema_));
+
+    ASSERT_EQ(mapping->partition_info, std::nullopt);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.non_partition_data_schema = {fields_[0], fields_[3]};
+    expected_non_part_info.idx_in_target_read_schema = {1, 0};
+    auto equal_new =
+        PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::STRING,
+                                Literal(FieldType::STRING, val.data(), val.size()));
+    auto less_than_new = PredicateBuilder::LessThan(/*field_index=*/3, /*field_name=*/"f3",
+                                                    FieldType::DOUBLE, Literal(10.4));
+    expected_non_part_info.non_partition_filter =
+        PredicateBuilder::And({equal_new, less_than_new}).value_or(nullptr);
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+}
+
+// test generate mapping with schema evolution
+TEST_F(FieldMappingTest, TestSchemaEvolution) {
+    // add field / delete field / rename / casting
+    // without predicate
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("key0", arrow::int32())),
+                                          DataField(1, arrow::field("key1", arrow::float64())),
+                                          DataField(2, arrow::field("a", arrow::int32())),
+                                          DataField(3, arrow::field("b", arrow::int32())),
+                                          DataField(4, arrow::field("c", arrow::int32())),
+                                          DataField(5, arrow::field("d", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> data_schema =
+        DataField::ConvertDataFieldsToArrowSchema(data_fields);
+
+    std::vector<DataField> read_fields = {DataField(0, arrow::field("key0", arrow::int32())),
+                                          DataField(1, arrow::field("key1", arrow::float64())),
+                                          DataField(3, arrow::field("c", arrow::int64())),
+                                          DataField(5, arrow::field("a", arrow::float32())),
+                                          DataField(7, arrow::field("d", arrow::int32())),
+                                          DataField(8, arrow::field("e", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    std::vector<std::string> partition_keys = {"key0", "key1"};
+    ASSERT_OK_AND_ASSIGN(
+        auto mapping_builder,
+        FieldMappingBuilder::Create(read_schema, partition_keys, /*predicate=*/nullptr));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(data_fields));
+
+    PartitionInfo expected_part_info;
+    expected_part_info.partition_read_schema = {
+        DataField(0, arrow::field("key0", arrow::int32())),
+        DataField(1, arrow::field("key1", arrow::float64()))};
+    expected_part_info.idx_in_target_read_schema = {0, 1};
+    expected_part_info.idx_in_partition = {0, 1};
+    expected_part_info.partition_filter = nullptr;
+    CheckPartitionInfo(mapping->partition_info.value(), expected_part_info);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = {
+        DataField(3, arrow::field("c", arrow::int64())),
+        DataField(5, arrow::field("a", arrow::float32()))};
+    expected_non_part_info.non_partition_data_schema = {
+        DataField(3, arrow::field("b", arrow::int32())),
+        DataField(5, arrow::field("d", arrow::int32()))};
+    expected_non_part_info.idx_in_target_read_schema = {2, 3};
+    expected_non_part_info.non_partition_filter = nullptr;
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+
+    NonExistFieldInfo expected_non_exist_field_info;
+    expected_non_exist_field_info.non_exist_read_schema = {
+        DataField(7, arrow::field("d", arrow::int32())),
+        DataField(8, arrow::field("e", arrow::int32()))};
+    expected_non_exist_field_info.idx_in_target_read_schema = {4, 5};
+    CheckNonExistFieldInfo(mapping->non_exist_field_info.value(), expected_non_exist_field_info);
+}
+
+TEST_F(FieldMappingTest, TestSchemaEvolutionWithPredicate) {
+    // add field / delete field / rename / reverse order / casting
+    // with predicate
+    // field_0 and field_1 is partition key.
+    // simulate schema evolution:
+    // field_2 is deleted;
+    // field_3 is renamed (b->c) and change type (Decimal(5, 2)->Decimal(6, 3));
+    // field_4 is deleted;
+    // field_5 is renamed (d->a) and change type (INT->BIGINT);
+    // field_6 order reversed;
+    // field_7 is added to the middle;
+    // field_8 is added to the last field.
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("key0", arrow::int32())),
+                                          DataField(1, arrow::field("key1", arrow::float64())),
+                                          DataField(2, arrow::field("a", arrow::int32())),
+                                          DataField(3, arrow::field("b", arrow::decimal128(5, 2))),
+                                          DataField(4, arrow::field("c", arrow::int32())),
+                                          DataField(5, arrow::field("d", arrow::int32())),
+                                          DataField(6, arrow::field("k", arrow::int32()))};
+
+    std::vector<DataField> table_fields = {DataField(0, arrow::field("key0", arrow::int32())),
+                                           DataField(1, arrow::field("key1", arrow::float64())),
+                                           DataField(6, arrow::field("k", arrow::int32())),
+                                           DataField(3, arrow::field("c", arrow::decimal128(6, 3))),
+                                           DataField(7, arrow::field("d", arrow::int32())),
+                                           DataField(5, arrow::field("a", arrow::int64())),
+                                           DataField(8, arrow::field("e", arrow::int32()))};
+    // the field order of read schema and table schema is consistent
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(table_fields);
+
+    auto greater_or_equal = PredicateBuilder::GreaterOrEqual(
+        /*field_index=*/0, /*field_name=*/"key0", FieldType::INT, Literal(4));
+    auto equal = PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"key1",
+                                         FieldType::DOUBLE, Literal(3.0));
+    auto less_or_equal = PredicateBuilder::LessOrEqual(/*field_index=*/2, /*field_name=*/"k",
+                                                       FieldType::INT, Literal(10));
+    // greater_than will not be pushed down, as with casting, only integer predicates can be pushed
+    // down
+    auto greater_than = PredicateBuilder::GreaterThan(
+        /*field_index=*/3, /*field_name=*/"c", FieldType::DECIMAL, Literal(Decimal(6, 3, 12345)));
+    auto not_equal = PredicateBuilder::NotEqual(/*field_index=*/4, /*field_name=*/"d",
+                                                FieldType::INT, Literal(40));
+    // in can be pushed down
+    auto in = PredicateBuilder::In(/*field_index=*/5, /*field_name=*/"a", FieldType::BIGINT,
+                                   {Literal(100l)});
+    auto not_in =
+        PredicateBuilder::In(/*field_index=*/6, /*field_name=*/"e", FieldType::INT, {Literal(50)});
+
+    ASSERT_OK_AND_ASSIGN(
+        auto predicate, PredicateBuilder::And({greater_or_equal, equal, less_or_equal, greater_than,
+                                               not_equal, in, not_in}));
+
+    std::vector<std::string> partition_keys = {"key0", "key1"};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(read_schema, partition_keys, predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(data_fields));
+
+    PartitionInfo expected_part_info;
+    expected_part_info.partition_read_schema = {
+        DataField(0, arrow::field("key0", arrow::int32())),
+        DataField(1, arrow::field("key1", arrow::float64()))};
+    expected_part_info.idx_in_target_read_schema = {0, 1};
+    expected_part_info.idx_in_partition = {0, 1};
+    expected_part_info.partition_filter =
+        PredicateBuilder::And({greater_or_equal, equal}).value_or(nullptr);
+    CheckPartitionInfo(mapping->partition_info.value(), expected_part_info);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = {
+        DataField(3, arrow::field("c", arrow::decimal128(6, 3))),
+        DataField(5, arrow::field("a", arrow::int64())),
+        DataField(6, arrow::field("k", arrow::int32()))};
+    expected_non_part_info.non_partition_data_schema = {
+        DataField(3, arrow::field("b", arrow::decimal128(5, 2))),
+        DataField(5, arrow::field("d", arrow::int32())),
+        DataField(6, arrow::field("k", arrow::int32()))};
+    expected_non_part_info.idx_in_target_read_schema = {3, 5, 2};
+    auto less_or_equal_new = PredicateBuilder::LessOrEqual(/*field_index=*/6, /*field_name=*/"k",
+                                                           FieldType::INT, Literal(10));
+    auto in_new =
+        PredicateBuilder::In(/*field_index=*/5, /*field_name=*/"d", FieldType::INT, {Literal(100)});
+    expected_non_part_info.non_partition_filter =
+        PredicateBuilder::And({less_or_equal_new, in_new}).value_or(nullptr);
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+
+    NonExistFieldInfo expected_non_exist_field_info;
+    expected_non_exist_field_info.non_exist_read_schema = {
+        DataField(7, arrow::field("d", arrow::int32())),
+        DataField(8, arrow::field("e", arrow::int32()))};
+    expected_non_exist_field_info.idx_in_target_read_schema = {4, 6};
+    CheckNonExistFieldInfo(mapping->non_exist_field_info.value(), expected_non_exist_field_info);
+}
+
+TEST_F(FieldMappingTest, TestSchemaEvolutionWithPredicate2) {
+    // add field / delete field / rename / reverse order / casting
+    // with predicate
+    // field_0 and field_1 is partition key.
+    // simulate schema evolution:
+    // field_2 is deleted;
+    // field_3 is renamed (b->c) and change type (Decimal(5, 2)->Decimal(6, 3));
+    // field_4 is deleted;
+    // field_5 is renamed (d->a) and change type (INT->BIGINT);
+    // field_6 order reversed;
+    // field_7 is added to the middle;
+    // field_8 is added to the last field.
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("key0", arrow::int32())),
+                                          DataField(1, arrow::field("key1", arrow::float64())),
+                                          DataField(2, arrow::field("a", arrow::int32())),
+                                          DataField(3, arrow::field("b", arrow::decimal128(5, 2))),
+                                          DataField(4, arrow::field("c", arrow::int32())),
+                                          DataField(5, arrow::field("d", arrow::int32())),
+                                          DataField(6, arrow::field("k", arrow::int32()))};
+
+    std::vector<DataField> table_fields = {DataField(0, arrow::field("key0", arrow::int32())),
+                                           DataField(1, arrow::field("key1", arrow::float64())),
+                                           DataField(6, arrow::field("k", arrow::int32())),
+                                           DataField(3, arrow::field("c", arrow::decimal128(6, 3))),
+                                           DataField(7, arrow::field("d", arrow::int32())),
+                                           DataField(5, arrow::field("a", arrow::int64())),
+                                           DataField(8, arrow::field("e", arrow::int32()))};
+
+    // the field order of read schema and table schema is inconsistent
+    std::vector<DataField> read_fields = {DataField(7, arrow::field("d", arrow::int32())),
+                                          DataField(1, arrow::field("key1", arrow::float64())),
+                                          DataField(5, arrow::field("a", arrow::int64())),
+                                          DataField(8, arrow::field("e", arrow::int32())),
+                                          DataField(6, arrow::field("k", arrow::int32())),
+                                          DataField(3, arrow::field("c", arrow::decimal128(6, 3))),
+                                          DataField(0, arrow::field("key0", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto greater_or_equal = PredicateBuilder::GreaterOrEqual(
+        /*field_index=*/6, /*field_name=*/"key0", FieldType::INT, Literal(4));
+    auto equal = PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"key1",
+                                         FieldType::DOUBLE, Literal(3.0));
+    auto less_or_equal = PredicateBuilder::LessOrEqual(/*field_index=*/4, /*field_name=*/"k",
+                                                       FieldType::INT, Literal(10));
+    // greater_than will not be pushed down, as with casting, only integer predicates can be pushed
+    // down
+    auto greater_than = PredicateBuilder::GreaterThan(
+        /*field_index=*/5, /*field_name=*/"c", FieldType::DECIMAL, Literal(Decimal(6, 3, 12345)));
+    auto not_equal = PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"d",
+                                                FieldType::INT, Literal(40));
+    // in will not be pushed down, as with casting, literal from BIGINT to INT is overflow
+    auto in = PredicateBuilder::In(/*field_index=*/2, /*field_name=*/"a", FieldType::BIGINT,
+                                   {Literal(9223372036854775807l)});
+    auto not_in =
+        PredicateBuilder::In(/*field_index=*/3, /*field_name=*/"e", FieldType::INT, {Literal(50)});
+
+    ASSERT_OK_AND_ASSIGN(
+        auto predicate, PredicateBuilder::And({greater_or_equal, equal, less_or_equal, greater_than,
+                                               not_equal, in, not_in}));
+
+    std::vector<std::string> partition_keys = {"key0", "key1"};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(read_schema, partition_keys, predicate));
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(data_fields));
+
+    PartitionInfo expected_part_info;
+    expected_part_info.partition_read_schema = {
+        DataField(0, arrow::field("key0", arrow::int32())),
+        DataField(1, arrow::field("key1", arrow::float64()))};
+    expected_part_info.idx_in_target_read_schema = {6, 1};
+    expected_part_info.idx_in_partition = {0, 1};
+    auto greater_or_equal_new = PredicateBuilder::GreaterOrEqual(
+        /*field_index=*/0, /*field_name=*/"key0", FieldType::INT, Literal(4));
+    auto equal_new = PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"key1",
+                                             FieldType::DOUBLE, Literal(3.0));
+    expected_part_info.partition_filter =
+        PredicateBuilder::And({greater_or_equal_new, equal_new}).value_or(nullptr);
+    CheckPartitionInfo(mapping->partition_info.value(), expected_part_info);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = {
+        DataField(3, arrow::field("c", arrow::decimal128(6, 3))),
+        DataField(5, arrow::field("a", arrow::int64())),
+        DataField(6, arrow::field("k", arrow::int32()))};
+    expected_non_part_info.non_partition_data_schema = {
+        DataField(3, arrow::field("b", arrow::decimal128(5, 2))),
+        DataField(5, arrow::field("d", arrow::int32())),
+        DataField(6, arrow::field("k", arrow::int32()))};
+    expected_non_part_info.idx_in_target_read_schema = {5, 2, 4};
+    auto less_or_equal_new = PredicateBuilder::LessOrEqual(/*field_index=*/6, /*field_name=*/"k",
+                                                           FieldType::INT, Literal(10));
+    expected_non_part_info.non_partition_filter =
+        PredicateBuilder::And({less_or_equal_new}).value_or(nullptr);
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+
+    NonExistFieldInfo expected_non_exist_field_info;
+    expected_non_exist_field_info.non_exist_read_schema = {
+        DataField(7, arrow::field("d", arrow::int32())),
+        DataField(8, arrow::field("e", arrow::int32()))};
+    expected_non_exist_field_info.idx_in_target_read_schema = {0, 3};
+    CheckNonExistFieldInfo(mapping->non_exist_field_info.value(), expected_non_exist_field_info);
+}
+
+TEST_F(FieldMappingTest, TestCompoundPredicateWithoutPushDown) {
+    std::vector<DataField> data_fields = {DataField(0, arrow::field("f0", arrow::int32())),
+                                          DataField(1, arrow::field("f1", arrow::float64())),
+                                          DataField(2, arrow::field("f2", arrow::int32())),
+                                          DataField(3, arrow::field("f3", arrow::utf8()))};
+
+    // the field type of read schema and data schema are inconsistent (f2, f3)
+    std::vector<DataField> read_fields = {DataField(0, arrow::field("f0", arrow::int32())),
+                                          DataField(1, arrow::field("f1", arrow::float64())),
+                                          DataField(2, arrow::field("f2", arrow::int64())),
+                                          DataField(3, arrow::field("f3", arrow::int32()))};
+    std::shared_ptr<arrow::Schema> read_schema =
+        DataField::ConvertDataFieldsToArrowSchema(read_fields);
+
+    auto equal = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::INT,
+                                         Literal(55));
+    auto greater_than = PredicateBuilder::GreaterThan(/*field_index=*/2, /*field_name=*/"f2",
+                                                      FieldType::BIGINT, Literal(30l));
+    auto less_than = PredicateBuilder::LessThan(/*field_index=*/3, /*field_name=*/"f3",
+                                                FieldType::INT, Literal(55));
+    ASSERT_OK_AND_ASSIGN(auto or_predicate, PredicateBuilder::Or({greater_than, less_than}));
+    ASSERT_OK_AND_ASSIGN(auto predicate, PredicateBuilder::And({equal, or_predicate}));
+
+    std::vector<std::string> partition_keys = {};
+    ASSERT_OK_AND_ASSIGN(auto mapping_builder,
+                         FieldMappingBuilder::Create(read_schema, partition_keys, predicate));
+    ASSERT_TRUE(mapping_builder);
+    ASSERT_OK_AND_ASSIGN(auto mapping, mapping_builder->CreateFieldMapping(data_fields));
+    ASSERT_FALSE(mapping->partition_info);
+
+    NonPartitionInfo expected_non_part_info;
+    expected_non_part_info.non_partition_read_schema = read_fields;
+    expected_non_part_info.non_partition_data_schema = data_fields;
+    expected_non_part_info.idx_in_target_read_schema = {0, 1, 2, 3};
+    // or_predicate includes int to string predicate converter, therefore it is removed
+    expected_non_part_info.non_partition_filter = equal;
+    CheckNonPartitionInfo(mapping->non_partition_info, expected_non_part_info);
+}
+
+}  // namespace paimon::test


### PR DESCRIPTION
### Purpose
Introduce `FieldMapping` and `FieldMappingBuilder` for resolving the mapping between a read schema and a data file schema, supporting partition pruning, schema evolution, and predicate push-down.

**`FieldMapping`** — A plain data structure that holds the resolved mapping result for a single data file. It contains three parts:
- `partition_info`: mapping info for fields that are partition keys, including their index in the read schema, index in the partition row, and a partition-level filter predicate.
- `non_partition_info`: mapping info for non-partition fields that exist in both the read schema and the data schema, including field-level cast executors for type evolution and a data-file-level filter predicate with field indices rewritten to match the data schema.
- `non_exist_field_info`: mapping info for fields requested by the read schema but absent in the data file (added via schema evolution), so the reader can fill them with nulls.

**`FieldMappingBuilder`** — A builder created once per query from the read schema, partition keys, and query predicate. For each data file, `CreateFieldMapping(data_fields)` produces a `FieldMapping` by:
1. Matching fields between the read schema and the data schema by field ID (schema evolution–safe).
2. Separating matched fields into partition and non-partition groups.
3. Building `CastExecutor` chains for type-evolved fields (atomic types only; complex types are rejected).
4. Reconstructing the query predicate against the data schema field indices and data types, including literal casting for integer widening and overflow detection; predicates on non-existent or type-incompatible fields are dropped.
5. Extracting a partition-level filter from the reconstructed predicate for partition pruning.

### Tests

- `TestBasicFieldMapping` — basic read/data schema mapping without partition or predicate
- `TestFieldMappingWithPartition` — partition field separation and index mapping
- `TestFieldMappingWithPredicate` — predicate rewriting for partition fields
- `TestFieldMappingWithPartitionAndPredicateInPartitionField` — predicate push-down into partition filter
- `TestFieldMappingWithPartitionAndPredicateInNonPartitionField` — predicate push-down into data file filter
- `TestSchemaEvolution` — field add / delete / rename / type casting without predicate
- `TestSchemaEvolutionWithPredicate` — schema evolution combined with predicate rewriting and overflow detection
- `TestSchemaEvolutionWithPredicate2` — schema evolution with inconsistent field order in read schema
- `TestCompoundPredicateWithoutPushDown` — OR compound predicate containing non-pushdownable sub-predicates is correctly dropped