### PR TITLE
build(lucene): use official Boost source archive

### DIFF
--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -324,7 +324,7 @@ elseif(EXISTS "${THIRDPARTY_DIR}/${PAIMON_BOOST_PKG_NAME}")
     set_urls(BOOST_SOURCE_URL "${THIRDPARTY_DIR}/${PAIMON_BOOST_PKG_NAME}")
 else()
     set_urls(BOOST_SOURCE_URL
-             "https://paimon-cpp.oss-cn-beijing.aliyuncs.com/thirdparty/boost/${PAIMON_BOOST_PKG_NAME}"
+             "https://archives.boost.io/release/1.66.0/source/${PAIMON_BOOST_PKG_NAME}"
     )
 endif()
 
@@ -1021,8 +1021,7 @@ macro(build_boost)
                                       --user-config=${BOOST_USER_CONFIG}
                                       toolset=${BOOST_TOOLSET} cxxflags=${EP_CXX_FLAGS}
                                       linkflags=${EP_CXX_FLAGS} install
-                        INSTALL_COMMAND bash -c
-                                        "mkdir -p ${BOOST_INSTALL}/include/boost && cp -r ${BOOST_PREFIX}/src/boost_ep/libs/*/include/boost/* ${BOOST_INSTALL}/include/boost && cp -r ${BOOST_PREFIX}/src/boost_ep/libs/*/*/include/boost/* ${BOOST_INSTALL}/include/boost"
+                        INSTALL_COMMAND ""
                         DEPENDS zlib
                         BUILD_BYPRODUCTS ${BOOST_BYPRODUCTS}
                         LOG_DOWNLOAD ON

--- a/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cmake_modules/ThirdpartyToolchain.cmake
@@ -324,8 +324,7 @@ elseif(EXISTS "${THIRDPARTY_DIR}/${PAIMON_BOOST_PKG_NAME}")
     set_urls(BOOST_SOURCE_URL "${THIRDPARTY_DIR}/${PAIMON_BOOST_PKG_NAME}")
 else()
     set_urls(BOOST_SOURCE_URL
-             "https://archives.boost.io/release/1.66.0/source/${PAIMON_BOOST_PKG_NAME}"
-    )
+             "https://archives.boost.io/release/1.66.0/source/${PAIMON_BOOST_PKG_NAME}")
 endif()
 
 if(APPLE)

--- a/third_party/versions.txt
+++ b/third_party/versions.txt
@@ -144,7 +144,7 @@ PAIMON_JIEBA_BUILD_SHA256_CHECKSUM=e6e517b778e0f4a99cbed1ee3eaa041616b74bc685e03
 PAIMON_JIEBA_PKG_NAME=jieba-${PAIMON_JIEBA_BUILD_VERSION}.tar.gz
 
 PAIMON_BOOST_BUILD_VERSION=1_66_0
-PAIMON_BOOST_BUILD_SHA256_CHECKSUM=28e9200637800fbfd1292b2c6876189dba7e8e1c5282c71fac6515e96f7af2b0
+PAIMON_BOOST_BUILD_SHA256_CHECKSUM=bd0df411efd9a585e5a2212275f8762079fed8842264954675a4fddc46cfcf60
 PAIMON_BOOST_PKG_NAME=boost_${PAIMON_BOOST_BUILD_VERSION}.tar.gz
 
 # The first field is the name of the environment variable expected by cmake.
@@ -184,5 +184,5 @@ DEPENDENCIES=(
   "PAIMON_LUCENE_URL ${PAIMON_LUCENE_PKG_NAME} ${THIRDPARTY_MIRROR_URL}https://github.com/luceneplusplus/LucenePlusPlus/archive/refs/tags/rel_${PAIMON_LUCENE_BUILD_VERSION}.tar.gz"
   "PAIMON_LIMONP_URL ${PAIMON_LIMONP_PKG_NAME} ${THIRDPARTY_MIRROR_URL}https://github.com/yanyiwu/limonp/archive/refs/tags/v${PAIMON_LIMONP_BUILD_VERSION}.tar.gz"
   "PAIMON_JIEBA_URL ${PAIMON_JIEBA_PKG_NAME} ${THIRDPARTY_MIRROR_URL}https://github.com/yanyiwu/cppjieba/archive/refs/tags/${PAIMON_JIEBA_BUILD_VERSION}.tar.gz"
-  "PAIMON_BOOST_URL ${PAIMON_BOOST_PKG_NAME} https://paimon-cpp.oss-cn-beijing.aliyuncs.com/thirdparty/boost/${PAIMON_BOOST_PKG_NAME}"
+  "PAIMON_BOOST_URL ${PAIMON_BOOST_PKG_NAME} https://archives.boost.io/release/1.66.0/source/${PAIMON_BOOST_PKG_NAME}"
 )


### PR DESCRIPTION
<!-- PR titles must follow Conventional Commits: <type>(<optional-scope>): <description> -->

### Purpose

<!-- Linking this pull request to the issue -->
No Linked issue.

The Lucene++ build currently downloads a repackaged Boost 1.66 archive from a Paimon-managed OSS bucket. This introduces an unnecessary dependency on project-specific infrastructure.

This change:

- Downloads Boost 1.66 from the official Boost archive.
- Updates the SHA256 checksum to match the official source package.
- Removes the custom header-copy step required by the previous repackaged archive.
- Uses Boost's standard `b2 install` process to install libraries and headers.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Generated-by: OpenAI Codex (GPT-5)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
