### PR TITLE
chore: clean up bitmap and CMake compatibility declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ Paimon C++ currently provides:
 - **Compatibility**: compatibility with Apache Paimon Java format and communication protocols,
   including commit messages, data splits, and manifests.
 
-> **Bitmap global index compatibility:** Java Paimon now uses a dedicated bitmap global index
-> format instead of the previously shared wrapped bitmap file index format.
-> Paimon C++ therefore currently treats the `bitmap` global index type as unsupported. The legacy
-> implementation remains in the codebase pending migration to the Java-compatible format.
-
 Note: Linux `x86_64` and `aarch64` builds are supported and verified in CI. See the supported
 platform matrix in [docs/source/building.rst](docs/source/building.rst) for other platforms.
 

--- a/cmake_modules/BuildAwsAuth.cmake
+++ b/cmake_modules/BuildAwsAuth.cmake
@@ -34,7 +34,6 @@ function(paimon_add_s2n_project)
     externalproject_add(s2n_ep
                         URL ${S2N_URL}
                         URL_HASH SHA256=${PAIMON_AWS_S2N_BUILD_SHA256_CHECKSUM}
-                        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
                         CMAKE_ARGS ${EP_COMMON_CMAKE_ARGS}
                                    -DCMAKE_C_FLAGS=${S2N_C_FLAGS}
                                    -DCMAKE_CXX_FLAGS=${S2N_CXX_FLAGS}
@@ -89,7 +88,6 @@ function(paimon_add_aws_c_project
     externalproject_add(${NAME}_ep
                         URL ${URL}
                         URL_HASH SHA256=${CHECKSUM}
-                        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
                         CMAKE_ARGS ${EP_COMMON_CMAKE_ARGS}
                                    -DCMAKE_INSTALL_PREFIX=${AWS_AUTH_PREFIX}
                                    -DCMAKE_INSTALL_LIBDIR=${AWS_AUTH_INSTALL_LIBDIR}


### PR DESCRIPTION
### Purpose

Linked issue: N/A

This change cleans up two obsolete compatibility declarations:

- Remove the outdated README note that describes the bitmap global index type as unsupported.
- Remove the CMake 3.24-only `DOWNLOAD_EXTRACT_TIMESTAMP` arguments from the bundled AWS authentication dependencies so the declared CMake 3.22 minimum is honored.

CMake 3.24 and newer retain extraction-time timestamps through the existing `CMP0135 NEW` policy setting. CMake 3.22 and 3.23 use the older timestamp behavior, which is acceptable for this project.

Users get accurate bitmap compatibility documentation, and S3 builds can be configured with the documented minimum CMake version.

### Tests

- CMake 3.22.6 configuration with `-DPAIMON_ENABLE_S3=ON -DPAIMON_BUILD_TESTS=OFF`
- `pre-commit run --files README.md`
- `pre-commit run --files cmake_modules/BuildAwsAuth.cmake`
- `git diff --check`

### API and Format

No API, storage format, or protocol changes.

### Documentation

Removes an outdated compatibility note from `README.md`; no new feature is introduced.

### Generative AI tooling

Generated-by: Codex (GPT-5)
