### PR TITLE
fix: make release version parsing portable

### DIFF
--- a/scripts/releasing/create_source_release.sh
+++ b/scripts/releasing/create_source_release.sh
@@ -115,8 +115,7 @@ done
 
 CMAKE_VERSION=$(
     git -C "${SOURCE_ROOT}" show "${GIT_REF}:CMakeLists.txt" |
-        sed -n 's/^[[:space:]]*VERSION[[:space:]]\+\([0-9][0-9.]*\).*$/\1/p' |
-        head -n 1
+        awk '$1 == "VERSION" && $2 ~ /^[0-9]+\.[0-9]+\.[0-9]+$/ { print $2; exit }'
 )
 [[ "${CMAKE_VERSION}" == "${RELEASE_VERSION}" ]] ||
     fail "CMake version ${CMAKE_VERSION:-<missing>} does not match ${RELEASE_VERSION}"

--- a/scripts/releasing/verify_release_candidate.sh
+++ b/scripts/releasing/verify_release_candidate.sh
@@ -167,9 +167,8 @@ for required_file in LICENSE NOTICE CMakeLists.txt docs/source/conf.py; do
 done
 
 CMAKE_VERSION=$(
-    sed -n 's/^[[:space:]]*VERSION[[:space:]]\+\([0-9][0-9.]*\).*$/\1/p' \
-        "${SOURCE_DIR}/CMakeLists.txt" |
-        head -n 1
+    awk '$1 == "VERSION" && $2 ~ /^[0-9]+\.[0-9]+\.[0-9]+$/ { print $2; exit }' \
+        "${SOURCE_DIR}/CMakeLists.txt"
 )
 [[ "${CMAKE_VERSION}" == "${RELEASE_VERSION}" ]] ||
     fail "CMake version ${CMAKE_VERSION:-<missing>} does not match ${RELEASE_VERSION}"


### PR DESCRIPTION
### Purpose

Linked issue: N/A

Make CMake project-version parsing portable across GNU/Linux and macOS/BSD environments. The previous basic regular expressions used the GNU sed extension `\+`, so both release scripts returned an empty version with BSD sed. Use POSIX awk extended regular expressions instead.

PR #156 fixes an unrelated cmake-format failure already present on the current main branch. Until that PR is merged, an all-files pre-commit run also rewrites examples/CMakeLists.txt; the hooks for the files changed here pass.

### Tests

- reproduced the old empty result with `sed --posix`
- parsed `0.2.3` from both the working tree and Git content with the new awk expression
- `bash -n scripts/releasing/create_source_release.sh scripts/releasing/verify_release_candidate.sh`
- `scripts/releasing/create_source_release.sh --version 0.2.3 --git-ref HEAD --output-dir <temp-dir>`
- `scripts/releasing/verify_release_candidate.sh --allow-unsigned --skip-rat --skip-build <artifact>`
- `pre-commit run --files scripts/releasing/create_source_release.sh scripts/releasing/verify_release_candidate.sh`
- `git diff --check`

### API and Format

No API, storage format, or protocol changes.

### Documentation

No documentation changes.

### Generative AI tooling

Generated-by: Codex (GPT-5)