### PR TITLE
build: introduce Lucene CI support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,10 +54,6 @@ option(PAIMON_ENABLE_AVRO "Whether to enable avro file format" ON)
 option(PAIMON_ENABLE_ORC "Whether to enable orc file format" ON)
 option(PAIMON_ENABLE_JINDO "Whether to enable jindo file system" OFF)
 option(PAIMON_ENABLE_LUCENE "Whether to enable lucene index" OFF)
-if(PAIMON_ENABLE_LUCENE)
-    message(FATAL_ERROR "PAIMON_ENABLE_LUCENE is temporarily disabled. Please configure with -DPAIMON_ENABLE_LUCENE=OFF."
-    )
-endif()
 
 if(PAIMON_ENABLE_ORC)
     add_definitions(-DPAIMON_ENABLE_ORC)

--- a/ci/scripts/build_paimon.sh
+++ b/ci/scripts/build_paimon.sh
@@ -40,7 +40,7 @@ CMAKE_ARGS=(
     "-DCMAKE_BUILD_TYPE=${build_type}"
     "-DPAIMON_BUILD_TESTS=ON"
     "-DPAIMON_ENABLE_JINDO=ON"
-    "-DPAIMON_ENABLE_LUCENE=OFF"
+    "-DPAIMON_ENABLE_LUCENE=ON"
 )
 
 if [[ "${enable_sanitizer}" == "true" ]]; then

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -281,6 +281,16 @@ else()
     endif()
 endif()
 
+if(DEFINED ENV{PAIMON_BOOST_URL})
+    set(BOOST_SOURCE_URL "$ENV{PAIMON_BOOST_URL}")
+elseif(EXISTS "${THIRDPARTY_DIR}/${PAIMON_BOOST_PKG_NAME}")
+    set_urls(BOOST_SOURCE_URL "${THIRDPARTY_DIR}/${PAIMON_BOOST_PKG_NAME}")
+else()
+    set_urls(BOOST_SOURCE_URL
+             "https://paimon-cpp.oss-cn-beijing.aliyuncs.com/thirdparty/boost/${PAIMON_BOOST_PKG_NAME}"
+    )
+endif()
+
 if(APPLE)
     set(JINDOSDK_C_DYNAMIC_LIB_NAME "jindosdk_c.${PAIMON_JINDOSDK_C_BUILD_VERSION}")
     set(JINDOSDK_C_DYNAMIC_LIB_FILE "lib${JINDOSDK_C_DYNAMIC_LIB_NAME}.dylib")
@@ -938,7 +948,7 @@ macro(build_boost)
     endif()
 
     externalproject_add(boost_ep
-                        URL "${THIRDPARTY_DIR}/boost/${PAIMON_BOOST_PKG_NAME}"
+                        URL ${BOOST_SOURCE_URL}
                         URL_HASH "SHA256=${PAIMON_BOOST_BUILD_SHA256_CHECKSUM}"
                         CONFIGURE_COMMAND ${BOOST_PREFIX}/src/boost_ep/bootstrap.sh
                                           --with-libraries=date_time,filesystem,iostreams,regex,system,thread,chrono,atomic

--- a/docs/source/build_system.rst
+++ b/docs/source/build_system.rst
@@ -91,6 +91,7 @@ Paimon provides a set of built-in optional plugins that you can link to as neede
 - Index plugins:
 
   - ``paimon_file_index_shared`` / ``paimon_file_index_static``
+  - ``paimon_lucene_index_shared`` / ``paimon_lucene_index_static``
 
 .. note::
 

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -124,6 +124,7 @@ boolean flags to ``cmake``.
 * ``-DPAIMON_ENABLE_ORC=ON``: Paimon integration with Apache ORC
 * ``-DPAIMON_ENABLE_AVRO=ON``: Apache Avro libraries and Paimon integration
 * ``-DPAIMON_ENABLE_JINDO=ON``: Support for Alibaba Jindo filesystems
+* ``-DPAIMON_ENABLE_LUCENE=ON``: Support for Lucene full-text search indexes
 
 Third-party dependency source
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/third_party/versions.txt
+++ b/third_party/versions.txt
@@ -106,7 +106,6 @@ PAIMON_JIEBA_BUILD_VERSION=v5.6.0
 PAIMON_JIEBA_BUILD_SHA256_CHECKSUM=e6e517b778e0f4a99cbed1ee3eaa041616b74bc685e03a6ca08887ad9cedfe49
 PAIMON_JIEBA_PKG_NAME=jieba-${PAIMON_JIEBA_BUILD_VERSION}.tar.gz
 
-# Boost source package is bundled at third_party/boost/
 PAIMON_BOOST_BUILD_VERSION=1_66_0
 PAIMON_BOOST_BUILD_SHA256_CHECKSUM=28e9200637800fbfd1292b2c6876189dba7e8e1c5282c71fac6515e96f7af2b0
 PAIMON_BOOST_PKG_NAME=boost_${PAIMON_BOOST_BUILD_VERSION}.tar.gz
@@ -137,4 +136,5 @@ DEPENDENCIES=(
   "PAIMON_LUCENE_URL ${PAIMON_LUCENE_PKG_NAME} ${THIRDPARTY_MIRROR_URL}https://github.com/luceneplusplus/LucenePlusPlus/archive/refs/tags/rel_${PAIMON_LUCENE_BUILD_VERSION}.tar.gz"
   "PAIMON_LIMONP_URL ${PAIMON_LIMONP_PKG_NAME} ${THIRDPARTY_MIRROR_URL}https://github.com/yanyiwu/limonp/archive/refs/tags/v${PAIMON_LIMONP_BUILD_VERSION}.tar.gz"
   "PAIMON_JIEBA_URL ${PAIMON_JIEBA_PKG_NAME} ${THIRDPARTY_MIRROR_URL}https://github.com/yanyiwu/cppjieba/archive/refs/tags/${PAIMON_JIEBA_BUILD_VERSION}.tar.gz"
+  "PAIMON_BOOST_URL ${PAIMON_BOOST_PKG_NAME} https://paimon-cpp.oss-cn-beijing.aliyuncs.com/thirdparty/boost/${PAIMON_BOOST_PKG_NAME}"
 )


### PR DESCRIPTION
### Purpose

Linked issue: N/A

This PR enables Lucene builds in Apache Paimon C++.

- Fetch Boost from a configurable URL, a local package, or the Paimon C++ OSS fallback.
- Remove the temporary CMake guard that rejected `PAIMON_ENABLE_LUCENE=ON`.
- Enable Lucene in the standard CI build script.
- Document the Lucene build option and linkable library targets.

The requested build, CI, and documentation changes are included without extra dependency files or skipped files. No `LICENSE` or `NOTICE` changes are needed because the Boost source archive is downloaded at build time rather than bundled in the repository. No `Co-authored-by` trailer was added, following the contributor review decision.

### Tests

### API and Format

No public API, storage format, or protocol changes.

### Documentation

Documents the Lucene build option and the shared and static Lucene index targets.

### Generative AI tooling

Migrated-by: OpenAI Codex
