### PR TITLE
fix: wait for async tasks before early return in orphan files cleaner

### DIFF
--- a/src/paimon/common/executor/future.h
+++ b/src/paimon/common/executor/future.h
@@ -47,6 +47,9 @@ namespace paimon {
 /// execution.
 ///
 /// @note If `func` returns `void`, the returned future is of type `std::future<void>`.
+///
+/// TODO: Since paimon-cpp uses `Status`/`Result` for error handling throughout, the exception
+/// capture logic (try/catch + set_exception) in `Via()` will be removed in the future.
 template <typename Func>
 auto Via(Executor* executor, Func&& func) -> std::future<decltype(func())> {
     using ResultType = decltype(func());

--- a/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
+++ b/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
@@ -99,11 +99,14 @@ Result<std::set<std::string>> OrphanFilesCleanerImpl::Clean() {
     }
     PAIMON_ASSIGN_OR_RAISE(std::set<std::string> all_dirs, ListPaimonFileDirs());
     std::vector<std::future<std::vector<std::unique_ptr<FileStatus>>>> file_statuses_futures;
+    ScopeGuard file_statuses_guard(
+        [&file_statuses_futures]() { CollectAll(file_statuses_futures); });
     for (const auto& dir : all_dirs) {
         file_statuses_futures.push_back(
             Via(executor_.get(), [this, dir] { return TryBestListingDirs(dir); }));
     }
     PAIMON_ASSIGN_OR_RAISE(std::set<std::string> used_file_names, GetUsedFiles());
+    file_statuses_guard.Release();
 
     Duration duration;
     std::set<std::string> need_to_deletes;


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx

Ensure outstanding directory-listing futures are collected when `GetUsedFiles()` returns an error. A scope guard waits for the asynchronous tasks on the early-return path and is released once the normal flow takes ownership of collecting the results.

This cherry-picks the fix from alibaba/paimon-cpp commit `433487eeff9850ebe2d3e1720fa82d847d097a62`.

### Tests

### API and Format

No API, storage format, or protocol changes.

### Documentation

No user-facing documentation changes.

### Generative AI tooling

Migrated-by: OpenAI Codex
