### PR TITLE
chore: add github triage collaborators

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,7 @@
 #
 
 # The format of this file is documented at
-# https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features
+# https://github.com/apache/infrastructure-asfyaml
 
 github:
   description: "Paimon-cpp is a high-performance C++ implementation of Apache Paimon."
@@ -29,6 +29,11 @@ github:
     - paimon
     - apache
     - cpp
+  collaborators:
+    - zjw1111
+    - lxy-9602
+    - lucasfang
+    - lszskye
   enabled_merge_buttons:
     merge: false
     squash: true


### PR DESCRIPTION
### Purpose

Linked issue: N/A

Add `zjw1111`, `lxy-9602`, `lucasfang`, and `lszskye` to the ASF GitHub collaborators configuration so they receive the repository triage role.

Also update the ASF YAML documentation reference to the current `apache/infrastructure-asfyaml` repository.

### Tests

- `pre-commit run --files .asf.yaml`
- `git diff --check`

### API and Format

No public API, storage format, or protocol changes.

### Documentation

Updates the configuration documentation link only; no user-facing feature documentation changes.

### Generative AI tooling

Generated-by: Codex (GPT-5)
