### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 
 project(paimon
-        VERSION 0.3.0
+        VERSION 0.4.0
         DESCRIPTION "Paimon C++ Project")
 
 string(TOUPPER "${CMAKE_BUILD_TYPE}" UPPERCASE_BUILD_TYPE)

--- a/docs/source/_static/versions.json
+++ b/docs/source/_static/versions.json
@@ -1,7 +1,7 @@
 [
     {
-        "name": "0.3.0",
-        "version": "0.3.0",
+        "name": "0.4.0",
+        "version": "0.4.0",
         "url": "https://paimon.apache.org/docs/cpp/"
     }
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -114,7 +114,7 @@ html_sidebars = {
 # The master toctree document.
 master_doc = "index"
 
-version = "0.3.0"
+version = "0.4.0"
 
 html_theme_options = {
     "show_toc_level": 2,


### PR DESCRIPTION
### Purpose

Bump the Paimon C++ development version from 0.3.0 to 0.4.0.

Keep the CMake project version, Sphinx documentation version, and documentation version selector aligned.

### Tests

- `git diff --check`
- `python3 -m json.tool docs/source/_static/versions.json`
- Release workflow version extraction from `CMakeLists.txt` (reported `0.4.0`)
- `pre-commit run --files CMakeLists.txt docs/source/conf.py docs/source/_static/versions.json`

### API and Format

No API, storage format, or protocol changes.

### Documentation

Updates the displayed documentation version to 0.4.0.

### Generative AI tooling

Generated-by: Codex (GPT-5)
