### PR TITLE
feat(read): support deletion vectors for data-evolution tables

### DIFF
--- a/docs/source/user_guide/compaction.rst
+++ b/docs/source/user_guide/compaction.rst
@@ -47,6 +47,21 @@ not block writes.
    (``bucket > 0``). Dynamic bucketing (``bucket = -1``) does not support
    compaction. Tables with blob columns also skip compaction.
 
+.. _data-evolution-deletion-vectors-compaction:
+
+.. note::
+   A data-evolution table (``data-evolution.enabled = true``) may enable
+   ``deletion-vectors.enabled``. Paimon C++ never compacts such a table: auto
+   compaction never runs on it, since data evolution requires ``bucket = -1``,
+   and ``AppendCompactCoordinator::Run``, the dedicated compaction entry point,
+   rejects it outright rather than dropping the deletes. This matches the
+   Paimon Java revision this support was ported from, which ends the compaction
+   scan as soon as deletion vectors are enabled; later Java releases do compact
+   such a table, and Paimon C++ has not caught up.
+
+   Reading such a table is supported; see
+   :ref:`data-evolution-deletion-vectors`.
+
 Auto Compaction
 ~~~~~~~~~~~~~~~
 During each flush, the writer triggers a best-effort auto compaction. The

--- a/docs/source/user_guide/read.rst
+++ b/docs/source/user_guide/read.rst
@@ -308,3 +308,45 @@ Implementation Guidance
 - Expect per-file schema variability; design readers to align by field IDs rather than positional indices.
 - Do not assume identical overflow semantics across C++ and Java; tests should validate acceptable ranges and nullability.
 - For timestamp handling, consider precision/range constraints in C++ when interoperating with Java-produced data splits.
+
+.. _data-evolution-deletion-vectors:
+
+Deletion Vectors on Data-Evolution Tables
+-----------------------------------------
+
+A data-evolution table (``data-evolution.enabled = true``) may enable
+``deletion-vectors.enabled``. Reading such a table is supported: a deleted row disappears
+from the result, including from the columns merged out of the other files that cover it.
+
+How the Deletion Vector Is Located
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A data-evolution split holds several files per row id range, one per group of columns. The
+deletion vector of such a row range group is not per file: it is maintained against the
+group's *anchor file*, the oldest normal file of the group, compared by
+``(max_sequence_number, file_name)`` and skipping blob and vector-store files. Its positions
+are therefore relative to the anchor file's row id range.
+
+Reading applies that one vector to every file of the group, shifted by the file's offset
+inside the anchor range, so all the readers being merged drop the same rows and stay
+positionally aligned. The blob fallback path has no file reader to wrap for the placeholder
+gaps it pads uncovered row ids with, so it removes the deleted row ids from those gap ranges
+instead.
+
+The rule that picks the anchor has to stay identical to the engine that writes the vectors:
+a vector keyed by any other file of the group is never found, and its deleted rows silently
+come back.
+
+Limitations
+~~~~~~~~~~~
+
+- Only the default 32-bit deletion vectors can be read. ``deletion-vectors.bitmap64`` is not
+  supported yet, and a read fails when it actually encounters a 64-bit deletion vector.
+- Paimon C++ does not write deletion vectors for data-evolution tables, so the deletes
+  themselves have to be issued by another engine.
+- A commit that drops data files from such a table, an overwrite for instance, is refused.
+  Whether it conflicts with a concurrent commit rewriting those files' deletion vectors cannot
+  be decided yet, so it fails rather than committing against a stale state. Appending is
+  unaffected, and so is another engine replacing a deletion vector.
+- Such a table is never compacted; see
+  :ref:`the compaction note <data-evolution-deletion-vectors-compaction>`.

--- a/include/paimon/defs.h
+++ b/include/paimon/defs.h
@@ -358,6 +358,9 @@ struct PAIMON_EXPORT Options {
     /// files containing deletion vectors are generated when data is written, which marks the data
     /// for deletion. During read operations, by applying these index files, merging can be avoided.
     /// Default value is false.
+    /// @note On a data-evolution table (`DATA_EVOLUTION_ENABLED`), Paimon C++ reads deletion
+    /// vectors but does not write them: the deletes have to be issued by another engine, and such
+    /// a table is never compacted.
     static const char DELETION_VECTORS_ENABLED[];
 
     /// "deletion-vector.index-file.target-size" - The target size of deletion vector index file.

--- a/src/paimon/CMakeLists.txt
+++ b/src/paimon/CMakeLists.txt
@@ -417,6 +417,7 @@ set(PAIMON_CORE_SRCS
     core/utils/branch_manager.cpp
     core/utils/blob_view_lookup.cpp
     core/utils/consumer_manager.cpp
+    core/utils/data_evolution_utils.cpp
     core/utils/field_mapping.cpp
     core/utils/nested_projection_utils.cpp
     core/utils/file_store_path_factory.cpp
@@ -871,6 +872,7 @@ if(PAIMON_BUILD_TESTS)
                     core/utils/blob_view_lookup_test.cpp
                     core/utils/branch_manager_test.cpp
                     core/utils/consumer_manager_test.cpp
+                    core/utils/data_evolution_utils_test.cpp
                     core/utils/file_store_path_factory_cache_test.cpp
                     core/utils/field_mapping_test.cpp
                     core/utils/nested_projection_utils_test.cpp

--- a/src/paimon/common/reader/blob_fallback_batch_reader.h
+++ b/src/paimon/common/reader/blob_fallback_batch_reader.h
@@ -50,7 +50,9 @@ namespace paimon {
 ///    first) and, inside each group, orders them by first row id. Row id ranges the group's
 ///    files do not cover are represented by gap segments, which stand for all-placeholder rows.
 /// 2. All groups span the same overall row id range, so with the same row-ranges selection
-///    applied they yield the same number of rows and can be stepped in lockstep.
+///    applied they yield the same number of rows and can be stepped in lockstep. A deletion
+///    vector has to reach every group the same way, through the file segments' readers and
+///    through the row ids the caller leaves in a gap segment's `gap_selected_ranges`.
 /// 3. Each output row takes the first group, in max-sequence order, whose row is not a
 ///    placeholder. Placeholder rows are identified by exact equality with the
 ///    BlobDefs::kPlaceholderSentinel bytes, emitted by the blob format reader when

--- a/src/paimon/core/deletionvectors/bitmap_deletion_vector.h
+++ b/src/paimon/core/deletionvectors/bitmap_deletion_vector.h
@@ -56,7 +56,7 @@ class BitmapDeletionVector : public DeletionVector {
         return roaring_bitmap_.IsEmpty();
     }
 
-    int64_t GetCardinality() const override {
+    Result<int64_t> GetCardinality() const override {
         return roaring_bitmap_.Cardinality();
     }
 

--- a/src/paimon/core/deletionvectors/bitmap_deletion_vector_test.cpp
+++ b/src/paimon/core/deletionvectors/bitmap_deletion_vector_test.cpp
@@ -36,7 +36,7 @@ TEST(BitmapDeletionVectorTest, BasicOperations) {
     for (int32_t i = 0; i < 2000; i += 2) {
         ASSERT_OK(dv.Delete(i));
     }
-    ASSERT_EQ(dv.GetCardinality(), 1000);
+    ASSERT_EQ(dv.GetCardinality().value(), 1000);
     for (int32_t i = 0; i < 2000; ++i) {
         if (i % 2 == 0) {
             ASSERT_TRUE(dv.IsDeleted(i).value());
@@ -102,24 +102,24 @@ TEST(BitmapDeletionVectorTest, SerializeToOutputStream) {
 TEST(BitmapDeletionVectorTest, GetCardinality) {
     RoaringBitmap32 empty;
     BitmapDeletionVector dv_empty(empty);
-    ASSERT_EQ(dv_empty.GetCardinality(), 0);
+    ASSERT_EQ(dv_empty.GetCardinality().value(), 0);
 
     RoaringBitmap32 cont;
     for (int32_t i = 0; i < 100; ++i) cont.Add(i);
     BitmapDeletionVector dv_cont(cont);
-    ASSERT_EQ(dv_cont.GetCardinality(), 100);
+    ASSERT_EQ(dv_cont.GetCardinality().value(), 100);
 
     RoaringBitmap32 gap;
     for (int32_t i = 0; i < 1000; i += 10) gap.Add(i);
     BitmapDeletionVector dv_gap(gap);
-    ASSERT_EQ(dv_gap.GetCardinality(), 100);
+    ASSERT_EQ(dv_gap.GetCardinality().value(), 100);
 
     RoaringBitmap32 del;
     for (int32_t i = 0; i < 10; ++i) del.Add(i);
     BitmapDeletionVector dv_del(del);
-    ASSERT_EQ(dv_del.GetCardinality(), 10);
+    ASSERT_EQ(dv_del.GetCardinality().value(), 10);
     ASSERT_OK(dv_del.Delete(100));
-    ASSERT_EQ(dv_del.GetCardinality(), 11);
+    ASSERT_EQ(dv_del.GetCardinality().value(), 11);
 }
 
 TEST(BitmapDeletionVectorTest, PositionOutOfRangeShouldFail) {
@@ -190,7 +190,7 @@ TEST(BitmapDeletionVectorTest, MergeTwoBitmapDeletionVectors) {
     ASSERT_TRUE(dv1->IsDeleted(5).value());
     ASSERT_FALSE(dv1->IsDeleted(0).value());
     ASSERT_FALSE(dv1->IsDeleted(6).value());
-    ASSERT_EQ(dv1->GetCardinality(), 5);
+    ASSERT_EQ(dv1->GetCardinality().value(), 5);
 }
 
 TEST(BitmapDeletionVectorTest, MergeEmptyDeletionVector) {
@@ -203,7 +203,7 @@ TEST(BitmapDeletionVectorTest, MergeEmptyDeletionVector) {
     auto dv_empty = std::make_shared<BitmapDeletionVector>(empty_roaring);
 
     ASSERT_OK(dv1->Merge(dv_empty));
-    ASSERT_EQ(dv1->GetCardinality(), 2);
+    ASSERT_EQ(dv1->GetCardinality().value(), 2);
     ASSERT_TRUE(dv1->IsDeleted(10).value());
     ASSERT_TRUE(dv1->IsDeleted(20).value());
 }
@@ -214,7 +214,7 @@ TEST(BitmapDeletionVectorTest, MergeNullDeletionVector) {
     auto dv1 = std::make_shared<BitmapDeletionVector>(roaring1);
 
     ASSERT_OK(dv1->Merge(nullptr));
-    ASSERT_EQ(dv1->GetCardinality(), 1);
+    ASSERT_EQ(dv1->GetCardinality().value(), 1);
     ASSERT_TRUE(dv1->IsDeleted(7).value());
 }
 
@@ -230,7 +230,7 @@ TEST(BitmapDeletionVectorTest, MergeIntoEmptyDeletionVector) {
     auto dv2 = std::make_shared<BitmapDeletionVector>(roaring2);
 
     ASSERT_OK(dv1->Merge(dv2));
-    ASSERT_EQ(dv1->GetCardinality(), 3);
+    ASSERT_EQ(dv1->GetCardinality().value(), 3);
     ASSERT_TRUE(dv1->IsDeleted(100).value());
     ASSERT_TRUE(dv1->IsDeleted(200).value());
     ASSERT_TRUE(dv1->IsDeleted(300).value());

--- a/src/paimon/core/deletionvectors/deletion_file_writer.cpp
+++ b/src/paimon/core/deletionvectors/deletion_file_writer.cpp
@@ -44,8 +44,9 @@ Status DeletionFileWriter::Write(const std::string& key,
     }
     DataOutputStream output_stream(out_);
     PAIMON_ASSIGN_OR_RAISE(int32_t length, deletion_vector->SerializeTo(pool_, &output_stream));
-    dv_metas_.insert_or_assign(key, DeletionVectorMeta(key, static_cast<int32_t>(start), length,
-                                                       deletion_vector->GetCardinality()));
+    PAIMON_ASSIGN_OR_RAISE(int64_t cardinality, deletion_vector->GetCardinality());
+    dv_metas_.insert_or_assign(
+        key, DeletionVectorMeta(key, static_cast<int32_t>(start), length, cardinality));
     return Status::OK();
 }
 

--- a/src/paimon/core/deletionvectors/deletion_file_writer_test.cpp
+++ b/src/paimon/core/deletionvectors/deletion_file_writer_test.cpp
@@ -77,8 +77,8 @@ TEST(DeletionFileWriterTest, WriteCloseAndReadBack) {
     ASSERT_OK_AND_ASSIGN(auto read_back, index_file.ReadAllDeletionVectors(meta));
 
     ASSERT_EQ(read_back.size(), 2);
-    ASSERT_EQ(read_back.at("data-file-1")->GetCardinality(), 3);
-    ASSERT_EQ(read_back.at("data-file-2")->GetCardinality(), 1);
+    ASSERT_EQ(read_back.at("data-file-1")->GetCardinality().value(), 3);
+    ASSERT_EQ(read_back.at("data-file-2")->GetCardinality().value(), 1);
 
     ASSERT_OK_AND_ASSIGN(bool is_deleted, read_back.at("data-file-1")->IsDeleted(3));
     ASSERT_TRUE(is_deleted);

--- a/src/paimon/core/deletionvectors/deletion_vector.h
+++ b/src/paimon/core/deletionvectors/deletion_vector.h
@@ -104,7 +104,7 @@ class DeletionVector {
     virtual bool IsEmpty() const = 0;
 
     /// @return the number of distinct integers added to the DeletionVector.
-    virtual int64_t GetCardinality() const = 0;
+    virtual Result<int64_t> GetCardinality() const = 0;
 
     /// Serializes the deletion vector.
     virtual Result<int32_t> SerializeTo(const std::shared_ptr<MemoryPool>& pool,

--- a/src/paimon/core/deletionvectors/deletion_vector_index_file_writer_test.cpp
+++ b/src/paimon/core/deletionvectors/deletion_vector_index_file_writer_test.cpp
@@ -51,7 +51,7 @@ class FailingDeletionVector : public DeletionVector {
         return true;
     }
 
-    int64_t GetCardinality() const override {
+    Result<int64_t> GetCardinality() const override {
         return 0;
     }
 

--- a/src/paimon/core/deletionvectors/deletion_vectors_index_file_test.cpp
+++ b/src/paimon/core/deletionvectors/deletion_vectors_index_file_test.cpp
@@ -66,8 +66,8 @@ TEST(DeletionVectorsIndexFileTest, Basic) {
     // Round trip: write then read all deletion vectors from index file.
     ASSERT_OK_AND_ASSIGN(auto read_back, index_file->ReadAllDeletionVectors(meta));
     ASSERT_EQ(read_back.size(), input.size());
-    ASSERT_EQ(read_back.at("dv1")->GetCardinality(), 10);
-    ASSERT_EQ(read_back.at("dv2")->GetCardinality(), 10);
+    ASSERT_EQ(read_back.at("dv1")->GetCardinality().value(), 10);
+    ASSERT_EQ(read_back.at("dv2")->GetCardinality().value(), 10);
 
     ASSERT_OK_AND_ASSIGN(bool is_deleted, read_back.at("dv1")->IsDeleted(0));
     ASSERT_TRUE(is_deleted);
@@ -102,7 +102,7 @@ TEST(DeletionVectorsIndexFileTest, ExternalPathAndIndexFileMeta) {
     // Round trip for external path index file.
     ASSERT_OK_AND_ASSIGN(auto read_back, index_file.ReadAllDeletionVectors(meta));
     ASSERT_EQ(read_back.size(), 1);
-    ASSERT_EQ(read_back.at("dv_ext")->GetCardinality(), 5);
+    ASSERT_EQ(read_back.at("dv_ext")->GetCardinality().value(), 5);
     ASSERT_OK_AND_ASSIGN(bool is_deleted, read_back.at("dv_ext")->IsDeleted(0));
     ASSERT_TRUE(is_deleted);
     ASSERT_OK_AND_ASSIGN(is_deleted, read_back.at("dv_ext")->IsDeleted(5));

--- a/src/paimon/core/index/index_file_handler_test.cpp
+++ b/src/paimon/core/index/index_file_handler_test.cpp
@@ -313,7 +313,9 @@ TEST_F(IndexFileHandlerTest, TestScanByPartitionBucketAndReadAllDeletionVectors)
     ASSERT_EQ(deletion_vectors.size(), 1);
     ASSERT_TRUE(deletion_vectors.find("data-0d0f29cc-63c6-4fab-a594-71bd7d06fcde-0.orc") !=
                 deletion_vectors.end());
-    ASSERT_EQ(deletion_vectors["data-0d0f29cc-63c6-4fab-a594-71bd7d06fcde-0.orc"]->GetCardinality(),
+    ASSERT_EQ(deletion_vectors["data-0d0f29cc-63c6-4fab-a594-71bd7d06fcde-0.orc"]
+                  ->GetCardinality()
+                  .value(),
               1);
 }
 

--- a/src/paimon/core/manifest/index_manifest_file_handler.cpp
+++ b/src/paimon/core/manifest/index_manifest_file_handler.cpp
@@ -19,15 +19,19 @@
 #include "paimon/core/manifest/index_manifest_file_handler.h"
 
 #include <set>
+#include <string>
 #include <unordered_map>
 #include <utility>
 
+#include "fmt/format.h"
+#include "paimon/common/utils/linked_hash_map.h"
 #include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
+#include "paimon/core/index/index_file_meta.h"
 namespace paimon {
 
 using BucketIdentifier = std::tuple<BinaryRow, int32_t, std::string>;
 
-std::vector<IndexManifestEntry> IndexManifestFileHandler::BucketedCombiner::Combine(
+Result<std::vector<IndexManifestEntry>> IndexManifestFileHandler::BucketedCombiner::Combine(
     const std::vector<IndexManifestEntry>& prev_index_files,
     const std::vector<IndexManifestEntry>& new_index_files) const {
     std::unordered_map<BucketIdentifier, IndexManifestEntry> index_entries;
@@ -67,7 +71,7 @@ std::vector<IndexManifestEntry> IndexManifestFileHandler::BucketedCombiner::Comb
     return result_entries;
 }
 
-std::vector<IndexManifestEntry> IndexManifestFileHandler::GlobalFileNameCombiner::Combine(
+Result<std::vector<IndexManifestEntry>> IndexManifestFileHandler::GlobalFileNameCombiner::Combine(
     const std::vector<IndexManifestEntry>& prev_index_files,
     const std::vector<IndexManifestEntry>& new_index_files) const {
     std::map<std::string, IndexManifestEntry> index_entries;
@@ -94,6 +98,92 @@ std::vector<IndexManifestEntry> IndexManifestFileHandler::GlobalFileNameCombiner
     }
     for (const auto& entry : added) {
         index_entries.insert_or_assign(entry.index_file->FileName(), entry);
+    }
+
+    std::vector<IndexManifestEntry> result_entries;
+    result_entries.reserve(index_entries.size());
+    for (const auto& [_, entry] : index_entries) {
+        result_entries.push_back(entry);
+    }
+    return result_entries;
+}
+
+namespace {
+using DeletionVectorRanges = LinkedHashMap<std::string, DeletionVectorMeta>;
+
+/// The deletion vectors an index file holds, keyed by the data file each covers. Null when the
+/// entry holds none.
+const DeletionVectorRanges* GetDeletionVectorRanges(const IndexManifestEntry& entry) {
+    const std::optional<DeletionVectorRanges>& dv_ranges = entry.index_file->DvRanges();
+    return dv_ranges == std::nullopt ? nullptr : &dv_ranges.value();
+}
+}  // namespace
+
+Result<std::vector<IndexManifestEntry>>
+IndexManifestFileHandler::GlobalDeletionVectorCombiner::Combine(
+    const std::vector<IndexManifestEntry>& prev_index_files,
+    const std::vector<IndexManifestEntry>& new_index_files) const {
+    std::map<std::string, IndexManifestEntry> index_entries;
+    std::set<std::string> covered_data_files;
+    for (const auto& entry : prev_index_files) {
+        index_entries.insert_or_assign(entry.index_file->FileName(), entry);
+        const DeletionVectorRanges* dv_ranges = GetDeletionVectorRanges(entry);
+        if (dv_ranges == nullptr) {
+            continue;
+        }
+        for (const auto& [data_file, _] : *dv_ranges) {
+            covered_data_files.insert(data_file);
+        }
+    }
+
+    std::vector<const IndexManifestEntry*> removed;
+    std::vector<const IndexManifestEntry*> added;
+    for (const auto& entry : new_index_files) {
+        if (entry.kind == FileKind::Delete()) {
+            removed.push_back(&entry);
+        } else if (entry.kind == FileKind::Add()) {
+            added.push_back(&entry);
+        }
+    }
+
+    // The deleted entry is processed first, so that an index file taking over the data files of
+    // the one it replaces is not rejected as a second vector for them. Paimon Java's
+    // GlobalCombiner is order sensitive here; its two sibling combiners are not.
+    for (const IndexManifestEntry* entry : removed) {
+        const std::string& file_name = entry->index_file->FileName();
+        if (index_entries.erase(file_name) == 0) {
+            return Status::Invalid(fmt::format(
+                "Trying to delete deletion vector index file {} which does not exist.", file_name));
+        }
+        const DeletionVectorRanges* dv_ranges = GetDeletionVectorRanges(*entry);
+        if (dv_ranges == nullptr) {
+            continue;
+        }
+        for (const auto& [data_file, _] : *dv_ranges) {
+            if (covered_data_files.erase(data_file) == 0) {
+                return Status::Invalid(
+                    fmt::format("Trying to delete the deletion vector of data file {}, which does "
+                                "not exist.",
+                                data_file));
+            }
+        }
+    }
+    for (const IndexManifestEntry* entry : added) {
+        const std::string& file_name = entry->index_file->FileName();
+        if (index_entries.find(file_name) != index_entries.end()) {
+            return Status::Invalid(fmt::format(
+                "Trying to add deletion vector index file {} which is already added.", file_name));
+        }
+        const DeletionVectorRanges* dv_ranges = GetDeletionVectorRanges(*entry);
+        if (dv_ranges != nullptr) {
+            for (const auto& [data_file, _] : *dv_ranges) {
+                if (!covered_data_files.insert(data_file).second) {
+                    return Status::Invalid(fmt::format(
+                        "Trying to add a second deletion vector for data file {}.", data_file));
+                }
+            }
+        }
+        index_entries.insert_or_assign(file_name, *entry);
     }
 
     std::vector<IndexManifestEntry> result_entries;
@@ -138,8 +228,8 @@ Result<std::string> IndexManifestFileHandler::Write(
             GetIndexManifestFileCombine(index_type, bucket_mode));
         std::vector<IndexManifestEntry> typed_previous_entries = previous[index_type];
         std::vector<IndexManifestEntry> typed_current_entries = current[index_type];
-        std::vector<IndexManifestEntry> combined_entries =
-            combiner->Combine(typed_previous_entries, typed_current_entries);
+        PAIMON_ASSIGN_OR_RAISE(std::vector<IndexManifestEntry> combined_entries,
+                               combiner->Combine(typed_previous_entries, typed_current_entries));
 
         index_entries.insert(index_entries.end(), combined_entries.begin(), combined_entries.end());
     }
@@ -167,8 +257,14 @@ IndexManifestFileHandler::GetIndexManifestFileCombine(const std::string& index_t
     if (index_type != DeletionVectorsIndexFile::DELETION_VECTORS_INDEX && index_type != "HASH") {
         return std::make_unique<GlobalFileNameCombiner>();
     }
+    // `bucket_mode` is the configured bucket, not a resolved BucketMode, standing in for Paimon
+    // Java's BucketMode.BUCKET_UNAWARE check. The two agree on every table that can exist:
+    // SchemaValidation rejects the other unaware bucket, 0, and BucketIdCalculator refuses to
+    // write the primary key table on which -1 means HASH_DYNAMIC instead. Lifting either
+    // restriction means passing the resolved BucketMode here, or a dynamic bucket table would
+    // combine its per-bucket deletion vectors by index file name.
     if (index_type == DeletionVectorsIndexFile::DELETION_VECTORS_INDEX && bucket_mode == -1) {
-        return Status::NotImplemented("not yet support dv with BUCKET_UNAWARE mode");
+        return std::make_unique<GlobalDeletionVectorCombiner>();
     }
     return std::make_unique<BucketedCombiner>();
 }

--- a/src/paimon/core/manifest/index_manifest_file_handler.h
+++ b/src/paimon/core/manifest/index_manifest_file_handler.h
@@ -43,7 +43,7 @@ class IndexManifestFileHandler {
     class IndexManifestFileCombiner {
      public:
         virtual ~IndexManifestFileCombiner() = default;
-        virtual std::vector<IndexManifestEntry> Combine(
+        virtual Result<std::vector<IndexManifestEntry>> Combine(
             const std::vector<IndexManifestEntry>& prev_index_files,
             const std::vector<IndexManifestEntry>& new_index_files) const = 0;
     };
@@ -51,7 +51,7 @@ class IndexManifestFileHandler {
     /// Combine previous and new index files by partition, bucket and index type.
     class BucketedCombiner : public IndexManifestFileCombiner {
      public:
-        std::vector<IndexManifestEntry> Combine(
+        Result<std::vector<IndexManifestEntry>> Combine(
             const std::vector<IndexManifestEntry>& prev_index_files,
             const std::vector<IndexManifestEntry>& new_index_files) const override;
     };
@@ -59,7 +59,20 @@ class IndexManifestFileHandler {
     /// Combine previous and new index files by file name.
     class GlobalFileNameCombiner : public IndexManifestFileCombiner {
      public:
-        std::vector<IndexManifestEntry> Combine(
+        Result<std::vector<IndexManifestEntry>> Combine(
+            const std::vector<IndexManifestEntry>& prev_index_files,
+            const std::vector<IndexManifestEntry>& new_index_files) const override;
+    };
+
+    /// Combine previous and new deletion vector index files by file name, for a table without
+    /// buckets, where the bucket cannot tell two index files apart.
+    ///
+    /// A data file is covered by at most one deletion vector, so a delta that adds a second one
+    /// for a data file, or drops one that is not there, was built against a different base and
+    /// is rejected rather than silently changing which rows the read returns.
+    class GlobalDeletionVectorCombiner : public IndexManifestFileCombiner {
+     public:
+        Result<std::vector<IndexManifestEntry>> Combine(
             const std::vector<IndexManifestEntry>& prev_index_files,
             const std::vector<IndexManifestEntry>& new_index_files) const override;
     };

--- a/src/paimon/core/manifest/index_manifest_file_handler_test.cpp
+++ b/src/paimon/core/manifest/index_manifest_file_handler_test.cpp
@@ -20,6 +20,7 @@
 
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -218,17 +219,119 @@ TEST_F(IndexManifestFileHandlerTest, GlobalCombinerOverwritesDuplicateAddedEntri
     ASSERT_EQ(written_entries[0].index_file->RowCount(), 20);
 }
 
-TEST_F(IndexManifestFileHandlerTest, DvWithBucketUnawareModeReturnsNotImplemented) {
+TEST_F(IndexManifestFileHandlerTest, GlobalDvCombinerReplacesIndexFileInBucketUnawareMode) {
     ASSERT_OK_AND_ASSIGN(auto index_manifest_file, CreateManifestFile(/*bucket_mode=*/-1));
 
     auto partition = BinaryRow::EmptyRow();
+    // an unaware bucket table writes every index file under bucket 0, so only the index file
+    // name tells the two entries apart
+    std::vector<IndexManifestEntry> previous_entries = {
+        MakeDvEntry(FileKind::Add(), partition, /*bucket=*/0, "dv-0", {"data-0.orc"}, 1),
+        MakeDvEntry(FileKind::Add(), partition, /*bucket=*/0, "dv-1", {"data-1.orc"}, 1)};
+
+    ASSERT_OK_AND_ASSIGN(std::string previous_manifest,
+                         IndexManifestFileHandler::Write(
+                             /*previous_index_manifest=*/std::nullopt, previous_entries,
+                             /*bucket_mode=*/-1, index_manifest_file.get()));
+
+    // updating the vector of data-0.orc replaces its index file, and the data file it covers
+    // moves to the new one
     std::vector<IndexManifestEntry> new_entries = {
+        MakeDvEntry(FileKind::Delete(), partition, /*bucket=*/0, "dv-0", {"data-0.orc"}, 1),
+        MakeDvEntry(FileKind::Add(), partition, /*bucket=*/0, "dv-0-new", {"data-0.orc"}, 2)};
+
+    ASSERT_OK_AND_ASSIGN(
+        std::string current_manifest,
+        IndexManifestFileHandler::Write(previous_manifest, new_entries,
+                                        /*bucket_mode=*/-1, index_manifest_file.get()));
+
+    std::vector<IndexManifestEntry> written_entries;
+    ASSERT_OK(index_manifest_file->Read(current_manifest, /*filter=*/nullptr, &written_entries));
+    ASSERT_EQ(written_entries.size(), 2);
+    std::set<std::string> written_file_names;
+    for (const auto& entry : written_entries) {
+        written_file_names.insert(entry.index_file->FileName());
+    }
+    ASSERT_EQ(written_file_names, (std::set<std::string>{"dv-0-new", "dv-1"}));
+
+    // the same replacement with the added entry listed first: the delta carries no order the
+    // commit path is bound to, so the added entry must not be read as a second vector for
+    // data-0.orc just because its delete trails it
+    std::vector<IndexManifestEntry> reordered_entries = {
+        MakeDvEntry(FileKind::Add(), partition, /*bucket=*/0, "dv-0-newer", {"data-0.orc"}, 3),
+        MakeDvEntry(FileKind::Delete(), partition, /*bucket=*/0, "dv-0-new", {"data-0.orc"}, 2)};
+
+    ASSERT_OK_AND_ASSIGN(
+        std::string reordered_manifest,
+        IndexManifestFileHandler::Write(current_manifest, reordered_entries,
+                                        /*bucket_mode=*/-1, index_manifest_file.get()));
+
+    written_entries.clear();
+    ASSERT_OK(index_manifest_file->Read(reordered_manifest, /*filter=*/nullptr, &written_entries));
+    ASSERT_EQ(written_entries.size(), 2);
+    written_file_names.clear();
+    for (const auto& entry : written_entries) {
+        written_file_names.insert(entry.index_file->FileName());
+    }
+    ASSERT_EQ(written_file_names, (std::set<std::string>{"dv-0-newer", "dv-1"}));
+}
+
+TEST_F(IndexManifestFileHandlerTest, GlobalDvCombinerRejectsInconsistentDelta) {
+    ASSERT_OK_AND_ASSIGN(auto index_manifest_file, CreateManifestFile(/*bucket_mode=*/-1));
+
+    auto partition = BinaryRow::EmptyRow();
+    std::vector<IndexManifestEntry> previous_entries = {
         MakeDvEntry(FileKind::Add(), partition, /*bucket=*/0, "dv-0", {"data-0.orc"}, 1)};
 
-    ASSERT_NOK_WITH_MSG(IndexManifestFileHandler::Write(
-                            /*previous_index_manifest=*/std::nullopt, new_entries,
-                            /*bucket_mode=*/-1, index_manifest_file.get()),
-                        "not yet support dv with BUCKET_UNAWARE mode");
+    ASSERT_OK_AND_ASSIGN(std::string previous_manifest,
+                         IndexManifestFileHandler::Write(
+                             /*previous_index_manifest=*/std::nullopt, previous_entries,
+                             /*bucket_mode=*/-1, index_manifest_file.get()));
+
+    // every delta below was built against a base the previous manifest is not, so applying it
+    // would leave the read either with two vectors for one data file or with none
+    {
+        // adding a vector for data-0.orc without dropping the one it already has
+        std::vector<IndexManifestEntry> new_entries = {
+            MakeDvEntry(FileKind::Add(), partition, /*bucket=*/0, "dv-1", {"data-0.orc"}, 1)};
+
+        ASSERT_NOK_WITH_MSG(
+            IndexManifestFileHandler::Write(previous_manifest, new_entries,
+                                            /*bucket_mode=*/-1, index_manifest_file.get()),
+            "Trying to add a second deletion vector for data file data-0.orc");
+    }
+    {
+        // adding an index file the manifest already holds
+        std::vector<IndexManifestEntry> new_entries = {
+            MakeDvEntry(FileKind::Add(), partition, /*bucket=*/0, "dv-0", {"data-1.orc"}, 1)};
+
+        ASSERT_NOK_WITH_MSG(
+            IndexManifestFileHandler::Write(previous_manifest, new_entries,
+                                            /*bucket_mode=*/-1, index_manifest_file.get()),
+            "Trying to add deletion vector index file dv-0 which is already added.");
+    }
+    {
+        // deleting an index file the manifest does not hold
+        std::vector<IndexManifestEntry> new_entries = {
+            MakeDvEntry(FileKind::Delete(), partition, /*bucket=*/0, "dv-1", {"data-1.orc"}, 1)};
+
+        ASSERT_NOK_WITH_MSG(
+            IndexManifestFileHandler::Write(previous_manifest, new_entries,
+                                            /*bucket_mode=*/-1, index_manifest_file.get()),
+            "Trying to delete deletion vector index file dv-1 which does not exist.");
+    }
+    {
+        // deleting an index file the manifest does hold, but under the data files of another
+        // one: the vector of data-1.orc is not there to drop, and dropping dv-0 silently would
+        // bring the deleted rows of data-0.orc back
+        std::vector<IndexManifestEntry> new_entries = {
+            MakeDvEntry(FileKind::Delete(), partition, /*bucket=*/0, "dv-0", {"data-1.orc"}, 1)};
+
+        ASSERT_NOK_WITH_MSG(
+            IndexManifestFileHandler::Write(previous_manifest, new_entries,
+                                            /*bucket_mode=*/-1, index_manifest_file.get()),
+            "Trying to delete the deletion vector of data file data-1.orc, which does not exist.");
+    }
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/operation/commit/conflict_detection.cpp
+++ b/src/paimon/core/operation/commit/conflict_detection.cpp
@@ -115,12 +115,7 @@ Status ConflictDetection::CheckConflicts(
         row_id_column_conflict_checker,
     const Snapshot::CommitKind& commit_kind) const {
     std::string base_commit_user = latest_snapshot.CommitUser();
-    if (options_.DeletionVectorsEnabled() &&
-        ResolveBucketMode(options_.GetBucket(), table_schema_) == BucketMode::BUCKET_UNAWARE) {
-        return Status::NotImplemented(
-            "check conflicts failed. not yet support dv with BUCKET_UNAWARE mode");
-    }
-
+    PAIMON_RETURN_NOT_OK(CheckDeletionVectorsNotBypassed(delta_entries));
     std::vector<ManifestEntry> all_entries = base_entries;
     all_entries.insert(all_entries.end(), delta_entries.begin(), delta_entries.end());
     PAIMON_RETURN_NOT_OK(CheckBucketKeepSame(all_entries, commit_kind, base_commit_user,
@@ -174,6 +169,24 @@ bool ConflictDetection::ShouldBeOverwriteCommit(
     }
 
     return false;
+}
+
+Status ConflictDetection::CheckDeletionVectorsNotBypassed(
+    const std::vector<ManifestEntry>& delta_entries) const {
+    if (!options_.DeletionVectorsEnabled() ||
+        ResolveBucketMode(options_.GetBucket(), table_schema_) != BucketMode::BUCKET_UNAWARE) {
+        return Status::OK();
+    }
+    for (const ManifestEntry& entry : delta_entries) {
+        if (entry.Kind() == FileKind::Delete()) {
+            return Status::NotImplemented(fmt::format(
+                "Committing the deletion of data file {} is not supported while deletion vectors "
+                "are enabled on a table without buckets: the conflict between it and a concurrent "
+                "commit rewriting that file's deletion vector cannot be detected yet.",
+                entry.File()->file_name));
+        }
+    }
+    return Status::OK();
 }
 
 Status ConflictDetection::CheckBucketKeepSame(

--- a/src/paimon/core/operation/commit/conflict_detection.h
+++ b/src/paimon/core/operation/commit/conflict_detection.h
@@ -81,6 +81,17 @@ class ConflictDetection {
         const std::unordered_map<BinaryRow, int32_t>& previous_total_buckets) const;
 
  private:
+    /// Refuses a delta that drops data files from a bucket-unaware table with deletion vectors.
+    ///
+    /// Such a table keeps its vectors in the index manifest, which the data file entries
+    /// compared here do not reference. Paimon Java pairs the two first
+    /// (ConflictDetection#buildBaseEntriesWithDV) so that dropping a data file conflicts with a
+    /// concurrent commit rewriting that file's vector; that pairing is not ported, so the shape
+    /// needing it is refused rather than let through unchecked. Adding files cannot orphan a
+    /// vector and stays allowed, as does replacing one, which travels through the delta index
+    /// entries this check does not inspect.
+    Status CheckDeletionVectorsNotBypassed(const std::vector<ManifestEntry>& delta_entries) const;
+
     Status CheckBucketKeepSame(const std::vector<ManifestEntry>& all_entries,
                                const Snapshot::CommitKind& commit_kind,
                                const std::string& base_commit_user,

--- a/src/paimon/core/operation/commit/conflict_detection_test.cpp
+++ b/src/paimon/core/operation/commit/conflict_detection_test.cpp
@@ -572,26 +572,10 @@ TEST_F(ConflictDetectionTest, TestBucketKeepSameCacheEviction) {
     ASSERT_EQ(1U, evicted_partition_buckets.size());
 }
 
-TEST_F(ConflictDetectionTest, TestDeletionVectorsNotSupportedWithBucketUnawareMode) {
-    ASSERT_OK_AND_ASSIGN(
-        std::shared_ptr<TableSchema> table_schema,
-        TableSchema::Create(/*schema_id=*/0, arrow::schema(fields_), /*partition_keys=*/{"f1"},
-                            /*primary_keys=*/{}, /*options=*/{}));
-    ASSERT_OK_AND_ASSIGN(CoreOptions core_options,
-                         CoreOptions::FromMap({{Options::BUCKET, "0"},
-                                               {Options::DELETION_VECTORS_ENABLED, "true"}}));
-    ConflictDetection detection(table_schema, core_options, /*snapshot_manager=*/nullptr,
-                                /*manifest_list=*/nullptr, /*manifest_file=*/nullptr,
-                                /*commit_scanner=*/nullptr, "test_user", "test_table",
-                                /*path_factory=*/nullptr);
-
-    ASSERT_NOK_WITH_MSG(CheckConflicts(detection, /*base_entries=*/{}, /*delta_entries=*/{},
-                                       Snapshot::CommitKind::Append()),
-                        "not yet support dv with BUCKET_UNAWARE mode");
-}
-
-TEST_F(ConflictDetectionTest,
-       TestDeletionVectorsNotSupportedWithResolvedBucketUnawareModeFromMinusOne) {
+TEST_F(ConflictDetectionTest, TestDeletionVectorsAllowedWithBucketUnawareMode) {
+    // an unaware bucket table may carry deletion vectors, told apart by index file name rather
+    // than by bucket. Adding files commits; dropping one needs the pairing this class does not
+    // build and is refused
     ASSERT_OK_AND_ASSIGN(
         std::shared_ptr<TableSchema> table_schema,
         TableSchema::Create(/*schema_id=*/0, arrow::schema(fields_), /*partition_keys=*/{"f1"},
@@ -604,9 +588,38 @@ TEST_F(ConflictDetectionTest,
                                 /*commit_scanner=*/nullptr, "test_user", "test_table",
                                 /*path_factory=*/nullptr);
 
-    ASSERT_NOK_WITH_MSG(CheckConflicts(detection, /*base_entries=*/{}, /*delta_entries=*/{},
-                                       Snapshot::CommitKind::Append()),
-                        "not yet support dv with BUCKET_UNAWARE mode");
+    ASSERT_OK(CheckConflicts(detection, /*base_entries=*/{}, /*delta_entries=*/{},
+                             Snapshot::CommitKind::Append()));
+
+    ASSERT_OK(CheckConflicts(detection, /*base_entries=*/{},
+                             {CreateManifestEntry("added.parquet", FileKind::Add())},
+                             Snapshot::CommitKind::Append()));
+
+    ASSERT_NOK_WITH_MSG(
+        CheckConflicts(detection, {CreateManifestEntry("dropped.parquet", FileKind::Add())},
+                       {CreateManifestEntry("dropped.parquet", FileKind::Delete())},
+                       Snapshot::CommitKind::Append()),
+        "Committing the deletion of data file dropped.parquet is not supported");
+}
+
+TEST_F(ConflictDetectionTest, TestDeletionVectorsDeleteAllowedWithoutBucketUnawareMode) {
+    // the guard above is specific to a table whose deletion vectors the entries cannot reference:
+    // a bucketed table pairs them by bucket, so deleting a data file stays allowed there
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<TableSchema> table_schema,
+        TableSchema::Create(/*schema_id=*/0, arrow::schema(fields_), /*partition_keys=*/{"f1"},
+                            /*primary_keys=*/{}, /*options=*/{}));
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options,
+                         CoreOptions::FromMap({{Options::BUCKET, "2"},
+                                               {Options::DELETION_VECTORS_ENABLED, "true"}}));
+    ConflictDetection detection(table_schema, core_options, /*snapshot_manager=*/nullptr,
+                                /*manifest_list=*/nullptr, /*manifest_file=*/nullptr,
+                                /*commit_scanner=*/nullptr, "test_user", "test_table",
+                                /*path_factory=*/nullptr);
+
+    ASSERT_OK(CheckConflicts(detection, {CreateManifestEntry("dropped.parquet", FileKind::Add())},
+                             {CreateManifestEntry("dropped.parquet", FileKind::Delete())},
+                             Snapshot::CommitKind::Append()));
 }
 
 TEST_F(ConflictDetectionTest, TestDeletionVectorsAllowedWithResolvedDynamicBucketMode) {

--- a/src/paimon/core/operation/data_evolution_split_read.cpp
+++ b/src/paimon/core/operation/data_evolution_split_read.cpp
@@ -19,11 +19,13 @@
 #include "paimon/core/operation/data_evolution_split_read.h"
 
 #include <algorithm>
+#include <cassert>
 #include <limits>
 #include <map>
 #include <string>
 #include <string_view>
 #include <thread>
+#include <unordered_map>
 #include <unordered_set>
 #include <utility>
 
@@ -48,9 +50,76 @@
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/range_helper.h"
 #include "paimon/core/core_options.h"
+#include "paimon/core/deletionvectors/apply_deletion_vector_batch_reader.h"
 #include "paimon/core/global_index/indexed_split_impl.h"
 #include "paimon/core/utils/blob_view_lookup.h"
+#include "paimon/core/utils/data_evolution_utils.h"
+
 namespace paimon {
+namespace {
+/// A read-only view over one file's window of a row range group's deletion vector. The reader
+/// probes with positions local to its file; IsDeleted(p) forwards them as IsDeleted(p + offset),
+/// the anchor-relative positions the group deletion vector is indexed by.
+///
+/// The shift rides on a full DeletionVector because that is what DeletionVector::Factory hands
+/// to ApplyIndexAndDvReaderIfNeeded; narrowing it to Paimon Java's read-only DeletionVectorJudger
+/// would reach every caller of the factory. The mutating and serializing halves reject instead.
+class PositionShiftedDeletionVector : public DeletionVector {
+ public:
+    PositionShiftedDeletionVector(const std::shared_ptr<DeletionVector>& inner, int64_t offset,
+                                  int64_t length)
+        : inner_(inner), offset_(offset), length_(length) {}
+
+    Result<bool> IsDeleted(int64_t position) const override {
+        if (position < 0 || position >= length_) {
+            return Status::Invalid(
+                fmt::format("PositionShiftedDeletionVector position {} out of window [0, {})",
+                            position, length_));
+        }
+        return inner_->IsDeleted(position + offset_);
+    }
+
+    /// Conservative: false only means the group deletion vector holds deletions somewhere, not
+    /// necessarily inside this window. Over-reporting just makes the wrapping filter a no-op.
+    bool IsEmpty() const override {
+        return inner_->IsEmpty();
+    }
+
+    /// Deleted positions inside this window. Off the read path, which only calls IsDeleted and
+    /// IsEmpty; the row counting that does consult a vector's cardinality builds its factory
+    /// from the split's deletion files, never from this view.
+    Result<int64_t> GetCardinality() const override {
+        PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 valid, inner_->IsValid(offset_, length_));
+        return length_ - valid.Cardinality();
+    }
+
+    Status Delete(int64_t) override {
+        return Status::Invalid("PositionShiftedDeletionVector is read-only");
+    }
+
+    Result<bool> CheckedDelete(int64_t) override {
+        return Status::Invalid("PositionShiftedDeletionVector is read-only");
+    }
+
+    Status Merge(const std::shared_ptr<DeletionVector>&) override {
+        return Status::Invalid("PositionShiftedDeletionVector is read-only");
+    }
+
+    Result<int32_t> SerializeTo(const std::shared_ptr<MemoryPool>&, DataOutputStream*) override {
+        return Status::Invalid("PositionShiftedDeletionVector does not support serialization");
+    }
+
+    Result<PAIMON_UNIQUE_PTR<Bytes>> SerializeToBytes(const std::shared_ptr<MemoryPool>&) override {
+        return Status::Invalid("PositionShiftedDeletionVector does not support serialization");
+    }
+
+ private:
+    std::shared_ptr<DeletionVector> inner_;
+    const int64_t offset_;
+    const int64_t length_;
+};
+}  // namespace
+
 int64_t DataEvolutionSplitRead::BlobBunch::RowCount() const {
     if (files_.empty()) {
         return 0;
@@ -145,7 +214,8 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateReader(
             batch_reader = std::make_unique<CompleteIndexScoreBatchReader>(
                 std::move(batch_reader), indexed_split->Scores(), pool_);
         }
-        return WrapWithBlobViewResolverIfNeeded(data_split, std::move(batch_reader));
+        return WrapWithBlobViewResolverIfNeeded(data_split, std::move(batch_reader),
+                                                indexed_split->RowRanges());
     } else if (auto data_split = std::dynamic_pointer_cast<DataSplit>(split)) {
         if (HasIndexScoreField(raw_read_schema_)) {
             return Status::Invalid(
@@ -153,14 +223,15 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateReader(
         }
         PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> inner_reader,
                                InnerCreateReader(data_split, /*row_ranges=*/std::nullopt));
-        return WrapWithBlobViewResolverIfNeeded(data_split, std::move(inner_reader));
+        return WrapWithBlobViewResolverIfNeeded(data_split, std::move(inner_reader),
+                                                /*row_ranges=*/std::nullopt);
     }
     return Status::Invalid("Invalid Split, cannot cast to IndexedSplit or DataSplit");
 }
 
 Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::WrapWithBlobViewResolverIfNeeded(
-    const std::shared_ptr<DataSplit>& data_split,
-    std::unique_ptr<BatchReader>&& inner_reader) const {
+    const std::shared_ptr<DataSplit>& data_split, std::unique_ptr<BatchReader>&& inner_reader,
+    const std::optional<std::vector<Range>>& row_ranges) const {
     if (!options_.BlobViewResolveEnabled()) {
         // preserve serialized BlobViewStruct bytes, e.g. for forwarding blob view values to
         // another blob-view table
@@ -176,7 +247,7 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::WrapWithBlobViewRes
             "invalid config for blob view, supposed to set BLOB_VIEW_UPSTREAM_WAREHOUSE");
     }
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> pre_reader,
-                           CreateBlobViewReader(data_split, read_blob_view_fields));
+                           CreateBlobViewReader(data_split, read_blob_view_fields, row_ranges));
     PAIMON_ASSIGN_OR_RAISE(std::unordered_set<BlobViewStruct> blob_view_structs,
                            ExtractBlobViewStructs(pre_reader.get()));
     auto catalog_context = std::make_shared<CatalogContext>(
@@ -194,7 +265,8 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::WrapWithBlobViewRes
 
 Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateBlobViewReader(
     const std::shared_ptr<DataSplit>& data_split,
-    const std::vector<std::string>& read_blob_view_fields) const {
+    const std::vector<std::string>& read_blob_view_fields,
+    const std::optional<std::vector<Range>>& row_ranges) const {
     auto split_impl = dynamic_cast<DataSplitImpl*>(data_split.get());
     if (split_impl == nullptr) {
         return Status::Invalid("unexpected error, split cast to impl failed");
@@ -217,23 +289,40 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateBlobViewReade
         std::shared_ptr<DataFilePathFactory> data_file_path_factory,
         path_factory_->CreateDataFilePathFactory(split_impl->Partition(), split_impl->Bucket()));
 
-    // skip blob files: they only contain blob payloads, not the blob-view columns.
-    std::vector<std::shared_ptr<DataFileMeta>> data_files;
-    data_files.reserve(split_impl->DataFiles().size());
-    for (const auto& file : split_impl->DataFiles()) {
-        if (!BlobUtils::IsBlobFile(file->file_name)) {
-            data_files.push_back(file);
+    DeletionVector::Factory split_dv_factory = CreateSplitDvFactory(*split_impl);
+    auto metas = split_impl->DataFiles();
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> split_by_row_id,
+                           MergeRangesAndSort(std::move(metas)));
+
+    std::vector<std::unique_ptr<BatchReader>> batch_readers;
+    for (const std::vector<std::shared_ptr<DataFileMeta>>& group : split_by_row_id) {
+        // skip blob files: they only contain blob payloads, not the blob-view columns.
+        std::vector<std::shared_ptr<DataFileMeta>> data_files;
+        data_files.reserve(group.size());
+        for (const auto& file : group) {
+            if (!BlobUtils::IsBlobFile(file->file_name)) {
+                data_files.push_back(file);
+            }
+        }
+        if (data_files.empty()) {
+            continue;
+        }
+        // the anchor is looked up over the whole group, as the main read does, so both find the
+        // same deletion vector; only the shifted views are built for the files read here
+        PAIMON_ASSIGN_OR_RAISE(std::optional<GroupDeletionVector> group_dv,
+                               ReadGroupDeletionVector(group, split_dv_factory));
+        PAIMON_ASSIGN_OR_RAISE(DeletionVector::Factory group_dv_factory,
+                               CreateGroupDvFactory(data_files, group_dv));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<std::unique_ptr<FileBatchReader>> raw_file_readers,
+            CreateRawFileReaders(split_impl->Partition(), data_files, blob_view_schema,
+                                 /*predicate=*/nullptr, group_dv_factory, row_ranges,
+                                 data_file_path_factory,
+                                 /*extra_format_options=*/{}));
+        for (std::unique_ptr<FileBatchReader>& raw_file_reader : raw_file_readers) {
+            batch_readers.push_back(std::move(raw_file_reader));
         }
     }
-    PAIMON_ASSIGN_OR_RAISE(
-        std::vector<std::unique_ptr<FileBatchReader>> raw_file_readers,
-        CreateRawFileReaders(split_impl->Partition(), data_files, blob_view_schema,
-                             /*predicate=*/nullptr, /*dv_factory=*/nullptr,
-                             /*row_ranges=*/std::nullopt, data_file_path_factory,
-                             /*extra_format_options=*/{}));
-
-    auto batch_readers =
-        ObjectUtils::MoveVector<std::unique_ptr<BatchReader>>(std::move(raw_file_readers));
     return std::make_unique<ConcatBatchReader>(std::move(batch_readers), pool_);
 }
 
@@ -298,25 +387,32 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::InnerCreateReader(
         std::shared_ptr<DataFilePathFactory> data_file_path_factory,
         path_factory_->CreateDataFilePathFactory(split_impl->Partition(), split_impl->Bucket()));
     auto metas = split_impl->DataFiles();
+    DeletionVector::Factory split_dv_factory = CreateSplitDvFactory(*split_impl);
+
     PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> split_by_row_id,
                            MergeRangesAndSort(std::move(metas)));
 
     std::vector<std::unique_ptr<BatchReader>> sub_readers;
     for (const std::vector<std::shared_ptr<DataFileMeta>>& need_merge_files : split_by_row_id) {
+        PAIMON_ASSIGN_OR_RAISE(std::optional<GroupDeletionVector> group_dv,
+                               ReadGroupDeletionVector(need_merge_files, split_dv_factory));
+        PAIMON_ASSIGN_OR_RAISE(DeletionVector::Factory group_dv_factory,
+                               CreateGroupDvFactory(need_merge_files, group_dv));
         if (need_merge_files.size() == 1) {
             // No need to merge fields, just create a single file reader
             PAIMON_ASSIGN_OR_RAISE(
                 std::vector<std::unique_ptr<FileBatchReader>> raw_file_readers,
                 CreateRawFileReaders(split_impl->Partition(), need_merge_files, raw_read_schema_,
-                                     /*predicate=*/nullptr,
-                                     /*dv_factory=*/nullptr, row_ranges, data_file_path_factory,
+                                     /*predicate=*/nullptr, group_dv_factory, row_ranges,
+                                     data_file_path_factory,
                                      /*extra_format_options=*/{}));
             assert(raw_file_readers.size() == 1);
             sub_readers.push_back(std::move(raw_file_readers[0]));
         } else {
-            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<DataEvolutionFileReader> evolution_reader,
-                                   CreateUnionReader(split_impl->Partition(), need_merge_files,
-                                                     row_ranges, data_file_path_factory));
+            PAIMON_ASSIGN_OR_RAISE(
+                std::unique_ptr<DataEvolutionFileReader> evolution_reader,
+                CreateUnionReader(split_impl->Partition(), need_merge_files, row_ranges,
+                                  data_file_path_factory, group_dv_factory, group_dv));
             sub_readers.push_back(std::move(evolution_reader));
         }
     }
@@ -333,13 +429,17 @@ Result<std::unique_ptr<FileBatchReader>> DataEvolutionSplitRead::ApplyIndexAndDv
     const std::shared_ptr<arrow::Schema>& read_schema, const std::shared_ptr<Predicate>& predicate,
     DeletionVector::Factory dv_factory, const std::optional<std::vector<Range>>& row_ranges,
     const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const {
-    if (dv_factory) {
-        return Status::Invalid("DataEvolutionSplitRead do not support deletion vector");
-    }
     if (predicate) {
         assert(false);
         // as DataEvolutionSplitRead will skip predicate
         return Status::Invalid("DataEvolutionSplitRead do not support predicate");
+    }
+    // the factory is per row range group and already returns a view taking file-local positions.
+    // Unlike RawFileSplitRead the vector is not folded into the format reader's selection: it is
+    // no BitmapDeletionVector, and the blob fallback path's gap segments have no format reader.
+    std::shared_ptr<DeletionVector> deletion_vector;
+    if (dv_factory) {
+        PAIMON_ASSIGN_OR_RAISE(deletion_vector, dv_factory(file->file_name));
     }
     PAIMON_ASSIGN_OR_RAISE(std::optional<RoaringBitmap32> selection_row_ids,
                            file->ToFileSelection(row_ranges));
@@ -358,6 +458,10 @@ Result<std::unique_ptr<FileBatchReader>> DataEvolutionSplitRead::ApplyIndexAndDv
         reader = std::move(file_reader);
     }
 
+    if (deletion_vector && !deletion_vector->IsEmpty()) {
+        reader =
+            std::make_unique<ApplyDeletionVectorBatchReader>(std::move(reader), deletion_vector);
+    }
     return std::move(reader);
 }
 
@@ -398,7 +502,9 @@ DataEvolutionSplitRead::SplitFieldBunches(
 Result<std::unique_ptr<DataEvolutionFileReader>> DataEvolutionSplitRead::CreateUnionReader(
     const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& need_merge_files,
     const std::optional<std::vector<Range>>& row_ranges,
-    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const {
+    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+    const DeletionVector::Factory& group_dv_factory,
+    const std::optional<GroupDeletionVector>& group_dv) const {
     auto blob_field_to_field_id =
         [&](const std::shared_ptr<DataFileMeta>& file_meta) -> Result<int32_t> {
         if (!BlobUtils::IsBlobFile(file_meta->file_name)) {
@@ -493,12 +599,13 @@ Result<std::unique_ptr<DataEvolutionFileReader>> DataEvolutionSplitRead::CreateU
                 PAIMON_ASSIGN_OR_RAISE(
                     file_batch_readers[file_idx],
                     CreateBlobFallbackReader(partition, blob_bunch->Files(), file_read_schema,
-                                             row_ranges, data_file_path_factory));
+                                             row_ranges, data_file_path_factory, group_dv_factory,
+                                             group_dv));
             } else {
                 PAIMON_ASSIGN_OR_RAISE(
                     std::vector<std::unique_ptr<FileBatchReader>> file_readers,
                     CreateRawFileReaders(partition, bunch->Files(), file_read_schema,
-                                         /*predicate=*/nullptr, /*dv_factory=*/{}, row_ranges,
+                                         /*predicate=*/nullptr, group_dv_factory, row_ranges,
                                          data_file_path_factory,
                                          /*extra_format_options=*/{}));
                 if (file_readers.size() == 1) {
@@ -543,7 +650,9 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateBlobFallbackR
     const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files,
     const std::shared_ptr<arrow::Schema>& file_read_schema,
     const std::optional<std::vector<Range>>& row_ranges,
-    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const {
+    const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+    const DeletionVector::Factory& group_dv_factory,
+    const std::optional<GroupDeletionVector>& group_dv) const {
     int64_t union_first_row_id = std::numeric_limits<int64_t>::max();
     int64_t union_last_row_id = std::numeric_limits<int64_t>::min();
     using FileWithFirstRowId = std::pair<int64_t, std::shared_ptr<DataFileMeta>>;
@@ -579,6 +688,13 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateBlobFallbackR
             if (first_row_id > next_row_id) {
                 std::vector<Range> gap_selected_ranges =
                     SelectedRangesInRange(next_row_id, first_row_id - 1, row_ranges);
+                if (group_dv && !gap_selected_ranges.empty()) {
+                    // gap segments have no file reader to wrap, so the deleted row ids are
+                    // dropped from their ranges to stay aligned with the other layers
+                    PAIMON_ASSIGN_OR_RAISE(
+                        gap_selected_ranges,
+                        ExcludeDeletedRowIds(gap_selected_ranges, group_dv.value()));
+                }
                 if (!gap_selected_ranges.empty()) {
                     segments.push_back(
                         BlobFallbackBatchReader::Segment{nullptr, std::move(gap_selected_ranges)});
@@ -587,7 +703,7 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateBlobFallbackR
             PAIMON_ASSIGN_OR_RAISE(
                 std::vector<std::unique_ptr<FileBatchReader>> file_readers,
                 CreateRawFileReaders(partition, {file}, file_read_schema,
-                                     /*predicate=*/nullptr, /*dv_factory=*/{}, row_ranges,
+                                     /*predicate=*/nullptr, group_dv_factory, row_ranges,
                                      data_file_path_factory, blob_format_options));
             if (file_readers.size() != 1) {
                 return Status::Invalid("Unexpected: blob fallback file reader was skipped.");
@@ -598,6 +714,10 @@ Result<std::unique_ptr<BatchReader>> DataEvolutionSplitRead::CreateBlobFallbackR
         if (next_row_id <= union_last_row_id) {
             std::vector<Range> gap_selected_ranges =
                 SelectedRangesInRange(next_row_id, union_last_row_id, row_ranges);
+            if (group_dv && !gap_selected_ranges.empty()) {
+                PAIMON_ASSIGN_OR_RAISE(gap_selected_ranges,
+                                       ExcludeDeletedRowIds(gap_selected_ranges, group_dv.value()));
+            }
             if (!gap_selected_ranges.empty()) {
                 segments.push_back(
                     BlobFallbackBatchReader::Segment{nullptr, std::move(gap_selected_ranges)});
@@ -674,5 +794,104 @@ DataEvolutionSplitRead::MergeRangesAndSort(std::vector<std::shared_ptr<DataFileM
                      std::make_move_iterator(blob_files.end()));
     }
     return result;
+}
+
+DeletionVector::Factory DataEvolutionSplitRead::CreateSplitDvFactory(
+    const DataSplitImpl& split_impl) const {
+    const std::vector<std::optional<DeletionFile>>& deletion_files = split_impl.DeletionFiles();
+    bool has_deletion_files =
+        std::any_of(deletion_files.begin(), deletion_files.end(),
+                    [](const std::optional<DeletionFile>& file) { return file != std::nullopt; });
+    if (!has_deletion_files) {
+        return DeletionVector::Factory();
+    }
+    return DeletionVector::CreateFactory(
+        options_.GetFileSystem(),
+        DeletionVector::CreateDeletionFileMap(split_impl.DataFiles(), deletion_files), pool_);
+}
+
+Result<std::optional<DataEvolutionSplitRead::GroupDeletionVector>>
+DataEvolutionSplitRead::ReadGroupDeletionVector(
+    const std::vector<std::shared_ptr<DataFileMeta>>& group,
+    const DeletionVector::Factory& split_dv_factory) {
+    if (!split_dv_factory) {
+        return std::optional<GroupDeletionVector>();
+    }
+    // A split may pack a group holding nothing but blob files, written when only the blob column
+    // was, next to one that does carry a deletion vector. No anchor means no writer could have
+    // keyed a vector by it, so it reads undeleted instead of failing the whole split.
+    if (std::none_of(group.begin(), group.end(), [](const std::shared_ptr<DataFileMeta>& file) {
+            return DataEvolutionUtils::IsNormalFile(file->file_name);
+        })) {
+        return std::optional<GroupDeletionVector>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<DataFileMeta> anchor,
+                           DataEvolutionUtils::RetrieveAnchorFile(group));
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<DeletionVector> deletion_vector,
+                           split_dv_factory(anchor->file_name));
+    if (!deletion_vector || deletion_vector->IsEmpty()) {
+        return std::optional<GroupDeletionVector>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(int64_t anchor_first_row_id, anchor->NonNullFirstRowId());
+    return std::make_optional(GroupDeletionVector{
+        deletion_vector, Range(anchor_first_row_id, anchor_first_row_id + anchor->row_count - 1)});
+}
+
+Result<DeletionVector::Factory> DataEvolutionSplitRead::CreateGroupDvFactory(
+    const std::vector<std::shared_ptr<DataFileMeta>>& group,
+    const std::optional<GroupDeletionVector>& group_dv) {
+    if (!group_dv) {
+        return DeletionVector::Factory();
+    }
+    auto shifted_dvs =
+        std::make_shared<std::unordered_map<std::string, std::shared_ptr<DeletionVector>>>();
+    for (const auto& file : group) {
+        PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+        int64_t last_row_id = first_row_id + file->row_count - 1;
+        if (first_row_id < group_dv->anchor_range.from || last_row_id > group_dv->anchor_range.to) {
+            return Status::Invalid(fmt::format(
+                "Deletion vector range [{}, {}] should contain row id range [{}, {}] of file {}.",
+                group_dv->anchor_range.from, group_dv->anchor_range.to, first_row_id, last_row_id,
+                file->file_name));
+        }
+        int64_t offset = first_row_id - group_dv->anchor_range.from;
+        bool covers_whole_anchor_range = offset == 0 && last_row_id == group_dv->anchor_range.to;
+        (*shifted_dvs)[file->file_name] =
+            covers_whole_anchor_range ? group_dv->deletion_vector
+                                      : std::make_shared<PositionShiftedDeletionVector>(
+                                            group_dv->deletion_vector, offset, file->row_count);
+    }
+    return DeletionVector::Factory(
+        [shifted_dvs](const std::string& file_name) -> Result<std::shared_ptr<DeletionVector>> {
+            auto iter = shifted_dvs->find(file_name);
+            if (iter == shifted_dvs->end()) {
+                return std::shared_ptr<DeletionVector>();
+            }
+            return iter->second;
+        });
+}
+
+Result<std::vector<Range>> DataEvolutionSplitRead::ExcludeDeletedRowIds(
+    const std::vector<Range>& ranges, const GroupDeletionVector& group_dv) {
+    std::vector<Range> remaining;
+    for (const auto& range : ranges) {
+        std::optional<int64_t> run_start;
+        for (int64_t row_id = range.from; row_id <= range.to; row_id++) {
+            PAIMON_ASSIGN_OR_RAISE(bool is_deleted, group_dv.deletion_vector->IsDeleted(
+                                                        row_id - group_dv.anchor_range.from));
+            if (is_deleted) {
+                if (run_start) {
+                    remaining.emplace_back(run_start.value(), row_id - 1);
+                    run_start = std::nullopt;
+                }
+            } else if (!run_start) {
+                run_start = row_id;
+            }
+        }
+        if (run_start) {
+            remaining.emplace_back(run_start.value(), range.to);
+        }
+    }
+    return remaining;
 }
 }  // namespace paimon

--- a/src/paimon/core/operation/data_evolution_split_read.h
+++ b/src/paimon/core/operation/data_evolution_split_read.h
@@ -44,6 +44,7 @@ class Schema;
 namespace paimon {
 class DataFilePathFactory;
 class DataSplit;
+class DataSplitImpl;
 class Executor;
 class FileBatchReader;
 class FileStorePathFactory;
@@ -61,14 +62,21 @@ struct DeletionFile;
 /// CompleteRowKindBatchReader->(PredicateBatchReader)
 /// ->ConcatBatchReader across files->DataEvolutionFileReader
 /// ->(ConcatBatchReader across blob files | BlobFallbackBatchReader across blob sequence layers)
-/// ->FieldMappingReader->(CompleteRowTrackingFieldsBatchReader)->(ShreddingFileReader)
+/// ->FieldMappingReader->(ApplyDeletionVectorBatchReader)->(ApplyBitmapIndexBatchReader)
+/// ->(CompleteRowTrackingFieldsBatchReader)->(ShreddingFileReader)
 /// ->(MapSharedShreddingFileReader)
 /// ->(DelegatingPrefetchReader)->(PrefetchFileBatchReader)->FormatReader
 ///
 ///
 /// A union `SplitRead` to read multiple inner files to merge columns, note that this class
-/// does not support filtering push down and deletion vectors, as they can interfere with the
-/// process of merging columns.
+/// does not support filtering push down: a predicate would have to be evaluated consistently
+/// across the files being merged, which is not implemented here.
+///
+/// Deletion vectors are supported: a row range group's vector is maintained against the
+/// group's anchor file (DataEvolutionUtils::RetrieveAnchorFile), so its positions are
+/// anchor-relative. Every reader of the group must drop the same rows to keep the column merge
+/// aligned: file readers apply it shifted by the file's offset inside the anchor range, and the
+/// blob fallback path drops the deleted row ids from its placeholder gap segments.
 class DataEvolutionSplitRead : public AbstractSplitRead {
  public:
     DataEvolutionSplitRead(const std::shared_ptr<FileStorePathFactory>& path_factory,
@@ -152,10 +160,41 @@ class DataEvolutionSplitRead : public AbstractSplitRead {
         std::vector<std::shared_ptr<DataFileMeta>> files_;
     };
 
+    /// The deletion vector of one row range group, read from the group's anchor file. Its
+    /// positions are relative to `anchor_range`, the anchor file's row id range.
+    struct GroupDeletionVector {
+        std::shared_ptr<DeletionVector> deletion_vector;
+        Range anchor_range;
+    };
+
  private:
     Result<std::unique_ptr<BatchReader>> InnerCreateReader(
         const std::shared_ptr<DataSplit>& data_split,
         const std::optional<std::vector<Range>>& row_ranges) const;
+
+    /// Builds the deletion vector factory over the split's deletion files, keyed by data file
+    /// name. Only anchor files carry one. Returns a null factory when the split has none.
+    DeletionVector::Factory CreateSplitDvFactory(const DataSplitImpl& split_impl) const;
+
+    /// Reads the deletion vector of one row range group from its anchor file. Returns nullopt
+    /// when `split_dv_factory` is null, or when the anchor carries no deletion vector or an
+    /// empty one.
+    static Result<std::optional<GroupDeletionVector>> ReadGroupDeletionVector(
+        const std::vector<std::shared_ptr<DataFileMeta>>& group,
+        const DeletionVector::Factory& split_dv_factory);
+
+    /// Builds the per-file deletion vector factory of one row range group: each file gets the
+    /// group's deletion vector at its own local positions, shifted by the file's offset inside
+    /// the anchor range and limited to its row count. Null factory when the group has no vector.
+    static Result<DeletionVector::Factory> CreateGroupDvFactory(
+        const std::vector<std::shared_ptr<DataFileMeta>>& group,
+        const std::optional<GroupDeletionVector>& group_dv);
+
+    /// Removes the row ids deleted by `group_dv` from the sorted disjoint `ranges` (absolute
+    /// row ids). Probes the vector once per row id, since it exposes no range API; the cost is
+    /// paid once per gap segment while building the reader, not per batch.
+    static Result<std::vector<Range>> ExcludeDeletedRowIds(const std::vector<Range>& ranges,
+                                                           const GroupDeletionVector& group_dv);
 
     static Result<std::vector<std::shared_ptr<DataEvolutionSplitRead::FieldBunch>>>
     SplitFieldBunches(const std::vector<std::shared_ptr<DataFileMeta>>& need_merge_files,
@@ -172,30 +211,45 @@ class DataEvolutionSplitRead : public AbstractSplitRead {
 
     static Result<std::unordered_set<BlobViewStruct>> ExtractBlobViewStructs(BatchReader* reader);
 
+    /// Pre-reads the blob view columns of `data_split` to collect the BlobViewStructs to
+    /// resolve. It applies the same `row_ranges` selection and the same row range group deletion
+    /// vectors as the main read, so a reference held only by a row those two drop is never
+    /// resolved.
+    ///
+    /// It stays wider than the main read: it passes no predicate and reads a group's normal
+    /// files one by one instead of merging their columns, so a reference the main read would
+    /// filter out or overwrite is still resolved here, and a dangling one still fails the query.
     Result<std::unique_ptr<BatchReader>> CreateBlobViewReader(
         const std::shared_ptr<DataSplit>& data_split,
-        const std::vector<std::string>& read_blob_view_fields) const;
+        const std::vector<std::string>& read_blob_view_fields,
+        const std::optional<std::vector<Range>>& row_ranges) const;
 
     Result<std::unique_ptr<BatchReader>> WrapWithBlobViewResolverIfNeeded(
-        const std::shared_ptr<DataSplit>& data_split,
-        std::unique_ptr<BatchReader>&& inner_reader) const;
+        const std::shared_ptr<DataSplit>& data_split, std::unique_ptr<BatchReader>&& inner_reader,
+        const std::optional<std::vector<Range>>& row_ranges) const;
 
  private:
     Result<std::unique_ptr<DataEvolutionFileReader>> CreateUnionReader(
         const BinaryRow& partition,
         const std::vector<std::shared_ptr<DataFileMeta>>& need_merge_files,
         const std::optional<std::vector<Range>>& row_ranges,
-        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const;
+        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+        const DeletionVector::Factory& group_dv_factory,
+        const std::optional<GroupDeletionVector>& group_dv) const;
 
     /// Builds the row-level fallback reader for a blob bunch spanning multiple max sequence
     /// number layers: groups the files by max sequence number, pads uncovered row id ranges of
     /// each layer with placeholder gap segments, and resolves each row to the newest
-    /// non-placeholder layer. See BlobFallbackBatchReader.
+    /// non-placeholder layer. See BlobFallbackBatchReader. `group_dv_factory` wraps the file
+    /// readers and `group_dv` drops deleted row ids from the gap segments, so every layer keeps
+    /// emitting the same surviving rows.
     Result<std::unique_ptr<BatchReader>> CreateBlobFallbackReader(
         const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files,
         const std::shared_ptr<arrow::Schema>& file_read_schema,
         const std::optional<std::vector<Range>>& row_ranges,
-        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory) const;
+        const std::shared_ptr<DataFilePathFactory>& data_file_path_factory,
+        const DeletionVector::Factory& group_dv_factory,
+        const std::optional<GroupDeletionVector>& group_dv) const;
 };
 
 }  // namespace paimon

--- a/src/paimon/core/operation/data_evolution_split_read_test.cpp
+++ b/src/paimon/core/operation/data_evolution_split_read_test.cpp
@@ -25,6 +25,7 @@
 
 #include "gtest/gtest.h"
 #include "paimon/common/data/binary_row.h"
+#include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 #include "paimon/core/io/data_file_meta.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/core/operation/internal_read_context.h"
@@ -687,6 +688,161 @@ TEST_F(DataEvolutionSplitReadTest, TestSplitWithMultipleBlobFilesPerGroup) {
     std::vector<std::vector<std::shared_ptr<DataFileMeta>>> expected_metas = {
         {files[6], files[0], files[1], files[2]}, {files[3], files[4], files[5]}};
     ASSERT_EQ(expected_metas, split_metas);
+}
+
+namespace {
+std::shared_ptr<DeletionVector> MakeBitmapDv(const std::vector<int64_t>& deleted_positions) {
+    RoaringBitmap32 bitmap;
+    for (int64_t position : deleted_positions) {
+        bitmap.Add(static_cast<uint32_t>(position));
+    }
+    return std::make_shared<BitmapDeletionVector>(bitmap);
+}
+
+DeletionVector::Factory MakeSingleFileDvFactory(const std::string& expected_file_name,
+                                                const std::shared_ptr<DeletionVector>& dv) {
+    return [expected_file_name,
+            dv](const std::string& file_name) -> Result<std::shared_ptr<DeletionVector>> {
+        if (file_name == expected_file_name) {
+            return dv;
+        }
+        return std::shared_ptr<DeletionVector>();
+    };
+}
+}  // namespace
+
+TEST_F(DataEvolutionSplitReadTest, TestReadGroupDeletionVector) {
+    // the anchor is the oldest normal file; blob files never anchor the deletion vector
+    std::vector<std::shared_ptr<DataFileMeta>> group = {
+        CreateNormalFile("newest.parquet", /*first_row_id=*/0, /*row_count=*/100,
+                         /*max_sequence_number=*/20),
+        CreateNormalFile("anchor.parquet", /*first_row_id=*/0, /*row_count=*/100,
+                         /*max_sequence_number=*/10),
+        CreateDataFileMeta("blob0.blob", /*first_row_id=*/0, /*row_count=*/100, /*max_seq=*/5)};
+
+    auto dv = MakeBitmapDv({3, 7});
+    ASSERT_OK_AND_ASSIGN(std::optional<DataEvolutionSplitRead::GroupDeletionVector> group_dv,
+                         DataEvolutionSplitRead::ReadGroupDeletionVector(
+                             group, MakeSingleFileDvFactory("anchor.parquet", dv)));
+    ASSERT_TRUE(group_dv.has_value());
+    ASSERT_EQ(group_dv->deletion_vector, dv);
+    ASSERT_EQ(group_dv->anchor_range, Range(0, 99));
+
+    // no deletion vector on the anchor file
+    ASSERT_OK_AND_ASSIGN(group_dv, DataEvolutionSplitRead::ReadGroupDeletionVector(
+                                       group, MakeSingleFileDvFactory("newest.parquet", dv)));
+    ASSERT_FALSE(group_dv.has_value());
+
+    // an empty deletion vector is treated as absent
+    ASSERT_OK_AND_ASSIGN(group_dv,
+                         DataEvolutionSplitRead::ReadGroupDeletionVector(
+                             group, MakeSingleFileDvFactory("anchor.parquet", MakeBitmapDv({}))));
+    ASSERT_FALSE(group_dv.has_value());
+
+    // a split without any deletion file hands down a null factory, which is not an error
+    ASSERT_OK_AND_ASSIGN(group_dv, DataEvolutionSplitRead::ReadGroupDeletionVector(
+                                       group, DeletionVector::Factory()));
+    ASSERT_FALSE(group_dv.has_value());
+
+    // a group of nothing but dedicated storage files has no anchor, so no deletion vector can be
+    // keyed by it. The split's factory is non-null because another group of the same split
+    // carries one, which must not fail this group's read.
+    std::vector<std::shared_ptr<DataFileMeta>> anchorless_group = {
+        CreateDataFileMeta("blob1.blob", /*first_row_id=*/100, /*row_count=*/100, /*max_seq=*/5),
+        CreateDataFileMeta("blob2.blob", /*first_row_id=*/100, /*row_count=*/100, /*max_seq=*/6),
+        CreateDataFileMeta("vector-store.vector.parquet", /*first_row_id=*/100, /*row_count=*/100,
+                           /*max_seq=*/7)};
+    ASSERT_OK_AND_ASSIGN(group_dv,
+                         DataEvolutionSplitRead::ReadGroupDeletionVector(
+                             anchorless_group, MakeSingleFileDvFactory("anchor.parquet", dv)));
+    ASSERT_FALSE(group_dv.has_value());
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestCreateGroupDvFactoryShiftsPositions) {
+    auto anchor = CreateNormalFile("anchor.parquet", /*first_row_id=*/100, /*row_count=*/100,
+                                   /*max_sequence_number=*/10);
+    // blob file covers row ids [140, 169], its offset inside the anchor range is 40
+    auto blob = CreateDataFileMeta("blob0.blob", /*first_row_id=*/140, /*row_count=*/30,
+                                   /*max_seq=*/20);
+    std::vector<std::shared_ptr<DataFileMeta>> group = {anchor, blob};
+
+    // deletion vector positions are anchor-relative: positions {10, 45} are row ids {110, 145}
+    DataEvolutionSplitRead::GroupDeletionVector group_dv{MakeBitmapDv({10, 45}), Range(100, 199)};
+    ASSERT_OK_AND_ASSIGN(DeletionVector::Factory factory,
+                         DataEvolutionSplitRead::CreateGroupDvFactory(group, group_dv));
+    ASSERT_TRUE(factory);
+
+    // the anchor file reads the deletion vector unshifted
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<DeletionVector> anchor_dv, factory("anchor.parquet"));
+    ASSERT_TRUE(anchor_dv);
+    ASSERT_OK_AND_ASSIGN(bool is_deleted, anchor_dv->IsDeleted(10));
+    ASSERT_TRUE(is_deleted);
+    ASSERT_OK_AND_ASSIGN(is_deleted, anchor_dv->IsDeleted(45));
+    ASSERT_TRUE(is_deleted);
+    ASSERT_OK_AND_ASSIGN(is_deleted, anchor_dv->IsDeleted(5));
+    ASSERT_FALSE(is_deleted);
+
+    // the blob file reads it shifted to its local positions: local 5 is row id 145
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<DeletionVector> blob_dv, factory("blob0.blob"));
+    ASSERT_TRUE(blob_dv);
+    ASSERT_OK_AND_ASSIGN(is_deleted, blob_dv->IsDeleted(5));
+    ASSERT_TRUE(is_deleted);
+    ASSERT_OK_AND_ASSIGN(is_deleted, blob_dv->IsDeleted(10));
+    ASSERT_FALSE(is_deleted);
+    ASSERT_FALSE(blob_dv->IsEmpty());
+    // the view is limited to the blob file's 30-row window: cardinality only counts the
+    // deleted position inside the window, probing beyond the window is rejected
+    ASSERT_EQ(blob_dv->GetCardinality().value(), 1);
+    ASSERT_NOK_WITH_MSG(blob_dv->IsDeleted(30), "out of window");
+
+    // the mutating and serializing halves would silently drop the shift, so they reject
+    ASSERT_NOK_WITH_MSG(blob_dv->Delete(0), "read-only");
+    ASSERT_NOK_WITH_MSG(blob_dv->CheckedDelete(0), "read-only");
+    ASSERT_NOK_WITH_MSG(blob_dv->Merge(MakeBitmapDv({0})), "read-only");
+    ASSERT_NOK_WITH_MSG(blob_dv->SerializeTo(GetDefaultPool(), /*out=*/nullptr),
+                        "does not support serialization");
+    ASSERT_NOK_WITH_MSG(blob_dv->SerializeToBytes(GetDefaultPool()),
+                        "does not support serialization");
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<DeletionVector> unknown_dv, factory("unknown.parquet"));
+    ASSERT_FALSE(unknown_dv);
+
+    ASSERT_OK_AND_ASSIGN(DeletionVector::Factory null_factory,
+                         DataEvolutionSplitRead::CreateGroupDvFactory(group, std::nullopt));
+    ASSERT_FALSE(null_factory);
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestCreateGroupDvFactoryRejectsFileOutsideAnchorRange) {
+    auto anchor = CreateNormalFile("anchor.parquet", /*first_row_id=*/100, /*row_count=*/100,
+                                   /*max_sequence_number=*/10);
+    auto blob = CreateDataFileMeta("blob0.blob", /*first_row_id=*/180, /*row_count=*/30,
+                                   /*max_seq=*/20);
+    std::vector<std::shared_ptr<DataFileMeta>> group = {anchor, blob};
+
+    DataEvolutionSplitRead::GroupDeletionVector group_dv{MakeBitmapDv({10}), Range(100, 199)};
+    ASSERT_NOK_WITH_MSG(DataEvolutionSplitRead::CreateGroupDvFactory(group, group_dv),
+                        "should contain row id range");
+}
+
+TEST_F(DataEvolutionSplitReadTest, TestExcludeDeletedRowIds) {
+    // anchor range starts at 100, deleted anchor positions {3, 4, 7} are row ids {103, 104, 107}
+    DataEvolutionSplitRead::GroupDeletionVector group_dv{MakeBitmapDv({3, 4, 7}), Range(100, 199)};
+
+    ASSERT_OK_AND_ASSIGN(std::vector<Range> remaining,
+                         DataEvolutionSplitRead::ExcludeDeletedRowIds({Range(102, 108)}, group_dv));
+    std::vector<Range> expected = {Range(102, 102), Range(105, 106), Range(108, 108)};
+    ASSERT_EQ(remaining, expected);
+
+    // ranges without deleted rows are kept whole
+    ASSERT_OK_AND_ASSIGN(remaining, DataEvolutionSplitRead::ExcludeDeletedRowIds(
+                                        {Range(110, 115), Range(120, 121)}, group_dv));
+    expected = {Range(110, 115), Range(120, 121)};
+    ASSERT_EQ(remaining, expected);
+
+    // a fully deleted range disappears
+    ASSERT_OK_AND_ASSIGN(remaining,
+                         DataEvolutionSplitRead::ExcludeDeletedRowIds({Range(103, 104)}, group_dv));
+    ASSERT_TRUE(remaining.empty());
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/operation/file_store_scan.h
+++ b/src/paimon/core/operation/file_store_scan.h
@@ -152,6 +152,10 @@ class FileStoreScan {
         return predicates_;
     }
 
+    const std::optional<RowRangeIndex>& GetRowRangeIndex() const {
+        return row_range_index_;
+    }
+
     std::shared_ptr<PredicateFilter> GetPartitionPredicate() const {
         return partition_filter_;
     }

--- a/src/paimon/core/schema/schema_validation.cpp
+++ b/src/paimon/core/schema/schema_validation.cpp
@@ -479,9 +479,6 @@ Status SchemaValidation::ValidateRowTracking(const TableSchema& table_schema,
     if (options.DataEvolutionEnabled()) {
         PAIMON_RETURN_NOT_OK(Preconditions::CheckState(
             row_tracking_enabled, "Data evolution config must enabled with row-tracking.enabled"));
-        PAIMON_RETURN_NOT_OK(Preconditions::CheckState(
-            !options.DeletionVectorsEnabled(),
-            "Data evolution config must disabled with deletion-vectors.enabled"));
     }
 
     std::vector<std::string> blob_names;

--- a/src/paimon/core/schema/schema_validation_test.cpp
+++ b/src/paimon/core/schema/schema_validation_test.cpp
@@ -63,6 +63,14 @@ TEST(SchemaValidationTest, TestRowTracking) {
         std::shared_ptr<TableSchema> table_schema,
         TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
     ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+
+    // such a table may also enable deletion vectors, which another engine issues and this one
+    // only reads
+    options.emplace(Options::DELETION_VECTORS_ENABLED, "true");
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<TableSchema> deletion_vector_table_schema,
+        TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+    ASSERT_OK(SchemaValidation::ValidateTableSchema(*deletion_vector_table_schema));
 }
 
 TEST(SchemaValidationTest, TestWithBlobField) {
@@ -79,6 +87,22 @@ TEST(SchemaValidationTest, TestWithBlobField) {
         std::map<std::string, std::string> options = {{Options::BUCKET, "-1"},
                                                       {Options::ROW_TRACKING_ENABLED, "true"},
                                                       {Options::DATA_EVOLUTION_ENABLED, "true"},
+                                                      {Options::BLOB_FIELD, "f3"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // a blob table with data evolution may also enable deletion vectors
+        arrow::FieldVector fields = {f0, f1, f2, f3};
+        auto schema = arrow::schema(fields);
+        std::vector<std::string> primary_keys = {};
+        std::vector<std::string> partition_keys = {"f1"};
+        std::map<std::string, std::string> options = {{Options::BUCKET, "-1"},
+                                                      {Options::ROW_TRACKING_ENABLED, "true"},
+                                                      {Options::DATA_EVOLUTION_ENABLED, "true"},
+                                                      {Options::DELETION_VECTORS_ENABLED, "true"},
                                                       {Options::BLOB_FIELD, "f3"}};
         ASSERT_OK_AND_ASSIGN(
             std::shared_ptr<TableSchema> table_schema,
@@ -772,16 +796,6 @@ TEST(SchemaValidationTest, ValidateInvalidConfiguration) {
                                                  /*primary_keys=*/{}, options));
         ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
                             "Data evolution config must enabled with row-tracking.enabled");
-    }
-    {
-        std::map<std::string, std::string> options = {{Options::ROW_TRACKING_ENABLED, "true"},
-                                                      {Options::DATA_EVOLUTION_ENABLED, "true"},
-                                                      {Options::DELETION_VECTORS_ENABLED, "true"}};
-        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
-                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
-                                                 /*primary_keys=*/{}, options));
-        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
-                            "Data evolution config must disabled with deletion-vectors.enabled");
     }
 }
 

--- a/src/paimon/core/table/source/data_split_impl.cpp
+++ b/src/paimon/core/table/source/data_split_impl.cpp
@@ -158,7 +158,8 @@ Result<std::optional<int64_t>> DataSplitImpl::RawMergedRowCount(
                 return Status::Invalid(
                     "deletion vector not found for file with missing cardinality");
             }
-            sum += data_file->row_count - deletion_vector->GetCardinality();
+            PAIMON_ASSIGN_OR_RAISE(int64_t deleted_row_count, deletion_vector->GetCardinality());
+            sum += data_file->row_count - deleted_row_count;
         }
     }
 
@@ -166,9 +167,17 @@ Result<std::optional<int64_t>> DataSplitImpl::RawMergedRowCount(
 }
 
 bool DataSplitImpl::DataEvolutionRowCountAvailable() const {
-    return std::all_of(data_files_.begin(), data_files_.end(),
-                       [](const std::shared_ptr<DataFileMeta>& file) {
-                           return file->first_row_id != std::nullopt;
+    bool all_files_have_first_row_id = std::all_of(data_files_.begin(), data_files_.end(),
+                                                   [](const std::shared_ptr<DataFileMeta>& file) {
+                                                       return file->first_row_id != std::nullopt;
+                                                   });
+    if (!all_files_have_first_row_id) {
+        return false;
+    }
+    return std::all_of(data_deletion_files_.begin(), data_deletion_files_.end(),
+                       [](const std::optional<DeletionFile>& deletion_file) {
+                           return deletion_file == std::nullopt ||
+                                  deletion_file.value().cardinality != std::nullopt;
                        });
 }
 
@@ -192,6 +201,11 @@ Result<int64_t> DataSplitImpl::DataEvolutionMergedRowCount() const {
             max_count = std::max(max_count, file->row_count);
         }
         sum += max_count;
+    }
+    for (const auto& deletion_file : data_deletion_files_) {
+        if (deletion_file != std::nullopt) {
+            sum -= deletion_file.value().cardinality.value();
+        }
     }
     return sum;
 }

--- a/src/paimon/core/table/source/data_split_impl.h
+++ b/src/paimon/core/table/source/data_split_impl.h
@@ -202,6 +202,8 @@ class DataSplitImpl : public DataSplit {
     std::vector<std::shared_ptr<DataFileMeta>> before_files_;
     std::vector<std::optional<DeletionFile>> before_deletion_files_;
     std::vector<std::shared_ptr<DataFileMeta>> data_files_;
+    /// Either empty or aligned one-to-one with `data_files_`. For data evolution tables, only
+    /// anchor files (the oldest normal file of a row range group) carry a deletion file.
     std::vector<std::optional<DeletionFile>> data_deletion_files_;
 
     bool is_streaming_ = false;

--- a/src/paimon/core/table/source/data_split_test.cpp
+++ b/src/paimon/core/table/source/data_split_test.cpp
@@ -1323,6 +1323,139 @@ TEST(DataSplitTest, TestPartialMergedRowCountFallsBackToDataEvolution) {
     ASSERT_EQ(std::optional<int64_t>(7), merged_row_count);
 }
 
+TEST(DataSplitTest, TestDataEvolutionMergedRowCountSubtractsDeletionFileCardinality) {
+    auto pool = GetDefaultPool();
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-0.orc", /*file_size=*/100, /*row_count=*/5, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562946338ll, 0),
+        /*delete_row_count=*/std::nullopt, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/100,
+        /*write_cols=*/std::nullopt);
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-1.orc", /*file_size=*/100, /*row_count=*/5, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_sequence_number=*/3, /*max_sequence_number=*/7, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562947338ll, 0),
+        /*delete_row_count=*/std::nullopt, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/100,
+        /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/"fake_table/f1=10/bucket-0", {file_meta1, file_meta2});
+
+    // only the anchor file of the row range group carries a deletion file
+    auto data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1)
+            .WithDataDeletionFiles({DeletionFile("fake/index-0", /*offset=*/1, /*length=*/22,
+                                                 /*cardinality=*/2),
+                                    std::nullopt})
+            .IsStreaming(false)
+            .RawConvertible(false)
+            .Build()
+            .value());
+
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> merged_row_count, data_split->MergedRowCount());
+    ASSERT_EQ(std::optional<int64_t>(3), merged_row_count);
+}
+
+// A data evolution split carrying deletion files is planned by one engine and read by another,
+// so the combination of first row ids and deletion files has to survive a serialization round
+// trip. Mirrors Java's DataSplitCompatibleTest#testDeletionFilesSerialize.
+TEST(DataSplitTest, TestSerializeDataEvolutionSplitWithDeletionFiles) {
+    auto pool = GetDefaultPool();
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-0.orc", /*file_size=*/100, /*row_count=*/10, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562946338ll, 0),
+        /*delete_row_count=*/std::nullopt, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/0,
+        /*write_cols=*/std::nullopt);
+    auto file_meta2 = std::make_shared<DataFileMeta>(
+        "data-1.orc", /*file_size=*/100, /*row_count=*/10, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_sequence_number=*/3, /*max_sequence_number=*/7, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562947338ll, 0),
+        /*delete_row_count=*/std::nullopt, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/0,
+        /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/"fake_table/f1=10/bucket-0", {file_meta1, file_meta2});
+    // only the anchor file of the row range group carries a deletion file
+    auto data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1)
+            .WithTotalBuckets(1)
+            .WithDataDeletionFiles({DeletionFile("fake/index-0", /*offset=*/1, /*length=*/22,
+                                                 /*cardinality=*/3),
+                                    std::nullopt})
+            .IsStreaming(false)
+            .RawConvertible(false)
+            .Build()
+            .value());
+
+    ASSERT_OK_AND_ASSIGN(std::string serialize_bytes, Split::Serialize(data_split, pool));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Split> deserialized,
+                         Split::Deserialize(serialize_bytes.data(), serialize_bytes.size(), pool));
+    auto result_data_split = std::dynamic_pointer_cast<DataSplitImpl>(deserialized);
+    ASSERT_TRUE(result_data_split);
+
+    ASSERT_EQ(*result_data_split, *data_split) << result_data_split->ToString();
+    ASSERT_EQ(result_data_split->DeletionFiles().size(), 2);
+    ASSERT_TRUE(result_data_split->DeletionFiles()[0].has_value());
+    ASSERT_EQ(result_data_split->DeletionFiles()[0].value().cardinality, std::optional<int64_t>(3));
+    ASSERT_FALSE(result_data_split->DeletionFiles()[1].has_value());
+    for (const auto& file : result_data_split->DataFiles()) {
+        ASSERT_EQ(file->first_row_id, std::optional<int64_t>(0));
+    }
+    // the deletion vector still shortens the merged row count after the round trip
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> merged_row_count,
+                         result_data_split->MergedRowCount());
+    ASSERT_EQ(std::optional<int64_t>(7), merged_row_count);
+}
+
+TEST(DataSplitTest, TestDataEvolutionMergedRowCountUnavailableWithoutCardinality) {
+    auto pool = GetDefaultPool();
+    auto file_meta1 = std::make_shared<DataFileMeta>(
+        "data-0.orc", /*file_size=*/100, /*row_count=*/5, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_sequence_number=*/0, /*max_sequence_number=*/2, /*schema_id=*/0,
+        /*level=*/0, /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(1725562946338ll, 0),
+        /*delete_row_count=*/std::nullopt, /*embedded_index=*/nullptr, FileSource::Append(),
+        /*value_stats_cols=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*first_row_id=*/100,
+        /*write_cols=*/std::nullopt);
+
+    DataSplitImpl::Builder builder(
+        /*partition=*/BinaryRowGenerator::GenerateRow({10}, pool.get()),
+        /*bucket=*/0, /*bucket_path=*/"fake_table/f1=10/bucket-0", {file_meta1});
+
+    auto data_split = std::dynamic_pointer_cast<DataSplitImpl>(
+        builder.WithSnapshot(1)
+            .WithDataDeletionFiles({DeletionFile("fake/index-0", /*offset=*/1, /*length=*/22,
+                                                 /*cardinality=*/std::nullopt)})
+            .IsStreaming(false)
+            .RawConvertible(false)
+            .Build()
+            .value());
+
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> merged_row_count, data_split->MergedRowCount());
+    ASSERT_EQ(std::nullopt, merged_row_count);
+}
+
 // Covers the refactored path where a deletion file exists but its cardinality metadata is
 // missing (nullopt). In that case MergedRowCount must call the provided dv_factory to read the
 // deletion vector and derive the exact cardinality, instead of returning nullopt.
@@ -1376,7 +1509,7 @@ TEST(DataSplitTest, TestPartialMergedRowCountResolvesMissingCardinalityViaFactor
     roaring.Add(1);
     roaring.Add(3);
     auto deletion_vector = std::make_shared<BitmapDeletionVector>(roaring);
-    ASSERT_EQ(2, deletion_vector->GetCardinality());
+    ASSERT_EQ(2, deletion_vector->GetCardinality().value());
 
     DeletionVector::Factory dv_factory =
         [&deletion_vector](

--- a/src/paimon/core/table/source/data_table_batch_scan.cpp
+++ b/src/paimon/core/table/source/data_table_batch_scan.cpp
@@ -37,7 +37,9 @@ class DataSplit;
 DataTableBatchScan::DataTableBatchScan(bool pk_table, const CoreOptions& core_options,
                                        const std::shared_ptr<SnapshotReader>& snapshot_reader,
                                        bool read_optimized, std::optional<int32_t> push_down_limit)
-    : AbstractTableScan(core_options, snapshot_reader), push_down_limit_(push_down_limit) {
+    : AbstractTableScan(core_options, snapshot_reader),
+      push_down_limit_(push_down_limit),
+      logger_(Logger::GetLogger("DataTableBatchScan")) {
     if (pk_table && read_optimized) {
         int32_t top_level = core_options.GetNumLevels() - 1;
         snapshot_reader_->WithLevelFilter(
@@ -67,6 +69,21 @@ Result<std::shared_ptr<Plan>> DataTableBatchScan::CreatePlan() {
     return Status::Invalid("end of scan");
 }
 
+bool DataTableBatchScan::CanPushDownLimit() const {
+    if (push_down_limit_ == std::nullopt) {
+        return false;
+    }
+    if (snapshot_reader_->GetNonPartitionPredicate()) {
+        // a non-partition filter runs while reading, so the metadata count is an upper bound
+        return false;
+    }
+    if (snapshot_reader_->GetRowRangeIndex()) {
+        // a row range index selects a subset of each split's rows, likewise an upper bound
+        return false;
+    }
+    return true;
+}
+
 Result<std::shared_ptr<Plan>> DataTableBatchScan::ApplyPushDownLimit(
     const std::shared_ptr<StartingScanner::ScanResult>& scan_result) const {
     auto current_scan_result =
@@ -75,7 +92,7 @@ Result<std::shared_ptr<Plan>> DataTableBatchScan::ApplyPushDownLimit(
         // NoSnapshot
         return PlanImpl::EmptyPlan();
     }
-    if (push_down_limit_ == std::nullopt) {
+    if (!CanPushDownLimit()) {
         return current_scan_result->GetPlan();
     }
     std::vector<std::shared_ptr<Split>> splits = current_scan_result->Splits();
@@ -87,19 +104,29 @@ Result<std::shared_ptr<Plan>> DataTableBatchScan::ApplyPushDownLimit(
         if (!data_split) {
             return Status::Invalid("DataSplit cannot cast to DataSplitImpl");
         }
-        if (data_split->RawConvertible()) {
-            PAIMON_ASSIGN_OR_RAISE(std::optional<int64_t> partial_merged_row_count,
-                                   data_split->MergedRowCount());
-            if (!partial_merged_row_count.has_value()) {
-                // Cannot safely estimate split rows from metadata; skip push-down limit.
-                return current_scan_result->GetPlan();
-            }
-            limited_data_splits.emplace_back(data_split);
-            scanned_row_count += partial_merged_row_count.value();
-            if (scanned_row_count >= push_down_limit_.value()) {
-                PAIMON_ASSIGN_OR_RAISE(int64_t snapshot_id, current_scan_result->SnapshotId());
-                return std::make_shared<PlanImpl>(snapshot_id, limited_data_splits);
-            }
+        // A split the read has to merge by key, or whose deletion file carries no cardinality,
+        // cannot be counted from metadata and would have to be pruned blindly, so the push down
+        // is abandoned. A data-evolution split merges by column over a known row id range and
+        // still counts.
+        PAIMON_ASSIGN_OR_RAISE(std::optional<int64_t> merged_row_count,
+                               data_split->MergedRowCount());
+        if (!merged_row_count.has_value()) {
+            PAIMON_LOG_DEBUG(logger_,
+                             "Limit push down abandoned: split %zu of %zu cannot be counted from "
+                             "metadata.",
+                             limited_data_splits.size() + 1, splits.size());
+            return current_scan_result->GetPlan();
+        }
+        limited_data_splits.emplace_back(data_split);
+        scanned_row_count += merged_row_count.value();
+        if (scanned_row_count >= push_down_limit_.value()) {
+            PAIMON_ASSIGN_OR_RAISE(int64_t snapshot_id, current_scan_result->SnapshotId());
+            PAIMON_LOG_DEBUG(logger_,
+                             "Limit push down kept %zu of %zu splits for limit %d, holding %ld "
+                             "rows.",
+                             limited_data_splits.size(), splits.size(), push_down_limit_.value(),
+                             scanned_row_count);
+            return std::make_shared<PlanImpl>(snapshot_id, limited_data_splits);
         }
     }
     return current_scan_result->GetPlan();

--- a/src/paimon/core/table/source/data_table_batch_scan.h
+++ b/src/paimon/core/table/source/data_table_batch_scan.h
@@ -24,6 +24,7 @@
 
 #include "paimon/core/table/source/abstract_table_scan.h"
 #include "paimon/core/table/source/snapshot/starting_scanner.h"
+#include "paimon/logging.h"
 #include "paimon/result.h"
 #include "paimon/table/source/plan.h"
 
@@ -53,12 +54,23 @@ class DataTableBatchScan : public AbstractTableScan {
     }
 
  private:
+    /// Drops the trailing splits once the kept ones already hold `push_down_limit_` rows.
+    ///
+    /// A split's row count comes from metadata, so this is only safe when every row it reports
+    /// is actually returned. Anything that drops rows after planning (a non-partition filter, a
+    /// row range index) turns the count into an upper bound, so the push down is skipped there.
+    /// The limit is still enforced downstream; skipping only costs the pruning.
     Result<std::shared_ptr<Plan>> ApplyPushDownLimit(
         const std::shared_ptr<StartingScanner::ScanResult>& scan_result) const;
+
+    /// Whether a limit is set and nothing drops rows after planning. Whether a given split's
+    /// own count is exact is decided per split.
+    bool CanPushDownLimit() const;
 
  private:
     std::shared_ptr<StartingScanner> starting_scanner_;
     bool has_next_ = true;
     std::optional<int32_t> push_down_limit_;
+    std::unique_ptr<Logger> logger_;
 };
 }  // namespace paimon

--- a/src/paimon/core/table/source/snapshot/snapshot_reader.h
+++ b/src/paimon/core/table/source/snapshot/snapshot_reader.h
@@ -96,6 +96,10 @@ class SnapshotReader {
         return scan_->GetNonPartitionPredicate();
     }
 
+    const std::optional<RowRangeIndex>& GetRowRangeIndex() const {
+        return scan_->GetRowRangeIndex();
+    }
+
     std::shared_ptr<PredicateFilter> GetPartitionPredicate() const {
         return scan_->GetPartitionPredicate();
     }

--- a/src/paimon/core/utils/data_evolution_utils.cpp
+++ b/src/paimon/core/utils/data_evolution_utils.cpp
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/data_evolution_utils.h"
+
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/utils/vector_store_utils.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/status.h"
+
+namespace paimon {
+
+bool DataEvolutionUtils::IsNormalFile(const std::string& file_name) {
+    return !BlobUtils::IsBlobFile(file_name) && !VectorStoreUtils::IsVectorStoreFile(file_name);
+}
+
+Result<std::shared_ptr<DataFileMeta>> DataEvolutionUtils::RetrieveAnchorFile(
+    const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+    std::shared_ptr<DataFileMeta> anchor;
+    for (const auto& file : files) {
+        if (!IsNormalFile(file->file_name)) {
+            continue;
+        }
+        if (anchor == nullptr || file->max_sequence_number < anchor->max_sequence_number ||
+            (file->max_sequence_number == anchor->max_sequence_number &&
+             file->file_name < anchor->file_name)) {
+            anchor = file;
+        }
+    }
+    if (anchor == nullptr) {
+        return Status::Invalid(
+            "Data-evolution deletion vectors should have a normal anchor file in each row range "
+            "group.");
+    }
+    return anchor;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/utils/data_evolution_utils.h
+++ b/src/paimon/core/utils/data_evolution_utils.h
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/result.h"
+
+namespace paimon {
+struct DataFileMeta;
+
+/// Util class for data evolution.
+class DataEvolutionUtils {
+ public:
+    DataEvolutionUtils() = delete;
+    ~DataEvolutionUtils() = delete;
+
+    /// Retrieves the anchor file of a row range group: always the oldest normal file (neither a
+    /// blob file nor a vector-store file), comparing files by (max_sequence_number, file_name)
+    /// pairs. A group's deletion vector is maintained against its anchor, so the vector's
+    /// positions are relative to the anchor's row id range.
+    ///
+    /// The rule has to stay identical to the engine that writes the vectors, which keys them by
+    /// the same file (Paimon Java's DataEvolutionUtils#retrieveAnchorFile). A vector keyed by
+    /// any other file of the group, or one whose anchor a pruning dropped, is never found here
+    /// and its deleted rows silently come back.
+    ///
+    /// @param files The files of one row range group, in any order.
+    /// @return The anchor file, or an error when the group holds no normal file.
+    static Result<std::shared_ptr<DataFileMeta>> RetrieveAnchorFile(
+        const std::vector<std::shared_ptr<DataFileMeta>>& files);
+
+    /// Whether the file can anchor a row range group, that is neither a blob file nor a
+    /// vector-store file.
+    static bool IsNormalFile(const std::string& file_name);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/utils/data_evolution_utils_test.cpp
+++ b/src/paimon/core/utils/data_evolution_utils_test.cpp
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/utils/data_evolution_utils.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+namespace {
+std::shared_ptr<DataFileMeta> CreateFile(const std::string& file_name,
+                                         int64_t max_sequence_number) {
+    return DataFileMeta::ForAppend(file_name, /*file_size=*/1, /*row_count=*/1,
+                                   /*row_stats=*/SimpleStats::EmptyStats(),
+                                   /*min_sequence_number=*/0, max_sequence_number,
+                                   /*schema_id=*/0, FileSource::Append(),
+                                   /*value_stats_cols=*/std::nullopt,
+                                   /*external_path=*/std::nullopt, /*first_row_id=*/0,
+                                   /*write_cols=*/std::nullopt)
+        .value();
+}
+}  // namespace
+
+TEST(DataEvolutionUtilsTest, TestRetrieveAnchorFileSkipsBlobAndVectorStoreFiles) {
+    auto blob_file = CreateFile("blob-file.blob", 1);
+    auto vector_store_file = CreateFile("vector-store.vector.parquet", 2);
+    auto oldest_normal_file = CreateFile("oldest-normal.parquet", 3);
+    auto newest_normal_file = CreateFile("newest-normal.parquet", 4);
+
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<DataFileMeta> anchor,
+        DataEvolutionUtils::RetrieveAnchorFile(
+            {blob_file, vector_store_file, newest_normal_file, oldest_normal_file}));
+    ASSERT_EQ(anchor, oldest_normal_file);
+
+    // the same rule a caller applies to tell whether a group can be anchored at all
+    ASSERT_TRUE(DataEvolutionUtils::IsNormalFile(oldest_normal_file->file_name));
+    ASSERT_FALSE(DataEvolutionUtils::IsNormalFile(blob_file->file_name));
+    ASSERT_FALSE(DataEvolutionUtils::IsNormalFile(vector_store_file->file_name));
+}
+
+TEST(DataEvolutionUtilsTest, TestRetrieveAnchorFileFailsWithoutNormalFile) {
+    auto blob_file_1 = CreateFile("blob-file-1.blob", 1);
+    auto blob_file_2 = CreateFile("blob-file-2.blob", 2);
+    auto vector_store_file = CreateFile("vector-store.vector.parquet", 3);
+
+    ASSERT_NOK_WITH_MSG(
+        DataEvolutionUtils::RetrieveAnchorFile({blob_file_1, blob_file_2, vector_store_file}),
+        "should have a normal anchor file in each row range group");
+    ASSERT_NOK_WITH_MSG(DataEvolutionUtils::RetrieveAnchorFile({}),
+                        "should have a normal anchor file in each row range group");
+}
+
+TEST(DataEvolutionUtilsTest, TestRetrieveAnchorFileTieBreaksWithFileName) {
+    auto larger_file_name = CreateFile("normal-2.parquet", 1);
+    auto smaller_file_name = CreateFile("normal-1.parquet", 1);
+
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<DataFileMeta> anchor,
+        DataEvolutionUtils::RetrieveAnchorFile({larger_file_name, smaller_file_name}));
+    ASSERT_EQ(anchor, smaller_file_name);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/testing/utils/deletion_vector_test_helper.h
+++ b/src/paimon/testing/utils/deletion_vector_test_helper.h
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "fmt/format.h"
+#include "paimon/commit_message.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/range_helper.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
+#include "paimon/core/deletionvectors/deletion_vector.h"
+#include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/index/index_path_factory.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/utils/data_evolution_utils.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/result.h"
+#include "paimon/status.h"
+#include "paimon/utils/roaring_bitmap32.h"
+
+namespace paimon::test {
+
+/// Helpers to express row-level deletes on an append or data-evolution table the way an
+/// external engine does: write a deletion vector index file and commit it as an index-only
+/// commit message.
+class DeletionVectorTestHelper {
+ public:
+    DeletionVectorTestHelper() = delete;
+    ~DeletionVectorTestHelper() = delete;
+
+    /// Builds, but does not commit, an index-only commit message holding one deletion vector per
+    /// entry of `deleted_positions_by_file`, all in a single index file. A data file is covered
+    /// by at most one deletion vector, so covering it again later is rejected unless that commit
+    /// also drops the index file holding the earlier one, which `replaced_commit_msg` does.
+    ///
+    /// @param file_format_identifier The table's data file format, for the path factory.
+    /// @param base_commit_msg A data commit message of the same partition and bucket, which
+    ///     supplies the partition, bucket and total buckets of the index commit message.
+    /// @param deleted_positions_by_file Deleted positions keyed by data file name. Positions
+    ///     are relative to that file; for a data evolution table the key must be the row range
+    ///     group's anchor file (see RetrieveAnchorFileNames).
+    /// @param replaced_commit_msg An earlier deletion vector commit message whose index files
+    ///     this one drops. Null when nothing is replaced.
+    static Result<std::shared_ptr<CommitMessage>> CreateDeletionVectorCommitMessage(
+        const std::shared_ptr<FileSystem>& file_system, const std::string& table_path,
+        const std::string& file_format_identifier,
+        const std::shared_ptr<CommitMessage>& base_commit_msg,
+        const std::map<std::string, std::vector<int64_t>>& deleted_positions_by_file,
+        const std::shared_ptr<MemoryPool>& pool,
+        const std::shared_ptr<CommitMessage>& replaced_commit_msg = nullptr) {
+        auto base_msg_impl = std::dynamic_pointer_cast<CommitMessageImpl>(base_commit_msg);
+        if (!base_msg_impl) {
+            return Status::Invalid("cannot cast commit message to CommitMessageImpl");
+        }
+        SchemaManager schema_manager(file_system, table_path);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::shared_ptr<TableSchema>> latest_schema_opt,
+                               schema_manager.Latest());
+        if (!latest_schema_opt) {
+            return Status::Invalid("table schema does not exist");
+        }
+        const std::shared_ptr<TableSchema>& table_schema = latest_schema_opt.value();
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions core_options,
+                               CoreOptions::FromMap(table_schema->Options(), file_system));
+        auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> external_paths,
+                               core_options.CreateExternalPaths());
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::string> global_index_external_path,
+                               core_options.CreateGlobalIndexExternalPath());
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<FileStorePathFactory> path_factory,
+            FileStorePathFactory::Create(table_path, arrow_schema, table_schema->PartitionKeys(),
+                                         core_options.GetPartitionDefaultName(),
+                                         file_format_identifier, core_options.DataFilePrefix(),
+                                         core_options.LegacyPartitionNameEnabled(), external_paths,
+                                         global_index_external_path,
+                                         core_options.IndexFileInDataFileDir(), pool));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<IndexPathFactory> index_path_factory,
+                               path_factory->CreateIndexFileFactory(base_msg_impl->Partition(),
+                                                                    base_msg_impl->Bucket()));
+        DeletionVectorsIndexFile index_file(
+            file_system, std::shared_ptr<IndexPathFactory>(std::move(index_path_factory)),
+            core_options.DeletionVectorsBitmap64(), pool);
+
+        std::map<std::string, std::shared_ptr<DeletionVector>> deletion_vectors;
+        for (const auto& [file_name, deleted_positions] : deleted_positions_by_file) {
+            // deleting through the vector itself applies the same position bound a writer is
+            // held to, instead of narrowing to the bitmap's index type and wrapping silently
+            auto deletion_vector = std::make_shared<BitmapDeletionVector>(RoaringBitmap32());
+            for (int64_t position : deleted_positions) {
+                if (position < 0) {
+                    return Status::Invalid(fmt::format(
+                        "Deleted position {} of data file {} is negative.", position, file_name));
+                }
+                PAIMON_RETURN_NOT_OK(deletion_vector->Delete(position));
+            }
+            deletion_vectors[file_name] = std::move(deletion_vector);
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<IndexFileMeta> index_file_meta,
+                               index_file.WriteSingleFile(deletion_vectors));
+
+        std::vector<std::shared_ptr<IndexFileMeta>> deleted_index_files;
+        if (replaced_commit_msg) {
+            auto replaced_msg_impl =
+                std::dynamic_pointer_cast<CommitMessageImpl>(replaced_commit_msg);
+            if (!replaced_msg_impl) {
+                return Status::Invalid("cannot cast replaced commit message to CommitMessageImpl");
+            }
+            deleted_index_files = replaced_msg_impl->GetNewFilesIncrement().NewIndexFiles();
+        }
+        return std::make_shared<CommitMessageImpl>(
+            base_msg_impl->Partition(), base_msg_impl->Bucket(), base_msg_impl->TotalBuckets(),
+            DataIncrement({}, {}, {}, {index_file_meta}, std::move(deleted_index_files)),
+            CompactIncrement({}, {}, {}));
+    }
+
+    /// Groups the new data files of `commit_msgs` into row range groups and returns the anchor
+    /// file name of each group, ordered by ascending first row id.
+    ///
+    /// @param commit_msgs The data commit messages whose files form the groups. Every file must
+    ///     already carry a first row id: the commit assigns them onto its own copies, so the
+    ///     caller has to stamp them here first.
+    /// @return One anchor file name per row range group.
+    static Result<std::vector<std::string>> RetrieveAnchorFileNames(
+        const std::vector<std::shared_ptr<CommitMessage>>& commit_msgs) {
+        std::vector<std::shared_ptr<DataFileMeta>> files;
+        for (const auto& commit_msg : commit_msgs) {
+            auto commit_msg_impl = std::dynamic_pointer_cast<CommitMessageImpl>(commit_msg);
+            if (!commit_msg_impl) {
+                return Status::Invalid("cannot cast commit message to CommitMessageImpl");
+            }
+            for (const auto& file : commit_msg_impl->GetNewFilesIncrement().NewFiles()) {
+                files.push_back(file);
+            }
+        }
+        return RetrieveAnchorFileNames(files);
+    }
+
+    /// The same over data file metas, so a test can derive the anchors from a planned split,
+    /// which is what the read looks a group's deletion vector up by. Deriving them only from
+    /// the metas the caller wrote hides a mismatch between the two.
+    static Result<std::vector<std::string>> RetrieveAnchorFileNames(
+        const std::vector<std::shared_ptr<DataFileMeta>>& data_files) {
+        std::vector<std::shared_ptr<DataFileMeta>> files = data_files;
+        RangeHelper<std::shared_ptr<DataFileMeta>> range_helper(
+            [](const std::shared_ptr<DataFileMeta>& meta) -> Result<int64_t> {
+                return meta->NonNullFirstRowId();
+            },
+            [](const std::shared_ptr<DataFileMeta>& meta) -> Result<int64_t> {
+                PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, meta->NonNullFirstRowId());
+                return first_row_id + meta->row_count - 1;
+            });
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> groups,
+                               range_helper.MergeOverlappingRanges(std::move(files)));
+
+        std::vector<std::string> anchor_file_names;
+        anchor_file_names.reserve(groups.size());
+        for (const auto& group : groups) {
+            PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<DataFileMeta> anchor,
+                                   DataEvolutionUtils::RetrieveAnchorFile(group));
+            anchor_file_names.push_back(anchor->file_name);
+        }
+        return anchor_file_names;
+    }
+
+    /// Convenience wrapper of RetrieveAnchorFileNames for a single row range group.
+    static Result<std::string> RetrieveAnchorFileName(
+        const std::vector<std::shared_ptr<CommitMessage>>& commit_msgs) {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> anchor_file_names,
+                               RetrieveAnchorFileNames(commit_msgs));
+        if (anchor_file_names.size() != 1) {
+            return Status::Invalid("expected exactly one row range group in commit messages");
+        }
+        return anchor_file_names[0];
+    }
+};
+
+}  // namespace paimon::test

--- a/src/paimon/testing/utils/test_helper.h
+++ b/src/paimon/testing/utils/test_helper.h
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -28,16 +29,19 @@
 #include "arrow/array/concatenate.h"
 #include "arrow/c/bridge.h"
 #include "arrow/ipc/api.h"
+#include "fmt/format.h"
 #include "paimon/api.h"
 #include "paimon/catalog/catalog.h"
 #include "paimon/commit_context.h"
 #include "paimon/common/data/blob_descriptor.h"
 #include "paimon/common/data/blob_utils.h"
+#include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/core/operation/append_only_file_store_write.h"
 #include "paimon/core/operation/file_store_commit_impl.h"
 #include "paimon/core/schema/schema_manager.h"
+#include "paimon/core/schema/table_schema.h"
 #include "paimon/core/table/sink/commit_message_impl.h"
 #include "paimon/core/utils/file_store_path_factory.h"
 #include "paimon/core/utils/snapshot_manager.h"
@@ -338,6 +342,29 @@ class TestHelper {
     Result<std::string> PartitionStr(const BinaryRow& partition) const {
         auto abstract_write = dynamic_cast<AbstractFileStoreWrite*>(write_.get());
         return abstract_write->file_store_path_factory_->GetPartitionString(partition);
+    }
+
+    /// Appends a new schema holding `fields` on top of the table's latest one, the way an ALTER
+    /// TABLE would, so later writes and reads see the evolved schema.
+    static Status WriteNextSchema(const std::shared_ptr<FileSystem>& file_system,
+                                  const std::string& table_path,
+                                  const std::vector<DataField>& fields, int32_t highest_field_id,
+                                  const std::map<std::string, std::string>& options) {
+        SchemaManager schema_manager(file_system, table_path);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::shared_ptr<TableSchema>> latest_schema_opt,
+                               schema_manager.Latest());
+        if (!latest_schema_opt) {
+            return Status::Invalid("table schema does not exist");
+        }
+        auto next_schema = std::make_shared<TableSchema>(*latest_schema_opt.value());
+        next_schema->id_ = latest_schema_opt.value()->Id() + 1;
+        next_schema->fields_ = fields;
+        next_schema->highest_field_id_ = highest_field_id;
+        next_schema->options_ = options;
+        PAIMON_ASSIGN_OR_RAISE(std::string schema_content, next_schema->ToJsonString());
+        std::string schema_path = PathUtil::JoinPath(schema_manager.SchemaDirectory(),
+                                                     fmt::format("schema-{}", next_schema->Id()));
+        return file_system->AtomicStore(schema_path, schema_content);
     }
 
     static void CheckCommitMessages(std::vector<std::shared_ptr<CommitMessage>> expected,

--- a/test/inte/blob_table_inte_test.cpp
+++ b/test/inte/blob_table_inte_test.cpp
@@ -54,7 +54,6 @@
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
 #include "paimon/core/global_index/indexed_split_impl.h"
-#include "paimon/core/schema/schema_manager.h"
 #include "paimon/core/snapshot.h"
 #include "paimon/core/stats/simple_stats.h"
 #include "paimon/core/table/source/data_split_impl.h"
@@ -78,6 +77,7 @@
 #include "paimon/table/source/data_split.h"
 #include "paimon/table/source/startup_mode.h"
 #include "paimon/table/source/table_read.h"
+#include "paimon/testing/utils/deletion_vector_test_helper.h"
 #include "paimon/testing/utils/io_exception_helper.h"
 #include "paimon/testing/utils/test_helper.h"
 #include "paimon/testing/utils/testharness.h"
@@ -187,23 +187,89 @@ class BlobTableInteTest : public testing::Test, public ::testing::WithParamInter
         return file_store_commit->Commit(commit_msgs);
     }
 
+    /// DeletionVectorTestHelper::CreateDeletionVectorCommitMessage, documented there, plus the
+    /// commit of the message it returns.
+    Result<std::shared_ptr<CommitMessage>> CommitDeletionVectors(
+        const std::string& table_path, const std::shared_ptr<CommitMessage>& base_commit_msg,
+        const std::map<std::string, std::vector<int64_t>>& deleted_positions_by_anchor,
+        const std::shared_ptr<CommitMessage>& replaced_commit_msg = nullptr) const {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<CommitMessage> commit_message,
+            DeletionVectorTestHelper::CreateDeletionVectorCommitMessage(
+                dir_->GetFileSystem(), table_path, /*file_format_identifier=*/GetParam(),
+                base_commit_msg, deleted_positions_by_anchor, pool_, replaced_commit_msg));
+        PAIMON_RETURN_NOT_OK(Commit(table_path, {commit_message}));
+        return commit_message;
+    }
+
+    /// Creates the (f0 INT, view) blob-view table the dangling-reference tests share: unaware
+    /// bucket, data evolution on, and `view` resolved against `upstream_warehouse`. Returns the
+    /// table's fields, which the callers reuse to build their expected arrays.
+    arrow::FieldVector CreateBlobViewTable(const std::string& upstream_warehouse,
+                                           bool deletion_vectors_enabled) const {
+        arrow::FieldVector fields = {arrow::field("f0", arrow::int32()),
+                                     BlobUtils::ToArrowField("view", true)};
+        std::map<std::string, std::string> options = {
+            {Options::MANIFEST_FORMAT, "orc"},
+            {Options::FILE_FORMAT, GetParam()},
+            {Options::BUCKET, "-1"},
+            {Options::ROW_TRACKING_ENABLED, "true"},
+            {Options::DATA_EVOLUTION_ENABLED, "true"},
+            {Options::BLOB_VIEW_FIELD, "view"},
+            {Options::BLOB_VIEW_UPSTREAM_WAREHOUSE, upstream_warehouse},
+            {Options::FILE_SYSTEM, "local"}};
+        if (deletion_vectors_enabled) {
+            options.emplace(Options::DELETION_VECTORS_ENABLED, "true");
+        }
+        CreateTable(fields, /*partition_keys=*/{}, options);
+        return fields;
+    }
+
+    /// Writes and commits the two rows the blob-view skip tests share: row 0 holds a blob view
+    /// reference to an upstream table that does not exist, row 1 holds no blob view at all.
+    /// Resolving row 0 fails the whole read, so any read the pre-read still reaches it from must
+    /// error; only dropping the row through the deletion vector or the row ranges avoids that,
+    /// because those are the two filters the pre-read applies. The table must already exist with
+    /// fields (f0, view).
+    ///
+    /// `first_row_id`, when set, is stamped on the returned metas before committing: the commit
+    /// assigns row ids onto its own copies, so a caller that needs them (to look up the group's
+    /// anchor) has to set them here, matching what the commit would assign.
+    Result<std::vector<std::shared_ptr<CommitMessage>>> WriteDanglingBlobViewRows(
+        const std::string& table_path,
+        const std::optional<int64_t>& first_row_id = std::nullopt) const {
+        Identifier upstream_identifier("nonexistent_db", "nonexistent_table");
+        BlobViewStruct view_struct(upstream_identifier, /*field_id=*/2, /*row_id=*/0);
+        auto serialized = view_struct.Serialize(pool_);
+        arrow::LargeBinaryBuilder view_builder;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(view_builder.Append(
+            reinterpret_cast<const uint8_t*>(serialized->data()), serialized->size()));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(view_builder.AppendNull());
+        std::shared_ptr<arrow::Array> write_view_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(view_builder.Finish(&write_view_array));
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            std::shared_ptr<arrow::Array> write_f0_array,
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::int32(), R"([100, 101])"));
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            std::shared_ptr<arrow::Array> write_struct,
+            arrow::StructArray::Make(arrow::ArrayVector({write_f0_array, write_view_array}),
+                                     std::vector<std::string>({"f0", "view"})));
+
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<std::shared_ptr<CommitMessage>> commit_msgs,
+            WriteArray(table_path, /*partition=*/{}, {"f0", "view"}, {write_struct}));
+        if (first_row_id) {
+            SetFirstRowId(first_row_id.value(), commit_msgs);
+        }
+        PAIMON_RETURN_NOT_OK(Commit(table_path, commit_msgs));
+        return commit_msgs;
+    }
+
     Status WriteNextSchema(const std::string& table_path, const std::vector<DataField>& fields,
                            int32_t highest_field_id,
                            const std::map<std::string, std::string>& options) const {
-        SchemaManager schema_manager(dir_->GetFileSystem(), table_path);
-        PAIMON_ASSIGN_OR_RAISE(auto latest_schema_opt, schema_manager.Latest());
-        if (!latest_schema_opt) {
-            return Status::Invalid("table schema does not exist");
-        }
-        auto next_schema = std::make_shared<TableSchema>(*latest_schema_opt.value());
-        next_schema->id_ = latest_schema_opt.value()->Id() + 1;
-        next_schema->fields_ = fields;
-        next_schema->highest_field_id_ = highest_field_id;
-        next_schema->options_ = options;
-        PAIMON_ASSIGN_OR_RAISE(std::string schema_content, next_schema->ToJsonString());
-        std::string schema_path = PathUtil::JoinPath(schema_manager.SchemaDirectory(),
-                                                     "schema-" + std::to_string(next_schema->Id()));
-        return dir_->GetFileSystem()->AtomicStore(schema_path, schema_content);
+        return TestHelper::WriteNextSchema(dir_->GetFileSystem(), table_path, fields,
+                                           highest_field_id, options);
     }
 
     /// Scan table and return the plan (without reading data).
@@ -1284,6 +1350,90 @@ TEST_P(BlobTableInteTest, TestDataEvolutionBlobPartialUpdateMultipleLayers) {
         ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_single,
                               /*predicate=*/nullptr, /*row_ranges=*/{Range(i, i)}));
     }
+}
+
+TEST_P(BlobTableInteTest, TestDataEvolutionBlobPartialUpdateWithDeletionVectors) {
+    arrow::FieldVector fields = {arrow::field("f0", arrow::int32()),
+                                 arrow::field("f1", arrow::utf8()), BlobUtils::ToArrowField("b0")};
+    std::map<std::string, std::string> options = {
+        {Options::MANIFEST_FORMAT, "orc"},         {Options::FILE_FORMAT, GetParam()},
+        {Options::FILE_SYSTEM, "local"},           {Options::ROW_TRACKING_ENABLED, "true"},
+        {Options::DATA_EVOLUTION_ENABLED, "true"}, {Options::DELETION_VECTORS_ENABLED, "true"}};
+    CreateTable(fields, /*partition_keys=*/{}, options);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields);
+
+    auto src_array0 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        [1, "a", "blob_0"],
+        [2, "b", "blob_1"],
+        [3, "c", "blob_2"],
+        [4, "d", "blob_3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs0,
+                         WriteArray(table_path, {}, schema->field_names(), {src_array0}));
+    SetFirstRowId(/*reset_first_row_id=*/0, commit_msgs0);
+    ASSERT_OK(Commit(table_path, commit_msgs0));
+
+    // second layer updates row 0 within rows [0, 1], rows [2, 3] are its placeholder gap
+    auto update_array1 = MakeBlobUpdateArray(fields[2], {"update1_0", "PH"});
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs1, WriteArray(table_path, {}, {"b0"}, {update_array1}));
+    SetFirstRowId(/*reset_first_row_id=*/0, commit_msgs1);
+    ASSERT_OK(Commit(table_path, commit_msgs1));
+
+    // third layer updates row 3 within rows [2, 3], rows [0, 1] are its placeholder gap
+    auto update_array2 = MakeBlobUpdateArray(fields[2], {"PH", "update2_3"});
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs2, WriteArray(table_path, {}, {"b0"}, {update_array2}));
+    SetFirstRowId(/*reset_first_row_id=*/2, commit_msgs2);
+    ASSERT_OK(Commit(table_path, commit_msgs2));
+
+    // delete row 1 and row 3: each sits inside one blob layer's file and the other layer's
+    // gap, so both blob layers and the normal file must drop the same rows to stay aligned
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name,
+                         DeletionVectorTestHelper::RetrieveAnchorFileName(commit_msgs0));
+    ASSERT_OK(CommitDeletionVectors(table_path, commit_msgs0[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{1, 3}}}));
+
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        [1, "a", "update1_0"],
+        [3, "c", "blob_2"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_array));
+
+    auto expected_with_row_id = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields[0], fields[1], fields[2], SpecialFields::RowId().field_}),
+            R"([
+        [1, "a", "update1_0", 0],
+        [3, "c", "blob_2", 2]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "b0", "_ROW_ID"}, expected_with_row_id));
+
+    // Projecting only the blob column leaves no data bunch, so the whole read is the blob
+    // fallback path: the layer files carry the shifted deletion vector and the placeholder gap
+    // segments drop the deleted row ids, with no normal file to anchor the row count.
+    auto expected_blob_only = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields[2]}), R"([
+        ["update1_0"],
+        ["blob_2"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"b0"}, expected_blob_only));
+
+    // a row-range selection composes with the deletion vector: rows {0, 1} minus deleted {1}.
+    // The range stops before row 2, the other survivor, so it cannot pass by returning what the
+    // unrestricted read above already returned.
+    auto expected_selected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+        [1, "a", "update1_0"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_selected,
+                          /*predicate=*/nullptr, /*row_ranges=*/{Range(0, 1)}));
 }
 
 TEST_P(BlobTableInteTest, TestDataEvolutionBlobPartialUpdateCompactedLayers) {
@@ -3890,53 +4040,131 @@ TEST_P(BlobTableInteTest, TestBlobViewFieldWithMultipleUpstreamTables) {
 }
 
 TEST_P(BlobTableInteTest, TestBlobViewFailsWhenBothPathsAbsent) {
-    auto file_format = GetParam();
     auto upstream_dir = UniqueTestDirectory::Create("local");
-    const std::string upstream_db_name = "nonexistent_db";
-    const std::string upstream_table_name = "nonexistent_table";
-
-    // Build downstream table that references the non-existent upstream table.
-    arrow::FieldVector fields = {arrow::field("f0", arrow::int32()),
-                                 BlobUtils::ToArrowField("view", true)};
-    std::map<std::string, std::string> options = {
-        {Options::MANIFEST_FORMAT, "orc"},
-        {Options::FILE_FORMAT, file_format},
-        {Options::BUCKET, "-1"},
-        {Options::ROW_TRACKING_ENABLED, "true"},
-        {Options::DATA_EVOLUTION_ENABLED, "true"},
-        {Options::BLOB_VIEW_FIELD, "view"},
-        {Options::BLOB_VIEW_UPSTREAM_WAREHOUSE, upstream_dir->Str()},
-        {Options::FILE_SYSTEM, "local"}};
-    CreateTable(fields, /*partition_keys=*/{}, options);
+    arrow::FieldVector fields =
+        CreateBlobViewTable(upstream_dir->Str(), /*deletion_vectors_enabled=*/false);
     std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
-
-    // Write a single row with a BlobViewStruct pointing to the non-existent upstream table.
-    Identifier upstream_identifier(upstream_db_name, upstream_table_name);
-    BlobViewStruct view_struct(upstream_identifier, /*field_id=*/2, /*row_id=*/0);
-    auto serialized = view_struct.Serialize(pool_);
-    arrow::LargeBinaryBuilder view_builder;
-    ASSERT_TRUE(
-        view_builder
-            .Append(reinterpret_cast<const uint8_t*>(serialized->data()), serialized->size())
-            .ok());
-    std::shared_ptr<arrow::Array> write_view_array;
-    ASSERT_TRUE(view_builder.Finish(&write_view_array).ok());
-    auto write_f0_array =
-        arrow::ipc::internal::json::ArrayFromJSON(arrow::int32(), R"([100])").ValueOrDie();
-    auto write_struct = std::dynamic_pointer_cast<arrow::StructArray>(
-        arrow::StructArray::Make(arrow::ArrayVector({write_f0_array, write_view_array}),
-                                 std::vector<std::string>({"f0", "view"}))
-            .ValueOrDie());
-
     auto schema = arrow::schema(fields);
-    ASSERT_OK_AND_ASSIGN(auto commit_msgs,
-                         WriteArray(table_path, {}, schema->field_names(), {write_struct}));
-    ASSERT_OK(Commit(table_path, commit_msgs));
 
-    // Reading should fail because both paths are absent.
+    ASSERT_OK(WriteDanglingBlobViewRows(table_path));
+
+    // reading fails because neither the table path nor the fallback one exists upstream
     ASSERT_OK_AND_ASSIGN(auto plan, ScanTable(table_path));
     ASSERT_NOK_WITH_MSG(ReadTable(table_path, schema->field_names(), plan, /*predicate=*/nullptr),
                         "Ambiguous table path");
+}
+
+TEST_P(BlobTableInteTest, TestBlobViewSkipsDanglingReferenceOfDeletedRow) {
+    auto upstream_dir = UniqueTestDirectory::Create("local");
+    arrow::FieldVector fields =
+        CreateBlobViewTable(upstream_dir->Str(), /*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields);
+
+    // resolving row 0 would fail the whole query, so the pre-read that collects the structs to
+    // resolve must honor the deletion vector too
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> commit_msgs,
+                         WriteDanglingBlobViewRows(table_path, /*first_row_id=*/0));
+
+    // without the deletion vector the dangling reference fails the read
+    ASSERT_OK_AND_ASSIGN(auto plan, ScanTable(table_path));
+    ASSERT_NOK_WITH_MSG(ReadTable(table_path, schema->field_names(), plan, /*predicate=*/nullptr),
+                        "Ambiguous table path");
+
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name,
+                         DeletionVectorTestHelper::RetrieveAnchorFileName(commit_msgs));
+    ASSERT_OK(CommitDeletionVectors(table_path, commit_msgs[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{0}}}));
+
+    // the deleted row is never resolved, so only the surviving row is returned
+    ASSERT_OK_AND_ASSIGN(auto dv_plan, ScanTable(table_path));
+    ASSERT_OK_AND_ASSIGN(auto result, ReadTable(table_path, schema->field_names(), dv_plan,
+                                                /*predicate=*/nullptr));
+    ASSERT_TRUE(result.chunked_array);
+    auto read_concat = arrow::Concatenate(result.chunked_array->chunks()).ValueOrDie();
+    auto read_struct = std::dynamic_pointer_cast<arrow::StructArray>(read_concat);
+    ASSERT_EQ(read_struct->length(), 1);
+
+    auto expected_struct = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([[101, null]])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto expected_with_rk, PrependRowKindColumn(expected_struct));
+    ASSERT_TRUE(read_struct->Equals(expected_with_rk))
+        << "read_struct:" << read_struct->ToString() << std::endl
+        << "expected:" << expected_with_rk->ToString();
+}
+
+TEST_P(BlobTableInteTest, TestBlobViewSkipsDanglingReferenceInEveryRowRangeGroup) {
+    auto upstream_dir = UniqueTestDirectory::Create("local");
+    arrow::FieldVector fields =
+        CreateBlobViewTable(upstream_dir->Str(), /*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields);
+
+    // two commits, so the two pairs of rows form two row range groups. The blob view pre-read
+    // walks the groups one by one; a group it drops, or reads with another group's deletion
+    // vector, still hands its dangling reference to the resolver and fails the whole read.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> commit_msgs0,
+                         WriteDanglingBlobViewRows(table_path, /*first_row_id=*/0));
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> commit_msgs1,
+                         WriteDanglingBlobViewRows(table_path, /*first_row_id=*/2));
+
+    // without deletion vectors both groups' dangling references fail the read
+    ASSERT_OK_AND_ASSIGN(auto plan, ScanTable(table_path));
+    ASSERT_NOK_WITH_MSG(ReadTable(table_path, schema->field_names(), plan, /*predicate=*/nullptr),
+                        "Ambiguous table path");
+
+    // each group's anchor gets a deletion vector dropping its row 0, the dangling one
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name0,
+                         DeletionVectorTestHelper::RetrieveAnchorFileName(commit_msgs0));
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name1,
+                         DeletionVectorTestHelper::RetrieveAnchorFileName(commit_msgs1));
+    ASSERT_NE(anchor_file_name0, anchor_file_name1);
+    ASSERT_OK(CommitDeletionVectors(table_path, commit_msgs0[0],
+                                    {{anchor_file_name0, /*deleted_positions=*/{0}},
+                                     {anchor_file_name1, /*deleted_positions=*/{0}}}));
+
+    // both groups keep only their row 1, which holds no blob view at all
+    auto expected_struct = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields),
+                                                  R"([[101, null], [101, null]])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_struct));
+}
+
+// Pins one of the limitations documented on CreateBlobViewReader: the pre-read takes no
+// predicate, so filtering a row out that way does not stop its blob view reference from being
+// resolved. This asserts the current behavior, not a desired one.
+TEST_P(BlobTableInteTest, TestBlobViewPreReadHonorsRowRangesNotPredicate) {
+    auto upstream_dir = UniqueTestDirectory::Create("local");
+    arrow::FieldVector fields =
+        CreateBlobViewTable(upstream_dir->Str(), /*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields);
+
+    // row 0 (f0 = 100) holds the dangling reference, row 1 (f0 = 101) holds no blob view
+    ASSERT_OK(WriteDanglingBlobViewRows(table_path));
+
+    // reading the whole split fails on the dangling reference of row 0
+    ASSERT_OK_AND_ASSIGN(auto plan, ScanTable(table_path));
+    ASSERT_NOK_WITH_MSG(ReadTable(table_path, schema->field_names(), plan, /*predicate=*/nullptr),
+                        "Ambiguous table path");
+
+    // a predicate keeping only row 1 does not rescue the query: it is evaluated above the split
+    // read, while the pre-read takes none, so row 0's reference is still collected and resolved
+    auto keep_row_1 = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
+                                              FieldType::INT, Literal(101));
+    ASSERT_OK_AND_ASSIGN(auto filtered_plan, ScanTable(table_path, keep_row_1));
+    ASSERT_NOK_WITH_MSG(ReadTable(table_path, schema->field_names(), filtered_plan, keep_row_1),
+                        "Ambiguous table path");
+
+    // dropping the same row through the row ranges does: the pre-read honors them the same way
+    // the main read does, so row 0 is never resolved
+    auto expected_struct = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([[101, null]])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_struct,
+                          /*predicate=*/nullptr, /*row_ranges=*/{Range(1, 1)}));
 }
 
 TEST_P(BlobTableInteTest, TestBlobViewWithFallbackPath) {

--- a/test/inte/data_evolution_table_test.cpp
+++ b/test/inte/data_evolution_table_test.cpp
@@ -16,9 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+#include <algorithm>
 #include <tuple>
 
 #include "arrow/type.h"
+#include "fmt/format.h"
 #include "gtest/gtest.h"
 #include "paimon/common/factories/io_hook.h"
 #include "paimon/common/io/cache/lru_cache.h"
@@ -37,6 +39,7 @@
 #include "paimon/predicate/predicate_builder.h"
 #include "paimon/result.h"
 #include "paimon/status.h"
+#include "paimon/testing/utils/deletion_vector_test_helper.h"
 #include "paimon/testing/utils/io_exception_helper.h"
 #include "paimon/testing/utils/test_helper.h"
 #include "paimon/testing/utils/testharness.h"
@@ -116,6 +119,9 @@ class DataEvolutionTableTest : public ::testing::Test,
         return WriteArray(table_path, /*partition=*/{}, write_cols, write_array);
     }
 
+    /// Stamps `reset_first_row_id` on the metas the caller holds. The commit assigns row ids
+    /// onto its own copies, so a caller that later looks a file up by row id range, to find a
+    /// row range group's anchor, has to mirror the assignment here.
     void SetFirstRowId(int64_t reset_first_row_id,
                        std::vector<std::shared_ptr<CommitMessage>>& commit_msgs) const {
         for (auto& commit_msg : commit_msgs) {
@@ -136,6 +142,245 @@ class DataEvolutionTableTest : public ::testing::Test,
         PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> file_store_commit,
                                FileStoreCommit::Create(std::move(commit_context)));
         return file_store_commit->Commit(commit_msgs);
+    }
+
+    /// Creates the default (f0, f1, f2) data evolution table and returns the options it was
+    /// created with, which a test that later evolves the schema has to pass along.
+    /// `extra_options` is merged in for tests that also pin a read batch or split target size.
+    std::map<std::string, std::string> CreateDataEvolutionTable(
+        bool deletion_vectors_enabled,
+        const std::map<std::string, std::string>& extra_options = {}) const {
+        std::map<std::string, std::string> options = {{Options::MANIFEST_FORMAT, "orc"},
+                                                      {Options::FILE_FORMAT, FileFormat()},
+                                                      {Options::FILE_SYSTEM, "local"},
+                                                      {Options::ROW_TRACKING_ENABLED, "true"},
+                                                      {Options::DATA_EVOLUTION_ENABLED, "true"}};
+        if (deletion_vectors_enabled) {
+            options.emplace(Options::DELETION_VECTORS_ENABLED, "true");
+        }
+        options.insert(extra_options.begin(), extra_options.end());
+        CreateTable(/*partition_keys=*/{}, options);
+        return options;
+    }
+
+    /// DeletionVectorTestHelper::CreateDeletionVectorCommitMessage, documented there, plus the
+    /// commit of the message it returns.
+    Result<std::shared_ptr<CommitMessage>> CommitDeletionVectors(
+        const std::string& table_path, const std::shared_ptr<CommitMessage>& base_commit_msg,
+        const std::map<std::string, std::vector<int64_t>>& deleted_positions_by_anchor,
+        const std::shared_ptr<CommitMessage>& replaced_commit_msg = nullptr) const {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<CommitMessage> commit_message,
+            DeletionVectorTestHelper::CreateDeletionVectorCommitMessage(
+                dir_->GetFileSystem(), table_path, /*file_format_identifier=*/FileFormat(),
+                base_commit_msg, deleted_positions_by_anchor, GetDefaultPool(),
+                replaced_commit_msg));
+        PAIMON_RETURN_NOT_OK(Commit(table_path, {commit_message}));
+        return commit_message;
+    }
+
+    /// Writes one row range group holding `f0_values`, starting at `first_row_id`: a full-row
+    /// write plus a partial f2 write over the same rows, so the group's split merges columns
+    /// from two files and is not raw convertible. When `partition` is set the files land in that
+    /// partition and every row carries its value in f1, the partition key.
+    ///
+    /// The f2 write starts only once the full-row write is committed, which is what makes the
+    /// f2 file the newer of the pair. Writing both before either commit left the column merge
+    /// free to serve f2 from the full-row write instead.
+    Result<std::vector<std::shared_ptr<CommitMessage>>> WriteAndCommitGroup(
+        const std::string& table_path, int64_t first_row_id, const std::vector<int32_t>& f0_values,
+        const std::map<std::string, std::string>& partition = {}) const {
+        auto partition_f1 = partition.find("f1");
+        std::string base_json = "[";
+        std::string f2_json = "[";
+        for (size_t i = 0; i < f0_values.size(); i++) {
+            if (i > 0) {
+                base_json += ", ";
+                f2_json += ", ";
+            }
+            std::string f1_value =
+                partition_f1 == partition.end() ? fmt::format("a{}", i) : partition_f1->second;
+            base_json += fmt::format(R"([{}, "{}", "x{}"])", f0_values[i], f1_value, i);
+            f2_json += fmt::format(R"(["y{}"])", i);
+        }
+        base_json += "]";
+        f2_json += "]";
+
+        auto base_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), base_json)
+                .ValueOrDie());
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<std::shared_ptr<CommitMessage>> base_msgs,
+            WriteArray(table_path, partition, arrow::schema(fields_)->field_names(), base_array));
+        // both writes are stamped with the same first row id, so their files cover the same row
+        // id range and form one row range group
+        SetFirstRowId(first_row_id, base_msgs);
+        PAIMON_RETURN_NOT_OK(Commit(table_path, base_msgs));
+
+        arrow::FieldVector f2_fields = {fields_[2]};
+        auto f2_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(f2_fields), f2_json)
+                .ValueOrDie());
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<CommitMessage>> f2_msgs,
+                               WriteArray(table_path, partition, {"f2"}, f2_array));
+        SetFirstRowId(first_row_id, f2_msgs);
+        PAIMON_RETURN_NOT_OK(Commit(table_path, f2_msgs));
+
+        std::vector<std::shared_ptr<CommitMessage>> group_msgs;
+        group_msgs.insert(group_msgs.end(), base_msgs.begin(), base_msgs.end());
+        group_msgs.insert(group_msgs.end(), f2_msgs.begin(), f2_msgs.end());
+        return group_msgs;
+    }
+
+    /// Flattens the f0 column of a read result, looked up by name so the row kind column the
+    /// reader prepends does not shift it.
+    static Result<std::vector<int32_t>> CollectF0Values(
+        const std::shared_ptr<arrow::ChunkedArray>& rows) {
+        std::vector<int32_t> values;
+        if (!rows) {
+            return values;
+        }
+        for (const std::shared_ptr<arrow::Array>& chunk : rows->chunks()) {
+            auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(chunk);
+            if (!struct_array) {
+                return Status::Invalid("read result chunk is not a struct array");
+            }
+            auto f0_array =
+                std::dynamic_pointer_cast<arrow::Int32Array>(struct_array->GetFieldByName("f0"));
+            if (!f0_array) {
+                return Status::Invalid("read result has no int32 f0 column");
+            }
+            for (int64_t i = 0; i < f0_array->length(); i++) {
+                values.push_back(f0_array->Value(i));
+            }
+        }
+        return values;
+    }
+
+    struct LimitScanResult {
+        /// The read that produced `rows`. Its memory pool owns the buffers behind them, so it
+        /// has to outlive them: these two members are declared first on purpose, since members
+        /// are destroyed in reverse order.
+        std::unique_ptr<TableRead> table_read;
+        std::unique_ptr<BatchReader> batch_reader;
+        /// The splits the limit push down kept in the plan.
+        std::vector<std::shared_ptr<Split>> splits;
+        /// The rows reading those splits produced, null when the read returned nothing. The
+        /// read does not truncate to the limit, so this is everything the kept splits hold, or
+        /// everything that survives the predicate when `enable_predicate_filter` is set.
+        std::shared_ptr<arrow::ChunkedArray> rows;
+    };
+
+    /// Scans with a pushed-down row limit and reads the planned splits back. The push down only
+    /// prunes splits, so a correct plan must still expose at least `limit` rows to the read.
+    ///
+    /// `enable_predicate_filter` turns the predicate into a row filter while reading. It is off
+    /// by default, matching the read context default: a predicate then only prunes while
+    /// planning, and the read returns every row the kept splits hold.
+    Result<LimitScanResult> ScanAndReadWithLimit(
+        const std::string& table_path, const std::vector<std::string>& read_schema, int32_t limit,
+        const std::shared_ptr<Predicate>& predicate = nullptr,
+        const std::vector<Range>& row_ranges = {}, bool enable_predicate_filter = false) const {
+        ScanContextBuilder scan_context_builder(table_path);
+        scan_context_builder.SetLimit(limit);
+        scan_context_builder.SetPredicate(predicate);
+        if (!row_ranges.empty()) {
+            scan_context_builder.SetGlobalIndexResult(
+                BitmapGlobalIndexResult::FromRanges(row_ranges));
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ScanContext> scan_context,
+                               FinishScanContext(scan_context_builder));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<TableScan> table_scan,
+                               TableScan::Create(std::move(scan_context)));
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Plan> result_plan, table_scan->CreatePlan());
+
+        LimitScanResult result;
+        result.splits = result_plan->Splits();
+        ReadContextBuilder read_context_builder(table_path);
+        read_context_builder.SetReadFieldNames(read_schema)
+            .SetPredicate(predicate)
+            .EnablePredicateFilter(enable_predicate_filter);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ReadContext> read_context,
+                               read_context_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(result.table_read, TableRead::Create(std::move(read_context)));
+        PAIMON_ASSIGN_OR_RAISE(result.batch_reader, result.table_read->CreateReader(result.splits));
+        PAIMON_ASSIGN_OR_RAISE(result.rows,
+                               ReadResultCollector::CollectResult(result.batch_reader.get()));
+        return result;
+    }
+
+    /// Plans the table without any push down and returns the planned splits, so a test can
+    /// assert what the scan handed the read: which data file each deletion file landed on, and
+    /// the row count derived from them. Reading the splits back is ScanAndReadWithLimit's job,
+    /// which keeps the reader that owns the returned rows alive.
+    Result<std::vector<std::shared_ptr<Split>>> PlanSplits(const std::string& table_path) const {
+        ScanContextBuilder scan_context_builder(table_path);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ScanContext> scan_context,
+                               FinishScanContext(scan_context_builder));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<TableScan> table_scan,
+                               TableScan::Create(std::move(scan_context)));
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Plan> plan, table_scan->CreatePlan());
+        return plan->Splits();
+    }
+
+    /// Anchor file name of every row range group of the table, ordered by ascending first row
+    /// id, derived from the planned splits.
+    ///
+    /// Deriving them from the same metas the read groups keeps the two in step. Deriving them
+    /// from the metas a write hands back uses pre-commit copies, and a vector keyed by a file
+    /// the read does not consider the anchor is never found, silently leaving rows undeleted.
+    Result<std::vector<std::string>> PlannedAnchorFileNames(const std::string& table_path) const {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<Split>> splits, PlanSplits(table_path));
+        std::vector<std::shared_ptr<DataFileMeta>> data_files;
+        for (const std::shared_ptr<Split>& split : splits) {
+            auto split_impl = std::dynamic_pointer_cast<DataSplitImpl>(split);
+            if (!split_impl) {
+                return Status::Invalid("split cannot cast to DataSplitImpl");
+            }
+            for (const std::shared_ptr<DataFileMeta>& file : split_impl->DataFiles()) {
+                data_files.push_back(file);
+            }
+        }
+        return DeletionVectorTestHelper::RetrieveAnchorFileNames(data_files);
+    }
+
+    /// PlannedAnchorFileNames for a table holding a single row range group.
+    Result<std::string> PlannedAnchorFileName(const std::string& table_path) const {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> anchor_file_names,
+                               PlannedAnchorFileNames(table_path));
+        if (anchor_file_names.size() != 1) {
+            return Status::Invalid("expected exactly one row range group in the table");
+        }
+        return anchor_file_names[0];
+    }
+
+    using DeletionCardinalityMap = std::map<std::string, int64_t>;
+
+    /// Maps every data file of `split` that carries a deletion file to that file's cardinality.
+    static Result<DeletionCardinalityMap> DeletionCardinalityByDataFile(
+        const std::shared_ptr<Split>& split) {
+        auto split_impl = std::dynamic_pointer_cast<DataSplitImpl>(split);
+        if (!split_impl) {
+            return Status::Invalid("split cannot cast to DataSplitImpl");
+        }
+        const std::vector<std::shared_ptr<DataFileMeta>>& data_files = split_impl->DataFiles();
+        const std::vector<std::optional<DeletionFile>>& deletion_files =
+            split_impl->DeletionFiles();
+        if (!deletion_files.empty() && deletion_files.size() != data_files.size()) {
+            return Status::Invalid("deletion files are not aligned with data files");
+        }
+        DeletionCardinalityMap cardinality_by_file;
+        for (size_t i = 0; i < deletion_files.size(); i++) {
+            if (deletion_files[i] == std::nullopt) {
+                continue;
+            }
+            if (deletion_files[i].value().cardinality == std::nullopt) {
+                return Status::Invalid("deletion file is missing its cardinality");
+            }
+            cardinality_by_file[data_files[i]->file_name] =
+                deletion_files[i].value().cardinality.value();
+        }
+        return cardinality_by_file;
     }
 
     Status CommitWithRowIdCheckFromSnapshot(
@@ -2106,6 +2351,600 @@ TEST_P(DataEvolutionTableTest, TestWithRowIds) {
                               expected_array, /*predicate=*/nullptr,
                               /*row_ranges=*/row_ranges));
     }
+}
+
+TEST_P(DataEvolutionTableTest, TestReadWithDeletionVectors) {
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    // full-row write assigns row ids 0-3, producing the anchor file of the row range group
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a", "x"],
+        [2, "b", "y"],
+        [3, "c", "z"],
+        [4, "d", "w"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs0,
+                         WriteArray(table_path, schema->field_names(), src_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, commit_msgs0);
+    ASSERT_OK(Commit(table_path, commit_msgs0));
+
+    // partial write of f2 over the same row range: the group merges columns from two files
+    arrow::FieldVector f2_fields = {fields_[2]};
+    auto update_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(f2_fields), R"([
+        ["x2"],
+        ["y2"],
+        ["z2"],
+        ["w2"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs1, WriteArray(table_path, {"f2"}, update_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, commit_msgs1);
+    ASSERT_OK(Commit(table_path, commit_msgs1));
+
+    auto expected_all = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a", "x2"],
+        [2, "b", "y2"],
+        [3, "c", "z2"],
+        [4, "d", "w2"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_all));
+
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name, PlannedAnchorFileName(table_path));
+    ASSERT_OK(CommitDeletionVectors(table_path, commit_msgs0[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{1, 3}}}));
+
+    // both files of the group must drop the same rows to keep the column merge aligned
+    auto expected_deleted = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a", "x2"],
+        [3, "c", "z2"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_deleted));
+
+    auto expected_with_row_id = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [1, "a", "x2", 0],
+        [3, "c", "z2", 2]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_with_row_id));
+
+    // a row-range selection composes with the deletion vector: rows {1, 2} minus deleted {1}
+    auto expected_selected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [3, "c", "z2"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_selected,
+                          /*predicate=*/nullptr, /*row_ranges=*/{Range(1, 2)}));
+}
+
+TEST_P(DataEvolutionTableTest, TestReadWithDeletionVectorsAcrossReadBatches) {
+    // the 12 rows below span several read batches, so the deletion vector empties a whole
+    // batch of every file of the group: each file reader then skips that batch entirely and
+    // the column merge has to stay aligned on the surviving row count alone
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true, {{Options::READ_BATCH_SIZE, "4"}});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> group_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0,
+                                             /*f0_values=*/{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11}));
+
+    // positions 4-7 cover a whole read batch, position 9 only part of the next one
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name, PlannedAnchorFileName(table_path));
+    ASSERT_OK(CommitDeletionVectors(table_path, group_msgs[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{4, 5, 6, 7, 9}}}));
+
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [0, "a0", "y0"],
+        [1, "a1", "y1"],
+        [2, "a2", "y2"],
+        [3, "a3", "y3"],
+        [8, "a8", "y8"],
+        [10, "a10", "y10"],
+        [11, "a11", "y11"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_array));
+
+    arrow::FieldVector row_id_fields = {SpecialFields::RowId().field_};
+    auto expected_row_ids = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(row_id_fields), R"([
+        [0], [1], [2], [3], [8], [10], [11]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"_ROW_ID"}, expected_row_ids));
+
+    // a row-range selection that spans the fully deleted batch composes with it
+    auto expected_selected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [3, "a3", "y3"],
+        [8, "a8", "y8"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_selected,
+                          /*predicate=*/nullptr, /*row_ranges=*/{Range(3, 8)}));
+}
+
+TEST_P(DataEvolutionTableTest, TestReadWithDeletionVectorsOnPartOfRowRangeGroups) {
+    // one split per row range group, so a group's deletion file must not reach the other
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true,
+                             {{Options::SOURCE_SPLIT_TARGET_SIZE, "1"}});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    auto src_array0 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a", "x"],
+        [2, "b", "y"],
+        [3, "c", "z"],
+        [4, "d", "w"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs0,
+                         WriteArray(table_path, schema->field_names(), src_array0));
+    SetFirstRowId(/*reset_first_row_id=*/0, commit_msgs0);
+    ASSERT_OK(Commit(table_path, commit_msgs0));
+
+    auto src_array1 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [5, "e", "v"],
+        [6, "f", "u"],
+        [7, "g", "t"],
+        [8, "h", "s"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs1,
+                         WriteArray(table_path, schema->field_names(), src_array1));
+    SetFirstRowId(/*reset_first_row_id=*/4, commit_msgs1);
+    ASSERT_OK(Commit(table_path, commit_msgs1));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> anchor_file_names,
+                         PlannedAnchorFileNames(table_path));
+    ASSERT_EQ(anchor_file_names.size(), 2);
+    ASSERT_OK(CommitDeletionVectors(table_path, commit_msgs0[0],
+                                    {{anchor_file_names[0], /*deleted_positions=*/{1, 3}}}));
+
+    // the deletion vector applies to its own group only, the other group keeps every row
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a", "x"],
+        [3, "c", "z"],
+        [5, "e", "v"],
+        [6, "f", "u"],
+        [7, "g", "t"],
+        [8, "h", "s"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_array));
+
+    // a projection-only read drops the same rows
+    arrow::FieldVector f0_fields = {fields_[0]};
+    auto expected_f0 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(f0_fields), R"([
+        [1], [3], [5], [6], [7], [8]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0"}, expected_f0));
+
+    arrow::FieldVector row_id_fields = {SpecialFields::RowId().field_};
+    auto expected_row_ids = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(row_id_fields), R"([
+        [0], [2], [4], [5], [6], [7]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"_ROW_ID"}, expected_row_ids));
+}
+
+TEST_P(DataEvolutionTableTest, TestReadWithDeletionVectorsOnEveryRowRangeGroup) {
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    // one split (the default target size keeps both groups together), so a single split
+    // deletion vector factory serves two groups anchored at different row ids
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> group_msgs0,
+        WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{0, 1, 2, 3}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/4, /*f0_values=*/{4, 5, 6, 7}));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> anchor_file_names,
+                         PlannedAnchorFileNames(table_path));
+    ASSERT_EQ(anchor_file_names.size(), 2);
+
+    // Positions are anchor-relative, so the groups deliberately delete different ones: group 0
+    // drops {1, 3} of row ids 0-3, group 1 drops {0, 2} of row ids 4-7. Reading a group with the
+    // other group's vector, or with its anchor range as the shift base, cannot match below.
+    ASSERT_OK(CommitDeletionVectors(table_path, group_msgs0[0],
+                                    {{anchor_file_names[0], /*deleted_positions=*/{1, 3}},
+                                     {anchor_file_names[1], /*deleted_positions=*/{0, 2}}}));
+
+    // The read looks a group's deletion vector up by its anchor file name, so the scan has to
+    // hand it exactly that. Asserting it separates a scan-side mix-up from a read-side one.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<Split>> planned_splits,
+                         PlanSplits(table_path));
+    ASSERT_EQ(planned_splits.size(), 1);
+    auto planned_split_impl = std::dynamic_pointer_cast<DataSplitImpl>(planned_splits[0]);
+    ASSERT_TRUE(planned_split_impl);
+
+    ASSERT_OK_AND_ASSIGN(DeletionCardinalityMap cardinality_by_file,
+                         DeletionCardinalityByDataFile(planned_splits[0]));
+    DeletionCardinalityMap expected_cardinalities = {{anchor_file_names[0], 2},
+                                                     {anchor_file_names[1], 2}};
+    ASSERT_EQ(cardinality_by_file, expected_cardinalities);
+
+    // the same split reports the surviving row count the limit push down prunes on: the two
+    // groups hold 4 rows each and each deletion vector drops 2 of them
+    ASSERT_OK_AND_ASSIGN(std::optional<int64_t> merged_row_count,
+                         planned_split_impl->MergedRowCount());
+    ASSERT_EQ(std::optional<int64_t>(4), merged_row_count);
+
+    // a count query answers from that metadata alone, never reading a row, so the deletion
+    // vectors have to reach it too: without them it reports the 8 rows the files hold
+    ReadContextBuilder count_context_builder(table_path);
+    count_context_builder.SetReadFieldNames(schema->field_names());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<ReadContext> count_context,
+                         count_context_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableRead> count_table_read,
+                         TableRead::Create(std::move(count_context)));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<CountReader> count_reader,
+                         count_table_read->CreateCountReader(planned_splits));
+    ASSERT_OK_AND_ASSIGN(int64_t counted_rows, count_reader->CountRows());
+    ASSERT_EQ(counted_rows, 4);
+
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [0, "a0", "y0"],
+        [2, "a2", "y2"],
+        [5, "a1", "y1"],
+        [7, "a3", "y3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_array));
+
+    arrow::FieldVector row_id_fields = {SpecialFields::RowId().field_};
+    auto expected_row_ids = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(row_id_fields), R"([
+        [0], [2], [5], [7]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"_ROW_ID"}, expected_row_ids));
+
+    // a row-range selection straddling the group boundary composes with both deletion vectors:
+    // row ids {2, 3, 4, 5} minus the deleted {3, 4}
+    auto expected_selected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [2, "a2", "y2"],
+        [5, "a1", "y1"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_selected,
+                          /*predicate=*/nullptr, /*row_ranges=*/{Range(2, 5)}));
+}
+
+TEST_P(DataEvolutionTableTest, TestReadWithFullyDeletedRowRangeGroup) {
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    // one split (the default target size keeps both groups together), so the emptied group's
+    // readers are concatenated with the surviving group's
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> group_msgs0,
+        WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{0, 1, 2, 3}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/4, /*f0_values=*/{4, 5, 6, 7}));
+
+    // both file readers of the first group then yield nothing, and its column merge must
+    // produce no rows at all instead of misaligning
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> anchor_file_names,
+                         PlannedAnchorFileNames(table_path));
+    ASSERT_EQ(anchor_file_names.size(), 2);
+    ASSERT_OK(CommitDeletionVectors(table_path, group_msgs0[0],
+                                    {{anchor_file_names[0], /*deleted_positions=*/{0, 1, 2, 3}}}));
+
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [4, "a0", "y0"],
+        [5, "a1", "y1"],
+        [6, "a2", "y2"],
+        [7, "a3", "y3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_array));
+
+    arrow::FieldVector row_id_fields = {SpecialFields::RowId().field_};
+    auto expected_row_ids = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(row_id_fields), R"([
+        [4], [5], [6], [7]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"_ROW_ID"}, expected_row_ids));
+
+    // a row-range selection spanning both groups keeps only what survives in the second one
+    auto expected_selected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [4, "a0", "y0"],
+        [5, "a1", "y1"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_selected,
+                          /*predicate=*/nullptr, /*row_ranges=*/{Range(0, 5)}));
+
+    // a selection covering only deleted rows returns nothing. The plan is asserted non-empty
+    // too: the scan cannot prune the split on row ids alone, so the emptiness comes from the
+    // deletion vector rather than from a plan with nothing to read.
+    ASSERT_OK_AND_ASSIGN(LimitScanResult only_deleted,
+                         ScanAndReadWithLimit(table_path, schema->field_names(), /*limit=*/100,
+                                              /*predicate=*/nullptr,
+                                              /*row_ranges=*/{Range(0, 3)}));
+    ASSERT_FALSE(only_deleted.splits.empty());
+    ASSERT_FALSE(only_deleted.rows);
+}
+
+TEST_P(DataEvolutionTableTest, TestReadAfterUpdatingDeletionVectors) {
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a", "x"],
+        [2, "b", "y"],
+        [3, "c", "z"],
+        [4, "d", "w"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs,
+                         WriteArray(table_path, schema->field_names(), src_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, commit_msgs);
+    ASSERT_OK(Commit(table_path, commit_msgs));
+
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name, PlannedAnchorFileName(table_path));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<CommitMessage> first_dv_msg,
+                         CommitDeletionVectors(table_path, commit_msgs[0],
+                                               {{anchor_file_name, /*deleted_positions=*/{1}}}));
+
+    auto expected_after_first = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a", "x"],
+        [3, "c", "z"],
+        [4, "d", "w"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_after_first));
+
+    // a second deletion vector replaces the first one instead of both staying live
+    ASSERT_OK(CommitDeletionVectors(table_path, commit_msgs[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{1, 3}}},
+                                    /*replaced_commit_msg=*/first_dv_msg));
+
+    auto expected_after_update = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a", "x"],
+        [3, "c", "z"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_after_update));
+}
+
+TEST_P(DataEvolutionTableTest, TestReadWithDeletionVectorsAfterAddingColumn) {
+    if (FileFormat() == "avro") {
+        GTEST_SKIP() << "Avro has no stats, which the added column's scan pruning relies on";
+    }
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a", "x"],
+        [2, "b", "y"],
+        [3, "c", "z"],
+        [4, "d", "w"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs,
+                         WriteArray(table_path, arrow::schema(fields_)->field_names(), src_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, commit_msgs);
+    ASSERT_OK(Commit(table_path, commit_msgs));
+
+    // add column f3, then fill it for the same row range: the group merges columns from two
+    // files written under different schema ids
+    auto f3 = arrow::field("f3", arrow::int64());
+    ASSERT_OK(TestHelper::WriteNextSchema(dir_->GetFileSystem(), table_path,
+                                          {DataField(0, fields_[0]), DataField(1, fields_[1]),
+                                           DataField(2, fields_[2]), DataField(3, f3)},
+                                          /*highest_field_id=*/3, options));
+
+    auto f3_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({f3}), R"([
+        [10], [20], [30], [40]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto f3_commit_msgs, WriteArray(table_path, {"f3"}, f3_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, f3_commit_msgs);
+    ASSERT_OK(Commit(table_path, f3_commit_msgs));
+
+    // the deletion vector is still anchored on the oldest normal file, written before the
+    // column was added
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name, PlannedAnchorFileName(table_path));
+    ASSERT_OK(CommitDeletionVectors(table_path, commit_msgs[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{1, 3}}}));
+
+    arrow::FieldVector evolved_fields = {fields_[0], fields_[1], fields_[2], f3};
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(evolved_fields), R"([
+        [1, "a", "x", 10],
+        [3, "c", "z", 30]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "f3"}, expected_array));
+
+    // projecting only the added column keeps the same surviving rows
+    auto expected_f3 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({f3}), R"([
+        [10], [30]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f3"}, expected_f3));
+}
+
+TEST_P(DataEvolutionTableTest, TestLimitPushDownWithHeavilyDeletedFirstRowRangeGroup) {
+    // one split per row range group, so the limit has to span both to be satisfied
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true,
+                             {{Options::SOURCE_SPLIT_TARGET_SIZE, "1"}});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> group_msgs0,
+        WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{0, 1, 2, 3}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/4, /*f0_values=*/{4, 5, 6, 7}));
+
+    // the first group keeps a single surviving row
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> anchor_file_names,
+                         PlannedAnchorFileNames(table_path));
+    ASSERT_EQ(anchor_file_names.size(), 2);
+    ASSERT_OK(CommitDeletionVectors(table_path, group_msgs0[0],
+                                    {{anchor_file_names[0], /*deleted_positions=*/{0, 1, 2}}}));
+
+    // the first split alone satisfies a limit of 1: it still holds the one row that survived
+    // the deletion vector
+    ASSERT_OK_AND_ASSIGN(LimitScanResult limit_1,
+                         ScanAndReadWithLimit(table_path, {"f0"}, /*limit=*/1));
+    ASSERT_EQ(limit_1.splits.size(), 1);
+    ASSERT_OK_AND_ASSIGN(std::vector<int32_t> limit_1_values, CollectF0Values(limit_1.rows));
+    ASSERT_EQ(limit_1_values, (std::vector<int32_t>{3}));
+
+    // the first split contributes only one surviving row, so a limit of 3 needs the second one
+    ASSERT_OK_AND_ASSIGN(LimitScanResult limit_3,
+                         ScanAndReadWithLimit(table_path, {"f0"}, /*limit=*/3));
+    ASSERT_EQ(limit_3.splits.size(), 2);
+    ASSERT_OK_AND_ASSIGN(std::vector<int32_t> limit_3_values, CollectF0Values(limit_3.rows));
+    ASSERT_EQ(limit_3_values, (std::vector<int32_t>{3, 4, 5, 6, 7}));
+}
+
+TEST_P(DataEvolutionTableTest, TestLimitPushDownDisabledByNonPartitionFilter) {
+    // one split per row range group, so the plan can drop the group holding the matches
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false,
+                             {{Options::SOURCE_SPLIT_TARGET_SIZE, "1"}});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // First row range group: no f0 value lies in [100, 200], but the 300 keeps the group's stats
+    // range straddling the filter so the scan cannot prune it. It therefore reaches the plan
+    // reporting four rows, and contributes none of them to the result.
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{0, 1, 2, 300}));
+    // second row range group: every f0 value matches
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/4,
+                                  /*f0_values=*/{100, 101, 102, 103}));
+
+    // the metadata row count of the first split alone satisfies the limit, but the filter runs
+    // while reading and drops every one of its rows. Pruning the plan on the metadata count
+    // would return nothing, so the push down has to be skipped and both splits kept.
+    auto at_least_100 = PredicateBuilder::GreaterOrEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                         FieldType::INT, Literal(100));
+    auto at_most_200 = PredicateBuilder::LessOrEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                     FieldType::INT, Literal(200));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Predicate> predicate,
+                         PredicateBuilder::And({at_least_100, at_most_200}));
+    // filtering while reading is what makes the metadata count an upper bound, so the read has
+    // to opt into it for the rows below to show what the push down would have thrown away
+    ASSERT_OK_AND_ASSIGN(LimitScanResult limited,
+                         ScanAndReadWithLimit(table_path, {"f0"}, /*limit=*/2, predicate,
+                                              /*row_ranges=*/{},
+                                              /*enable_predicate_filter=*/true));
+    ASSERT_EQ(limited.splits.size(), 2);
+    ASSERT_OK_AND_ASSIGN(std::vector<int32_t> values, CollectF0Values(limited.rows));
+    ASSERT_EQ(values, (std::vector<int32_t>{100, 101, 102, 103}));
+}
+
+TEST_P(DataEvolutionTableTest, TestLimitPushDownKeptByPartitionFilter) {
+    std::vector<std::string> partition_keys = {"f1"};
+    CreateTable(partition_keys);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // one row range group per partition, each holding four rows with its own f0 range. A split
+    // never spans partitions, so the plan holds one split per partition for the push down to
+    // prune.
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{0, 1, 2, 3},
+                                  /*partition=*/{{"f1", "p0"}}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/4,
+                                  /*f0_values=*/{10, 11, 12, 13}, /*partition=*/{{"f1", "p1"}}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/8,
+                                  /*f0_values=*/{20, 21, 22, 23}, /*partition=*/{{"f1", "p2"}}));
+
+    // a predicate on the partition key alone is evaluated while planning, never while reading,
+    // so every row a surviving split reports is actually returned and the push down stays on
+    auto not_p0 =
+        PredicateBuilder::NotEqual(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                   Literal(FieldType::STRING, "p0", 2));
+
+    // baseline: a limit no split combination can reach prunes nothing, so this only shows which
+    // splits the partition filter itself leaves behind
+    ASSERT_OK_AND_ASSIGN(LimitScanResult unpruned,
+                         ScanAndReadWithLimit(table_path, {"f0", "f1"}, /*limit=*/100, not_p0));
+    ASSERT_EQ(unpruned.splits.size(), 2);
+    ASSERT_OK_AND_ASSIGN(std::vector<int32_t> unpruned_values, CollectF0Values(unpruned.rows));
+    std::sort(unpruned_values.begin(), unpruned_values.end());
+    ASSERT_EQ(unpruned_values, (std::vector<int32_t>{10, 11, 12, 13, 20, 21, 22, 23}));
+
+    // the first matching split already holds four rows, so a limit of 2 drops the second one.
+    // Treating the partition filter as a read-time filter would skip the push down and keep both.
+    ASSERT_OK_AND_ASSIGN(LimitScanResult limited,
+                         ScanAndReadWithLimit(table_path, {"f0", "f1"}, /*limit=*/2, not_p0));
+    ASSERT_EQ(limited.splits.size(), 1);
+    ASSERT_OK_AND_ASSIGN(std::vector<int32_t> limited_values, CollectF0Values(limited.rows));
+    std::sort(limited_values.begin(), limited_values.end());
+    ASSERT_TRUE(limited_values == (std::vector<int32_t>{10, 11, 12, 13}) ||
+                limited_values == (std::vector<int32_t>{20, 21, 22, 23}))
+        << "unexpected kept rows for limit 2";
+
+    // one non-partition conjunct added to the same partition filter: the predicate is no longer
+    // settled while planning, so the push down is skipped and the split the limit would have
+    // dropped stays
+    auto at_least_10 = PredicateBuilder::GreaterOrEqual(/*field_index=*/0, /*field_name=*/"f0",
+                                                        FieldType::INT, Literal(10));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Predicate> mixed_predicate,
+                         PredicateBuilder::And({not_p0, at_least_10}));
+    ASSERT_OK_AND_ASSIGN(LimitScanResult mixed, ScanAndReadWithLimit(table_path, {"f0", "f1"},
+                                                                     /*limit=*/2, mixed_predicate));
+    ASSERT_EQ(mixed.splits.size(), 2);
+    ASSERT_OK_AND_ASSIGN(std::vector<int32_t> mixed_values, CollectF0Values(mixed.rows));
+    std::sort(mixed_values.begin(), mixed_values.end());
+    ASSERT_EQ(mixed_values, (std::vector<int32_t>{10, 11, 12, 13, 20, 21, 22, 23}));
+}
+
+TEST_P(DataEvolutionTableTest, TestLimitPushDownDisabledByRowRangeIndex) {
+    // one split per row range group, so the plan can drop the group holding the selection
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false,
+                             {{Options::SOURCE_SPLIT_TARGET_SIZE, "1"}});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{0, 1, 2, 3}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/4,
+                                  /*f0_values=*/{100, 101, 102, 103}));
+
+    // the index selects one row of the first group and two of the second, but the first split
+    // still reports four rows. Pruning on that count would drop the second group and return a
+    // single row for a limit of 2, so the push down has to be skipped.
+    ASSERT_OK_AND_ASSIGN(LimitScanResult limited,
+                         ScanAndReadWithLimit(table_path, {"f0"}, /*limit=*/2,
+                                              /*predicate=*/nullptr,
+                                              /*row_ranges=*/{Range(3, 3), Range(5, 6)}));
+    ASSERT_EQ(limited.splits.size(), 2);
+    ASSERT_OK_AND_ASSIGN(std::vector<int32_t> values, CollectF0Values(limited.rows));
+    ASSERT_EQ(values, (std::vector<int32_t>{3, 101, 102}));
 }
 
 std::vector<DataEvolutionTableParam> GetTestValuesForDataEvolutionTableTest() {

--- a/test/inte/write_and_read_inte_test.cpp
+++ b/test/inte/write_and_read_inte_test.cpp
@@ -90,22 +90,9 @@ class WriteAndReadInteTest
 
     Status WriteNextSchema(const std::vector<DataField>& fields, int32_t highest_field_id,
                            const std::map<std::string, std::string>& options) const {
-        auto file_system = dir_->GetFileSystem();
-        std::string table_path = PathUtil::JoinPath(test_dir_, "foo.db/bar");
-        SchemaManager schema_manager(file_system, table_path);
-        PAIMON_ASSIGN_OR_RAISE(auto latest_schema_opt, schema_manager.Latest());
-        if (!latest_schema_opt) {
-            return Status::Invalid("table schema does not exist");
-        }
-        auto next_schema = std::make_shared<TableSchema>(*latest_schema_opt.value());
-        next_schema->id_ = latest_schema_opt.value()->Id() + 1;
-        next_schema->fields_ = fields;
-        next_schema->highest_field_id_ = highest_field_id;
-        next_schema->options_ = options;
-        PAIMON_ASSIGN_OR_RAISE(std::string schema_content, next_schema->ToJsonString());
-        std::string schema_path = PathUtil::JoinPath(schema_manager.SchemaDirectory(),
-                                                     "schema-" + std::to_string(next_schema->Id()));
-        return file_system->AtomicStore(schema_path, schema_content);
+        return TestHelper::WriteNextSchema(dir_->GetFileSystem(),
+                                           PathUtil::JoinPath(test_dir_, "foo.db/bar"), fields,
+                                           highest_field_id, options);
     }
 
     Status WriteNextSchemaWithRawFieldTypes(const std::string& fields_json,


### PR DESCRIPTION
### Purpose

Linked issue: close #169

Port the read side of Apache Paimon [`d2be7eace`](https://github.com/apache/paimon/commit/d2be7eacedf7c001ed1022856a62ade089e954c4) (apache/paimon#8380), so a data-evolution table can enable `deletion-vectors.enabled`.

A row range group's deletion vector is maintained against the group's **anchor file**, so its positions are anchor-relative rather than file-relative. Every reader of the group must therefore drop the same rows to keep the column merge positionally aligned: file readers apply the vector shifted by the file's offset inside the anchor row id range, and the blob fallback path drops the deleted row ids from its placeholder gap segments, which have no file reader to wrap.

Main changes:

- Add `DataEvolutionUtils::RetrieveAnchorFile`, matching Java's anchor rule: the oldest normal file of the group by `(max_sequence_number, file_name)`, skipping blob and vector-store files. The producer side (`AppendDeleteFileMaintainer`) follows the same rule, so the file a Java engine attaches the deletion vector to is the one this read path looks it up by.
- Drop the `SchemaValidation` rule forbidding `data-evolution.enabled` together with `deletion-vectors.enabled`, matching Java.
- Support committing a deletion vector index file for a table without buckets, which a data-evolution table always is. `IndexManifestFileHandler` combines such index files by file name, the way Java's `GlobalCombiner` does, rejecting a second vector for a data file or the removal of one that is not there. Without this the deletes another engine issues could not reach the table through this commit path at all, so lifting only the `SchemaValidation` rule would have left the combination unusable.
- Narrow, rather than drop, `ConflictDetection`'s refusal of deletion vectors in `BUCKET_UNAWARE` mode. It now refuses only a delta that **deletes data files**: such a table keeps its vectors in the index manifest, which the data file entries do not reference, and Java pairs the two first (`ConflictDetection#buildBaseEntriesWithDV`) so that dropping a data file conflicts with a concurrent commit rewriting that file's vector. That pairing is not ported, so the shape needing it fails fast instead of committing against a stale state. Adding files stays allowed, and so does another engine replacing a vector, which travels through the delta index entries this check does not inspect.
- Subtract deletion vector cardinality from `DataSplit::MergedRowCount`, and report the count unavailable when a deletion file carries no cardinality.
- Skip the limit push down when a non-partition filter or a row range index is present: a split's metadata row count is then only an upper bound of what the read returns, so pruning on it could return fewer rows than the limit.
- Apply the row ranges selection and the row range groups' deletion vectors to the blob view pre-read, so a reference held only by a dropped row is no longer resolved.
- Read a row range group made only of blob files, which a split can pack next to a group carrying a deletion vector, without an anchor. No writer can key a vector by such a group, so it reads undeleted rather than failing the whole split on the missing anchor. **Paimon Java throws here**; this is a deliberate divergence.

Scope: Paimon C++ **does not produce** these deletion vectors — the deletes are issued by another engine, and this change only lets that engine's index-only commit land and be read back. `deletion-vectors.bitmap64` and compaction of such a table remain unsupported.

Two behavior changes worth calling out for reviewers, since they reach append and primary key tables too:

- `ApplyPushDownLimit` used to consider only raw convertible splits, silently leaving a merged split out of the pruned plan. It now asks every split for its row count and abandons the push down as soon as one cannot be counted from metadata, which is the same conservative answer the raw convertible path already gave. That is what lets a data-evolution split, which is not raw convertible but does have an exact count, take part in the pruning.
- The new `CanPushDownLimit` guard also fixes a wrong result that predates deletion vectors: the push down never consulted the non-partition predicate, so a limited query carrying a value filter pruned splits on row counts the filter had not been applied to yet, and could return fewer rows than the limit asked for while more still existed.

### Tests

Unit tests:

| Case | Covers |
| --- | --- |
| `DataEvolutionUtilsTest.TestRetrieveAnchorFileSkipsBlobAndVectorStoreFiles` | anchor skips blob / vector-store files; `IsNormalFile` agrees |
| `DataEvolutionUtilsTest.TestRetrieveAnchorFileFailsWithoutNormalFile` | group with no normal file errors |
| `DataEvolutionUtilsTest.TestRetrieveAnchorFileTieBreaksWithFileName` | `(max_sequence_number, file_name)` tie-break |
| `DataEvolutionSplitReadTest.TestReadGroupDeletionVector` | anchor lookup; null factory, absent and empty vector all yield nullopt; a group with no anchor yields nullopt instead of failing |
| `DataEvolutionSplitReadTest.TestCreateGroupDvFactoryShiftsPositions` | per-file offset shift, window limit, read-only guards |
| `DataEvolutionSplitReadTest.TestCreateGroupDvFactoryRejectsFileOutsideAnchorRange` | file outside the anchor range is rejected |
| `DataEvolutionSplitReadTest.TestExcludeDeletedRowIds` | gap range arithmetic, including a fully deleted range |
| `DataSplitTest.TestDataEvolutionMergedRowCountSubtractsDeletionFileCardinality` | cardinality subtracted |
| `DataSplitTest.TestDataEvolutionMergedRowCountUnavailableWithoutCardinality` | missing cardinality makes the count unavailable |
| `DataSplitTest.TestSerializeDataEvolutionSplitWithDeletionFiles` | first row ids + deletion files survive a serialization round trip |
| `SchemaValidationTest` (2 cases updated) | the combination is now accepted, including on a blob table |
| `IndexManifestFileHandlerTest.GlobalDvCombinerReplacesIndexFileInBucketUnawareMode` | an updated vector replaces its index file, keeping the other group's |
| `IndexManifestFileHandlerTest.GlobalDvCombinerRejectsInconsistentDelta` | a second vector for one data file, a re-added index file and a deleted absent one are all rejected |
| `ConflictDetectionTest.TestDeletionVectorsAllowedWithBucketUnawareMode` (updated) | adding files commits; deleting a data file is refused |
| `ConflictDetectionTest.TestDeletionVectorsDeleteAllowedWithoutBucketUnawareMode` | the refusal is scoped to bucket-unaware tables |

Integration tests (`DataEvolutionTableTest`, parquet/orc/avro):

`TestReadWithDeletionVectors`, `TestReadWithDeletionVectorsAcrossReadBatches`, `TestReadWithDeletionVectorsOnPartOfRowRangeGroups`, `TestReadWithDeletionVectorsOnEveryRowRangeGroup` (two groups with their own vectors in one split, plus plan-level assertions on which data file carries which deletion file), `TestReadWithFullyDeletedRowRangeGroup`, `TestReadAfterUpdatingDeletionVectors`, `TestReadWithDeletionVectorsAfterAddingColumn`, `TestLimitPushDownWithHeavilyDeletedFirstRowRangeGroup`, `TestLimitPushDownDisabledByNonPartitionFilter`, `TestLimitPushDownKeptByPartitionFilter`, `TestLimitPushDownDisabledByRowRangeIndex`.

Integration tests (`BlobTableInteTest`):

`TestDataEvolutionBlobPartialUpdateWithDeletionVectors` (multi-layer blob fallback, placeholder gaps, blob-only projection), `TestBlobViewSkipsDanglingReferenceOfDeletedRow`, `TestBlobViewSkipsDanglingReferenceInEveryRowRangeGroup`, `TestBlobViewPreReadHonorsRowRangesNotPredicate`.

Deletion vectors are committed the way an external engine does, through the new `DeletionVectorTestHelper`: a deletion vector index file written with the production `DeletionVectorsIndexFile` writer and committed as an index-only commit message keyed by the group's anchor file.

### API and Format

No public API changes: the only edit under `include/` is a comment, an `@note` on `Options::DELETION_VECTORS_ENABLED` recording that Paimon C++ reads but does not write these vectors on a data-evolution table. No storage format or protocol changes.

`IndexManifestFileHandler::IndexManifestFileCombiner::Combine` now returns a `Result`, so the new combiner can report a rejected delta instead of writing an index manifest that contradicts itself; the class is private to the handler and the other two combiners keep their behavior. Review feedback likewise turned `DeletionVector::GetCardinality` into a `Result<int64_t>`: the position-shifted window view over a group's vector is the one implementation that can fail, and it now propagates that failure instead of asserting and returning a guess; the interface is internal, and its two production callers propagate the error. The deletion vector index format read here is the existing one; this change only makes it reachable for data-evolution tables. `DataSplitImpl::data_deletion_files_` gains a documented invariant (aligned one-to-one with the data files; only anchor files carry an entry) but its serialized form is unchanged, which `DataSplitTest.TestSerializeDataEvolutionSplitWithDeletionFiles` pins.

### Documentation

Yes.

- `docs/source/user_guide/read.rst` gains a section, *Deletion Vectors on Data-Evolution Tables*, covering how the anchor file locates a group's vector, how the shift and the blob fallback gaps apply it, and the limitations: only the default 32-bit vectors are readable, Paimon C++ does not write them, a commit dropping data files is refused, and such a table is never compacted.
- `docs/source/user_guide/compaction.rst` gains a note that such a table is never compacted here, matching the Paimon Java revision this was ported from; later Java releases do compact it and Paimon C++ has not caught up.

### Generative AI tooling

Generated-by: Claude Opus 5 (1M context)

