### PR TITLE
fix(tests): use portable bigint test literals

### DIFF
--- a/src/paimon/format/parquet/predicate_converter_test.cpp
+++ b/src/paimon/format/parquet/predicate_converter_test.cpp
@@ -32,6 +32,16 @@
 
 namespace paimon::parquet::test {
 
+namespace {
+
+// Use an explicit int64_t literal for BIGINT predicates. On macOS arm64, `long` and
+// `int64_t` are distinct types, so `Literal(5l)` may instantiate `Literal<long>`.
+Literal BigIntLiteral(int64_t value) {
+    return Literal(value);
+}
+
+}  // namespace
+
 TEST(PredicateConverterTest, TestSimple) {
     // "struct<f0:bigint,f1:double,f2:string,f3:int,f4:tinyint,f5:decimal(6,2),f6:date,f7:timestamp>";
     {
@@ -50,7 +60,7 @@ TEST(PredicateConverterTest, TestSimple) {
     }
     {
         auto predicate = PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0",
-                                                 FieldType::BIGINT, Literal(5l));
+                                                 FieldType::BIGINT, BigIntLiteral(5));
         ASSERT_OK_AND_ASSIGN(auto expression, PredicateConverter::Convert(
                                                   predicate, /*predicate_node_count_limit=*/100));
         ASSERT_EQ("(f0 == 5)", expression.ToString());
@@ -71,21 +81,21 @@ TEST(PredicateConverterTest, TestSimple) {
     }
     {
         auto predicate = PredicateBuilder::NotEqual(/*field_index=*/0, /*field_name=*/"f0",
-                                                    FieldType::BIGINT, Literal(5l));
+                                                    FieldType::BIGINT, BigIntLiteral(5));
         ASSERT_OK_AND_ASSIGN(auto expression, PredicateConverter::Convert(
                                                   predicate, /*predicate_node_count_limit=*/100));
         ASSERT_EQ("(f0 != 5)", expression.ToString());
     }
     {
         auto predicate = PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"f0",
-                                                       FieldType::BIGINT, Literal(5l));
+                                                       FieldType::BIGINT, BigIntLiteral(5));
         ASSERT_OK_AND_ASSIGN(auto expression, PredicateConverter::Convert(
                                                   predicate, /*predicate_node_count_limit=*/100));
         ASSERT_EQ("(f0 > 5)", expression.ToString());
     }
     {
         auto predicate = PredicateBuilder::GreaterOrEqual(/*field_index=*/0, /*field_name=*/"f0",
-                                                          FieldType::BIGINT, Literal(5l));
+                                                          FieldType::BIGINT, BigIntLiteral(5));
         ASSERT_OK_AND_ASSIGN(auto expression, PredicateConverter::Convert(
                                                   predicate, /*predicate_node_count_limit=*/100));
         ASSERT_EQ("(f0 >= 5)", expression.ToString());
@@ -100,14 +110,14 @@ TEST(PredicateConverterTest, TestSimple) {
     }
     {
         auto predicate = PredicateBuilder::LessThan(/*field_index=*/0, /*field_name=*/"f0",
-                                                    FieldType::BIGINT, Literal(5l));
+                                                    FieldType::BIGINT, BigIntLiteral(5));
         ASSERT_OK_AND_ASSIGN(auto expression, PredicateConverter::Convert(
                                                   predicate, /*predicate_node_count_limit=*/100));
         ASSERT_EQ("(f0 < 5)", expression.ToString());
     }
     {
         auto predicate = PredicateBuilder::LessOrEqual(/*field_index=*/0, /*field_name=*/"f0",
-                                                       FieldType::BIGINT, Literal(5l));
+                                                       FieldType::BIGINT, BigIntLiteral(5));
         ASSERT_OK_AND_ASSIGN(auto expression, PredicateConverter::Convert(
                                                   predicate, /*predicate_node_count_limit=*/100));
         ASSERT_EQ("(f0 <= 5)", expression.ToString());
@@ -115,7 +125,7 @@ TEST(PredicateConverterTest, TestSimple) {
     {
         auto predicate =
             PredicateBuilder::In(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
-                                 {Literal(1l), Literal(3l), Literal(5l)});
+                                 {BigIntLiteral(1), BigIntLiteral(3), BigIntLiteral(5)});
         ASSERT_OK_AND_ASSIGN(auto expression, PredicateConverter::Convert(
                                                   predicate, /*predicate_node_count_limit=*/100));
         ASSERT_EQ("(((f0 == 1) or (f0 == 3)) or (f0 == 5))", expression.ToString());
@@ -123,7 +133,7 @@ TEST(PredicateConverterTest, TestSimple) {
     {
         auto predicate =
             PredicateBuilder::NotIn(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
-                                    {Literal(1l), Literal(3l), Literal(5l)});
+                                    {BigIntLiteral(1), BigIntLiteral(3), BigIntLiteral(5)});
         ASSERT_OK_AND_ASSIGN(auto expression, PredicateConverter::Convert(
                                                   predicate, /*predicate_node_count_limit=*/100));
         ASSERT_EQ("(((f0 != 1) and (f0 != 3)) and (f0 != 5))", expression.ToString());
@@ -320,7 +330,7 @@ TEST(PredicateConverterTest, TestCompound) {
             auto predicate,
             PredicateBuilder::And({
                 PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
-                                        Literal(3l)),
+                                        BigIntLiteral(3)),
                 PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                         Literal(static_cast<float>(5.0))),
                 PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
@@ -349,7 +359,7 @@ TEST(PredicateConverterTest, TestCompound) {
             auto predicate,
             PredicateBuilder::Or({
                 PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"f0", FieldType::BIGINT,
-                                        Literal(3l)),
+                                        BigIntLiteral(3)),
                 PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                         Literal(static_cast<float>(5.0))),
                 PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2", FieldType::STRING,
@@ -370,7 +380,7 @@ TEST(PredicateConverterTest, TestCompound) {
                      {PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",
                                               FieldType::BOOLEAN, Literal(true)),
                       PredicateBuilder::LessThan(/*field_index=*/0, /*field_name=*/"f0",
-                                                 FieldType::BIGINT, Literal(3l))})
+                                                 FieldType::BIGINT, BigIntLiteral(3))})
                      .value(),
                  PredicateBuilder::And(
                      {PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3",

--- a/src/paimon/format/parquet/predicate_pushdown_test.cpp
+++ b/src/paimon/format/parquet/predicate_pushdown_test.cpp
@@ -418,16 +418,16 @@ TEST_F(PredicatePushdownTest, TestPredicatePushdownWithAllDataNull) {
     // other predicate, always return IS_NULL (no data)
     {
         // f4 in [1,2], no data
-        auto predicate = PredicateBuilder::In(/*field_index=*/4, /*field_name=*/"f4",
-                                              FieldType::BIGINT,
-                                              {BigIntLiteral(1), BigIntLiteral(2)});
+        auto predicate =
+            PredicateBuilder::In(/*field_index=*/4, /*field_name=*/"f4", FieldType::BIGINT,
+                                 {BigIntLiteral(1), BigIntLiteral(2)});
         CheckResult(read_schema, predicate, /*expected_array=*/nullptr);
     }
     {
         // f4 not in [1,2], no data
-        auto predicate = PredicateBuilder::NotIn(/*field_index=*/4, /*field_name=*/"f4",
-                                                 FieldType::BIGINT,
-                                                 {BigIntLiteral(1), BigIntLiteral(2)});
+        auto predicate =
+            PredicateBuilder::NotIn(/*field_index=*/4, /*field_name=*/"f4", FieldType::BIGINT,
+                                    {BigIntLiteral(1), BigIntLiteral(2)});
         CheckResult(read_schema, predicate, /*expected_array=*/nullptr);
     }
     {

--- a/src/paimon/format/parquet/predicate_pushdown_test.cpp
+++ b/src/paimon/format/parquet/predicate_pushdown_test.cpp
@@ -55,6 +55,16 @@ class Predicate;
 
 namespace paimon::parquet::test {
 
+namespace {
+
+// Use an explicit int64_t literal for BIGINT predicates. On macOS arm64, `long` and
+// `int64_t` are distinct types, so `Literal(5l)` may instantiate `Literal<long>`.
+Literal BigIntLiteral(int64_t value) {
+    return Literal(value);
+}
+
+}  // namespace
+
 class PredicatePushdownTest : public ::testing::Test {
  public:
     void SetUp() override {
@@ -186,19 +196,19 @@ TEST_F(PredicatePushdownTest, TestIntDoubleData) {
     {
         // f2 != 4, has data
         auto predicate = PredicateBuilder::NotEqual(/*field_index=*/2, /*field_name=*/"f2",
-                                                    FieldType::BIGINT, Literal(4l));
+                                                    FieldType::BIGINT, BigIntLiteral(4));
         CheckResult(read_schema, predicate, expected_array);
     }
     {
         // f2 == 6, has data
         auto predicate = PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2",
-                                                 FieldType::BIGINT, Literal(6l));
+                                                 FieldType::BIGINT, BigIntLiteral(6));
         CheckResult(read_schema, predicate, expected_array);
     }
     {
         // f2 == 1, no data
         auto predicate = PredicateBuilder::Equal(/*field_index=*/2, /*field_name=*/"f2",
-                                                 FieldType::BIGINT, Literal(1l));
+                                                 FieldType::BIGINT, BigIntLiteral(1));
         CheckResult(read_schema, predicate, /*expected_array=*/
                     nullptr);
     }
@@ -206,14 +216,14 @@ TEST_F(PredicatePushdownTest, TestIntDoubleData) {
         // f2 in [1,2,3], no data
         auto predicate =
             PredicateBuilder::In(/*field_index=*/2, /*field_name=*/"f2", FieldType::BIGINT,
-                                 {Literal(1l), Literal(2l), Literal(3l)});
+                                 {BigIntLiteral(1), BigIntLiteral(2), BigIntLiteral(3)});
         CheckResult(read_schema, predicate, /*expected_array=*/nullptr);
     }
     {
         // f2 in [1,2,3] but has small predicate node limit, has data
         auto predicate =
             PredicateBuilder::In(/*field_index=*/2, /*field_name=*/"f2", FieldType::BIGINT,
-                                 {Literal(1l), Literal(2l), Literal(3l)});
+                                 {BigIntLiteral(1), BigIntLiteral(2), BigIntLiteral(3)});
         CheckResult(read_schema, predicate, expected_array,
                     /*predicate_node_count_limit=*/1);
     }
@@ -221,21 +231,21 @@ TEST_F(PredicatePushdownTest, TestIntDoubleData) {
         // f2 not in [1,2,3], has data
         auto predicate =
             PredicateBuilder::NotIn(/*field_index=*/2, /*field_name=*/"f2", FieldType::BIGINT,
-                                    {Literal(1l), Literal(2l), Literal(3l)});
+                                    {BigIntLiteral(1), BigIntLiteral(2), BigIntLiteral(3)});
         CheckResult(read_schema, predicate, expected_array);
     }
     {
         // f2 in [2,3,4], has data
         auto predicate =
             PredicateBuilder::In(/*field_index=*/2, /*field_name=*/"f2", FieldType::BIGINT,
-                                 {Literal(2l), Literal(3l), Literal(4l)});
+                                 {BigIntLiteral(2), BigIntLiteral(3), BigIntLiteral(4)});
         CheckResult(read_schema, predicate, expected_array);
     }
     {
         // f2 not in [2,3,4], has data
         auto predicate =
             PredicateBuilder::NotIn(/*field_index=*/2, /*field_name=*/"f2", FieldType::BIGINT,
-                                    {Literal(2l), Literal(3l), Literal(4l)});
+                                    {BigIntLiteral(2), BigIntLiteral(3), BigIntLiteral(4)});
         CheckResult(read_schema, predicate, expected_array);
     }
 }
@@ -409,25 +419,27 @@ TEST_F(PredicatePushdownTest, TestPredicatePushdownWithAllDataNull) {
     {
         // f4 in [1,2], no data
         auto predicate = PredicateBuilder::In(/*field_index=*/4, /*field_name=*/"f4",
-                                              FieldType::BIGINT, {Literal(1l), Literal(2l)});
+                                              FieldType::BIGINT,
+                                              {BigIntLiteral(1), BigIntLiteral(2)});
         CheckResult(read_schema, predicate, /*expected_array=*/nullptr);
     }
     {
         // f4 not in [1,2], no data
         auto predicate = PredicateBuilder::NotIn(/*field_index=*/4, /*field_name=*/"f4",
-                                                 FieldType::BIGINT, {Literal(1l), Literal(2l)});
+                                                 FieldType::BIGINT,
+                                                 {BigIntLiteral(1), BigIntLiteral(2)});
         CheckResult(read_schema, predicate, /*expected_array=*/nullptr);
     }
     {
         // f4 >= 3, no data
         auto predicate = PredicateBuilder::GreaterOrEqual(/*field_index=*/4, /*field_name=*/"f4",
-                                                          FieldType::BIGINT, Literal(3l));
+                                                          FieldType::BIGINT, BigIntLiteral(3));
         CheckResult(read_schema, predicate, /*expected_array=*/nullptr);
     }
     {
         // f4 <= 3, no data
         auto predicate = PredicateBuilder::LessOrEqual(/*field_index=*/4, /*field_name=*/"f4",
-                                                       FieldType::BIGINT, Literal(3l));
+                                                       FieldType::BIGINT, BigIntLiteral(3));
         CheckResult(read_schema, predicate, /*expected_array=*/nullptr);
     }
 }
@@ -484,7 +496,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::And(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(6l)),
+                                            FieldType::BIGINT, BigIntLiteral(6)),
                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                          Literal(static_cast<float>(4.0))),
                  PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
@@ -498,7 +510,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::And(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(6l)),
+                                            FieldType::BIGINT, BigIntLiteral(6)),
                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                          Literal(static_cast<float>(4.0))),
                  PredicateBuilder::IsNull(/*field_index=*/3, /*field_name=*/"f3",
@@ -512,7 +524,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::And(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(6l)),
+                                            FieldType::BIGINT, BigIntLiteral(6)),
                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                          Literal(static_cast<float>(4.0))),
                  PredicateBuilder::IsNull(/*field_index=*/5, /*field_name=*/"f5",
@@ -526,7 +538,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::And(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(6l)),
+                                            FieldType::BIGINT, BigIntLiteral(6)),
                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                          Literal(static_cast<float>(4.0))),
                  PredicateBuilder::Equal(/*field_index=*/5, /*field_name=*/"f5", FieldType::BINARY,
@@ -540,7 +552,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::And(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(6l)),
+                                            FieldType::BIGINT, BigIntLiteral(6)),
                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                          Literal(static_cast<float>(5.0))),
                  PredicateBuilder::IsNull(/*field_index=*/5, /*field_name=*/"f5",
@@ -554,7 +566,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::Or(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(6l)),
+                                            FieldType::BIGINT, BigIntLiteral(6)),
                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                          Literal(static_cast<float>(4.0)))}));
         ASSERT_TRUE(predicate);
@@ -566,7 +578,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::Or(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(6l)),
+                                            FieldType::BIGINT, BigIntLiteral(6)),
                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                          Literal(static_cast<float>(5.0)))}));
         ASSERT_TRUE(predicate);
@@ -577,7 +589,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
         ASSERT_OK_AND_ASSIGN(
             auto predicate,
             PredicateBuilder::Or({PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                                             FieldType::BIGINT, Literal(2l)),
+                                                             FieldType::BIGINT, BigIntLiteral(2)),
                                   PredicateBuilder::IsNull(/*field_index=*/5, /*field_name=*/"f5",
                                                            FieldType::BINARY)}));
         ASSERT_TRUE(predicate);
@@ -589,7 +601,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::Or(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(2l)),
+                                            FieldType::BIGINT, BigIntLiteral(2)),
                  PredicateBuilder::Equal(/*field_index=*/5, /*field_name=*/"f5", FieldType::BINARY,
                                          Literal(FieldType::BINARY, "zoo", 3))}));
         ASSERT_TRUE(predicate);
@@ -601,7 +613,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::Or(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(2l)),
+                                            FieldType::BIGINT, BigIntLiteral(2)),
                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                          Literal(static_cast<float>(4.0))),
                  PredicateBuilder::Equal(/*field_index=*/3, /*field_name=*/"f3", FieldType::BOOLEAN,
@@ -615,7 +627,7 @@ TEST_F(PredicatePushdownTest, TestCompoundPredicate) {
             auto predicate,
             PredicateBuilder::Or(
                 {PredicateBuilder::LessThan(/*field_index=*/2, /*field_name=*/"f2",
-                                            FieldType::BIGINT, Literal(2l)),
+                                            FieldType::BIGINT, BigIntLiteral(2)),
                  PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::FLOAT,
                                          Literal(static_cast<float>(5.0))),
                  PredicateBuilder::IsNull(/*field_index=*/3, /*field_name=*/"f3",


### PR DESCRIPTION
### Purpose

Linked issue: N/A

On macOS arm64, `long` and `int64_t` are distinct C++ types. As a result, expressions such as `Literal(5l)` instantiate `Literal<long>`, while `Literal` only explicitly instantiates its constructor for `int64_t`. This causes the Parquet test executable to fail during linking:

```text
Undefined symbols for architecture arm64:
  "paimon::Literal::Literal<long>(long const&)"
```

This change replaces the plain `long` literals used by Parquet BIGINT predicate tests with an explicit `int64_t` helper. It follows the existing approach used by the corresponding ORC predicate tests.

Both predicate conversion and predicate pushdown tests are updated so that the complete `paimon-parquet-format-test` target can link successfully on macOS arm64.

### Tests

Verified on macOS arm64:

```bash
cmake --build build --target paimon-parquet-format-test -j 8
./build/debug/paimon-parquet-format-test \
  --gtest_filter='PredicateConverterTest.*'
git diff --check HEAD^ HEAD
```

Results:

- `paimon-parquet-format-test` compiled and linked successfully.
- `PredicateConverterTest.*`: 7 tests passed.
- `git diff --check`: passed.

The complete Parquet test binary was also started locally. Some existing Parquet I/O tests fail during Arrow JSON test-data setup with `std::bad_cast` or an Arrow assertion. Those failures occur outside the code changed by this patch.

### API and Format

No public API, storage format, or protocol changes.

### Documentation

No documentation changes. This patch only improves test portability.

### Generative AI tooling

Generated-by: OpenAI Codex (GPT-5)