### PR TITLE
fix(commit): allow disabled manifest delete stats option

### DIFF
--- a/src/paimon/core/operation/file_store_commit_impl.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl.cpp
@@ -42,6 +42,7 @@
 #include "paimon/common/utils/binary_row_partition_computer.h"
 #include "paimon/common/utils/date_time_utils.h"
 #include "paimon/common/utils/fields_comparator.h"
+#include "paimon/common/utils/options_utils.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
 #include "paimon/core/catalog/catalog_snapshot_commit.h"
@@ -116,7 +117,12 @@ Status FileStoreCommitImpl::ValidateCommitOptions(const CoreOptions& options) {
         unsupported_options.emplace_back(kCommitStrictModeLastSafeSnapshot);
     }
     if (raw_options.find(kManifestDeleteFileDropStats) != raw_options.end()) {
-        unsupported_options.emplace_back(kManifestDeleteFileDropStats);
+        PAIMON_ASSIGN_OR_RAISE(
+            bool manifest_delete_file_drop_stats,
+            OptionsUtils::GetValueFromMap<bool>(raw_options, kManifestDeleteFileDropStats));
+        if (manifest_delete_file_drop_stats) {
+            unsupported_options.emplace_back(kManifestDeleteFileDropStats);
+        }
     }
     if (raw_options.find(kSequenceSnapshotOrdering) != raw_options.end()) {
         unsupported_options.emplace_back(kSequenceSnapshotOrdering);

--- a/src/paimon/core/operation/file_store_commit_impl_test.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl_test.cpp
@@ -2550,6 +2550,12 @@ TEST_F(FileStoreCommitImplTest, ValidateCommitOptionsRejectsUnsupportedOptions) 
     ASSERT_OK(FileStoreCommitImpl::ValidateCommitOptions(ok_options));
 }
 
+TEST_F(FileStoreCommitImplTest, ValidateCommitOptionsAllowsDisabledManifestDeleteFileDropStats) {
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({{"manifest.delete-file-drop-stats", "false"}}));
+    ASSERT_OK(FileStoreCommitImpl::ValidateCommitOptions(options));
+}
+
 TEST_F(FileStoreCommitImplTest, DropPartitionWithEmptyPartitionsFails) {
     CommitContextBuilder context_builder(table_path_, "commit_user_1");
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<CommitContext> commit_context,


### PR DESCRIPTION
### Purpose

Allow the C++ commit path to accept `manifest.delete-file-drop-stats=false`. The disabled value matches the existing C++ behavior, which preserves statistics in DELETE manifest entries. The enabled value remains unsupported and rejected.

### Tests

- `./build-release/release/paimon-core-test --gtest_filter='FileStoreCommitImplTest.ValidateCommitOptionsAllowsDisabledManifestDeleteFileDropStats:FileStoreCommitImplTest.ValidateCommitOptionsRejectsUnsupportedOptions'`
- `./build-release/release/paimon-core-test --gtest_brief=1` (1579 tests passed)
- `pre-commit run --files src/paimon/core/operation/file_store_commit_impl.cpp src/paimon/core/operation/file_store_commit_impl_test.cpp`

### API and Format

No public API, storage format, or protocol changes.

### Documentation

No documentation changes. This fixes validation of an existing option.

### Generative AI tooling

Generated-by: Codex, GPT-5.