### PR TITLE
chore: enable rebase merges

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,7 +32,7 @@ github:
   enabled_merge_buttons:
     merge: false
     squash: true
-    rebase: false
+    rebase: true
   rulesets:
     - name: "Branch Protection"
       type: branch


### PR DESCRIPTION
### Purpose

Linked issue: N/A

Enable rebase-and-merge for GitHub pull requests while keeping squash-and-merge enabled. This allows maintainers to preserve individual commits in a linear history when appropriate.

### Tests

- `pre-commit run --files .asf.yaml`

### API and Format

No.

### Documentation

No.

### Generative AI tooling

Generated-by: OpenAI Codex (GPT-5)
