### PR TITLE
docs: standardize Paimon C++ naming

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,9 @@
   ~ under the License.
 -->
 
-# Contributing to Apache Paimon-cpp
+# Contributing to Apache Paimon C++
 
-Thank you for your interest in contributing to paimon-cpp! This document explains how to get started.
+Thank you for your interest in contributing to Paimon C++! This document explains how to get started.
 
 ---
 
@@ -116,4 +116,4 @@ If you make improvements that could benefit all developers, please update the te
 
 ## License
 
-By contributing to paimon-cpp, you agree that your contributions will be licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).
+By contributing to Paimon C++, you agree that your contributions will be licensed under the [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0).

--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@
   ~ under the License.
 -->
 
-# Apache Paimon-cpp
+# Apache Paimon C++
 
 [![License](https://img.shields.io/badge/license-Apache%202-4EB1BA.svg)](https://www.apache.org/licenses/LICENSE-2.0.html)
 
-Paimon-cpp is the C++ implementation of [Apache Paimon](https://paimon.apache.org).
+Paimon C++ is the C++ implementation of [Apache Paimon](https://paimon.apache.org).
 It provides native, high-performance, and extensible access to the Paimon lake format for C++ engines and services without JVM dependencies.
 
 Background and documentation are available at [paimon.apache.org](https://paimon.apache.org).
 
 ## Features
 
-Paimon-cpp currently provides:
+Paimon C++ currently provides:
 
 - **Write**: append table and primary key table write support with compaction.
 - **Commit**: append table commit support for simple append-only tables.
@@ -78,7 +78,7 @@ cp devcontainer.json.template devcontainer.json
 
 ## Collaboration
 
-Paimon-cpp is an active open-source project and we welcome people who want to contribute or share good ideas!
+Paimon C++ is an active open-source project and we welcome people who want to contribute or share good ideas!
 Before contributing, please read the [Contributing Guide](CONTRIBUTING.md) and the [Code Style Guide](docs/code-style.md). You are encouraged to check out our [documentation](https://paimon.apache.org/docs/cpp/).
 
 ## License

--- a/docs/code-style.md
+++ b/docs/code-style.md
@@ -17,9 +17,9 @@
   ~ under the License.
 -->
 
-# Paimon C++ Code Style Guide
+# Apache Paimon C++ Code Style Guide
 
-This document defines the coding conventions for the paimon-cpp project. All pull requests are expected to follow these rules. Automated tooling (clang-format, clang-tidy, cpplint, pre-commit) enforces many of them.
+This document defines the coding conventions for the Paimon C++ project. All pull requests are expected to follow these rules. Automated tooling (clang-format, clang-tidy, cpplint, pre-commit) enforces many of them.
 
 ---
 

--- a/docs/source/build_system.rst
+++ b/docs/source/build_system.rst
@@ -18,9 +18,9 @@
 .. default-domain:: cpp
 .. highlight:: cpp
 
-======================
-Integrating Paimon C++
-======================
+=============================
+Integrating Apache Paimon C++
+=============================
 
 This section assumes that you have already built and installed the Paimon C++
 libraries on your system after :ref:`building them yourself <building-paimon-cpp>`.

--- a/docs/source/building.rst
+++ b/docs/source/building.rst
@@ -19,9 +19,9 @@
 
 .. _building-paimon-cpp:
 
-===================
-Building Paimon C++
-===================
+==========================
+Building Apache Paimon C++
+==========================
 
 System setup
 ============

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -22,8 +22,8 @@ Getting Started
 ===============
 
 The following articles demonstrate installation, usage, and a basic
-understanding of C++ Paimon. These articles will get you set up quickly with C++
-Paimon and give you a taste of what the library is capable of.
+understanding of Paimon C++. These articles will get you set up quickly with
+Paimon C++ and give you a taste of what the library is capable of.
 
 Start here to gain a basic understanding of Paimon, and move on to the
 :doc:`/user_guide` to explore more specific topics and

--- a/docs/source/user_guide/catalog.rst
+++ b/docs/source/user_guide/catalog.rst
@@ -19,18 +19,18 @@
 
 Catalog
 ==========================
-C++ Paimon provides a :ref:`Catalog abstraction <cpp-api-catalog>` to manage the table of contents and metadata. The Catalog
+Paimon C++ provides a :ref:`Catalog abstraction <cpp-api-catalog>` to manage the table of contents and metadata. The Catalog
 abstraction provides a series of ways to help you better integrate with computing engines. We always
 recommend that you use Catalog to access the Paimon table.
 
 Filesystem Catalog
 ~~~~~~~~~~~~~~~~~~
-C++ Paimon catalog currently support one types of metastores filesystem metastore (default),
+Paimon C++ catalog currently support one types of metastores filesystem metastore (default),
 which stores both metadata and table files in filesystems.
 
 .. note::
 
-  Current C++ Paimon only supports filesystem catalog. In the future, we will
+  Current Paimon C++ only supports filesystem catalog. In the future, we will
   support REST catalog.
   By using the Paimon REST catalog, changes to the catalog will be directly stored
   in a remote catalog server which exposed through REST API. See `Java Paimon REST

--- a/docs/source/user_guide/compaction.rst
+++ b/docs/source/user_guide/compaction.rst
@@ -26,7 +26,7 @@ compaction is therefore a trade-off between write throughput and read efficiency
 .. note::
    - There can only be one job working on the same partition's compaction,
      otherwise it will cause conflicts.
-   - C++ Paimon does not support producing changelog for now.
+   - Paimon C++ does not support producing changelog for now.
    - Compaction is disabled when ``write-only`` is set to ``true``, or when the
      table uses dynamic bucketing (``bucket = -1``) for append-only tables.
    - For a complete list of compaction-related configurations, see the

--- a/docs/source/user_guide/data_types.rst
+++ b/docs/source/user_guide/data_types.rst
@@ -21,7 +21,7 @@ Data Types
 A data type describes the logical type of a value in the table ecosystem. It can
 be used to declare input and/or output types of operations.
 
-All data types by Java Paimon are as follows, C++ Paimon uses Apache Arrow as
+All data types by Java Paimon are as follows, Paimon C++ uses Apache Arrow as
 its schema representation. The following table shows the mapping between `Java
 Paimon DataTypes <https://paimon.apache.org/docs/master/concepts/data-types/>`_
 and `Arrow DataTypes <https://arrow.apache.org/docs/format/Columnar.html#data-types>`_:
@@ -194,7 +194,7 @@ and `Arrow DataTypes <https://arrow.apache.org/docs/format/Columnar.html#data-ty
 
        The type can be declared using ``MAP<kt, vt>`` where kt is the data type of the key elements and vt is the data type of the value elements.
 
-       **Note:** In C++ Paimon, map keys must be explicitly marked as ``NOT NULL``.
+       **Note:** In Paimon C++, map keys must be explicitly marked as ``NOT NULL``.
        Apache Arrow does not support nullable map keys. If the key type is not
        marked as ``NOT NULL`` in the schema, parsing will fail with an error.
 
@@ -234,7 +234,7 @@ and `Arrow DataTypes <https://arrow.apache.org/docs/format/Columnar.html#data-ty
        Variant values are encoded with two binaries following the parquet-format
        `Variant Binary Encoding <https://github.com/apache/parquet-format/blob/master/VariantEncoding.md>`_
        specification (compatible with the Java Paimon / Spark implementation). In
-       C++ Paimon, a variant field is represented in an Arrow schema as
+       Paimon C++, a variant field is represented in an Arrow schema as
        ``Struct{value: Binary NOT NULL, metadata: Binary NOT NULL}`` marked with
        Paimon-specific field metadata; use ``paimon::Variant::ArrowField`` to
        construct such a field, and ``paimon::Variant`` (``FromJson``/``ToJson``/

--- a/docs/source/user_guide/manifest_cache.rst
+++ b/docs/source/user_guide/manifest_cache.rst
@@ -21,7 +21,7 @@ Manifest Cache
 Overview
 --------
 
-paimon-cpp caches raw manifest file bytes at the ``ObjectsFile<T>::Read()``
+Paimon C++ caches raw manifest file bytes at the ``ObjectsFile<T>::Read()``
 layer. The cache uses the public ``Cache`` abstraction and is enabled through
 ``ScanContextBuilder::WithCache()``. The cache covers data manifests, manifest
 lists, and index manifests because they all read through ``ObjectsFile<T>``.

--- a/docs/source/user_guide/parquet_metadata_cache.rst
+++ b/docs/source/user_guide/parquet_metadata_cache.rst
@@ -21,11 +21,11 @@ Parquet Metadata Cache
 Overview
 --------
 
-paimon-cpp can cache serialized Parquet metadata footer bytes for Parquet data files.
+Paimon C++ can cache serialized Parquet metadata footer bytes for Parquet data files.
 The cache is used by ``ParquetReaderBuilder`` before opening the Arrow Parquet
-reader. On a cache miss, paimon-cpp loads the Parquet file metadata, serializes
+reader. On a cache miss, Paimon C++ loads the Parquet file metadata, serializes
 it as a complete metadata footer, and stores those bytes in the public
-``Cache`` abstraction. On a cache hit, paimon-cpp parses the cached footer bytes into
+``Cache`` abstraction. On a cache hit, Paimon C++ parses the cached footer bytes into
 ``parquet::FileMetaData`` and passes the metadata to the Parquet reader.
 
 The cache stores serialized metadata footer bytes instead of caching a
@@ -36,7 +36,7 @@ bytes, while the Parquet library still owns metadata parsing and validation.
 This optimization is useful when the same Parquet files are opened repeatedly
 in the same process, for example repeated ``get`` or ``scan`` requests over the
 same snapshot. On a cache hit, the read path avoids reading the Parquet footer
-bytes from the filesystem again. paimon-cpp still parses the cached footer bytes
+bytes from the filesystem again. Paimon C++ still parses the cached footer bytes
 into ``parquet::FileMetaData`` for each reader open. Data pages, page indexes,
 and column chunks are still read from the file as usual.
 
@@ -97,7 +97,7 @@ Example:
    read_builder.WithCache(cache);
 
 Passing ``nullptr`` or omitting ``WithCache()`` leaves Parquet metadata caching
-disabled. If a file URI cannot be obtained, paimon-cpp also bypasses the cache
+disabled. If a file URI cannot be obtained, Paimon C++ also bypasses the cache
 and opens the Parquet file normally.
 
 Future Optimizations

--- a/docs/source/user_guide/primary_key_table.rst
+++ b/docs/source/user_guide/primary_key_table.rst
@@ -38,7 +38,7 @@ efficient querying.
 Each bucket directory contains an LSM tree and its changelog files.
 
 .. note::
-   Changelog is not supported yet for C++ Paimon primary key table write.
+   Changelog is not supported yet for Paimon C++ primary key table write.
 
 The range for a bucket is determined by the hash value of one or more columns in
 the records. Users can specify bucketing columns by providing the bucket-key option.

--- a/docs/source/user_guide/read.rst
+++ b/docs/source/user_guide/read.rst
@@ -28,7 +28,7 @@ Paimon by functionality can be divided into two layers:
   - Readers for various file formats
   - Coordinated reading of file collections
 
-The control plane and data plane interact primarily via DataSplit (the query plan). C++ Paimon currently supports a standard
+The control plane and data plane interact primarily via DataSplit (the query plan). Paimon C++ currently supports a standard
 DataSplit protocol which includes the necessary meta information to access data files. With DataSplit, a high-performance
 data access path can be integrated.
 
@@ -46,7 +46,7 @@ Schema Evolution
 Scope and Compatibility
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-C++ Paimon supports all evolution kinds available in Java Paimon for non-nested types:
+Paimon C++ supports all evolution kinds available in Java Paimon for non-nested types:
 
 - Add column
 - Drop column
@@ -77,7 +77,7 @@ Overflow behavior is undefined for C++ and Java Paimon. Results in overflow scen
 - Return an error status,
 - Or be null.
 
-C++ Paimon does not guarantee identical results to Java Paimon in overflow scenarios. Users should not rely on identical
+Paimon C++ does not guarantee identical results to Java Paimon in overflow scenarios. Users should not rely on identical
 return values between implementations.
 
 Type Change Support Matrix
@@ -275,17 +275,17 @@ for caveats.
     - C++:  inf, -inf, nan
 
   4️⃣ Printing difference:
-    - C++ Paimon prints 1.0 as ``1``
-    - Java Paimon prints 1.0 as ``1.0``
+    - C++ prints 1.0 as ``1``
+    - Java prints 1.0 as ``1.0``
 
   5️⃣ Timestamp precision and range differences:
-    - Java Paimon: 0000-01-01 00:00:00.000000000 to 9999-12-31 23:59:59.999999999
-    - C++ Paimon:  1677-09-21 00:12:43.145224192 to 2262-04-11 23:47:16.854775807
+    - Java: 0000-01-01 00:00:00.000000000 to 9999-12-31 23:59:59.999999999
+    - C++:  1677-09-21 00:12:43.145224192 to 2262-04-11 23:47:16.854775807
     - C++ only supports nanosecond precision; range is smaller.
 
   6️⃣ bigint -> timestamp range differences:
-    - Java Paimon (ms):   ``[MIN_INT64/1000, MAX_INT64/1000]`` seconds
-    - C++ Paimon (ns):    ``[MIN_INT64/1e9,  MAX_INT64/1e9]`` seconds
+    - Java (ms):   ``[MIN_INT64/1000, MAX_INT64/1000]`` seconds
+    - C++ (ns):    ``[MIN_INT64/1e9,  MAX_INT64/1e9]`` seconds
 
   7️⃣ string -> decimal with precision > 38:
     - C++ returns ``null`` if parsing would overflow 128-bit arithmetic.


### PR DESCRIPTION
### Purpose

Linked issue: N/A

Standardize the project name across user and contributor documentation. Titles now use `Apache Paimon C++`, while repeated references in prose use `Paimon C++`. Repository URLs, directory names, Sphinx labels, and other technical identifiers keep the existing `paimon-cpp` spelling.

### Tests

- `pre-commit run --files <changed documentation files>`
- `sphinx-build -b html -E -W --keep-going -j8 docs/source /tmp/paimon-docs-html`
- `git diff --check`

The Sphinx build used a temporary dependency overlay to work around this host's unrelated urllib3/OpenSSL and IPython/_sqlite3 environment issues.

### API and Format

No API, storage format, or protocol changes.

### Documentation

This PR only standardizes existing project-name references and does not introduce new functionality.

### Generative AI tooling

Generated-by: OpenAI Codex (GPT-5)
