### PR TITLE
feat(core): support primary-key managed BLOBs and normal-file data-evolution compaction

### DIFF
--- a/docs/source/user_guide/compaction.rst
+++ b/docs/source/user_guide/compaction.rst
@@ -43,24 +43,13 @@ to improve read efficiency. The compaction is performed asynchronously and does
 not block writes.
 
 .. note::
-   Append-only table compaction is only available for fixed-bucket mode
-   (``bucket > 0``). Dynamic bucketing (``bucket = -1``) does not support
-   compaction. Tables with blob columns also skip compaction.
-
-.. _data-evolution-deletion-vectors-compaction:
-
-.. note::
-   A data-evolution table (``data-evolution.enabled = true``) may enable
-   ``deletion-vectors.enabled``. Paimon C++ never compacts such a table: auto
-   compaction never runs on it, since data evolution requires ``bucket = -1``,
-   and ``AppendCompactCoordinator::Run``, the dedicated compaction entry point,
-   rejects it outright rather than dropping the deletes. This matches the
-   Paimon Java revision this support was ported from, which ends the compaction
-   scan as soon as deletion vectors are enabled; later Java releases do compact
-   such a table, and Paimon C++ has not caught up.
-
-   Reading such a table is supported; see
-   :ref:`data-evolution-deletion-vectors`.
+   Automatic append-only compaction is only available for fixed-bucket mode
+   (``bucket > 0``); it never runs under dynamic bucketing (``bucket = -1``)
+   or for tables with blob columns. Unaware-bucket append tables
+   (``bucket = -1``) are compacted through the dedicated entry point
+   ``AppendCompactCoordinator::Run`` instead; for a data-evolution table that
+   entry point plans across evolved field groups, described in
+   :ref:`data-evolution-compaction`.
 
 Auto Compaction
 ~~~~~~~~~~~~~~~
@@ -107,6 +96,67 @@ Append-Only Table Compaction Options
      - The minimum number of files to trigger an auto compaction for
        append-only tables.
 
+
+.. _data-evolution-compaction:
+
+Data-Evolution Table Compaction
+-------------------------------
+For a data-evolution table (``data-evolution.enabled = true``),
+``AppendCompactCoordinator::Run`` plans compaction across evolved field groups
+instead of running the plain append rewrite. Files are grouped by row id range:
+files covering the exact same rows form one evolved field group, holding
+different versions or different subsets of the table columns produced by
+partial-column updates. Each compact task merges the field groups of one
+contiguous row id run — the newest version of every column wins — and rewrites
+them into a single normal file holding every non-dedicated column.
+
+Row ids are never changed by this compaction: ``_ROW_ID`` values stay stable.
+The rewritten file carries the merged ``[min, max]`` sequence number range of
+its inputs, so per-row ``_SEQUENCE_NUMBER`` values, which derive from the
+file-level maximum, may rise to the group's maximum after the compaction.
+Blob files are dedicated storage and are not rewritten; their row ranges
+remain covered by the compacted data file. Tables holding vector-store files
+are rejected until Paimon C++ gains a ``VECTOR`` schema type that lets the
+rewrite exclude their columns; Paimon Java instead compacts the normal files
+of such tables and leaves the vector files in place.
+
+The normal-file bin-packing rules follow Paimon Java's
+``DataEvolutionCompactCoordinator``:
+
+- A file group's weight is ``sum(max(file_size, source.split.open-file-cost))``;
+  a bin of groups becomes a task once its weight exceeds ``target-file-size``.
+- A single file group heavier than the target is compacted on its own —
+  provided it holds at least ``compaction.min.file-num`` files (merging its
+  files is still worthwhile) — and is never packed with neighbors.
+- A row id gap always cuts the current bin, so tasks stay contiguous.
+- A bin becomes a task only when it holds at least ``compaction.min.file-num``
+  files.
+
+.. note::
+   Paimon C++ does not yet compact a data-evolution table with
+   ``deletion-vectors.enabled``: deletion vectors are keyed by the row range
+   group's anchor file and would need to be migrated onto the rewritten files
+   at commit time (Java's ``DataEvolutionCompactDeletionVectorRewriter``),
+   which is not ported yet. ``AppendCompactCoordinator::Run`` keeps rejecting
+   such a table. Auto compaction also never runs on data-evolution tables,
+   since data evolution requires ``bucket = -1``.
+
+   Compared with Paimon Java, the following are also not ported yet: the
+   projected-manifest candidate planning with its ~100,000-file batches and
+   multi-round commits (Paimon C++ plans the whole snapshot in one pass and
+   commits once), the concurrent-MERGE rebase retry of the Spark integration,
+   and the ``blob-compaction.enabled`` blob pack rewriting — that option has no
+   effect here, blob packs are never rewritten whatever it is set to.
+
+   Two further differences are intentional. The planning scan drops manifest
+   statistics only when ``manifest.delete-file-drop-stats`` asks for it, while
+   Paimon Java always drops them for this scan, so the DELETE entries this
+   compaction commits may carry statistics Java would have left out; the plans
+   themselves are identical. A table holding vector-store files is rejected
+   outright rather than compacted for its normal files, as described above.
+
+   Reading a data-evolution table with deletion vectors is supported; see
+   :ref:`data-evolution-deletion-vectors`.
 
 Primary Key Table Compaction
 ----------------------------

--- a/docs/source/user_guide/primary_key_table.rst
+++ b/docs/source/user_guide/primary_key_table.rst
@@ -80,3 +80,65 @@ merged according to the user-specified merge engine and the timestamp of each re
 New records written into the LSM tree will be first buffered in memory. When the
 memory buffer is full, all records in memory will be sorted and flushed to disk.
 A new sorted run is now created.
+
+.. _primary-key-managed-blob:
+
+Managed BLOB Storage
+--------------------
+A primary-key table may define top-level ``BLOB`` columns. Their payload bytes
+are table-managed: they never enter the merge-tree write buffer or the data
+files. Unlike ``BLOB`` columns in append tables, primary-key managed BLOB
+storage does not require ``row-tracking.enabled`` or
+``data-evolution.enabled`` — a row-tracking table cannot define primary keys
+in the first place. When a row is written, each non-null blob value is copied into a pack
+file named ``data-<uuid>-<n>.managed.blob`` in the bucket directory, and the
+row stores only a small descriptor (pack path, offset, length) in its place.
+A pack is sealed once it reaches ``blob.target-file-size``; the copy uses a
+``blob.copy-buffer-size`` buffer (default ``4 kb``, must be between 1 byte and
+2147483647 bytes). Retract rows (``DELETE`` / ``UPDATE_BEFORE``) never keep a
+payload; their blob value becomes NULL.
+
+Reads resolve the descriptors back to payload bytes with one ranged read per
+value, after merging, so only surviving rows ever fetch their payloads. Set
+``blob-as-descriptor`` to ``true`` to receive the serialized descriptors
+instead.
+
+Every data file carries a ``.blobref`` sidecar in its extra files, listing the
+pack files its rows reference. Compaction rewrites descriptors verbatim —
+payloads are never copied again — and rebuilds the sidecar so it lists exactly
+the packs the surviving rows still reference. The sidecar is removed wherever
+its data file is removed with its companion files; a pack file may be shared
+by several data files and is never deleted by table maintenance (orphan file
+clean skips ``.managed.blob`` files).
+
+.. note::
+   Snapshot expiration removes a ``.blobref`` sidecar together with its
+   expired data file, and an aborted writer cleans up its own sidecars. A
+   sidecar left behind by an abandoned uncommitted write or a failed commit
+   (e.g. a crashed process), however, is only removed once the orphan files
+   cleaner supports primary-key tables.
+
+Restrictions:
+
+- Only top-level scalar ``BLOB`` columns are managed. ``ARRAY<BLOB>`` and
+  ``MAP<K, BLOB>`` fields, which Paimon Java also externalizes, are not
+  supported yet.
+- ``blob-descriptor.source-table`` (re-materializing descriptors through the
+  source table's credentials) is not supported: configuring it fails schema
+  validation, and descriptors are always read and copied through the table's
+  own file system.
+- ``pk-clustering-override`` set to ``true`` is not supported; an explicit
+  ``false`` is accepted.
+- Only the ``deduplicate``, ``partial-update`` and ``first-row`` merge engines
+  are supported, and ``changelog-producer`` must stay ``none``.
+- A managed ``BLOB`` column cannot be a primary key, bucket key, sequence
+  field or partition key, and the table needs at least one other normal
+  column.
+- A ``BLOB`` column cannot order a partial-update sequence group, and a
+  sequence-group-protected managed ``BLOB`` field only supports no aggregate
+  function, ``last_value``, or ``fields.<field>.ignore-retract`` set to
+  ``true`` (retract rows do not retain the payload).
+- ``data-file.external-paths`` is not supported.
+- ``blob-descriptor-field`` / ``blob-view-field`` columns are inline blob
+  fields: they keep caller-provided bytes in the data files and are not
+  table-managed.

--- a/docs/source/user_guide/read.rst
+++ b/docs/source/user_guide/read.rst
@@ -348,5 +348,5 @@ Limitations
   Whether it conflicts with a concurrent commit rewriting those files' deletion vectors cannot
   be decided yet, so it fails rather than committing against a stale state. Appending is
   unaffected, and so is another engine replacing a deletion vector.
-- Such a table is never compacted; see
-  :ref:`the compaction note <data-evolution-deletion-vectors-compaction>`.
+- Such a table is never compacted while its deletion vectors are enabled; see
+  :ref:`data-evolution-compaction`.

--- a/include/paimon/append/append_compact_coordinator.h
+++ b/include/paimon/append/append_compact_coordinator.h
@@ -37,6 +37,12 @@ class MemoryPool;
 /// and generates compaction tasks using a bin-packing algorithm. It then synchronously
 /// executes all tasks and returns the resulting commit messages.
 ///
+/// For a data-evolution table (`data-evolution.enabled` = true) the coordinator instead plans
+/// with `DataEvolutionCompactCoordinator`: files are grouped by row id range into evolved
+/// field groups, each task merges the field groups of one contiguous row id run into a single
+/// normal file holding every non-dedicated column, and row ids and file-level sequence number
+/// ranges are preserved.
+///
 /// @note This implementation does not support deletion vectors or streaming mode.
 ///       It only scans the current latest snapshot (batch mode).
 class PAIMON_EXPORT AppendCompactCoordinator {
@@ -45,12 +51,15 @@ class PAIMON_EXPORT AppendCompactCoordinator {
     ~AppendCompactCoordinator() = delete;
     /// Run the compaction coordinator.
     ///
-    /// Scans the latest snapshot for small files across the specified partitions,
-    /// generates compact tasks via bin-packing, executes them synchronously,
-    /// and returns the resulting commit messages.
+    /// Scans the latest snapshot across the specified partitions — small files only for a
+    /// plain append table, every live file for a data-evolution table — generates compact
+    /// tasks, executes them synchronously, and returns the resulting commit messages.
     ///
     /// @param table_path The root path of the table.
-    /// @param options User-defined options (will be merged with schema options).
+    /// @param options User-defined options, merged over the schema options. Options that
+    ///                decide the compaction path or the physical layout (row tracking, data
+    ///                evolution, deletion vectors, bucket and the blob layout fields) must
+    ///                not change the persisted values; such an override is rejected.
     /// @param partitions Partition filters; each element is a partition spec as key-value pairs.
     ///                   Empty vector means all partitions.
     /// @param file_system The file system to use. If nullptr, will be created from options.

--- a/include/paimon/defs.h
+++ b/include/paimon/defs.h
@@ -141,6 +141,10 @@ struct PAIMON_EXPORT Options {
     /// scan splitting. When unset, defaults to the negation of BLOB_AS_DESCRIPTOR.
     static const char BLOB_SPLIT_BY_FILE_SIZE[];
 
+    /// "blob.copy-buffer-size" - Buffer size used when copying blob payloads into blob files.
+    /// Must be between 1 byte and 2147483647 bytes. Default value is "4 kb".
+    static const char BLOB_COPY_BUFFER_SIZE[];
+
     /// "partition.default-name" - The default partition name in case the dynamic partition column
     /// value is null/empty string. Default is "__DEFAULT_PARTITION__".
     static const char PARTITION_DEFAULT_NAME[];
@@ -425,6 +429,14 @@ struct PAIMON_EXPORT Options {
     /// "data-evolution.enabled" - Whether enable data evolution for row tracking table. Default
     /// value is "false".
     static const char DATA_EVOLUTION_ENABLED[];
+    /// "data-evolution.compaction.rewrite-row-ids" - The legacy data-evolution row-id rewriting
+    /// mode. No longer supported; setting it to "true" fails the compaction. Default value is
+    /// "false".
+    static const char DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS[];
+    /// "pk-clustering-override" - Whether to override clustering for primary-key tables. Not
+    /// supported by Paimon C++: "true" is rejected by the commit path (and by schema validation
+    /// for primary-key managed BLOB tables, like Java). Default value is "false".
+    static const char PK_CLUSTERING_OVERRIDE[];
     /// "partition.legacy-name" - The legacy partition name is using `ToString` for all types. If
     /// false, using casting to string for all types. Default value is "true".
     static const char PARTITION_GENERATE_LEGACY_NAME[];
@@ -490,6 +502,11 @@ struct PAIMON_EXPORT Options {
     /// "blob-descriptor-field" - Comma-separated field names to treat as BLOB fields and store as
     /// serialized BlobDescriptor bytes inline in data files. No default value.
     static const char BLOB_DESCRIPTOR_FIELD[];
+    /// "blob-descriptor.source-table" - The source table whose credentials re-materialize blob
+    /// descriptors in Java. Not supported by Paimon C++, which always reads descriptors through
+    /// the table's own file system; configuring it on a primary-key managed BLOB table fails
+    /// schema validation instead of silently changing semantics. No default value.
+    static const char BLOB_DESCRIPTOR_SOURCE_TABLE[];
     /// "blob.stored-descriptor-fields" deprecated as a fallback for `BLOB_DESCRIPTOR_FIELD`.
     static const char FALLBACK_BLOB_DESCRIPTOR_FIELD[];
     /// "blob-view-field" - Comma-separated field names to treat as BLOB fields and store as

--- a/src/paimon/CMakeLists.txt
+++ b/src/paimon/CMakeLists.txt
@@ -138,6 +138,7 @@ set(PAIMON_COMMON_SRCS
     common/reader/reader_utils.cpp
     common/reader/blob_fallback_batch_reader.cpp
     common/reader/blob_view_resolving_batch_reader.cpp
+    common/reader/managed_blob_resolving_batch_reader.cpp
     common/reader/complete_row_kind_batch_reader.cpp
     common/reader/data_evolution_file_reader.cpp
     common/sst/block_handle.cpp
@@ -207,6 +208,8 @@ set(PAIMON_CORE_SRCS
     core/bucket/bucket_select_converter.cpp
     core/append/append_compact_task.cpp
     core/append/append_compact_coordinator.cpp
+    core/append/data_evolution_compact_coordinator.cpp
+    core/append/data_evolution_normal_compact_task.cpp
     core/bucket/hive_bucket_function.cpp
     core/bucket/mod_bucket_function.cpp
     core/bucket/bucket_id_calculator.cpp
@@ -274,6 +277,9 @@ set(PAIMON_CORE_SRCS
     core/io/key_value_data_file_record_reader.cpp
     core/io/key_value_data_file_writer_factory.cpp
     core/io/key_value_data_file_writer.cpp
+    core/io/managed_blob_reference_collector.cpp
+    core/io/managed_blob_reference_file.cpp
+    core/io/primary_key_blob_externalizer.cpp
     core/io/key_value_in_memory_record_reader.cpp
     core/io/merged_key_value_record_reader.cpp
     core/io/key_value_meta_projection_consumer.cpp
@@ -590,6 +596,7 @@ if(PAIMON_BUILD_TESTS)
                     common/reader/complete_row_kind_batch_reader_test.cpp
                     common/reader/blob_fallback_batch_reader_test.cpp
                     common/reader/blob_view_resolving_batch_reader_test.cpp
+                    common/reader/managed_blob_resolving_batch_reader_test.cpp
                     common/reader/data_evolution_file_reader_test.cpp
                     common/reader/data_evolution_array_test.cpp
                     common/reader/data_evolution_row_test.cpp
@@ -692,6 +699,7 @@ if(PAIMON_BUILD_TESTS)
                     core/append/append_only_writer_test.cpp
                     core/append/append_compact_coordinator_test.cpp
                     core/append/bucketed_append_compact_manager_test.cpp
+                    core/append/data_evolution_compact_coordinator_test.cpp
                     core/bucket/bucket_select_converter_test.cpp
                     core/bucket/default_bucket_function_test.cpp
                     core/bucket/hive_bucket_function_test.cpp
@@ -737,6 +745,9 @@ if(PAIMON_BUILD_TESTS)
                     core/io/complete_row_tracking_fields_reader_test.cpp
                     core/io/data_file_meta_test.cpp
                     core/io/file_index_evaluator_test.cpp
+                    core/io/managed_blob_reference_collector_test.cpp
+                    core/io/managed_blob_reference_file_test.cpp
+                    core/io/primary_key_blob_externalizer_test.cpp
                     core/io/single_file_writer_test.cpp
                     core/io/rolling_blob_file_writer_test.cpp
                     core/global_index/indexed_split_test.cpp

--- a/src/paimon/common/data/blob.cpp
+++ b/src/paimon/common/data/blob.cpp
@@ -94,23 +94,32 @@ Result<std::unique_ptr<InputStream>> Blob::NewInputStream(
     if (fs == nullptr) {
         return Status::Invalid("file system is nullptr");
     }
-    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> file,
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> opened,
                            fs->Open(impl_->GetDescriptor()->Uri()));
 
-    int64_t blob_length = impl_->GetDescriptor()->Length();
-    int64_t blob_offset = impl_->GetDescriptor()->Offset();
+    // Keep a shared handle so the stream is explicitly closed when a check below or
+    // OffsetInputStream::Create itself fails; on success the offset stream shares ownership.
+    std::shared_ptr<InputStream> file = std::move(opened);
+    Result<std::unique_ptr<InputStream>> result = [&]() -> Result<std::unique_ptr<InputStream>> {
+        int64_t blob_length = impl_->GetDescriptor()->Length();
+        int64_t blob_offset = impl_->GetDescriptor()->Offset();
 
-    PAIMON_ASSIGN_OR_RAISE(int64_t total_length, file->Length());
-    if (PAIMON_UNLIKELY(blob_offset > total_length)) {
-        return Status::Invalid(
-            fmt::format("offset {} exceed total length {}", blob_offset, total_length));
-    }
-    if (blob_length == -1) {
-        // blob_length == -1 means it's dynamic length, should read to the end
-        blob_length = total_length - blob_offset;
-    }
+        PAIMON_ASSIGN_OR_RAISE(int64_t total_length, file->Length());
+        if (PAIMON_UNLIKELY(blob_offset > total_length)) {
+            return Status::Invalid(
+                fmt::format("offset {} exceed total length {}", blob_offset, total_length));
+        }
+        if (blob_length == -1) {
+            // blob_length == -1 means it's dynamic length, should read to the end
+            blob_length = total_length - blob_offset;
+        }
 
-    return OffsetInputStream::Create(std::move(file), blob_length, blob_offset, total_length);
+        return OffsetInputStream::Create(file, blob_length, blob_offset, total_length);
+    }();
+    if (!result.ok()) {
+        [[maybe_unused]] Status close_status = file->Close();
+    }
+    return result;
 }
 
 Result<PAIMON_UNIQUE_PTR<Bytes>> Blob::ToData(const std::shared_ptr<FileSystem>& fs,

--- a/src/paimon/common/data/blob_defs.h
+++ b/src/paimon/common/data/blob_defs.h
@@ -50,6 +50,10 @@ class BlobDefs {
     /// Metadata value identifying a Paimon Blob extension type field.
     static constexpr char kExtensionTypeValue[] = "paimon.type.blob";
 
+    /// Default buffer size for copying blob payloads into blob files, aligned with the "4 kb"
+    /// default of Java's `blob.copy-buffer-size` (Options::BLOB_COPY_BUFFER_SIZE).
+    static constexpr int64_t kDefaultCopyBufferSize = 4 * 1024;
+
     /// A bin_length value of -1 in the index indicates a null blob entry.
     static constexpr int64_t kNullBinLength = -1;
     /// A bin_length value of -2 in the index indicates a placeholder blob entry, written by

--- a/src/paimon/common/data/blob_utils.cpp
+++ b/src/paimon/common/data/blob_utils.cpp
@@ -97,6 +97,17 @@ Result<BlobUtils::SeparatedStructArrays> BlobUtils::SeparateBlobArray(
     return result;
 }
 
+std::vector<std::string> BlobUtils::ManagedBlobFieldNames(
+    const std::shared_ptr<arrow::Schema>& schema, const std::set<std::string>& inline_fields) {
+    std::vector<std::string> managed_fields;
+    for (const auto& field : schema->fields()) {
+        if (IsBlobField(field) && inline_fields.count(field->name()) == 0) {
+            managed_fields.push_back(field->name());
+        }
+    }
+    return managed_fields;
+}
+
 bool BlobUtils::IsBlobField(const std::shared_ptr<arrow::Field>& field) {
     const auto& type = field->type();
     if (type->id() != arrow::Type::LARGE_BINARY) {

--- a/src/paimon/common/data/blob_utils.h
+++ b/src/paimon/common/data/blob_utils.h
@@ -76,6 +76,14 @@ class PAIMON_EXPORT BlobUtils {
     static bool IsBlobMetadata(const std::shared_ptr<const arrow::KeyValueMetadata>& metadata);
     static bool IsBlobFile(const std::string& file_name);
 
+    /// Names of the blob fields in `schema` whose payloads live outside the data file, which
+    /// holds a descriptor in their place. Inline blob fields (descriptor / view) are excluded,
+    /// they hold caller-provided bytes. Where the payload goes depends on the table: a
+    /// primary-key table externalizes it into a `.managed.blob` pack, an append
+    /// data-evolution table writes a dedicated `.blob` file per field group.
+    static std::vector<std::string> ManagedBlobFieldNames(
+        const std::shared_ptr<arrow::Schema>& schema, const std::set<std::string>& inline_fields);
+
     static std::shared_ptr<arrow::Field> ToArrowField(
         const std::string& field_name, bool nullable = false,
         std::unordered_map<std::string, std::string> metadata = {});

--- a/src/paimon/common/data/columnar/columnar_utils.h
+++ b/src/paimon/common/data/columnar/columnar_utils.h
@@ -51,6 +51,13 @@ class ColumnarUtils {
         auto type_id = array->type_id();
         bool is_dict = (type_id == arrow::Type::type::DICTIONARY);
         if (!is_dict) {
+            // Large binary/string arrays carry 64-bit offsets and must not be read through
+            // the 32-bit-offset BinaryArray accessors (e.g. managed blob descriptor columns).
+            if (type_id == arrow::Type::type::LARGE_BINARY ||
+                type_id == arrow::Type::type::LARGE_STRING) {
+                const auto* typed_array = checked_cast<const arrow::LargeBinaryArray*>(array);
+                return typed_array->GetView(pos);
+            }
             const auto* typed_array = checked_cast<const arrow::BinaryArray*>(array);
             return typed_array->GetView(pos);
         } else {

--- a/src/paimon/common/data/internal_row.cpp
+++ b/src/paimon/common/data/internal_row.cpp
@@ -103,6 +103,18 @@ Result<InternalRow::FieldGetterFunc> InternalRow::CreateFieldGetter(
             };
             break;
         }
+        case arrow::Type::type::LARGE_BINARY: {
+            // Managed blob columns of a primary-key table hold their serialized descriptors
+            // as large binary (mirrors Java's BLOB field getter).
+            field_getter = [field_idx, use_view](const InternalRow& row) -> VariantType {
+                if (use_view) {
+                    return row.GetStringView(field_idx);
+                } else {
+                    return row.GetBinary(field_idx);
+                }
+            };
+            break;
+        }
         case arrow::Type::type::TIMESTAMP: {
             auto timestamp_type = checked_pointer_cast<arrow::TimestampType>(field_type);
             int32_t precision = DateTimeUtils::GetPrecisionFromType(timestamp_type);

--- a/src/paimon/common/data/internal_row_test.cpp
+++ b/src/paimon/common/data/internal_row_test.cpp
@@ -70,6 +70,7 @@ TEST(InternalRowTest, TestCreateFieldGetter) {
         arrow::field("f21",
                      arrow::struct_({field("sub1", arrow::int64()), field("sub2", arrow::float64()),
                                      field("sub3", arrow::boolean())})),
+        arrow::field("f22", arrow::large_binary()),
     };
 
     auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
@@ -77,7 +78,7 @@ TEST(InternalRowTest, TestCreateFieldGetter) {
         [true, 1, 2, 3, 4, 5.1, 6.12, "abc", "def", "1970-01-02 00:00:01", "1970-01-02 00:00:00.001",
         "1970-01-02 00:00:00.000001", "1970-01-02 00:00:00.000000001", "1970-01-02 00:00:02", "1970-01-02 00:00:00.002",
         "1970-01-02 00:00:00.000002", "1970-01-02 00:00:00.000000002", "-123456789987654321.45678", 12345,
-        [1, 2, 3], [[true, 3], [false, 4]], [10, 10.1, false]]
+        [1, 2, 3], [[true, 3], [false, 4]], [10, 10.1, false], "ghi"]
     ])")
             .ValueOrDie());
     auto pool = GetDefaultPool();
@@ -134,6 +135,8 @@ TEST(InternalRowTest, TestCreateFieldGetter) {
     ASSERT_EQ(inner_row->GetLong(0), 10l);
     ASSERT_EQ(inner_row->GetDouble(1), 10.1);
     ASSERT_EQ(inner_row->GetBoolean(2), false);
+    auto string_view22 = DataDefine::GetVariantValue<std::string_view>(getters[22](row));
+    ASSERT_EQ(std::string(string_view22), "ghi");
 }
 
 TEST(InternalRowTest, TestCreateFieldGetterWithNull) {

--- a/src/paimon/common/defs.cpp
+++ b/src/paimon/common/defs.cpp
@@ -42,6 +42,7 @@ const char Options::TARGET_FILE_SIZE[] = "target-file-size";
 const char Options::TARGET_FILE_ROW_NUM[] = "target-file-row-num";
 const char Options::BLOB_TARGET_FILE_SIZE[] = "blob.target-file-size";
 const char Options::BLOB_SPLIT_BY_FILE_SIZE[] = "blob.split-by-file-size";
+const char Options::BLOB_COPY_BUFFER_SIZE[] = "blob.copy-buffer-size";
 const char Options::PAGE_SIZE[] = "page-size";
 const char Options::PARTITION_DEFAULT_NAME[] = "partition.default-name";
 const char Options::FILE_COMPRESSION[] = "file.compression";
@@ -108,6 +109,9 @@ const char Options::ROW_TRACKING_ENABLED[] = "row-tracking.enabled";
 const char Options::ROW_TRACKING_PARTITION_GROUP_ON_COMMIT[] =
     "row-tracking.partition-group-on-commit";
 const char Options::DATA_EVOLUTION_ENABLED[] = "data-evolution.enabled";
+const char Options::DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS[] =
+    "data-evolution.compaction.rewrite-row-ids";
+const char Options::PK_CLUSTERING_OVERRIDE[] = "pk-clustering-override";
 const char Options::PARTITION_GENERATE_LEGACY_NAME[] = "partition.legacy-name";
 const char Options::MAP_STORAGE_LAYOUT[] = "map.storage-layout";
 const char Options::MAP_SHARED_SHREDDING_MAX_COLUMNS[] = "map.shared-shredding.max-columns";
@@ -130,6 +134,7 @@ const char Options::VARIANT_SHREDDING_ADAPTIVE_RETENTION_RATIO[] =
 const char Options::BLOB_AS_DESCRIPTOR[] = "blob-as-descriptor";
 const char Options::BLOB_FIELD[] = "blob-field";
 const char Options::BLOB_DESCRIPTOR_FIELD[] = "blob-descriptor-field";
+const char Options::BLOB_DESCRIPTOR_SOURCE_TABLE[] = "blob-descriptor.source-table";
 const char Options::FALLBACK_BLOB_DESCRIPTOR_FIELD[] = "blob.stored-descriptor-fields";
 const char Options::BLOB_VIEW_FIELD[] = "blob-view-field";
 const char Options::BLOB_VIEW_RESOLVE_ENABLED[] = "blob-view.resolve.enabled";

--- a/src/paimon/common/reader/managed_blob_resolving_batch_reader.cpp
+++ b/src/paimon/common/reader/managed_blob_resolving_batch_reader.cpp
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/common/reader/managed_blob_resolving_batch_reader.h"
+
+#include <iterator>
+#include <string_view>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/data/blob.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/status.h"
+
+namespace paimon {
+
+ManagedBlobResolvingBatchReader::ManagedBlobResolvingBatchReader(
+    std::unique_ptr<BatchReader>&& reader, std::vector<std::string> managed_blob_fields,
+    const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool)
+    : pool_(pool),
+      arrow_pool_(GetArrowPool(pool)),
+      reader_(std::move(reader)),
+      managed_blob_fields_(std::make_move_iterator(managed_blob_fields.begin()),
+                           std::make_move_iterator(managed_blob_fields.end())),
+      fs_(fs) {}
+
+Result<BatchReader::ReadBatch> ManagedBlobResolvingBatchReader::NextBatch() {
+    PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch batch, reader_->NextBatch());
+    if (BatchReader::IsEofBatch(batch)) {
+        return batch;
+    }
+    if (managed_blob_fields_.empty()) {
+        return batch;
+    }
+
+    auto& [c_array, c_schema] = batch;
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                      arrow::ImportArray(c_array.get(), c_schema.get()));
+    auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+    if (struct_array == nullptr) {
+        return Status::Invalid(
+            "invalid batch, ManagedBlobResolvingBatchReader expects a StructArray batch.");
+    }
+    const auto struct_type = struct_array->struct_type();
+
+    arrow::ArrayVector new_fields = struct_array->fields();
+    for (int32_t field_idx = 0; field_idx < struct_type->num_fields(); ++field_idx) {
+        const auto& field = struct_type->field(field_idx);
+        if (managed_blob_fields_.find(field->name()) == managed_blob_fields_.end()) {
+            continue;
+        }
+        const auto& column = struct_array->field(field_idx);
+        auto descriptor_array = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(column);
+        if (descriptor_array == nullptr) {
+            return Status::Invalid(fmt::format(
+                "ManagedBlobResolvingBatchReader expects managed blob column {} to be a "
+                "LargeBinaryArray.",
+                field->name()));
+        }
+        PAIMON_ASSIGN_OR_RAISE(new_fields[field_idx], ResolveBlobColumn(descriptor_array));
+    }
+    // Rebuild with the original fields so the blob extension metadata and nullability survive
+    // the resolution.
+    std::shared_ptr<arrow::StructArray> resolved_struct_array;
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(resolved_struct_array,
+                                      arrow::StructArray::Make(new_fields, struct_type->fields()));
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        arrow::ExportArray(*resolved_struct_array, c_array.get(), c_schema.get()));
+    return batch;
+}
+
+Result<std::shared_ptr<arrow::Array>> ManagedBlobResolvingBatchReader::ResolveBlobColumn(
+    const std::shared_ptr<arrow::LargeBinaryArray>& descriptor_array) {
+    arrow::LargeBinaryBuilder builder(arrow_pool_.get());
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Reserve(descriptor_array->length()));
+    for (int64_t row = 0; row < descriptor_array->length(); ++row) {
+        if (descriptor_array->IsNull(row)) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.AppendNull());
+            continue;
+        }
+        std::string_view value = descriptor_array->GetView(row);
+        // Every non-null managed value is a descriptor written by the externalizer; anything
+        // else means the file was not produced by a managed blob write.
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<Blob> blob,
+                               Blob::FromDescriptor(value.data(), value.size()));
+        PAIMON_ASSIGN_OR_RAISE(PAIMON_UNIQUE_PTR<Bytes> payload, blob->ToData(fs_, pool_));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(
+            builder.Append(reinterpret_cast<const uint8_t*>(payload->data()), payload->size()));
+    }
+    std::shared_ptr<arrow::Array> payload_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Finish(&payload_array));
+    return payload_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/common/reader/managed_blob_resolving_batch_reader.h
+++ b/src/paimon/common/reader/managed_blob_resolving_batch_reader.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "arrow/memory_pool.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class Array;
+class LargeBinaryArray;
+}  // namespace arrow
+
+namespace paimon {
+
+/// Materializes the managed blob columns of a primary-key read: every non-null value is a
+/// serialized `BlobDescriptor` pointing into a `.managed.blob` pack, and this reader replaces
+/// it with the payload bytes through one ranged read per value. Wraps the fully merged batch
+/// stream, so only values of surviving rows are ever fetched. Not used when the read keeps
+/// descriptors (`blob-as-descriptor`).
+class ManagedBlobResolvingBatchReader : public BatchReader {
+ public:
+    ManagedBlobResolvingBatchReader(std::unique_ptr<BatchReader>&& reader,
+                                    std::vector<std::string> managed_blob_fields,
+                                    const std::shared_ptr<FileSystem>& fs,
+                                    const std::shared_ptr<MemoryPool>& pool);
+
+    Result<ReadBatch> NextBatch() override;
+
+    void Close() override {
+        reader_->Close();
+    }
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return reader_->GetReaderMetrics();
+    }
+
+ private:
+    Result<std::shared_ptr<arrow::Array>> ResolveBlobColumn(
+        const std::shared_ptr<arrow::LargeBinaryArray>& descriptor_array);
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::unique_ptr<BatchReader> reader_;
+    std::set<std::string> managed_blob_fields_;
+    std::shared_ptr<FileSystem> fs_;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/reader/managed_blob_resolving_batch_reader_test.cpp
+++ b/src/paimon/common/reader/managed_blob_resolving_batch_reader_test.cpp
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/common/reader/managed_blob_resolving_batch_reader.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/metrics/metrics_impl.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class ManagedBlobResolvingBatchReaderTest : public ::testing::Test {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+        dir_ = UniqueTestDirectory::Create("local");
+        fields_ = {arrow::field("id", arrow::int32()),
+                   BlobUtils::ToArrowField("b", /*nullable=*/true)};
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    class InMemoryBatchReader : public BatchReader {
+     public:
+        explicit InMemoryBatchReader(const std::shared_ptr<arrow::StructArray>& struct_array)
+            : struct_array_(struct_array) {}
+
+        Result<ReadBatch> NextBatch() override {
+            if (exhausted_) {
+                return MakeEofBatch();
+            }
+            exhausted_ = true;
+            auto c_array = std::make_unique<ArrowArray>();
+            auto c_schema = std::make_unique<ArrowSchema>();
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                arrow::ExportArray(*struct_array_, c_array.get(), c_schema.get()));
+            return std::make_pair(std::move(c_array), std::move(c_schema));
+        }
+
+        std::shared_ptr<Metrics> GetReaderMetrics() const override {
+            return std::make_shared<MetricsImpl>();
+        }
+
+        void Close() override {}
+
+     private:
+        std::shared_ptr<arrow::StructArray> struct_array_;
+        bool exhausted_ = false;
+    };
+
+    /// Writes `payload` to a file and returns serialized descriptor bytes pointing at it.
+    std::string WritePayloadAndMakeDescriptor(const std::string& file_name,
+                                              const std::string& payload) {
+        std::string path = PathUtil::JoinPath(dir_->Str(), file_name);
+        auto out = dir_->GetFileSystem()->Create(path, /*overwrite=*/false).value();
+        EXPECT_EQ(out->Write(payload.data(), payload.size()).value(),
+                  static_cast<int64_t>(payload.size()));
+        EXPECT_OK(out->Close());
+        auto descriptor =
+            BlobDescriptor::Create(path, /*offset=*/0, /*length=*/payload.size()).value();
+        PAIMON_UNIQUE_PTR<Bytes> bytes = descriptor->Serialize(pool_);
+        return std::string(bytes->data(), bytes->size());
+    }
+
+    std::shared_ptr<arrow::StructArray> BuildBatch(
+        const std::vector<int32_t>& ids,
+        const std::vector<std::optional<std::string>>& blob_values) {
+        arrow::Int32Builder id_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        for (size_t i = 0; i < ids.size(); i++) {
+            EXPECT_TRUE(id_builder.Append(ids[i]).ok());
+            if (blob_values[i]) {
+                EXPECT_TRUE(blob_builder.Append(blob_values[i].value()).ok());
+            } else {
+                EXPECT_TRUE(blob_builder.AppendNull().ok());
+            }
+        }
+        std::shared_ptr<arrow::Array> id_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(id_builder.Finish(&id_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        return arrow::StructArray::Make({id_array, blob_array}, fields_).ValueOrDie();
+    }
+
+    /// Reads the resolver's single batch back as a struct array.
+    Result<std::shared_ptr<arrow::StructArray>> ResolveOneBatch(
+        ManagedBlobResolvingBatchReader* reader) {
+        PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch batch, reader->NextBatch());
+        if (BatchReader::IsEofBatch(batch)) {
+            return Status::Invalid("unexpected eof");
+        }
+        auto& [c_array, c_schema] = batch;
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                          arrow::ImportArray(c_array.get(), c_schema.get()));
+        auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+        if (struct_array == nullptr) {
+            return Status::Invalid("not a struct array");
+        }
+        return struct_array;
+    }
+
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<UniqueTestDirectory> dir_;
+    arrow::FieldVector fields_;
+};
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestResolvesDescriptorsAndPreservesNulls) {
+    std::string descriptor_bytes = WritePayloadAndMakeDescriptor("pack-1", "resolved-payload");
+    auto batch = BuildBatch({1, 2}, {descriptor_bytes, std::nullopt});
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(batch), {"b"},
+                                           dir_->GetFileSystem(), pool_);
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> resolved, ResolveOneBatch(&reader));
+    auto blob_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved->GetFieldByName("b"));
+    ASSERT_TRUE(blob_column != nullptr);
+    ASSERT_EQ(blob_column->length(), 2);
+    EXPECT_EQ(std::string(blob_column->GetView(0)), "resolved-payload");
+    EXPECT_TRUE(blob_column->IsNull(1));
+
+    // The resolution must not strip the blob extension metadata or the nullability off the
+    // resolved field.
+    auto resolved_field = resolved->struct_type()->GetFieldByName("b");
+    ASSERT_TRUE(resolved_field != nullptr);
+    EXPECT_TRUE(BlobUtils::IsBlobField(resolved_field));
+    EXPECT_TRUE(resolved_field->nullable());
+
+    // Untouched columns pass through.
+    auto id_column = std::dynamic_pointer_cast<arrow::Int32Array>(resolved->GetFieldByName("id"));
+    ASSERT_TRUE(id_column != nullptr);
+    EXPECT_EQ(id_column->Value(0), 1);
+    EXPECT_EQ(id_column->Value(1), 2);
+}
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestRejectsNonDescriptorValue) {
+    auto batch = BuildBatch({1}, {std::string("raw-bytes-not-a-descriptor")});
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(batch), {"b"},
+                                           dir_->GetFileSystem(), pool_);
+    // The failure must come from descriptor deserialization, not from a later resolution step.
+    ASSERT_NOK_WITH_MSG(ResolveOneBatch(&reader).status(), "BlobDescriptor");
+}
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestPassThroughWithoutManagedFields) {
+    auto batch = BuildBatch({1}, {std::string("raw-bytes-left-alone")});
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(batch), {},
+                                           dir_->GetFileSystem(), pool_);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> resolved, ResolveOneBatch(&reader));
+    auto blob_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved->GetFieldByName("b"));
+    ASSERT_TRUE(blob_column != nullptr);
+    EXPECT_EQ(std::string(blob_column->GetView(0)), "raw-bytes-left-alone");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/append/append_compact_coordinator.cpp
+++ b/src/paimon/core/append/append_compact_coordinator.cpp
@@ -24,12 +24,17 @@
 #include <utility>
 #include <vector>
 
+#include "fmt/format.h"
+#include "fmt/ranges.h"
 #include "paimon/common/data/binary_row.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/linked_hash_map.h"
 #include "paimon/core/append/append_compact_task.h"
+#include "paimon/core/append/data_evolution_compact_coordinator.h"
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
 #include "paimon/core/core_options.h"
 #include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/manifest/file_kind.h"
 #include "paimon/core/manifest/manifest_entry.h"
 #include "paimon/core/manifest/manifest_file.h"
@@ -40,10 +45,14 @@
 #include "paimon/core/schema/schema_manager.h"
 #include "paimon/core/schema/table_schema.h"
 #include "paimon/core/snapshot.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
 #include "paimon/core/utils/field_mapping.h"
 #include "paimon/core/utils/file_store_path_factory.h"
 #include "paimon/core/utils/snapshot_manager.h"
+#include "paimon/defs.h"
 #include "paimon/executor.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/logging.h"
 #include "paimon/memory/memory_pool.h"
 namespace paimon {
 
@@ -174,6 +183,46 @@ std::unique_ptr<AppendOnlyFileStoreWrite> CreateFileStoreWrite(
         /*realtime_context=*/nullptr, executor, pool);
 }
 
+/// Rejects caller options that change an immutable table option: they decide which
+/// compaction path runs and the physical layout the rewrite must preserve, so overriding
+/// them could route a data-evolution table into the plain append rewrite (reordering row
+/// ids) or slip a deletion-vector table past its rejection. Mirrors the immutable-option
+/// check of Java's AbstractFileStoreTable#copy, compared on the parsed effective values so
+/// that passing an explicit default is still allowed.
+Status ValidateImmutableOptions(const CoreOptions& schema_options,
+                                const CoreOptions& merged_options) {
+    std::vector<std::string> changed_options;
+    if (schema_options.RowTrackingEnabled() != merged_options.RowTrackingEnabled()) {
+        changed_options.emplace_back(Options::ROW_TRACKING_ENABLED);
+    }
+    if (schema_options.DataEvolutionEnabled() != merged_options.DataEvolutionEnabled()) {
+        changed_options.emplace_back(Options::DATA_EVOLUTION_ENABLED);
+    }
+    if (schema_options.DeletionVectorsEnabled() != merged_options.DeletionVectorsEnabled()) {
+        changed_options.emplace_back(Options::DELETION_VECTORS_ENABLED);
+    }
+    if (schema_options.GetBucket() != merged_options.GetBucket()) {
+        changed_options.emplace_back(Options::BUCKET);
+    }
+    if (schema_options.GetBlobFields() != merged_options.GetBlobFields()) {
+        changed_options.emplace_back(Options::BLOB_FIELD);
+    }
+    if (schema_options.GetBlobDescriptorFields() != merged_options.GetBlobDescriptorFields()) {
+        changed_options.emplace_back(Options::BLOB_DESCRIPTOR_FIELD);
+    }
+    if (schema_options.GetBlobViewFields() != merged_options.GetBlobViewFields()) {
+        changed_options.emplace_back(Options::BLOB_VIEW_FIELD);
+    }
+    if (!changed_options.empty()) {
+        return Status::Invalid(
+            fmt::format("Compaction options must not change immutable table options [{}]: they "
+                        "decide the compaction path and the physical layout the rewrite must "
+                        "preserve.",
+                        fmt::join(changed_options, ", ")));
+    }
+    return Status::OK();
+}
+
 /// Load schema from table path and merge user options with schema options.
 Result<std::pair<std::shared_ptr<TableSchema>, CoreOptions>> LoadSchemaAndOptions(
     const std::string& table_path, const std::map<std::string, std::string>& options,
@@ -193,6 +242,9 @@ Result<std::pair<std::shared_ptr<TableSchema>, CoreOptions>> LoadSchemaAndOption
     }
     PAIMON_ASSIGN_OR_RAISE(CoreOptions core_options,
                            CoreOptions::FromMap(final_options, file_system));
+    PAIMON_ASSIGN_OR_RAISE(CoreOptions schema_core_options,
+                           CoreOptions::FromMap(table_schema->Options(), file_system));
+    PAIMON_RETURN_NOT_OK(ValidateImmutableOptions(schema_core_options, core_options));
     return std::make_pair(table_schema, std::move(core_options));
 }
 
@@ -206,7 +258,7 @@ Status ValidateTable(const std::shared_ptr<TableSchema>& table_schema,
     }
     if (core_options.DeletionVectorsEnabled()) {
         return Status::NotImplemented(
-            "AppendCompactCoordinator not support for dv in UNAWARE_BUCKET mode");
+            "AppendCompactCoordinator does not support deletion vectors in UNAWARE_BUCKET mode");
     }
     return Status::OK();
 }
@@ -227,15 +279,18 @@ Result<std::shared_ptr<FileStorePathFactory>> BuildPathFactory(
         global_index_external_path, core_options.IndexFileInDataFileDir(), pool);
 }
 
-/// Scan the latest snapshot and collect small files grouped by partition.
-Result<LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>> ScanSmallFiles(
+/// Scan the latest snapshot and collect files grouped by partition. When `small_files_only` is
+/// set, files at or above the compaction trigger size are dropped; a data-evolution plan needs
+/// every live file instead, since whether a file takes part depends on its field group, not
+/// only on its size.
+Result<LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>> ScanFiles(
     const std::shared_ptr<SnapshotManager>& snapshot_manager,
     const std::shared_ptr<SchemaManager>& schema_manager,
     const std::shared_ptr<TableSchema>& table_schema,
     const std::shared_ptr<arrow::Schema>& arrow_schema,
     const std::shared_ptr<arrow::Schema>& partition_schema, const CoreOptions& core_options,
     const std::shared_ptr<FileStorePathFactory>& path_factory,
-    const std::vector<std::map<std::string, std::string>>& partitions,
+    const std::vector<std::map<std::string, std::string>>& partitions, bool small_files_only,
     const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool) {
     auto scan_filter = std::make_shared<ScanFilter>(
         /*predicate=*/nullptr, partitions, /*bucket_filter=*/std::nullopt);
@@ -256,7 +311,7 @@ Result<LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>> Sca
 
     for (const auto& entry : add_entries) {
         const auto& file = entry.File();
-        if (file->file_size < compaction_file_size) {
+        if (!small_files_only || file->file_size < compaction_file_size) {
             partition_files[entry.Partition()].push_back(file);
         }
     }
@@ -279,6 +334,75 @@ std::vector<AppendCompactTask> GenerateCompactTasks(
         }
     }
     return tasks;
+}
+
+/// Cleans up the rewritten output files of already finished tasks, best effort. Used when a
+/// later task fails: the collected commit messages are discarded, so their outputs would
+/// otherwise linger until an orphan clean. Failures are logged and never mask the original
+/// compaction error the caller returns.
+void CleanupCompactOutputs(const std::vector<std::shared_ptr<CommitMessage>>& commit_messages,
+                           const std::shared_ptr<FileStorePathFactory>& path_factory,
+                           const CoreOptions& core_options) {
+    auto logger = Logger::GetLogger("AppendCompactCoordinator");
+    for (const auto& message : commit_messages) {
+        auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(message);
+        if (!message_impl) {
+            // The log macros require at least one format argument.
+            PAIMON_LOG_WARN(logger, "%s",
+                            "Skipping cleanup of a compact output: unexpected commit message "
+                            "type");
+            continue;
+        }
+        Result<std::shared_ptr<DataFilePathFactory>> data_file_path_factory =
+            path_factory->CreateDataFilePathFactory(message_impl->Partition(),
+                                                    message_impl->Bucket());
+        if (!data_file_path_factory.ok()) {
+            PAIMON_LOG_WARN(logger,
+                            "Skipping cleanup of compact outputs in partition %s bucket %d: %s",
+                            message_impl->Partition().ToString().c_str(), message_impl->Bucket(),
+                            data_file_path_factory.status().ToString().c_str());
+            continue;
+        }
+        for (const auto& file : message_impl->GetCompactIncrement().CompactAfter()) {
+            for (const auto& path : data_file_path_factory.value()->CollectFiles(file)) {
+                auto status = core_options.GetFileSystem()->Delete(path);
+                if (!status.ok()) {
+                    PAIMON_LOG_WARN(logger, "Failed to delete compact output %s: %s", path.c_str(),
+                                    status.ToString().c_str());
+                }
+            }
+        }
+    }
+}
+
+/// Execute data-evolution compact tasks synchronously and collect commit messages.
+Result<std::vector<std::shared_ptr<CommitMessage>>> ExecuteDataEvolutionNormalCompactTasks(
+    std::vector<DataEvolutionNormalCompactTask>&& tasks, const std::string& table_path,
+    const std::shared_ptr<TableSchema>& table_schema,
+    const std::shared_ptr<arrow::Schema>& arrow_schema, const CoreOptions& core_options,
+    const std::shared_ptr<FileStorePathFactory>& path_factory,
+    const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool) {
+    DataEvolutionCompactContext context{table_path,   table_schema, arrow_schema, core_options,
+                                        path_factory, executor,     pool};
+    auto logger = Logger::GetLogger("AppendCompactCoordinator");
+    PAIMON_LOG_DEBUG(logger, "Executing %zu data-evolution compact tasks for table %s",
+                     tasks.size(), table_path.c_str());
+
+    std::vector<std::shared_ptr<CommitMessage>> commit_messages;
+    commit_messages.reserve(tasks.size());
+    for (auto& task : tasks) {
+        Result<std::shared_ptr<CommitMessage>> message = task.DoCompact(context);
+        if (!message.ok()) {
+            PAIMON_LOG_WARN(logger, "Data-evolution compact task failed: %s, status: %s",
+                            task.ToString().c_str(), message.status().ToString().c_str());
+            // The failed task aborted its own output; the finished tasks' outputs will never
+            // be committed anymore, so remove them too.
+            CleanupCompactOutputs(commit_messages, path_factory, core_options);
+            return message.status();
+        }
+        commit_messages.push_back(std::move(message).value());
+    }
+    return commit_messages;
 }
 
 /// Execute compact tasks synchronously and collect commit messages.
@@ -338,15 +462,42 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> AppendCompactCoordinator::Ru
         std::shared_ptr<FileStorePathFactory> path_factory,
         BuildPathFactory(table_path, table_schema, arrow_schema, core_options, pool));
 
-    // Scan small files from latest snapshot
+    // The legacy row-id rewriting mode was removed in Java; honor the same contract for
+    // tables whose options still carry it, instead of silently ignoring the option. Checked
+    // before any scanning, so even an empty table fails loudly.
+    bool data_evolution = core_options.DataEvolutionEnabled();
+    if (data_evolution && core_options.DataEvolutionCompactionRewriteRowIds()) {
+        return Status::Invalid(fmt::format(
+            "'{}' is no longer supported: normal data-evolution compaction preserves row ids "
+            "and logical deletions.",
+            Options::DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS));
+    }
+
+    // Scan files from the latest snapshot. A data-evolution plan considers every live file,
+    // the plain append plan only small ones.
     LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>> partition_files;
-    PAIMON_ASSIGN_OR_RAISE(
-        partition_files,
-        ScanSmallFiles(snapshot_manager, schema_manager, table_schema, arrow_schema,
-                       partition_schema, core_options, path_factory, partitions, executor, pool));
+    PAIMON_ASSIGN_OR_RAISE(partition_files,
+                           ScanFiles(snapshot_manager, schema_manager, table_schema, arrow_schema,
+                                     partition_schema, core_options, path_factory, partitions,
+                                     /*small_files_only=*/!data_evolution, executor, pool));
 
     if (partition_files.empty()) {
         return std::vector<std::shared_ptr<CommitMessage>>{};
+    }
+
+    if (data_evolution) {
+        // Data-evolution tables compact across evolved field groups while preserving row ids;
+        // the plain append rewrite would reorder rows and drop the column merge, so it must
+        // not run here.
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<DataEvolutionNormalCompactTask> tasks,
+            DataEvolutionCompactCoordinator::PlanCompactTasks(partition_files, core_options));
+        if (tasks.empty()) {
+            return std::vector<std::shared_ptr<CommitMessage>>{};
+        }
+        return ExecuteDataEvolutionNormalCompactTasks(std::move(tasks), table_path, table_schema,
+                                                      arrow_schema, core_options, path_factory,
+                                                      executor, pool);
     }
 
     // Generate compact tasks via bin-packing

--- a/src/paimon/core/append/append_compact_coordinator_test.cpp
+++ b/src/paimon/core/append/append_compact_coordinator_test.cpp
@@ -508,7 +508,7 @@ TEST_F(AppendCompactCoordinatorTest, TestValidateFailsOnDvTable) {
 
     ASSERT_NOK_WITH_MSG(AppendCompactCoordinator::Run(TablePath(), options, /*partitions=*/{},
                                                       /*file_system=*/nullptr, pool_),
-                        "not support for dv in UNAWARE_BUCKET mode");
+                        "does not support deletion vectors in UNAWARE_BUCKET mode");
 }
 
 /// Test that compact output files are written to external path when configured.

--- a/src/paimon/core/append/data_evolution_compact_coordinator.cpp
+++ b/src/paimon/core/append/data_evolution_compact_coordinator.cpp
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_compact_coordinator.h"
+
+#include <algorithm>
+#include <iterator>
+#include <limits>
+#include <string>
+#include <utility>
+
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/common/utils/range_helper.h"
+#include "paimon/common/utils/vector_store_utils.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/utils/data_evolution_utils.h"
+
+namespace paimon {
+
+namespace {
+
+/// A bin that packs evolved field groups of one contiguous row id run into one compact task.
+class CompactBin {
+ public:
+    Status Add(std::vector<std::shared_ptr<DataFileMeta>>&& file_group, int64_t weight) {
+        if (weight_ > std::numeric_limits<int64_t>::max() - weight) {
+            return Status::Invalid("Data evolution compaction bin weight overflows.");
+        }
+        files_.insert(files_.end(), std::make_move_iterator(file_group.begin()),
+                      std::make_move_iterator(file_group.end()));
+        weight_ += weight;
+        return Status::OK();
+    }
+
+    int64_t Weight() const {
+        return weight_;
+    }
+
+    std::vector<std::shared_ptr<DataFileMeta>> Drain() {
+        std::vector<std::shared_ptr<DataFileMeta>> result = std::move(files_);
+        files_.clear();
+        weight_ = 0;
+        return result;
+    }
+
+ private:
+    std::vector<std::shared_ptr<DataFileMeta>> files_;
+    int64_t weight_ = 0;
+};
+
+/// Emits a task for the bin's files when there are enough of them; too few files are simply
+/// left as they are (they will be reconsidered by a later coordinator run once neighbors
+/// appear).
+Status TriggerTask(std::vector<std::shared_ptr<DataFileMeta>>&& files, const BinaryRow& partition,
+                   int32_t compact_min_file_num,
+                   std::vector<DataEvolutionNormalCompactTask>* tasks) {
+    if (static_cast<int32_t>(files.size()) < compact_min_file_num) {
+        return Status::OK();
+    }
+    PAIMON_ASSIGN_OR_RAISE(DataEvolutionNormalCompactTask task,
+                           DataEvolutionNormalCompactTask::Create(partition, files));
+    tasks->push_back(std::move(task));
+    return Status::OK();
+}
+
+int64_t FileWeight(const std::shared_ptr<DataFileMeta>& file, int64_t open_file_cost) {
+    return std::max(file->file_size, open_file_cost);
+}
+
+Status PlanPartition(const BinaryRow& partition,
+                     const std::vector<std::shared_ptr<DataFileMeta>>& files,
+                     int64_t target_file_size, int64_t open_file_cost, int32_t compact_min_file_num,
+                     std::vector<DataEvolutionNormalCompactTask>* tasks) {
+    // Blob files are dedicated storage: they are not rewritten and never enter a task, and
+    // their row ranges stay covered by the rewritten data files. Vector-store tables are
+    // rejected outright: without a VECTOR schema type the rewrite cannot exclude the vector
+    // columns the way Java does, and a normal file claiming them as NULL would shadow the
+    // dedicated files.
+    std::vector<std::shared_ptr<DataFileMeta>> data_files;
+    data_files.reserve(files.size());
+    for (const auto& file : files) {
+        if (VectorStoreUtils::IsVectorStoreFile(file->file_name)) {
+            return Status::NotImplemented(
+                "Data-evolution compaction does not support tables with vector-store files "
+                "yet.");
+        }
+        if (DataEvolutionUtils::IsNormalFile(file->file_name)) {
+            data_files.push_back(file);
+        }
+    }
+    if (data_files.empty()) {
+        return Status::OK();
+    }
+
+    // Contiguous runs extend each file's range to [first, first + row_count], one past its
+    // last row: adjacent files share an endpoint and overlap, so a run only breaks on a real
+    // row id gap.
+    RangeHelper<std::shared_ptr<DataFileMeta>> adjacency_helper(
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            return file->NonNullFirstRowId();
+        },
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+            return first_row_id + file->row_count;
+        });
+    // Field groups use the closed range [first, first + row_count - 1]: only files holding the
+    // same rows overlap here, and a group must cover the exact same range in every file.
+    RangeHelper<std::shared_ptr<DataFileMeta>> field_group_helper(
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            return file->NonNullFirstRowId();
+        },
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+            return first_row_id + file->row_count - 1;
+        });
+
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> components,
+                           adjacency_helper.MergeOverlappingRanges(std::move(data_files)));
+    for (auto& component : components) {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> field_groups,
+                               field_group_helper.MergeOverlappingRanges(std::move(component)));
+        CompactBin bin;
+        for (auto& field_group : field_groups) {
+            PAIMON_ASSIGN_OR_RAISE(bool same_range,
+                                   field_group_helper.AreAllRangesSame(field_group));
+            if (!same_range) {
+                std::vector<std::string> file_names;
+                file_names.reserve(field_group.size());
+                for (const auto& file : field_group) {
+                    file_names.push_back(file->file_name);
+                }
+                return Status::Invalid(fmt::format(
+                    "Files of one data evolution field group should share the same row range, "
+                    "but got [{}].",
+                    fmt::join(file_names, ", ")));
+            }
+            int64_t weight = 0;
+            for (const auto& file : field_group) {
+                int64_t file_weight = FileWeight(file, open_file_cost);
+                if (weight > std::numeric_limits<int64_t>::max() - file_weight) {
+                    return Status::Invalid(
+                        "Data evolution compaction field group weight overflows.");
+                }
+                weight += file_weight;
+            }
+            if (weight > target_file_size) {
+                // A heavy group cuts the current bin and is considered on its own (still
+                // subject to the min-file-num gate): merging its files is worthwhile, but
+                // nothing else is packed on top of it.
+                PAIMON_RETURN_NOT_OK(
+                    TriggerTask(bin.Drain(), partition, compact_min_file_num, tasks));
+                CompactBin single_group_bin;
+                PAIMON_RETURN_NOT_OK(single_group_bin.Add(std::move(field_group), weight));
+                PAIMON_RETURN_NOT_OK(
+                    TriggerTask(single_group_bin.Drain(), partition, compact_min_file_num, tasks));
+                continue;
+            }
+            PAIMON_RETURN_NOT_OK(bin.Add(std::move(field_group), weight));
+            if (bin.Weight() > target_file_size) {
+                PAIMON_RETURN_NOT_OK(
+                    TriggerTask(bin.Drain(), partition, compact_min_file_num, tasks));
+            }
+        }
+        // A row id gap follows: whatever is left in the bin cannot be packed any further.
+        PAIMON_RETURN_NOT_OK(TriggerTask(bin.Drain(), partition, compact_min_file_num, tasks));
+    }
+    return Status::OK();
+}
+
+}  // namespace
+
+Result<std::vector<DataEvolutionNormalCompactTask>>
+DataEvolutionCompactCoordinator::PlanCompactTasks(
+    const LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>& partition_files,
+    const CoreOptions& options) {
+    int64_t target_file_size = options.GetTargetFileSize(/*has_primary_key=*/false);
+    int64_t open_file_cost = options.GetSourceSplitOpenFileCost();
+    int32_t compact_min_file_num = options.GetCompactionMinFileNum();
+    if (target_file_size <= 0 || open_file_cost < 0 || compact_min_file_num <= 0) {
+        return Status::Invalid(fmt::format(
+            "Invalid data-evolution compaction options: target-file-size {} must be positive, "
+            "open-file-cost {} must be non-negative, min-file-num {} must be positive.",
+            target_file_size, open_file_cost, compact_min_file_num));
+    }
+
+    std::vector<DataEvolutionNormalCompactTask> tasks;
+    for (const auto& [partition, files] : partition_files) {
+        for (const auto& file : files) {
+            // PlanCompactTasks is a public entry, so the input is validated here before any
+            // planning arithmetic runs on it.
+            if (file == nullptr) {
+                return Status::Invalid("Data evolution compaction files must not be null.");
+            }
+            PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+            if (file->row_count <= 0 || file->file_size < 0 || first_row_id < 0 ||
+                first_row_id > std::numeric_limits<int64_t>::max() - file->row_count) {
+                return Status::Invalid(fmt::format(
+                    "Invalid data-evolution compaction input {}: file size {}, first row id "
+                    "{} and row count {} must form a valid file and row id range.",
+                    file->file_name, file->file_size, first_row_id, file->row_count));
+            }
+        }
+        PAIMON_RETURN_NOT_OK(PlanPartition(partition, files, target_file_size, open_file_cost,
+                                           compact_min_file_num, &tasks));
+    }
+    return tasks;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_compact_coordinator.h
+++ b/src/paimon/core/append/data_evolution_compact_coordinator.h
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/linked_hash_map.h"
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/result.h"
+
+namespace paimon {
+
+class CoreOptions;
+
+/// Plans compaction for data-evolution tables, mirroring the planning part of Java's
+/// `DataEvolutionCompactCoordinator`.
+///
+/// Files of a data-evolution table are grouped by row id range: files sharing the exact same
+/// range form one evolved field group (different versions or subsets of the table columns for
+/// the same rows, produced by partial-column updates). The planner packs field groups of one
+/// contiguous row id run into bins and emits a `DataEvolutionNormalCompactTask` per bin, so
+/// one task merges its field groups back into a single normal file holding every
+/// non-dedicated column, without changing any row id.
+///
+/// Planning rules (the normal-file bin packing follows Java):
+/// - Blob files are dedicated storage and never enter a task. Tables holding vector-store
+///   files are rejected until a VECTOR schema type allows excluding their columns from the
+///   rewrite.
+/// - A file group's weight is `sum(max(file_size, open_file_cost))`. A bin is emitted once its
+///   weight exceeds `target-file-size` (strictly greater).
+/// - A single group heavier than the target cuts the current bin and is emitted on its own —
+///   provided it holds at least `compaction.min.file-num` files — so bins never span a large
+///   file.
+/// - A row id gap always cuts the current bin: tasks stay contiguous.
+/// - A bin becomes a task only when it holds at least `compaction.min.file-num` files.
+class DataEvolutionCompactCoordinator {
+ public:
+    DataEvolutionCompactCoordinator() = delete;
+    ~DataEvolutionCompactCoordinator() = delete;
+
+    /// Plans compact tasks from the ADD file entries of one snapshot, grouped by partition.
+    /// `partition_files` must contain every live file of the scanned partitions, small or
+    /// large: whether a file takes part in compaction is decided here, not by a size
+    /// pre-filter.
+    static Result<std::vector<DataEvolutionNormalCompactTask>> PlanCompactTasks(
+        const LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>& partition_files,
+        const CoreOptions& options);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_compact_coordinator_test.cpp
+++ b/src/paimon/core/append/data_evolution_compact_coordinator_test.cpp
@@ -1,0 +1,344 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_compact_coordinator.h"
+
+#include <limits>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
+#include "paimon/core/core_options.h"
+#include "paimon/defs.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class DataEvolutionCompactCoordinatorTest : public testing::Test {
+ protected:
+    static std::shared_ptr<DataFileMeta> NewFile(const std::string& file_name, int64_t file_size,
+                                                 int64_t first_row_id, int64_t row_count,
+                                                 int64_t min_sequence_number,
+                                                 int64_t max_sequence_number) {
+        return DataFileMeta::ForAppend(file_name, file_size, row_count, SimpleStats::EmptyStats(),
+                                       min_sequence_number, max_sequence_number, /*schema_id=*/0,
+                                       FileSource::Append(),
+                                       /*value_stats_cols=*/std::nullopt,
+                                       /*external_path=*/std::nullopt, first_row_id,
+                                       /*write_cols=*/std::nullopt)
+            .value();
+    }
+
+    static BinaryRow CreateIntRow(int32_t value) {
+        BinaryRow row(1);
+        BinaryRowWriter writer(&row, 20, GetDefaultPool().get());
+        writer.WriteInt(0, value);
+        writer.Complete();
+        return row;
+    }
+
+    static CoreOptions CreateOptions(const std::string& target_file_size,
+                                     const std::string& open_file_cost,
+                                     const std::string& min_file_num) {
+        return CoreOptions::FromMap({{Options::TARGET_FILE_SIZE, target_file_size},
+                                     {Options::SOURCE_SPLIT_OPEN_FILE_COST, open_file_cost},
+                                     {Options::COMPACTION_MIN_FILE_NUM, min_file_num},
+                                     {Options::ROW_TRACKING_ENABLED, "true"},
+                                     {Options::DATA_EVOLUTION_ENABLED, "true"}})
+            .value();
+    }
+
+    static Result<std::vector<DataEvolutionNormalCompactTask>> Plan(
+        const std::vector<std::shared_ptr<DataFileMeta>>& files, const CoreOptions& options,
+        const BinaryRow& partition = BinaryRow::EmptyRow()) {
+        LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>> partition_files;
+        partition_files[partition] = files;
+        return DataEvolutionCompactCoordinator::PlanCompactTasks(partition_files, options);
+    }
+
+    static std::vector<std::string> FileNames(const DataEvolutionNormalCompactTask& task) {
+        std::vector<std::string> names;
+        names.reserve(task.CompactBefore().size());
+        for (const auto& file : task.CompactBefore()) {
+            names.push_back(file->file_name);
+        }
+        return names;
+    }
+};
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestSingleFileProducesNoTask) {
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks,
+                         Plan({NewFile("f1", 100, 0, 100, 1, 1)}, options));
+    ASSERT_TRUE(tasks.empty());
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestContiguousFilesPackedByTargetSize) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 100, 100, 100, 2, 2),
+                                                        NewFile("f3", 100, 200, 100, 3, 3)};
+
+    // The bin is emitted once its weight strictly exceeds the target: with target 199 the first
+    // two files trigger a task and the third stays alone (too few files for its own task).
+    CoreOptions options = CreateOptions("199", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 199));
+
+    // With target 200 two files weigh exactly the target, so all three files pack together.
+    options = CreateOptions("200", "1", "2");
+    ASSERT_OK_AND_ASSIGN(tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2", "f3"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 299));
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestOpenFileCostWeighsSmallFiles) {
+    // A bin weighs each file by max(file_size, open-file-cost), so many tiny files still cost
+    // an open each and fill a bin far sooner than their bytes suggest.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 1, 0, 1, 1, 1), NewFile("f2", 1, 1, 1, 2, 2), NewFile("f3", 1, 2, 1, 3, 3)};
+
+    // With an open-file cost of 100 each file weighs 100: the first two exceed the target and
+    // form a task, leaving the third below the minimum file count.
+    CoreOptions options = CreateOptions("199", "100", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 1));
+
+    // Weighed by their bytes alone the same files never fill the bin and pack together.
+    options = CreateOptions("199", "1", "2");
+    ASSERT_OK_AND_ASSIGN(tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2", "f3"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 2));
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestRowIdGapCutsBin) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 100, 0, 100, 1, 1), NewFile("f2", 100, 100, 100, 2, 2),
+        NewFile("f3", 100, 1000, 100, 3, 3), NewFile("f4", 100, 1100, 100, 4, 4)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 2);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 199));
+    EXPECT_EQ(FileNames(tasks[1]), (std::vector<std::string>{"f3", "f4"}));
+    EXPECT_EQ(tasks[1].RowRange(), Range(1000, 1199));
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestLargeFileSkippedAndCutsBin) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 100, 0, 100, 1, 1), NewFile("f2", 100, 100, 100, 2, 2),
+        NewFile("big", 5000, 200, 100, 3, 3), NewFile("f4", 100, 300, 100, 4, 4),
+        NewFile("f5", 100, 400, 100, 5, 5)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    // The large file exceeds the target on its own: it cuts the bin, is not packed with its
+    // neighbors, and alone it stays below the configured minimum file count.
+    ASSERT_EQ(tasks.size(), 2);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    // The rewritten ranges stop short of the large file's rows and resume after them.
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 199));
+    EXPECT_EQ(FileNames(tasks[1]), (std::vector<std::string>{"f4", "f5"}));
+    EXPECT_EQ(tasks[1].RowRange(), Range(300, 499));
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestEvolvedFieldGroupsPackTogether) {
+    // f1 holds all columns of rows [0, 99], f2 is a newer partial-column file over the exact
+    // same rows (one evolved field group), f3 continues the row id run.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 50, 0, 100, 2, 2),
+                                                        NewFile("f3", 100, 100, 100, 3, 3)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2", "f3"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 199));
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestHeavyFieldGroupCompactedAlone) {
+    // The field group of rows [100, 199] outweighs the target by itself: it still becomes a
+    // task (merging versions is worthwhile), but nothing else is packed on top of it.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 100, 0, 100, 1, 1), NewFile("g1", 600, 100, 100, 2, 2),
+        NewFile("g2", 600, 100, 100, 3, 3), NewFile("f4", 100, 200, 100, 4, 4)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"g1", "g2"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(100, 199));
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestMismatchedFieldGroupRangesRejected) {
+    // Overlapping files that do not cover the exact same rows cannot form a field group.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 100, 0, 50, 2, 2)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    Result<std::vector<DataEvolutionNormalCompactTask>> result = Plan(files, options);
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().ToString().find("same row range") != std::string::npos)
+        << result.status().ToString();
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestBlobFilesExcluded) {
+    // Blob files share the row range of their data files but are dedicated storage: they must
+    // not join a field group or a task.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 50, 0, 100, 2, 2),
+                                                        NewFile("f3.blob", 100, 0, 100, 2, 2)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    // The excluded blob file shares these rows, so the range must stay the data files' own.
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 99));
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestVectorStoreFilesRejected) {
+    // Without a VECTOR schema type the rewrite cannot exclude vector columns the way Java
+    // does, so a table holding vector-store files is rejected instead of silently mis-planned.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 100, 0, 100, 1, 1), NewFile("f2", 50, 0, 100, 2, 2),
+        NewFile("f3.vector.lance", 100, 0, 100, 2, 2)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    Result<std::vector<DataEvolutionNormalCompactTask>> result = Plan(files, options);
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().ToString().find("vector-store") != std::string::npos)
+        << result.status().ToString();
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestPartitionsPlanIndependently) {
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>> partition_files;
+    partition_files[CreateIntRow(0)] = {NewFile("p0-f1", 100, 0, 100, 1, 1),
+                                        NewFile("p0-f2", 100, 100, 100, 2, 2)};
+    partition_files[CreateIntRow(1)] = {NewFile("p1-f1", 100, 0, 100, 1, 1),
+                                        NewFile("p1-f2", 100, 100, 100, 2, 2)};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<DataEvolutionNormalCompactTask> tasks,
+        DataEvolutionCompactCoordinator::PlanCompactTasks(partition_files, options));
+    ASSERT_EQ(tasks.size(), 2);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"p0-f1", "p0-f2"}));
+    EXPECT_EQ(FileNames(tasks[1]), (std::vector<std::string>{"p1-f1", "p1-f2"}));
+    EXPECT_EQ(tasks[0].Partition(), CreateIntRow(0));
+    EXPECT_EQ(tasks[1].Partition(), CreateIntRow(1));
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestMinFileNumOneAllowsSingleFileTask) {
+    // Java places no lower bound on a normal task's input size: with compaction.min.file-num=1
+    // even a lone file may be rewritten.
+    CoreOptions options = CreateOptions("1024", "1", "1");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks,
+                         Plan({NewFile("f1", 100, 0, 100, 1, 1)}, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1"}));
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestMinFileNumSuppressesSmallBins) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 100, 100, 100, 2, 2)};
+    CoreOptions options = CreateOptions("1024", "1", "5");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_TRUE(tasks.empty());
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestTaskCreateRejectsInvalidFileMeta) {
+    // Create() is a public entry and validates its input on its own, without relying on the
+    // coordinator's planning checks. Each input must fail for its own reason.
+    auto expect_task_error = [](const Result<DataEvolutionNormalCompactTask>& result,
+                                const std::string& expected) {
+        EXPECT_FALSE(result.ok());
+        EXPECT_NE(result.status().ToString().find(expected), std::string::npos)
+            << result.status().ToString();
+    };
+    expect_task_error(DataEvolutionNormalCompactTask::Create(BinaryRow::EmptyRow(), {}),
+                      "compact files should not be empty");
+    expect_task_error(DataEvolutionNormalCompactTask::Create(BinaryRow::EmptyRow(), {nullptr}),
+                      "compact files must not be null");
+    // Zero row count.
+    expect_task_error(
+        DataEvolutionNormalCompactTask::Create(
+            BinaryRow::EmptyRow(), {NewFile("f1", 100, /*first_row_id=*/0, /*row_count=*/0, 1, 1)}),
+        "must form a valid row id range");
+    // Negative first row id.
+    expect_task_error(DataEvolutionNormalCompactTask::Create(
+                          BinaryRow::EmptyRow(),
+                          {NewFile("f1", 100, /*first_row_id=*/-5, /*row_count=*/100, 1, 1)}),
+                      "must form a valid row id range");
+    // A row range overflowing int64.
+    expect_task_error(
+        DataEvolutionNormalCompactTask::Create(
+            BinaryRow::EmptyRow(),
+            {NewFile("f1", 100, /*first_row_id=*/std::numeric_limits<int64_t>::max() - 1,
+                     /*row_count=*/100, 1, 1)}),
+        "must form a valid row id range");
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestTaskCreateRejectsDisjointRowRanges) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 100, 1000, 100, 2, 2)};
+    Result<DataEvolutionNormalCompactTask> task =
+        DataEvolutionNormalCompactTask::Create(BinaryRow::EmptyRow(), files);
+    ASSERT_FALSE(task.ok());
+    EXPECT_TRUE(task.status().ToString().find("contiguous row range") != std::string::npos)
+        << task.status().ToString();
+}
+
+TEST_F(DataEvolutionCompactCoordinatorTest, TestPlanRejectsInvalidFileMeta) {
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    auto expect_plan_error = [](const Result<std::vector<DataEvolutionNormalCompactTask>>& result,
+                                const std::string& expected) {
+        EXPECT_FALSE(result.ok());
+        EXPECT_NE(result.status().ToString().find(expected), std::string::npos)
+            << result.status().ToString();
+    };
+    // A null file must fail the plan instead of crashing it.
+    expect_plan_error(Plan({nullptr}, options), "compaction files must not be null");
+    // A zero row count cannot form a valid row id range.
+    expect_plan_error(
+        Plan({NewFile("f1", 100, /*first_row_id=*/0, /*row_count=*/0, 1, 1)}, options),
+        "must form a valid file and row id range");
+    // A negative file size cannot weigh a bin.
+    expect_plan_error(
+        Plan({NewFile("f1", -1, /*first_row_id=*/0, /*row_count=*/100, 1, 1)}, options),
+        "must form a valid file and row id range");
+    // A row range overflowing int64 is rejected before any packing arithmetic runs on it.
+    expect_plan_error(
+        Plan({NewFile("f1", 100, /*first_row_id=*/std::numeric_limits<int64_t>::max() - 1,
+                      /*row_count=*/100, 1, 1)},
+             options),
+        "must form a valid file and row id range");
+    // A file without a first row id cannot take part in data evolution planning.
+    auto file_without_row_id =
+        DataFileMeta::ForAppend("f1", 100, 100, SimpleStats::EmptyStats(), 1, 1, /*schema_id=*/0,
+                                FileSource::Append(), /*value_stats_cols=*/std::nullopt,
+                                /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt,
+                                /*write_cols=*/std::nullopt)
+            .value();
+    expect_plan_error(Plan({file_without_row_id, NewFile("f2", 100, 100, 100, 2, 2)}, options),
+                      "First row id of f1 should not be null");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/append/data_evolution_normal_compact_task.cpp
+++ b/src/paimon/core/append/data_evolution_normal_compact_task.cpp
@@ -1,0 +1,305 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <set>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "arrow/c/helpers.h"
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/data/shredding/shredding_write_plan_factories.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/utils/arrow/arrow_utils.h"
+#include "paimon/common/utils/long_counter.h"
+#include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/io/append_data_file_writer_factory.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/io/rolling_file_writer.h"
+#include "paimon/core/io/shredding_append_data_file_writer_factory.h"
+#include "paimon/core/operation/data_evolution_split_read.h"
+#include "paimon/core/operation/internal_read_context.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/defs.h"
+#include "paimon/read_context.h"
+#include "paimon/reader/batch_reader.h"
+
+namespace paimon {
+
+DataEvolutionNormalCompactTask::DataEvolutionNormalCompactTask(
+    const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files,
+    const Range& row_range)
+    : partition_(partition), compact_before_(files), row_range_(row_range) {}
+
+Result<DataEvolutionNormalCompactTask> DataEvolutionNormalCompactTask::Create(
+    const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+    PAIMON_ASSIGN_OR_RAISE(Range row_range, CheckContiguousRowRange(files));
+    return DataEvolutionNormalCompactTask(partition, files, row_range);
+}
+
+Result<Range> DataEvolutionNormalCompactTask::CheckContiguousRowRange(
+    const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+    if (files.empty()) {
+        return Status::Invalid("Data evolution compact files should not be empty.");
+    }
+    std::vector<Range> ranges;
+    ranges.reserve(files.size());
+    for (const auto& file : files) {
+        // Create() is a public entry, so the row id range is validated here as well, not
+        // only by the coordinator's planning input checks.
+        if (file == nullptr) {
+            return Status::Invalid("Data evolution compact files must not be null.");
+        }
+        PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+        if (file->row_count <= 0 || first_row_id < 0 ||
+            first_row_id > std::numeric_limits<int64_t>::max() - file->row_count) {
+            return Status::Invalid(
+                fmt::format("Invalid data evolution compact input {}: first row id {} and row "
+                            "count {} must form a valid row id range.",
+                            file->file_name, first_row_id, file->row_count));
+        }
+        ranges.emplace_back(first_row_id, first_row_id + file->row_count - 1);
+    }
+    std::vector<Range> merged = Range::SortAndMergeOverlap(ranges, /*adjacent=*/true);
+    if (merged.size() != 1) {
+        std::vector<std::string> range_strings;
+        range_strings.reserve(merged.size());
+        for (const auto& range : merged) {
+            range_strings.push_back(range.ToString());
+        }
+        return Status::Invalid(
+            fmt::format("Data evolution compact files should have a contiguous row range, "
+                        "but got [{}].",
+                        fmt::join(range_strings, ", ")));
+    }
+    return merged[0];
+}
+
+Result<std::shared_ptr<CommitMessage>> DataEvolutionNormalCompactTask::DoCompact(
+    const DataEvolutionCompactContext& context) {
+    if (compact_before_.empty()) {
+        return Status::Invalid("DataEvolutionNormalCompactTask needs at least one file input.");
+    }
+
+    // The read/write schema drops blob fields stored in dedicated .blob files: they are not
+    // rewritten by data-evolution compaction. Inline blob fields (descriptor / view) live in
+    // the normal data files and stay in the schema.
+    std::vector<std::string> inline_field_names = context.core_options.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> dedicated_field_names =
+        BlobUtils::ManagedBlobFieldNames(context.arrow_schema, inline_fields);
+    std::set<std::string> dedicated_fields(dedicated_field_names.begin(),
+                                           dedicated_field_names.end());
+    std::vector<std::string> read_write_field_names;
+    arrow::FieldVector write_fields;
+    for (const auto& field : context.arrow_schema->fields()) {
+        if (dedicated_fields.count(field->name()) != 0) {
+            continue;
+        }
+        read_write_field_names.push_back(field->name());
+        write_fields.push_back(field);
+    }
+    if (write_fields.empty()) {
+        return Status::Invalid(
+            "Data evolution compaction requires at least one non-blob column to rewrite.");
+    }
+    auto write_schema = arrow::schema(write_fields);
+
+    // A file holding every table column stores no write cols; a partial-column file names the
+    // columns it holds.
+    std::optional<std::vector<std::string>> write_cols = read_write_field_names;
+    if (context.arrow_schema->Equals(*write_schema)) {
+        write_cols = std::nullopt;
+    }
+
+    // Deletion files are intentionally not attached to the read, so the output file keeps
+    // every input row. Today the entry point rejects deletion-vector tables outright; keeping
+    // every row is what will let their logical deletions survive a rewrite once the deletion
+    // vector migration is ported.
+    ReadContextBuilder context_builder(context.table_path);
+    context_builder.SetOptions(context.core_options.ToMap())
+        .WithFileSystem(context.core_options.GetFileSystem())
+        .SetReadFieldNames(read_write_field_names)
+        .EnablePrefetch(true)
+        .SetPrefetchMaxParallelNum(1)
+        .SetPrefetchBatchCount(3)
+        .WithMemoryPool(context.pool);
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ReadContext> read_context, context_builder.Finish());
+    // TODO(xinyu.lxy): temporarily disabled pre-buffer for parquet, which may cause high
+    // memory usage during compaction. Will fix via parquet format refactor.
+    std::map<std::string, std::string> read_options = context.core_options.ToMap();
+    if (read_options.find("parquet.read.enable-pre-buffer") == read_options.end()) {
+        read_options["parquet.read.enable-pre-buffer"] = "false";
+    }
+    // Blob-view columns must be rewritten as their serialized BlobViewStruct bytes: resolving
+    // them here would bake descriptors into the blob-view column and break later reads.
+    read_options[Options::BLOB_VIEW_RESOLVE_ENABLED] = "false";
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<InternalReadContext> internal_read_context,
+        InternalReadContext::Create(read_context, context.table_schema, read_options));
+    auto split_read = std::make_unique<DataEvolutionSplitRead>(
+        context.path_factory, internal_read_context, context.pool, context.executor);
+
+    PAIMON_ASSIGN_OR_RAISE(std::string bucket_path,
+                           context.path_factory->BucketPath(partition_, /*bucket=*/0));
+    auto data_files = compact_before_;
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<DataSplitImpl> split,
+        DataSplitImpl::Builder(partition_, /*bucket=*/0, bucket_path, std::move(data_files))
+            .RawConvertible(false)
+            .Build());
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> reader,
+                           split_read->CreateReader(std::static_pointer_cast<Split>(split)));
+    ScopeGuard reader_guard([&]() {
+        if (reader) {
+            reader->Close();
+        }
+    });
+
+    // A single output file: rolling is disabled so the rewritten rows keep exactly the input
+    // group's row range. The sequence counter is irrelevant, the real sequence numbers are
+    // assigned on the result below.
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<DataFilePathFactory> data_file_path_factory,
+        context.path_factory->CreateDataFilePathFactory(partition_, /*bucket=*/0));
+    auto seq_num_counter = std::make_shared<LongCounter>(0);
+    std::shared_ptr<SingleFileWriterFactory<::ArrowArray*, std::shared_ptr<DataFileMeta>>>
+        writer_factory;
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ShreddingWritePlanFactory> plan_factory,
+                           ShreddingWritePlanFactories::SelectActive(context.core_options,
+                                                                     write_schema, context.pool));
+    if (plan_factory != nullptr) {
+        writer_factory = std::make_shared<ShreddingAppendDataFileWriterFactory>(
+            context.core_options, context.table_schema->Id(), write_schema, write_cols,
+            seq_num_counter, FileSource::Compact(), data_file_path_factory, plan_factory,
+            context.pool);
+    } else {
+        writer_factory = std::make_shared<AppendDataFileWriterFactory>(
+            context.core_options, context.table_schema->Id(), write_schema, write_cols,
+            seq_num_counter, FileSource::Compact(), data_file_path_factory, context.pool);
+    }
+    auto rewriter =
+        std::make_unique<RollingFileWriter<::ArrowArray*, std::shared_ptr<DataFileMeta>>>(
+            /*target_file_size=*/std::numeric_limits<int64_t>::max(),
+            /*target_file_row_num=*/std::numeric_limits<int64_t>::max(), writer_factory);
+    // Abort on any failure up to and including result validation: a half-written or
+    // unvalidated output must be deleted, never committed. RollingFileWriter::Abort also
+    // removes files already sealed by Close().
+    ScopeGuard rewriter_guard([&]() {
+        if (rewriter) {
+            rewriter->Abort();
+        }
+    });
+
+    while (true) {
+        PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch batch, reader->NextBatch());
+        if (BatchReader::IsEofBatch(batch)) {
+            break;
+        }
+        auto& [c_array, c_schema] = batch;
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                          arrow::ImportArray(c_array.get(), c_schema.get()));
+        auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+        if (!struct_array) {
+            return Status::Invalid(
+                "cannot cast array to StructArray in DataEvolutionNormalCompactTask");
+        }
+        PAIMON_ASSIGN_OR_RAISE(struct_array, ArrowUtils::RemoveFieldFromStructArray(
+                                                 struct_array, SpecialFields::ValueKind().Name()));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(
+            arrow::ExportArray(*struct_array, c_array.get(), c_schema.get()));
+        ArrowSchemaRelease(c_schema.get());
+        ScopeGuard guard([array = c_array.get()]() { ArrowArrayRelease(array); });
+        PAIMON_RETURN_NOT_OK(rewriter->Write(c_array.get()));
+        guard.Release();
+    }
+    PAIMON_RETURN_NOT_OK(rewriter->Close());
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<DataFileMeta>> write_result,
+                           rewriter->GetResult());
+    if (write_result.size() != 1) {
+        return Status::Invalid(
+            fmt::format("Data evolution compaction should produce exactly one file, but got {}.",
+                        write_result.size()));
+    }
+    rewriter_guard.Release();
+
+    // Keep the row ids and the merged [min, max] sequence number range of the input group:
+    // _ROW_ID values stay unchanged and the rewritten file keeps its position in the "newest
+    // field group wins" ordering, while per-row _SEQUENCE_NUMBER values, derived from the
+    // file-level maximum, may rise to the group's maximum.
+    int64_t min_sequence_number = std::numeric_limits<int64_t>::max();
+    int64_t max_sequence_number = std::numeric_limits<int64_t>::min();
+    for (const auto& file : compact_before_) {
+        min_sequence_number = std::min(min_sequence_number, file->min_sequence_number);
+        max_sequence_number = std::max(max_sequence_number, file->max_sequence_number);
+    }
+    const std::shared_ptr<DataFileMeta>& compacted_file = write_result[0];
+    compacted_file->AssignFirstRowId(row_range_.from);
+    compacted_file->AssignSequenceNumber(min_sequence_number, max_sequence_number);
+    compact_after_.push_back(compacted_file);
+
+    auto compact_before_copy = compact_before_;
+    auto compact_after_copy = compact_after_;
+    CompactIncrement compact_increment(std::move(compact_before_copy),
+                                       std::move(compact_after_copy),
+                                       /*changelog_files=*/{},
+                                       /*new_index_files=*/{},
+                                       /*deleted_index_files=*/{});
+    DataIncrement data_increment(/*new_files=*/{}, /*deleted_files=*/{}, /*changelog_files=*/{});
+
+    // Bucket 0 is the bucket for unaware-bucket table, for compatibility with the old design.
+    // Total buckets stay unset, matching Java's contract for data-evolution compact messages
+    // (its deletion-vector rewriter asserts on it).
+    auto commit_message = std::make_shared<CommitMessageImpl>(
+        partition_,
+        /*bucket=*/0, /*total_buckets=*/std::nullopt, data_increment, compact_increment);
+    return std::static_pointer_cast<CommitMessage>(commit_message);
+}
+
+std::string DataEvolutionNormalCompactTask::ToString() const {
+    std::vector<std::string> before_names;
+    before_names.reserve(compact_before_.size());
+    for (const auto& file : compact_before_) {
+        before_names.emplace_back(file->file_name);
+    }
+
+    std::vector<std::string> after_names;
+    after_names.reserve(compact_after_.size());
+    for (const auto& file : compact_after_) {
+        after_names.emplace_back(file->file_name);
+    }
+
+    return fmt::format(
+        "DataEvolutionNormalCompactTask {{partition = {}, rowRange = {}, compactBefore = [{}], "
+        "compactAfter = [{}]}}",
+        partition_.ToString(), row_range_.ToString(), fmt::join(before_names, ", "),
+        fmt::join(after_names, ", "));
+}
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_normal_compact_task.h
+++ b/src/paimon/core/append/data_evolution_normal_compact_task.h
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/result.h"
+#include "paimon/utils/range.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+class CommitMessage;
+class Executor;
+class FileStorePathFactory;
+class MemoryPool;
+class TableSchema;
+
+/// Everything a data-evolution compact task needs to rewrite its files, shared by all tasks of
+/// one coordinator run.
+struct DataEvolutionCompactContext {
+    std::string table_path;
+    std::shared_ptr<TableSchema> table_schema;
+    std::shared_ptr<arrow::Schema> arrow_schema;
+    CoreOptions core_options;
+    std::shared_ptr<FileStorePathFactory> path_factory;
+    std::shared_ptr<Executor> executor;
+    std::shared_ptr<MemoryPool> pool;
+};
+
+/// Compaction task for data-evolution tables.
+///
+/// The files to compact cover one contiguous row id range and may span several evolved field
+/// groups: files sharing the exact same row range whose columns are different versions or
+/// different subsets of the table fields, produced by partial-column updates. The task reads the
+/// files through `DataEvolutionSplitRead`, which merges the field groups so the newest version
+/// of every column wins, and rewrites the merged rows into a single new file.
+///
+/// Row ids are never changed: the output file keeps the input group's first row id and its
+/// merged `[min, max]` sequence number range, so `_ROW_ID` values derived from manifest
+/// metadata and the "newest field group wins" ordering stay intact. Preserving row ids is
+/// also a prerequisite for row-id-keyed deletion vectors, whose commit-time migration is not
+/// ported yet: the compaction entry point still rejects deletion-vector tables. Blob files
+/// are dedicated storage and are not part of a task; their row ranges remain covered by the
+/// rewritten data file.
+class DataEvolutionNormalCompactTask {
+ public:
+    /// Creates a task after validating that `files` cover one contiguous row id range.
+    static Result<DataEvolutionNormalCompactTask> Create(
+        const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files);
+
+    ~DataEvolutionNormalCompactTask() = default;
+
+    const BinaryRow& Partition() const {
+        return partition_;
+    }
+
+    const std::vector<std::shared_ptr<DataFileMeta>>& CompactBefore() const {
+        return compact_before_;
+    }
+
+    const std::vector<std::shared_ptr<DataFileMeta>>& CompactAfter() const {
+        return compact_after_;
+    }
+
+    /// The contiguous row id range covered by the task's input files.
+    const Range& RowRange() const {
+        return row_range_;
+    }
+
+    Result<std::shared_ptr<CommitMessage>> DoCompact(const DataEvolutionCompactContext& context);
+
+    std::string ToString() const;
+
+ private:
+    DataEvolutionNormalCompactTask(const BinaryRow& partition,
+                                   const std::vector<std::shared_ptr<DataFileMeta>>& files,
+                                   const Range& row_range);
+
+    /// Checks that the row id ranges of `files` merge into one contiguous range and returns it.
+    static Result<Range> CheckContiguousRowRange(
+        const std::vector<std::shared_ptr<DataFileMeta>>& files);
+
+ private:
+    BinaryRow partition_;
+    std::vector<std::shared_ptr<DataFileMeta>> compact_before_;
+    std::vector<std::shared_ptr<DataFileMeta>> compact_after_;
+    Range row_range_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/core_options.cpp
+++ b/src/paimon/core/core_options.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "fmt/format.h"
+#include "paimon/common/data/blob_defs.h"
 #include "paimon/common/fs/resolving_file_system.h"
 #include "paimon/common/options/memory_size.h"
 #include "paimon/common/options/time_duration.h"
@@ -381,6 +382,7 @@ struct CoreOptions::Impl {
     std::optional<int64_t> target_file_size;
     int64_t target_file_row_num = std::numeric_limits<int64_t>::max();
     std::optional<int64_t> blob_target_file_size;
+    int64_t blob_copy_buffer_size = BlobDefs::kDefaultCopyBufferSize;
     int64_t source_split_target_size = 128 * 1024 * 1024;
     int64_t source_split_open_file_cost = 4 * 1024 * 1024;
     int64_t manifest_target_file_size = 8 * 1024 * 1024;
@@ -479,6 +481,8 @@ struct CoreOptions::Impl {
     double variant_shredding_adaptive_retention_ratio = 0.05;
     bool blob_view_resolve_enabled = true;
     bool blob_as_descriptor = false;
+    bool data_evolution_compaction_rewrite_row_ids = false;
+    bool pk_clustering_override = false;
     std::optional<bool> blob_split_by_file_size;
     bool legacy_partition_name_enabled = true;
     bool global_index_enabled = true;
@@ -535,6 +539,17 @@ struct CoreOptions::Impl {
         // Parse blob.target-file-size - target size of a blob file
         PAIMON_RETURN_NOT_OK(
             parser.ParseMemorySize(Options::BLOB_TARGET_FILE_SIZE, &blob_target_file_size));
+        // Parse blob.copy-buffer-size - buffer size for copying blob payloads into blob files
+        PAIMON_RETURN_NOT_OK(
+            parser.ParseMemorySize(Options::BLOB_COPY_BUFFER_SIZE, &blob_copy_buffer_size));
+        // Mirror Java's checkedBlobCopyBufferSize bounds, checked at parse time.
+        if (blob_copy_buffer_size <= 0 ||
+            blob_copy_buffer_size > std::numeric_limits<int32_t>::max()) {
+            return Status::Invalid(
+                fmt::format("'{}' must be between 1 byte and {} bytes, but was {} bytes.",
+                            Options::BLOB_COPY_BUFFER_SIZE, std::numeric_limits<int32_t>::max(),
+                            blob_copy_buffer_size));
+        }
         // Parse source.split.target-size - target size of a source split when scanning a bucket
         PAIMON_RETURN_NOT_OK(
             parser.ParseMemorySize(Options::SOURCE_SPLIT_TARGET_SIZE, &source_split_target_size));
@@ -619,6 +634,14 @@ struct CoreOptions::Impl {
             parser.Parse<bool>(Options::BLOB_VIEW_RESOLVE_ENABLED, &blob_view_resolve_enabled));
         // Parse blob-as-descriptor - read blob field as descriptor rather than blob bytes
         PAIMON_RETURN_NOT_OK(parser.Parse<bool>(Options::BLOB_AS_DESCRIPTOR, &blob_as_descriptor));
+        // Parse data-evolution.compaction.rewrite-row-ids - legacy row-id rewriting mode,
+        // kept only so a table carrying it fails loudly instead of being mis-compacted
+        PAIMON_RETURN_NOT_OK(parser.Parse<bool>(Options::DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS,
+                                                &data_evolution_compaction_rewrite_row_ids));
+        // Parse pk-clustering-override - unsupported clustering override; parsed so an
+        // explicit false can be told apart from true (only true is rejected, like Java)
+        PAIMON_RETURN_NOT_OK(
+            parser.Parse<bool>(Options::PK_CLUSTERING_OVERRIDE, &pk_clustering_override));
         // Parse blob.split-by-file-size - whether blob file size counts in scan splitting
         PAIMON_RETURN_NOT_OK(
             parser.Parse(Options::BLOB_SPLIT_BY_FILE_SIZE, &blob_split_by_file_size));
@@ -1121,6 +1144,22 @@ int64_t CoreOptions::GetBlobTargetFileSize() const {
 
 bool CoreOptions::BlobSplitByFileSize() const {
     return impl_->blob_split_by_file_size.value_or(!impl_->blob_as_descriptor);
+}
+
+int64_t CoreOptions::GetBlobCopyBufferSize() const {
+    return impl_->blob_copy_buffer_size;
+}
+
+bool CoreOptions::BlobAsDescriptor() const {
+    return impl_->blob_as_descriptor;
+}
+
+bool CoreOptions::DataEvolutionCompactionRewriteRowIds() const {
+    return impl_->data_evolution_compaction_rewrite_row_ids;
+}
+
+bool CoreOptions::PkClusteringOverride() const {
+    return impl_->pk_clustering_override;
 }
 
 int64_t CoreOptions::GetCompactionFileSize(bool has_primary_key) const {

--- a/src/paimon/core/core_options.h
+++ b/src/paimon/core/core_options.h
@@ -89,6 +89,18 @@ class PAIMON_EXPORT CoreOptions {
     int64_t GetTargetFileRowNum() const;
     int64_t GetBlobTargetFileSize() const;
     bool BlobSplitByFileSize() const;
+    /// Buffer size in bytes for copying blob payloads into blob files. Validated at parse
+    /// time to lie in [1, INT32_MAX], mirroring Java's checkedBlobCopyBufferSize.
+    int64_t GetBlobCopyBufferSize() const;
+    /// Whether reads return blob values as serialized descriptors instead of payload bytes.
+    bool BlobAsDescriptor() const;
+    /// The legacy data-evolution row-id rewriting mode; no longer supported and rejected by
+    /// the compaction entry point when set.
+    bool DataEvolutionCompactionRewriteRowIds() const;
+    /// The unsupported clustering override for primary-key tables; only "true" is rejected
+    /// (by the commit path and by managed-blob schema validation), an explicit "false"
+    /// equals the C++ behavior and is allowed.
+    bool PkClusteringOverride() const;
     int64_t GetCompactionFileSize(bool has_primary_key) const;
     std::string GetPartitionDefaultName() const;
 

--- a/src/paimon/core/core_options_test.cpp
+++ b/src/paimon/core/core_options_test.cpp
@@ -48,6 +48,7 @@ TEST(CoreOptionsTest, TestDefaultValue) {
     ASSERT_EQ(std::numeric_limits<int64_t>::max(), core_options.GetTargetFileRowNum());
     ASSERT_EQ(256 * 1024 * 1024L, core_options.GetBlobTargetFileSize());
     ASSERT_TRUE(core_options.BlobSplitByFileSize());
+    ASSERT_EQ(4 * 1024L, core_options.GetBlobCopyBufferSize());
     ASSERT_EQ(187904815, core_options.GetCompactionFileSize(/*has_primary_key=*/false));
     ASSERT_EQ(93952404, core_options.GetCompactionFileSize(/*has_primary_key=*/true));
 
@@ -191,6 +192,7 @@ TEST(CoreOptionsTest, TestFromMap) {
         {Options::TARGET_FILE_SIZE, "512MB"},
         {Options::TARGET_FILE_ROW_NUM, "123"},
         {Options::BLOB_TARGET_FILE_SIZE, "1G"},
+        {Options::BLOB_COPY_BUFFER_SIZE, "8 kb"},
         {Options::PARTITION_DEFAULT_NAME, "foo"},
         {Options::MANIFEST_TARGET_FILE_SIZE, "16MB"},
         {Options::MANIFEST_FULL_COMPACTION_FILE_SIZE, "32MB"},
@@ -326,6 +328,7 @@ TEST(CoreOptionsTest, TestFromMap) {
     ASSERT_EQ(512 * 1024 * 1024L, core_options.GetTargetFileSize(/*has_primary_key=*/false));
     ASSERT_EQ(123, core_options.GetTargetFileRowNum());
     ASSERT_EQ(1024 * 1024 * 1024L, core_options.GetBlobTargetFileSize());
+    ASSERT_EQ(8 * 1024L, core_options.GetBlobCopyBufferSize());
     ASSERT_EQ("foo", core_options.GetPartitionDefaultName());
     ASSERT_EQ(16 * 1024 * 1024L, core_options.GetManifestTargetFileSize());
     ASSERT_EQ(32 * 1024 * 1024L, core_options.GetManifestFullCompactionThresholdSize());
@@ -475,6 +478,10 @@ TEST(CoreOptionsTest, TestFromMap) {
 TEST(CoreOptionsTest, TestInvalidCase) {
     ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::TARGET_FILE_ROW_NUM, "0"}}),
                         "target-file-row-num should be at least 1");
+    ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::BLOB_COPY_BUFFER_SIZE, "0"}}),
+                        "must be between 1 byte and");
+    ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::BLOB_COPY_BUFFER_SIZE, "3 gb"}}),
+                        "must be between 1 byte and");
     ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::BUCKET, "3.5"}}),
                         "Invalid Config [bucket: 3.5]");
     ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::SCAN_SNAPSHOT_ID, "3.5"}}),

--- a/src/paimon/core/io/data_file_path_factory.h
+++ b/src/paimon/core/io/data_file_path_factory.h
@@ -27,6 +27,7 @@
 #include "paimon/common/fs/external_path_provider.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
 #include "paimon/core/utils/path_factory.h"
 
 namespace paimon {
@@ -62,6 +63,14 @@ class DataFilePathFactory : public PathFactory {
 
     std::string NewBlobPath() const {
         return NewPathFromName(NewFileName(data_file_prefix_, ".blob"));
+    }
+
+    /// A new managed blob pack path for primary-key managed blob storage. Managed packs stay
+    /// in the default bucket directory: external data paths are rejected for primary-key
+    /// managed blob tables.
+    std::string NewManagedBlobPath() const {
+        return PathUtil::JoinPath(
+            parent_, NewFileName(data_file_prefix_, ManagedBlobReferenceFile::kManagedBlobSuffix));
     }
 
     std::string NewPathFromName(const std::string& file_name) const {

--- a/src/paimon/core/io/key_value_data_file_writer.cpp
+++ b/src/paimon/core/io/key_value_data_file_writer.cpp
@@ -68,6 +68,11 @@ void KeyValueDataFileWriter::SetMetadataFinalizer(MetadataFinalizer finalizer) {
     metadata_finalizer_ = std::move(finalizer);
 }
 
+void KeyValueDataFileWriter::SetBlobReferenceCollector(
+    std::unique_ptr<ManagedBlobReferenceCollector> collector) {
+    blob_reference_collector_ = std::move(collector);
+}
+
 Status KeyValueDataFileWriter::Write(KeyValueBatch batch) {
     // update min and max key
     if (!min_key_) {
@@ -79,6 +84,10 @@ Status KeyValueDataFileWriter::Write(KeyValueBatch batch) {
     max_sequence_number_ = std::max(max_sequence_number_, batch.max_sequence_number);
     // update delete row count
     delete_row_count_ += batch.delete_row_count;
+
+    if (blob_reference_collector_) {
+        PAIMON_RETURN_NOT_OK(blob_reference_collector_->Collect(&batch));
+    }
 
     PAIMON_RETURN_NOT_OK(SingleFileWriter::Write(std::move(batch)));
     return Status::OK();
@@ -92,7 +101,28 @@ Status KeyValueDataFileWriter::BeforeFinish() {
             PAIMON_RETURN_NOT_OK(UpdateSchema(updated_schema));
         }
     }
+    if (blob_reference_collector_) {
+        PAIMON_RETURN_NOT_OK(blob_reference_collector_->Close());
+    }
     return Status::OK();
+}
+
+void KeyValueDataFileWriter::Abort() {
+    if (blob_reference_collector_) {
+        blob_reference_collector_->Abort();
+    }
+    SingleFileWriter::Abort();
+}
+
+Result<KeyValueDataFileWriter::AbortExecutor> KeyValueDataFileWriter::GetAbortExecutor() const {
+    if (!closed_) {
+        return Status::Invalid("Writer should be closed!");
+    }
+    if (blob_reference_collector_) {
+        return AbortExecutor(
+            fs_, std::vector<std::string>{path_, blob_reference_collector_->SidecarPath()});
+    }
+    return AbortExecutor(fs_, path_);
 }
 
 Result<std::shared_ptr<DataFileMeta>> KeyValueDataFileWriter::GetResult() {
@@ -120,10 +150,17 @@ Result<std::shared_ptr<DataFileMeta>> KeyValueDataFileWriter::GetResult() {
         final_path = external_path.ToString();
     }
     PAIMON_ASSIGN_OR_RAISE(int64_t local_micro, DateTimeUtils::GetCurrentLocalTimeUs());
+    // The blob reference sidecar travels in the extra files, tying its lifecycle to the data
+    // file wherever extra files are collected for deletion.
+    std::vector<std::optional<std::string>> extra_files;
+    if (blob_reference_collector_) {
+        PAIMON_ASSIGN_OR_RAISE(std::string sidecar_file_name,
+                               blob_reference_collector_->ResultFileName());
+        extra_files.emplace_back(std::move(sidecar_file_name));
+    }
     return std::make_shared<DataFileMeta>(
         PathUtil::GetName(path_), output_bytes_, RecordCount(), min_key, max_key, key_stats,
-        value_stats, min_sequence_number_, max_sequence_number_, schema_id_, level_,
-        /*extra_files=*/std::vector<std::optional<std::string>>(),
+        value_stats, min_sequence_number_, max_sequence_number_, schema_id_, level_, extra_files,
         Timestamp(/*millisecond=*/local_micro / 1000, /*nano_of_millisecond=*/0), delete_row_count_,
         /*embedded_index=*/nullptr, file_source_,
         /*value_stats_cols=*/std::nullopt, final_path, /*first_row_id=*/std::nullopt,

--- a/src/paimon/core/io/key_value_data_file_writer.h
+++ b/src/paimon/core/io/key_value_data_file_writer.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/managed_blob_reference_collector.h"
 #include "paimon/core/io/single_file_writer.h"
 #include "paimon/core/key_value.h"
 #include "paimon/core/manifest/file_source.h"
@@ -64,9 +65,19 @@ class KeyValueDataFileWriter
     /// schema and perform finalization callbacks. Must be set before Close().
     void SetMetadataFinalizer(MetadataFinalizer finalizer);
 
+    /// Attaches the managed blob reference collector of a primary-key managed blob table. The
+    /// collector records the pack files this data file's rows reference; its `.blobref`
+    /// sidecar is written on close and carried in the result's extra files. Must be set before
+    /// the first Write().
+    void SetBlobReferenceCollector(std::unique_ptr<ManagedBlobReferenceCollector> collector);
+
     Status Write(KeyValueBatch batch) override;
 
     Result<std::shared_ptr<DataFileMeta>> GetResult() override;
+
+    void Abort() override;
+
+    Result<AbortExecutor> GetAbortExecutor() const override;
 
  protected:
     Status BeforeFinish() override;
@@ -97,6 +108,7 @@ class KeyValueDataFileWriter
     std::shared_ptr<InternalRow> min_key_;
     std::shared_ptr<InternalRow> max_key_;
     MetadataFinalizer metadata_finalizer_;
+    std::unique_ptr<ManagedBlobReferenceCollector> blob_reference_collector_;
 };
 
 }  // namespace paimon

--- a/src/paimon/core/io/key_value_data_file_writer_factory.cpp
+++ b/src/paimon/core/io/key_value_data_file_writer_factory.cpp
@@ -20,9 +20,12 @@
 #include "paimon/core/io/key_value_data_file_writer_factory.h"
 
 #include <functional>
+#include <set>
 #include <utility>
 
 #include "arrow/c/helpers.h"
+#include "arrow/type.h"
+#include "paimon/common/data/blob_utils.h"
 #include "paimon/core/core_options.h"
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/io/key_value_data_file_writer.h"
@@ -56,14 +59,36 @@ KeyValueDataFileWriterFactory::CreateWriter() const {
     auto format = options_.GetWriteFileFormat(level_);
     PAIMON_ASSIGN_OR_RAISE(WriterResources resources,
                            CreateWriterResources(*format, write_schema_, create_stats_extractor_));
+    std::string path = path_factory_->NewPath();
     auto writer = std::make_unique<KeyValueDataFileWriter>(
         options_.GetWriteFileCompression(level_), std::move(converter), schema_id_, level_,
         file_source_, primary_keys_, resources.stats_extractor, write_schema_,
         path_factory_->IsExternalPath(), pool_);
-    PAIMON_RETURN_NOT_OK(
-        writer->Init(options_.GetFileSystem(), path_factory_->NewPath(), resources.writer_builder));
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ManagedBlobReferenceCollector> collector,
+                           CreateBlobReferenceCollector(path));
+    if (collector) {
+        writer->SetBlobReferenceCollector(std::move(collector));
+    }
+    PAIMON_RETURN_NOT_OK(writer->Init(options_.GetFileSystem(), path, resources.writer_builder));
     return std::unique_ptr<SingleFileWriter<KeyValueBatch, std::shared_ptr<DataFileMeta>>>(
         std::move(writer));
+}
+
+Result<std::unique_ptr<ManagedBlobReferenceCollector>>
+KeyValueDataFileWriterFactory::CreateBlobReferenceCollector(
+    const std::string& data_file_path) const {
+    std::vector<std::string> inline_field_names = options_.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> managed_fields =
+        BlobUtils::ManagedBlobFieldNames(write_schema_, inline_fields);
+    if (managed_fields.empty()) {
+        return std::unique_ptr<ManagedBlobReferenceCollector>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(
+        std::unique_ptr<ManagedBlobReferenceCollector> collector,
+        ManagedBlobReferenceCollector::Create(options_.GetFileSystem(), data_file_path,
+                                              write_schema_, managed_fields));
+    return collector;
 }
 
 }  // namespace paimon

--- a/src/paimon/core/io/key_value_data_file_writer_factory.h
+++ b/src/paimon/core/io/key_value_data_file_writer_factory.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "paimon/core/io/data_file_writer_factory.h"
+#include "paimon/core/io/managed_blob_reference_collector.h"
 #include "paimon/core/io/single_file_writer_factory.h"
 #include "paimon/core/key_value.h"
 #include "paimon/core/manifest/file_source.h"
@@ -56,6 +57,11 @@ class KeyValueDataFileWriterFactory
     CreateWriter() const override;
 
  protected:
+    /// Builds the managed blob reference collector for the data file at `data_file_path`, or
+    /// nullptr when the write schema holds no managed blob field.
+    Result<std::unique_ptr<ManagedBlobReferenceCollector>> CreateBlobReferenceCollector(
+        const std::string& data_file_path) const;
+
     std::shared_ptr<arrow::Schema> write_schema_;
     int32_t level_;
     FileSource file_source_;

--- a/src/paimon/core/io/managed_blob_reference_collector.cpp
+++ b/src/paimon/core/io/managed_blob_reference_collector.cpp
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/managed_blob_reference_collector.h"
+
+#include <optional>
+#include <string_view>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "fmt/format.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
+#include "paimon/fs/file_system.h"
+
+namespace paimon {
+
+Result<std::unique_ptr<ManagedBlobReferenceCollector>> ManagedBlobReferenceCollector::Create(
+    const std::shared_ptr<FileSystem>& fs, const std::string& data_file_path,
+    const std::shared_ptr<arrow::Schema>& write_schema,
+    const std::vector<std::string>& managed_field_names) {
+    if (managed_field_names.empty()) {
+        return Status::Invalid(
+            "ManagedBlobReferenceCollector requires at least one managed blob field.");
+    }
+    std::vector<int32_t> managed_field_indices;
+    managed_field_indices.reserve(managed_field_names.size());
+    for (const auto& field_name : managed_field_names) {
+        int32_t index = write_schema->GetFieldIndex(field_name);
+        if (index < 0) {
+            return Status::Invalid(
+                fmt::format("Managed blob field {} is not part of the write schema.", field_name));
+        }
+        managed_field_indices.push_back(index);
+    }
+    int32_t value_kind_index = write_schema->GetFieldIndex(SpecialFields::ValueKind().Name());
+    if (value_kind_index < 0) {
+        return Status::Invalid(
+            "ManagedBlobReferenceCollector requires the value kind column in the write schema.");
+    }
+    auto batch_type = arrow::struct_(write_schema->fields());
+    return std::unique_ptr<ManagedBlobReferenceCollector>(new ManagedBlobReferenceCollector(
+        fs, data_file_path, batch_type, std::move(managed_field_indices), value_kind_index));
+}
+
+ManagedBlobReferenceCollector::ManagedBlobReferenceCollector(
+    const std::shared_ptr<FileSystem>& fs, const std::string& data_file_path,
+    const std::shared_ptr<arrow::DataType>& batch_type, std::vector<int32_t> managed_field_indices,
+    int32_t value_kind_index)
+    : fs_(fs),
+      sidecar_path_(ManagedBlobReferenceFile::SidecarPath(data_file_path)),
+      batch_type_(batch_type),
+      managed_field_indices_(std::move(managed_field_indices)),
+      value_kind_index_(value_kind_index),
+      logger_(Logger::GetLogger("ManagedBlobReferenceCollector")) {}
+
+Status ManagedBlobReferenceCollector::Collect(KeyValueBatch* batch) {
+    if (closed_) {
+        return Status::Invalid("ManagedBlobReferenceCollector is already closed.");
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                      arrow::ImportArray(batch->batch.get(), batch_type_));
+    // Re-export immediately so the batch stays writable; the imported view shares the buffers.
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*arrow_array, batch->batch.get()));
+
+    auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+    if (struct_array == nullptr) {
+        return Status::Invalid(
+            "ManagedBlobReferenceCollector expects a StructArray key-value batch.");
+    }
+    auto value_kind_column =
+        std::dynamic_pointer_cast<arrow::Int8Array>(struct_array->field(value_kind_index_));
+    if (value_kind_column == nullptr) {
+        return Status::Invalid("ManagedBlobReferenceCollector expects an int8 value kind column.");
+    }
+    for (int32_t field_index : managed_field_indices_) {
+        auto blob_column =
+            std::dynamic_pointer_cast<arrow::LargeBinaryArray>(struct_array->field(field_index));
+        if (blob_column == nullptr) {
+            return Status::Invalid(
+                fmt::format("ManagedBlobReferenceCollector expects managed blob column {} to be a "
+                            "LargeBinaryArray.",
+                            struct_array->struct_type()->field(field_index)->name()));
+        }
+        for (int64_t row = 0; row < blob_column->length(); row++) {
+            if (blob_column->IsNull(row)) {
+                continue;
+            }
+            PAIMON_ASSIGN_OR_RAISE(const RowKind* row_kind,
+                                   RowKind::FromByteValue(value_kind_column->Value(row)));
+            // A retract row keeps no payload, so it contributes no reference.
+            if (row_kind->IsRetract()) {
+                continue;
+            }
+            std::string_view value = blob_column->GetView(row);
+            PAIMON_ASSIGN_OR_RAISE(bool is_descriptor,
+                                   BlobDescriptor::IsBlobDescriptor(value.data(), value.size()));
+            // Only descriptor values reference external payloads; other bytes (for example
+            // inline blob data) carry their payload with the row.
+            if (!is_descriptor) {
+                continue;
+            }
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BlobDescriptor> descriptor,
+                                   BlobDescriptor::Deserialize(value.data(), value.size()));
+            descriptor_uris_.insert(descriptor->Uri());
+        }
+    }
+    return Status::OK();
+}
+
+Status ManagedBlobReferenceCollector::Close() {
+    if (closed_) {
+        return Status::OK();
+    }
+    std::vector<ManagedBlobReferenceFile::Reference> references;
+    for (const auto& uri : descriptor_uris_) {
+        PAIMON_ASSIGN_OR_RAISE(std::optional<ManagedBlobReferenceFile::Reference> reference,
+                               ManagedBlobReferenceFile::FromDescriptorUri(uri));
+        // URIs of non-managed storage carry their own lifecycle and are not recorded.
+        if (reference) {
+            references.push_back(std::move(reference.value()));
+        }
+    }
+    descriptor_uris_.clear();
+    Status status = ManagedBlobReferenceFile::Write(fs_, sidecar_path_, std::move(references));
+    if (!status.ok()) {
+        Abort();
+        return status;
+    }
+    closed_ = true;
+    return Status::OK();
+}
+
+void ManagedBlobReferenceCollector::Abort() {
+    Status status = fs_->Delete(sidecar_path_);
+    // A missing sidecar is normal here (a failed write already removes its partial file);
+    // only a real cleanup failure is worth a warning (Java: deleteQuietly).
+    if (!status.ok() && !status.IsNotExist()) {
+        PAIMON_LOG_WARN(logger_, "Failed to delete managed blob reference sidecar %s: %s",
+                        sidecar_path_.c_str(), status.ToString().c_str());
+    }
+    closed_ = true;
+}
+
+Result<std::string> ManagedBlobReferenceCollector::ResultFileName() const {
+    if (!closed_) {
+        return Status::Invalid(
+            "ManagedBlobReferenceCollector result requires the collector to be closed.");
+    }
+    return PathUtil::GetName(sidecar_path_);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/managed_blob_reference_collector.h
+++ b/src/paimon/core/io/managed_blob_reference_collector.h
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "paimon/core/key_value.h"
+#include "paimon/logging.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+class FileSystem;
+
+/// Collects, for one primary-key data file, the managed blob pack files its rows reference,
+/// and writes them to the file's `.blobref` sidecar on close. Mirrors Java's
+/// ManagedBlobReferenceCollector on the columnar write path.
+///
+/// The collector scans every written key-value batch: managed blob values of non-retract rows
+/// hold serialized blob descriptors after externalization, and each descriptor URI ending in
+/// `.managed.blob` contributes one reference. Values that are not descriptors (for example
+/// inline blob bytes) are ignored. Because compaction rewrites descriptors verbatim, the
+/// sidecar of a compacted file lists exactly the packs its surviving rows still reference.
+class ManagedBlobReferenceCollector {
+ public:
+    /// Creates a collector for the data file at `data_file_path`. `write_schema` is the
+    /// key-value batch schema (special fields followed by value fields); `managed_field_names`
+    /// selects the managed blob columns in it.
+    static Result<std::unique_ptr<ManagedBlobReferenceCollector>> Create(
+        const std::shared_ptr<FileSystem>& fs, const std::string& data_file_path,
+        const std::shared_ptr<arrow::Schema>& write_schema,
+        const std::vector<std::string>& managed_field_names);
+
+    /// Records the managed blob references of `batch`. The batch's Arrow array is imported and
+    /// re-exported in place, its content is not changed.
+    Status Collect(KeyValueBatch* batch);
+
+    /// Writes the sidecar next to the data file. A failed write aborts the collector.
+    Status Close();
+
+    /// Deletes the sidecar, logging a warning on failure, and marks the collector closed.
+    void Abort();
+
+    /// The sidecar file name to record in the data file's extra files. Only valid after a
+    /// successful Close().
+    Result<std::string> ResultFileName() const;
+
+    /// The sidecar path next to the data file.
+    const std::string& SidecarPath() const {
+        return sidecar_path_;
+    }
+
+ private:
+    ManagedBlobReferenceCollector(const std::shared_ptr<FileSystem>& fs,
+                                  const std::string& data_file_path,
+                                  const std::shared_ptr<arrow::DataType>& batch_type,
+                                  std::vector<int32_t> managed_field_indices,
+                                  int32_t value_kind_index);
+
+ private:
+    std::shared_ptr<FileSystem> fs_;
+    std::string sidecar_path_;
+    std::shared_ptr<arrow::DataType> batch_type_;
+    std::vector<int32_t> managed_field_indices_;
+    int32_t value_kind_index_;
+
+    std::unique_ptr<Logger> logger_;
+
+    std::set<std::string> descriptor_uris_;
+    bool closed_ = false;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/managed_blob_reference_collector_test.cpp
+++ b/src/paimon/core/io/managed_blob_reference_collector_test.cpp
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/managed_blob_reference_collector.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class ManagedBlobReferenceCollectorTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        dir_ = UniqueTestDirectory::Create("local");
+        // The key-value batch schema: special fields followed by the value fields.
+        std::vector<DataField> write_fields = {SpecialFields::SequenceNumber(),
+                                               SpecialFields::ValueKind()};
+        write_fields.emplace_back(0, arrow::field("k", arrow::int32()));
+        write_fields.emplace_back(1, BlobUtils::ToArrowField("b", /*nullable=*/true));
+        write_schema_ = DataField::ConvertDataFieldsToArrowSchema(write_fields);
+        data_file_path_ = PathUtil::JoinPath(dir_->Str(), "data-1.parquet");
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    std::string SerializedDescriptor(const std::string& uri) {
+        auto descriptor = BlobDescriptor::Create(uri, /*offset=*/4, /*length=*/10).value();
+        PAIMON_UNIQUE_PTR<Bytes> bytes = descriptor->Serialize(GetDefaultPool());
+        return std::string(bytes->data(), bytes->size());
+    }
+
+    /// Builds a KeyValueBatch whose blob column holds the given cells; a nullopt cell is NULL.
+    /// `value_kinds` are RowKind byte values, aligned with the rows.
+    KeyValueBatch MakeBatch(const std::vector<int8_t>& value_kinds,
+                            const std::vector<std::optional<std::string>>& blob_values) {
+        arrow::Int64Builder sequence_builder;
+        arrow::Int8Builder value_kind_builder;
+        arrow::Int32Builder key_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        for (size_t i = 0; i < value_kinds.size(); i++) {
+            EXPECT_TRUE(sequence_builder.Append(static_cast<int64_t>(i)).ok());
+            EXPECT_TRUE(value_kind_builder.Append(value_kinds[i]).ok());
+            EXPECT_TRUE(key_builder.Append(static_cast<int32_t>(i)).ok());
+            if (blob_values[i]) {
+                EXPECT_TRUE(blob_builder.Append(blob_values[i].value()).ok());
+            } else {
+                EXPECT_TRUE(blob_builder.AppendNull().ok());
+            }
+        }
+        std::shared_ptr<arrow::Array> sequence_array;
+        std::shared_ptr<arrow::Array> value_kind_array;
+        std::shared_ptr<arrow::Array> key_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(sequence_builder.Finish(&sequence_array).ok());
+        EXPECT_TRUE(value_kind_builder.Finish(&value_kind_array).ok());
+        EXPECT_TRUE(key_builder.Finish(&key_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        auto struct_array =
+            arrow::StructArray::Make({sequence_array, value_kind_array, key_array, blob_array},
+                                     write_schema_->fields())
+                .ValueOrDie();
+        KeyValueBatch batch;
+        batch.batch = std::make_unique<ArrowArray>();
+        EXPECT_TRUE(arrow::ExportArray(*struct_array, batch.batch.get()).ok());
+        return batch;
+    }
+
+    std::unique_ptr<ManagedBlobReferenceCollector> CreateCollector() {
+        return ManagedBlobReferenceCollector::Create(dir_->GetFileSystem(), data_file_path_,
+                                                     write_schema_, {"b"})
+            .value();
+    }
+
+    std::unique_ptr<UniqueTestDirectory> dir_;
+    std::shared_ptr<arrow::Schema> write_schema_;
+    std::string data_file_path_;
+};
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestCollectsManagedReferences) {
+    auto collector = CreateCollector();
+    // Row kinds: INSERT(0), INSERT, DELETE(3), UPDATE_BEFORE(1), INSERT, INSERT.
+    KeyValueBatch batch =
+        MakeBatch({0, 0, 3, 1, 0, 0},
+                  {SerializedDescriptor("/warehouse/bucket-0/data-a.managed.blob"),
+                   SerializedDescriptor("/other/bucket-1/data-b.managed.blob"),
+                   SerializedDescriptor("/warehouse/bucket-0/data-retracted.managed.blob"),
+                   SerializedDescriptor("/warehouse/bucket-0/data-retracted.managed.blob"),
+                   SerializedDescriptor("/warehouse/bucket-0/data-c.blob"),  // not a managed pack
+                   std::nullopt});
+    ASSERT_OK(collector->Collect(&batch));
+    // The batch stays writable after collecting: its arrow array is still exported.
+    ASSERT_TRUE(batch.batch != nullptr);
+    ASSERT_NE(batch.batch->release, nullptr);
+
+    ASSERT_OK(collector->Close());
+    ASSERT_OK_AND_ASSIGN(std::string result_file_name, collector->ResultFileName());
+    ASSERT_EQ(result_file_name, "data-1.parquet.blobref");
+
+    // Retract rows and non-managed URIs contribute nothing; cross-directory managed packs are
+    // both recorded, sorted.
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<ManagedBlobReferenceFile::Reference> references,
+        ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), collector->SidecarPath()));
+    ASSERT_EQ(references.size(), 2);
+    EXPECT_EQ(references[0].ToString(), "/other/bucket-1/data-b.managed.blob");
+    EXPECT_EQ(references[1].ToString(), "/warehouse/bucket-0/data-a.managed.blob");
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestCollectsOnlyDeclaredColumns) {
+    // The sidecar must be built from the declared managed columns, not from the shape of the
+    // values: an inline blob column is skipped even when its descriptor happens to point at a
+    // path that looks exactly like a managed pack.
+    std::vector<DataField> write_fields = {SpecialFields::SequenceNumber(),
+                                           SpecialFields::ValueKind()};
+    write_fields.emplace_back(0, arrow::field("k", arrow::int32()));
+    write_fields.emplace_back(1, BlobUtils::ToArrowField("b", /*nullable=*/true));
+    write_fields.emplace_back(2, BlobUtils::ToArrowField("d", /*nullable=*/true));
+    write_schema_ = DataField::ConvertDataFieldsToArrowSchema(write_fields);
+
+    arrow::Int64Builder sequence_builder;
+    arrow::Int8Builder value_kind_builder;
+    arrow::Int32Builder key_builder;
+    arrow::LargeBinaryBuilder managed_builder;
+    arrow::LargeBinaryBuilder inline_builder;
+    ASSERT_TRUE(sequence_builder.Append(0).ok());
+    ASSERT_TRUE(value_kind_builder.Append(0).ok());
+    ASSERT_TRUE(key_builder.Append(0).ok());
+    ASSERT_TRUE(
+        managed_builder.Append(SerializedDescriptor("/warehouse/bucket-0/data-a.managed.blob"))
+            .ok());
+    ASSERT_TRUE(
+        inline_builder.Append(SerializedDescriptor("/warehouse/bucket-0/data-inline.managed.blob"))
+            .ok());
+    std::vector<std::shared_ptr<arrow::Array>> columns(5);
+    ASSERT_TRUE(sequence_builder.Finish(&columns[0]).ok());
+    ASSERT_TRUE(value_kind_builder.Finish(&columns[1]).ok());
+    ASSERT_TRUE(key_builder.Finish(&columns[2]).ok());
+    ASSERT_TRUE(managed_builder.Finish(&columns[3]).ok());
+    ASSERT_TRUE(inline_builder.Finish(&columns[4]).ok());
+    auto struct_array = arrow::StructArray::Make(columns, write_schema_->fields()).ValueOrDie();
+    KeyValueBatch batch;
+    batch.batch = std::make_unique<ArrowArray>();
+    ASSERT_TRUE(arrow::ExportArray(*struct_array, batch.batch.get()).ok());
+
+    // Only "b" is declared managed; "d" is an inline blob column.
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<ManagedBlobReferenceCollector> collector,
+                         ManagedBlobReferenceCollector::Create(
+                             dir_->GetFileSystem(), data_file_path_, write_schema_, {"b"}));
+    ASSERT_OK(collector->Collect(&batch));
+    ASSERT_OK(collector->Close());
+
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<ManagedBlobReferenceFile::Reference> references,
+        ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), collector->SidecarPath()));
+    ASSERT_EQ(references.size(), 1);
+    EXPECT_EQ(references[0].ToString(), "/warehouse/bucket-0/data-a.managed.blob");
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestNonDescriptorValuesIgnored) {
+    auto collector = CreateCollector();
+    // Inline payload bytes are not descriptors and carry their payload with the row.
+    KeyValueBatch batch = MakeBatch({0}, {std::string("raw-inline-bytes")});
+    ASSERT_OK(collector->Collect(&batch));
+    ASSERT_OK(collector->Close());
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<ManagedBlobReferenceFile::Reference> references,
+        ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), collector->SidecarPath()));
+    ASSERT_TRUE(references.empty());
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestEmptySidecarWrittenWithoutReferences) {
+    auto collector = CreateCollector();
+    ASSERT_OK(collector->Close());
+    // The sidecar is written even with nothing to reference, so the data file always has the
+    // extra file its meta declares.
+    ASSERT_TRUE(dir_->GetFileSystem()->GetFileStatus(collector->SidecarPath()).ok());
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<ManagedBlobReferenceFile::Reference> references,
+        ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), collector->SidecarPath()));
+    ASSERT_TRUE(references.empty());
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestAbortDeletesSidecar) {
+    auto collector = CreateCollector();
+    KeyValueBatch batch =
+        MakeBatch({0}, {SerializedDescriptor("/warehouse/bucket-0/data-a.managed.blob")});
+    ASSERT_OK(collector->Collect(&batch));
+    ASSERT_OK(collector->Close());
+    ASSERT_TRUE(dir_->GetFileSystem()->GetFileStatus(collector->SidecarPath()).ok());
+
+    collector->Abort();
+    ASSERT_FALSE(dir_->GetFileSystem()->GetFileStatus(collector->SidecarPath()).ok());
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestCollectAfterCloseRejected) {
+    // The sidecar is already written at Close, so a later batch could never reach it.
+    auto collector = CreateCollector();
+    ASSERT_OK(collector->Close());
+    KeyValueBatch batch =
+        MakeBatch({0}, {SerializedDescriptor("/warehouse/bucket-0/data-a.managed.blob")});
+    ASSERT_NOK_WITH_MSG(collector->Collect(&batch), "already closed");
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestResultFileNameRequiresClose) {
+    // The name is only meaningful once the sidecar it points at exists.
+    auto collector = CreateCollector();
+    ASSERT_NOK_WITH_MSG(collector->ResultFileName().status(),
+                        "requires the collector to be closed");
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestCreateRejectsUnknownField) {
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceCollector::Create(
+                            dir_->GetFileSystem(), data_file_path_, write_schema_, {"missing"})
+                            .status(),
+                        "is not part of the write schema");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/managed_blob_reference_file.cpp
+++ b/src/paimon/core/io/managed_blob_reference_file.cpp
@@ -1,0 +1,400 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/managed_blob_reference_file.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string_view>
+#include <utility>
+
+#include "arrow/util/crc32.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/status.h"
+
+namespace paimon {
+
+namespace {
+
+constexpr int32_t kMagic = 0x50424C52;  // "PBLR"
+constexpr int8_t kVersion = 1;
+
+void AppendBigEndianInt32(int32_t value, std::string* out) {
+    auto bits = static_cast<uint32_t>(value);
+    out->push_back(static_cast<char>((bits >> 24) & 0xFF));
+    out->push_back(static_cast<char>((bits >> 16) & 0xFF));
+    out->push_back(static_cast<char>((bits >> 8) & 0xFF));
+    out->push_back(static_cast<char>(bits & 0xFF));
+}
+
+/// A sequential big-endian reader over an in-memory buffer.
+class BigEndianBufferReader {
+ public:
+    BigEndianBufferReader(const char* data, size_t size) : data_(data), size_(size) {}
+
+    Result<int32_t> ReadInt32() {
+        PAIMON_RETURN_NOT_OK(Require(4));
+        uint32_t bits = (static_cast<uint32_t>(static_cast<uint8_t>(data_[pos_])) << 24) |
+                        (static_cast<uint32_t>(static_cast<uint8_t>(data_[pos_ + 1])) << 16) |
+                        (static_cast<uint32_t>(static_cast<uint8_t>(data_[pos_ + 2])) << 8) |
+                        static_cast<uint32_t>(static_cast<uint8_t>(data_[pos_ + 3]));
+        pos_ += 4;
+        return static_cast<int32_t>(bits);
+    }
+
+    Result<int8_t> ReadInt8() {
+        PAIMON_RETURN_NOT_OK(Require(1));
+        return static_cast<int8_t>(data_[pos_++]);
+    }
+
+    Result<uint16_t> ReadUInt16() {
+        PAIMON_RETURN_NOT_OK(Require(2));
+        auto bits = static_cast<uint16_t>((static_cast<uint8_t>(data_[pos_]) << 8) |
+                                          static_cast<uint8_t>(data_[pos_ + 1]));
+        pos_ += 2;
+        return bits;
+    }
+
+    Result<std::string_view> ReadBytes(size_t length) {
+        PAIMON_RETURN_NOT_OK(Require(length));
+        std::string_view view(data_ + pos_, length);
+        pos_ += length;
+        return view;
+    }
+
+    size_t Position() const {
+        return pos_;
+    }
+
+    size_t Remaining() const {
+        return size_ - pos_;
+    }
+
+ private:
+    Status Require(size_t length) const {
+        if (pos_ + length > size_) {
+            return Status::Invalid("Managed blob reference file is truncated.");
+        }
+        return Status::OK();
+    }
+
+    const char* data_;
+    size_t size_;
+    size_t pos_ = 0;
+};
+
+/// Encodes a UTF-8 string in Java DataOutputStream#writeUTF form: a uint16 big-endian byte
+/// length followed by Java modified UTF-8 bytes. Modified UTF-8 equals standard UTF-8 except
+/// that U+0000 becomes the two-byte form 0xC0 0x80 and supplementary characters are encoded as
+/// a CESU-8 surrogate pair (two three-byte groups).
+Status AppendJavaUtf(const std::string& value, std::string* out) {
+    std::string encoded;
+    encoded.reserve(value.size());
+    size_t i = 0;
+    const auto* bytes = reinterpret_cast<const uint8_t*>(value.data());
+    while (i < value.size()) {
+        uint8_t lead = bytes[i];
+        uint32_t code_point = 0;
+        size_t sequence_length = 0;
+        if (lead < 0x80) {
+            code_point = lead;
+            sequence_length = 1;
+        } else if ((lead >> 5) == 0x6) {
+            code_point = lead & 0x1F;
+            sequence_length = 2;
+        } else if ((lead >> 4) == 0xE) {
+            code_point = lead & 0x0F;
+            sequence_length = 3;
+        } else if ((lead >> 3) == 0x1E) {
+            code_point = lead & 0x07;
+            sequence_length = 4;
+        } else {
+            return Status::Invalid("Managed blob reference contains invalid UTF-8.");
+        }
+        if (i + sequence_length > value.size()) {
+            return Status::Invalid("Managed blob reference contains truncated UTF-8.");
+        }
+        for (size_t j = 1; j < sequence_length; j++) {
+            uint8_t continuation = bytes[i + j];
+            if ((continuation >> 6) != 0x2) {
+                return Status::Invalid("Managed blob reference contains invalid UTF-8.");
+            }
+            code_point = (code_point << 6) | (continuation & 0x3F);
+        }
+        i += sequence_length;
+
+        if (code_point == 0) {
+            encoded.push_back(static_cast<char>(0xC0));
+            encoded.push_back(static_cast<char>(0x80));
+        } else if (code_point < 0x10000) {
+            // The single-, two- and three-byte forms match standard UTF-8.
+            encoded.append(value, i - sequence_length, sequence_length);
+        } else {
+            // Supplementary character: encode the UTF-16 surrogate pair, three bytes each.
+            uint32_t offset = code_point - 0x10000;
+            uint32_t high = 0xD800 + (offset >> 10);
+            uint32_t low = 0xDC00 + (offset & 0x3FF);
+            for (uint32_t surrogate : {high, low}) {
+                encoded.push_back(static_cast<char>(0xE0 | (surrogate >> 12)));
+                encoded.push_back(static_cast<char>(0x80 | ((surrogate >> 6) & 0x3F)));
+                encoded.push_back(static_cast<char>(0x80 | (surrogate & 0x3F)));
+            }
+        }
+    }
+    if (encoded.size() > 0xFFFF) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference string is too long: {} bytes.", encoded.size()));
+    }
+    out->push_back(static_cast<char>((encoded.size() >> 8) & 0xFF));
+    out->push_back(static_cast<char>(encoded.size() & 0xFF));
+    out->append(encoded);
+    return Status::OK();
+}
+
+/// Decodes a Java writeUTF value back to a standard UTF-8 string.
+Result<std::string> ReadJavaUtf(BigEndianBufferReader* reader) {
+    PAIMON_ASSIGN_OR_RAISE(uint16_t length, reader->ReadUInt16());
+    PAIMON_ASSIGN_OR_RAISE(std::string_view encoded, reader->ReadBytes(length));
+    std::string decoded;
+    decoded.reserve(encoded.size());
+    const auto* bytes = reinterpret_cast<const uint8_t*>(encoded.data());
+    size_t i = 0;
+    while (i < encoded.size()) {
+        uint8_t lead = bytes[i];
+        if (lead < 0x80) {
+            decoded.push_back(static_cast<char>(lead));
+            i += 1;
+            continue;
+        }
+        size_t sequence_length = (lead >> 5) == 0x6 ? 2 : (lead >> 4) == 0xE ? 3 : 0;
+        if (sequence_length == 0 || i + sequence_length > encoded.size()) {
+            return Status::Invalid("Managed blob reference file holds invalid modified UTF-8.");
+        }
+        uint32_t code_point = lead & (sequence_length == 2 ? 0x1F : 0x0F);
+        for (size_t j = 1; j < sequence_length; j++) {
+            uint8_t continuation = bytes[i + j];
+            if ((continuation >> 6) != 0x2) {
+                return Status::Invalid("Managed blob reference file holds invalid modified UTF-8.");
+            }
+            code_point = (code_point << 6) | (continuation & 0x3F);
+        }
+        i += sequence_length;
+
+        if (code_point >= 0xD800 && code_point <= 0xDBFF) {
+            // High surrogate: the low surrogate must follow as another three-byte group with
+            // valid continuation bytes. Java's readUTF rejects the malformed continuation
+            // bytes below, but not a well-formed group outside the low-surrogate range nor a
+            // high surrogate at the end of the input; both are rejected here instead of
+            // decoding into an unpaired surrogate that no longer round-trips.
+            if (i + 3 > encoded.size() || (bytes[i] >> 4) != 0xE || (bytes[i + 1] >> 6) != 0x2 ||
+                (bytes[i + 2] >> 6) != 0x2) {
+                return Status::Invalid("Managed blob reference file holds an unpaired surrogate.");
+            }
+            uint32_t low =
+                ((bytes[i] & 0x0F) << 12) | ((bytes[i + 1] & 0x3F) << 6) | (bytes[i + 2] & 0x3F);
+            if (low < 0xDC00 || low > 0xDFFF) {
+                return Status::Invalid("Managed blob reference file holds an unpaired surrogate.");
+            }
+            i += 3;
+            uint32_t supplementary = 0x10000 + ((code_point - 0xD800) << 10) + (low - 0xDC00);
+            decoded.push_back(static_cast<char>(0xF0 | (supplementary >> 18)));
+            decoded.push_back(static_cast<char>(0x80 | ((supplementary >> 12) & 0x3F)));
+            decoded.push_back(static_cast<char>(0x80 | ((supplementary >> 6) & 0x3F)));
+            decoded.push_back(static_cast<char>(0x80 | (supplementary & 0x3F)));
+            continue;
+        }
+        if (code_point == 0 && sequence_length == 2) {
+            decoded.push_back('\0');
+            continue;
+        }
+        // BMP character: re-encode as standard UTF-8, identical to the input bytes.
+        decoded.append(encoded.substr(i - sequence_length, sequence_length));
+    }
+    return decoded;
+}
+
+}  // namespace
+
+Result<ManagedBlobReferenceFile::Reference> ManagedBlobReferenceFile::Reference::Create(
+    const std::string& storage_root_id, const std::string& relative_path) {
+    if (storage_root_id.empty() || relative_path.empty()) {
+        return Status::Invalid("Managed blob reference parts must not be empty.");
+    }
+    if (relative_path != PathUtil::GetName(relative_path) || relative_path == "." ||
+        relative_path == "..") {
+        return Status::Invalid(fmt::format(
+            "Managed blob reference relative path must be a bare file name, but got {}.",
+            relative_path));
+    }
+    Reference reference;
+    reference.storage_root_id = storage_root_id;
+    reference.relative_path = relative_path;
+    return reference;
+}
+
+std::string ManagedBlobReferenceFile::Reference::ToString() const {
+    return storage_root_id + "/" + relative_path;
+}
+
+Result<std::optional<ManagedBlobReferenceFile::Reference>>
+ManagedBlobReferenceFile::FromDescriptorUri(const std::string& uri) {
+    std::string name = PathUtil::GetName(uri);
+    if (!StringUtils::EndsWith(name, kManagedBlobSuffix)) {
+        return std::optional<Reference>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(Reference reference,
+                           Reference::Create(PathUtil::GetParentDirPath(uri), name));
+    return std::optional<Reference>(std::move(reference));
+}
+
+std::string ManagedBlobReferenceFile::SidecarPath(const std::string& data_file_path) {
+    return data_file_path + kReferenceFileSuffix;
+}
+
+Status ManagedBlobReferenceFile::Write(const std::shared_ptr<FileSystem>& fs,
+                                       const std::string& path, std::vector<Reference> references) {
+    std::sort(references.begin(), references.end());
+    references.erase(std::unique(references.begin(), references.end()), references.end());
+
+    std::string buffer;
+    AppendBigEndianInt32(kMagic, &buffer);
+    size_t covered_start = buffer.size();
+    buffer.push_back(static_cast<char>(kVersion));
+    AppendBigEndianInt32(static_cast<int32_t>(references.size()), &buffer);
+    for (const auto& reference : references) {
+        PAIMON_RETURN_NOT_OK(AppendJavaUtf(reference.storage_root_id, &buffer));
+        PAIMON_RETURN_NOT_OK(AppendJavaUtf(reference.relative_path, &buffer));
+    }
+    uint32_t checksum =
+        arrow::internal::crc32(0, buffer.data() + covered_start, buffer.size() - covered_start);
+    AppendBigEndianInt32(static_cast<int32_t>(checksum), &buffer);
+
+    Status status = [&]() -> Status {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<OutputStream> out,
+                               fs->Create(path, /*overwrite=*/false));
+        // The stream is closed on every path; a failed write keeps its own error.
+        Status write_status = [&]() -> Status {
+            int64_t total_written = 0;
+            while (total_written < static_cast<int64_t>(buffer.size())) {
+                PAIMON_ASSIGN_OR_RAISE(
+                    int64_t written,
+                    out->Write(buffer.data() + total_written,
+                               static_cast<int64_t>(buffer.size()) - total_written));
+                if (written <= 0 || written > static_cast<int64_t>(buffer.size()) - total_written) {
+                    return Status::IOError(
+                        fmt::format("Short write of managed blob reference file {}.", path));
+                }
+                total_written += written;
+            }
+            return out->Flush();
+        }();
+        Status close_status = out->Close();
+        if (write_status.ok()) {
+            write_status = close_status;
+        }
+        return write_status;
+    }();
+    if (!status.ok()) {
+        [[maybe_unused]] Status delete_status = fs->Delete(path);
+        return status;
+    }
+    return Status::OK();
+}
+
+Result<std::vector<ManagedBlobReferenceFile::Reference>> ManagedBlobReferenceFile::Read(
+    const std::shared_ptr<FileSystem>& fs, const std::string& path) {
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStatus> file_status, fs->GetFileStatus(path));
+    int64_t length = file_status->GetLen();
+    if (length < 0) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has unknown length.", path));
+    }
+    std::string buffer(static_cast<size_t>(length), '\0');
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> in, fs->Open(*file_status));
+    Status read_status = [&]() -> Status {
+        int64_t total_read = 0;
+        while (total_read < length) {
+            PAIMON_ASSIGN_OR_RAISE(int64_t read,
+                                   in->Read(buffer.data() + total_read, length - total_read));
+            if (read <= 0 || read > length - total_read) {
+                return Status::IOError(
+                    fmt::format("Short read of managed blob reference file {}.", path));
+            }
+            total_read += read;
+        }
+        return Status::OK();
+    }();
+    // The stream is closed on every path; a failed read keeps its own error.
+    Status close_status = in->Close();
+    if (read_status.ok()) {
+        read_status = close_status;
+    }
+    PAIMON_RETURN_NOT_OK(read_status);
+
+    BigEndianBufferReader reader(buffer.data(), buffer.size());
+    PAIMON_ASSIGN_OR_RAISE(int32_t magic, reader.ReadInt32());
+    if (magic != kMagic) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has a bad magic number.", path));
+    }
+    size_t covered_start = reader.Position();
+    PAIMON_ASSIGN_OR_RAISE(int8_t version, reader.ReadInt8());
+    if (version != kVersion) {
+        return Status::Invalid(fmt::format(
+            "Managed blob reference file {} has unsupported version {}.", path, version));
+    }
+    PAIMON_ASSIGN_OR_RAISE(int32_t count, reader.ReadInt32());
+    if (count < 0) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has a negative count.", path));
+    }
+    // Each reference occupies at least two writeUTF values with non-empty content (2-byte
+    // length prefix plus one byte each): bound the untrusted count by the remaining bytes
+    // before allocating for it.
+    if (static_cast<uint64_t>(count) > reader.Remaining() / 6) {
+        return Status::Invalid(fmt::format(
+            "Managed blob reference file {} declares more references than it can hold.", path));
+    }
+    std::vector<Reference> references;
+    references.reserve(count);
+    for (int32_t i = 0; i < count; i++) {
+        PAIMON_ASSIGN_OR_RAISE(std::string storage_root_id, ReadJavaUtf(&reader));
+        PAIMON_ASSIGN_OR_RAISE(std::string relative_path, ReadJavaUtf(&reader));
+        PAIMON_ASSIGN_OR_RAISE(Reference reference,
+                               Reference::Create(storage_root_id, relative_path));
+        references.push_back(std::move(reference));
+    }
+    size_t covered_end = reader.Position();
+    uint32_t expected_checksum =
+        arrow::internal::crc32(0, buffer.data() + covered_start, covered_end - covered_start);
+    PAIMON_ASSIGN_OR_RAISE(int32_t checksum, reader.ReadInt32());
+    if (static_cast<uint32_t>(checksum) != expected_checksum) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has a checksum mismatch.", path));
+    }
+    if (reader.Remaining() != 0) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has trailing bytes.", path));
+    }
+    return references;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/managed_blob_reference_file.h
+++ b/src/paimon/core/io/managed_blob_reference_file.h
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "paimon/result.h"
+
+namespace paimon {
+
+class FileSystem;
+
+/// The `.blobref` sidecar of a primary-key data file, listing the managed blob pack files
+/// (`.managed.blob`) whose payloads the data file's blob descriptors reference. The sidecar is
+/// carried in the data file's extra files, so it is removed together with the data file
+/// wherever the data file's companion files are collected for deletion, while a
+/// pack file may be shared by several data files and is never deleted by table maintenance.
+///
+/// On-disk layout, byte-compatible with Java's ManagedBlobReferenceFile (big-endian):
+///
+///   magic    int32  = 0x50424C52 ("PBLR"), not covered by the checksum
+///   version  byte   = 1                     -- checksum covers from here ...
+///   count    int32
+///   count x { storage_root_id : Java writeUTF (uint16 length + modified UTF-8 bytes)
+///             relative_path   : Java writeUTF }                      -- ... to here
+///   checksum int32  = CRC32 over the covered region
+///
+/// An empty reference list is a valid file and means "this data file references no pack",
+/// which is different from a missing sidecar.
+class ManagedBlobReferenceFile {
+ public:
+    static constexpr char kManagedBlobSuffix[] = ".managed.blob";
+    static constexpr char kReferenceFileSuffix[] = ".blobref";
+
+    /// One referenced pack file: the directory it lives in and its bare file name.
+    struct Reference {
+        /// Creates a reference after validating that `relative_path` is a bare file name.
+        static Result<Reference> Create(const std::string& storage_root_id,
+                                        const std::string& relative_path);
+
+        bool operator==(const Reference& other) const {
+            return storage_root_id == other.storage_root_id && relative_path == other.relative_path;
+        }
+        bool operator<(const Reference& other) const {
+            if (storage_root_id != other.storage_root_id) {
+                return storage_root_id < other.storage_root_id;
+            }
+            return relative_path < other.relative_path;
+        }
+
+        std::string ToString() const;
+
+        std::string storage_root_id;
+        std::string relative_path;
+    };
+
+    ManagedBlobReferenceFile() = delete;
+    ~ManagedBlobReferenceFile() = delete;
+
+    /// Resolves a blob descriptor URI to a pack reference. Returns nullopt when the URI does
+    /// not point at a managed pack file (its name does not end with `.managed.blob`).
+    static Result<std::optional<Reference>> FromDescriptorUri(const std::string& uri);
+
+    /// The sidecar path of a data file: the data file path plus `.blobref`.
+    static std::string SidecarPath(const std::string& data_file_path);
+
+    /// Writes `references` to `path`, normalized by sorting and deduplication so the content
+    /// is deterministic. A failed write deletes the partial file.
+    static Status Write(const std::shared_ptr<FileSystem>& fs, const std::string& path,
+                        std::vector<Reference> references);
+
+    /// Reads and validates a sidecar: magic, version, reference validity, checksum, and that
+    /// no trailing bytes follow the checksum.
+    static Result<std::vector<Reference>> Read(const std::shared_ptr<FileSystem>& fs,
+                                               const std::string& path);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/managed_blob_reference_file_test.cpp
+++ b/src/paimon/core/io/managed_blob_reference_file_test.cpp
@@ -1,0 +1,310 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/managed_blob_reference_file.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/util/crc32.h"
+#include "gtest/gtest.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class ManagedBlobReferenceFileTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        dir_ = UniqueTestDirectory::Create("local");
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    static ManagedBlobReferenceFile::Reference NewReference(const std::string& root,
+                                                            const std::string& name) {
+        return ManagedBlobReferenceFile::Reference::Create(root, name).value();
+    }
+
+    static void AppendBe32(std::string* buffer, uint32_t value) {
+        buffer->push_back(static_cast<char>((value >> 24) & 0xFF));
+        buffer->push_back(static_cast<char>((value >> 16) & 0xFF));
+        buffer->push_back(static_cast<char>((value >> 8) & 0xFF));
+        buffer->push_back(static_cast<char>(value & 0xFF));
+    }
+
+    /// Writes `content` verbatim, replacing any file already at `path`.
+    void WriteRawFile(const std::string& path, const std::string& content) {
+        if (dir_->GetFileSystem()->GetFileStatus(path).ok()) {
+            ASSERT_OK(dir_->GetFileSystem()->Delete(path));
+        }
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<OutputStream> out,
+                             dir_->GetFileSystem()->Create(path, /*overwrite=*/false));
+        ASSERT_OK_AND_ASSIGN(int64_t written, out->Write(content.data(), content.size()));
+        ASSERT_EQ(written, static_cast<int64_t>(content.size()));
+        ASSERT_OK(out->Close());
+    }
+
+    void ReadRawFile(const std::string& path, std::string* content) {
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStatus> status,
+                             dir_->GetFileSystem()->GetFileStatus(path));
+        content->assign(status->GetLen(), '\0');
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<InputStream> in, dir_->GetFileSystem()->Open(*status));
+        ASSERT_OK_AND_ASSIGN(int64_t read, in->Read(content->data(), content->size()));
+        ASSERT_EQ(read, static_cast<int64_t>(content->size()));
+        ASSERT_OK(in->Close());
+    }
+
+    /// A well-formed header carrying `count` in its count slot, followed by a matching CRC32
+    /// over the checksum-covered region. Used to reach the header checks with a valid checksum.
+    static std::string HeaderOnlyFile(uint32_t magic, char version, uint32_t count) {
+        std::string content;
+        AppendBe32(&content, magic);
+        size_t covered_start = content.size();
+        content.push_back(version);
+        AppendBe32(&content, count);
+        AppendBe32(&content, arrow::internal::crc32(0, content.data() + covered_start,
+                                                    content.size() - covered_start));
+        return content;
+    }
+
+    std::unique_ptr<UniqueTestDirectory> dir_;
+};
+
+TEST_F(ManagedBlobReferenceFileTest, TestRoundTripSortsAndDeduplicates) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-1.parquet.blobref");
+    std::vector<ManagedBlobReferenceFile::Reference> references = {
+        NewReference("/warehouse/bucket-0", "data-b.managed.blob"),
+        NewReference("/warehouse/bucket-0", "data-a.managed.blob"),
+        NewReference("/warehouse/bucket-0", "data-a.managed.blob"),
+        NewReference("/other/bucket-0", "data-c.managed.blob"),
+    };
+    ASSERT_OK(ManagedBlobReferenceFile::Write(dir_->GetFileSystem(), path, references));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> read_back,
+                         ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path));
+    ASSERT_EQ(read_back.size(), 3);
+    EXPECT_EQ(read_back[0], NewReference("/other/bucket-0", "data-c.managed.blob"));
+    EXPECT_EQ(read_back[1], NewReference("/warehouse/bucket-0", "data-a.managed.blob"));
+    EXPECT_EQ(read_back[2], NewReference("/warehouse/bucket-0", "data-b.managed.blob"));
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestEmptyReferenceListIsValid) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-2.parquet.blobref");
+    ASSERT_OK(ManagedBlobReferenceFile::Write(dir_->GetFileSystem(), path, {}));
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> read_back,
+                         ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path));
+    ASSERT_TRUE(read_back.empty());
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestNonAsciiReferenceRoundTrip) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-3.parquet.blobref");
+    std::vector<ManagedBlobReferenceFile::Reference> references = {
+        NewReference("/warehouse/p0=中文分区/bucket-0", "data-a.managed.blob")};
+    ASSERT_OK(ManagedBlobReferenceFile::Write(dir_->GetFileSystem(), path, references));
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> read_back,
+                         ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path));
+    ASSERT_EQ(read_back.size(), 1);
+    EXPECT_EQ(read_back[0], references[0]);
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestJavaGoldenBytes) {
+    // The exact bytes Java's ManagedBlobReferenceFile#write produces for these two references
+    // (magic, version, count and CRC32 big-endian, strings in DataOutputStream#writeUTF form).
+    // The checksum constant was computed independently of this codebase; the test locks the
+    // on-disk format against both accidental layout changes and checksum-coverage changes.
+    const std::string root = "/tmp/warehouse/foo.db/bar/bucket-0";
+    const std::string pack0 = "data-2b1a7f4e-0.managed.blob";
+    const std::string pack1 = "data-2b1a7f4e-1.managed.blob";
+    std::string golden;
+    auto append_utf = [&golden](const std::string& value) {
+        golden.push_back(static_cast<char>((value.size() >> 8) & 0xFF));
+        golden.push_back(static_cast<char>(value.size() & 0xFF));
+        golden.append(value);
+    };
+    AppendBe32(&golden, 0x50424C52);  // magic "PBLR"
+    golden.push_back(0x01);           // version
+    AppendBe32(&golden, 2);           // reference count
+    append_utf(root);
+    append_utf(pack0);
+    append_utf(root);
+    append_utf(pack1);
+    AppendBe32(&golden, 0x919BDB75);  // CRC32 of the covered region, computed with zlib
+    ASSERT_EQ(golden.size(), 145);
+
+    // A Java-written file is readable.
+    std::string java_path = PathUtil::JoinPath(dir_->Str(), "data-java.parquet.blobref");
+    WriteRawFile(java_path, golden);
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> read_back,
+                         ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), java_path));
+    ASSERT_EQ(read_back.size(), 2);
+    EXPECT_EQ(read_back[0], NewReference(root, pack0));
+    EXPECT_EQ(read_back[1], NewReference(root, pack1));
+
+    // A C++-written file is byte-identical, including the sort normalization.
+    std::string cpp_path = PathUtil::JoinPath(dir_->Str(), "data-cpp.parquet.blobref");
+    ASSERT_OK(ManagedBlobReferenceFile::Write(
+        dir_->GetFileSystem(), cpp_path, {NewReference(root, pack1), NewReference(root, pack0)}));
+    std::string cpp_content;
+    ReadRawFile(cpp_path, &cpp_content);
+    ASSERT_FALSE(HasFatalFailure());
+    EXPECT_EQ(cpp_content, golden);
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsCorruptedFile) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-4.parquet.blobref");
+    ASSERT_OK(ManagedBlobReferenceFile::Write(
+        dir_->GetFileSystem(), path, {NewReference("/warehouse/bucket-0", "data-a.managed.blob")}));
+
+    // Flip one byte inside a reference string's content, leaving every length prefix intact:
+    // the file still parses, so only the checksum can catch the change. Corrupting a length
+    // prefix instead would trip the framing checks before the checksum is ever compared.
+    std::string content;
+    ReadRawFile(path, &content);
+    ASSERT_FALSE(HasFatalFailure());
+    size_t corrupt_at = content.find("bucket-0");
+    ASSERT_NE(corrupt_at, std::string::npos);
+    content[corrupt_at] = static_cast<char>(content[corrupt_at] ^ 0x1);
+    WriteRawFile(path, content);
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "checksum mismatch");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsTrailingBytes) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-5.parquet.blobref");
+    ASSERT_OK(ManagedBlobReferenceFile::Write(dir_->GetFileSystem(), path, {}));
+    std::string content;
+    ReadRawFile(path, &content);
+    ASSERT_FALSE(HasFatalFailure());
+    content.push_back('x');
+    WriteRawFile(path, content);
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "trailing bytes");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsBadMagic) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-9.parquet.blobref");
+    WriteRawFile(path, HeaderOnlyFile(/*magic=*/0x50424C53, /*version=*/0x01, /*count=*/0));
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "bad magic number");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsUnsupportedVersion) {
+    // A future writer bumps the version; this reader must refuse the file instead of parsing
+    // it under the version 1 layout.
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-10.parquet.blobref");
+    WriteRawFile(path, HeaderOnlyFile(/*magic=*/0x50424C52, /*version=*/0x02, /*count=*/0));
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "unsupported version");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsNegativeCount) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-11.parquet.blobref");
+    WriteRawFile(path,
+                 HeaderOnlyFile(/*magic=*/0x50424C52, /*version=*/0x01, /*count=*/0xFFFFFFFF));
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "negative count");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsOversizedCount) {
+    // A corrupted or malicious file may declare a huge reference count with a valid checksum;
+    // the reader must bound it by the remaining bytes before allocating for it.
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-7.parquet.blobref");
+    // Count far beyond what the payload can hold, under a valid checksum.
+    WriteRawFile(path,
+                 HeaderOnlyFile(/*magic=*/0x50424C52, /*version=*/0x01, /*count=*/0x7FFFFFFF));
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "more references than it can hold");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsMalformedLowSurrogate) {
+    // A "low surrogate" group whose middle byte is not a continuation byte (0x30, ASCII '0')
+    // still masks into [0xDC00, 0xDFFF] under plain bit-masking. Java's readUTF rejects such
+    // bytes, so the C++ reader must reject them too, even under a valid checksum.
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-8.parquet.blobref");
+    std::string content;
+    AppendBe32(&content, 0x50424C52);  // magic
+    size_t covered_start = content.size();
+    content.push_back(0x01);  // version
+    AppendBe32(&content, 1);  // one reference
+    // storage root id: a high surrogate (ED A0 80 = U+D800) followed by ED 30 80, whose
+    // middle byte is not a continuation byte but masks to the low surrogate 0xDC00
+    const uint8_t malformed_root[] = {0xED, 0xA0, 0x80, 0xED, 0x30, 0x80};
+    content.push_back(0x00);
+    content.push_back(static_cast<char>(sizeof(malformed_root)));
+    for (uint8_t byte : malformed_root) {
+        content.push_back(static_cast<char>(byte));
+    }
+    // relative path: a well-formed bare file name
+    const std::string relative_path = "a.managed.blob";
+    content.push_back(0x00);
+    content.push_back(static_cast<char>(relative_path.size()));
+    content += relative_path;
+    AppendBe32(&content, arrow::internal::crc32(0, content.data() + covered_start,
+                                                content.size() - covered_start));
+    WriteRawFile(path, content);
+    ASSERT_FALSE(HasFatalFailure());
+    // The rejection must come from the surrogate pairing check, not from the framing around it.
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "unpaired surrogate");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestFromDescriptorUri) {
+    ASSERT_OK_AND_ASSIGN(std::optional<ManagedBlobReferenceFile::Reference> managed,
+                         ManagedBlobReferenceFile::FromDescriptorUri(
+                             "/warehouse/foo.db/bar/bucket-0/data-1.managed.blob"));
+    ASSERT_TRUE(managed.has_value());
+    EXPECT_EQ(managed->storage_root_id, "/warehouse/foo.db/bar/bucket-0");
+    EXPECT_EQ(managed->relative_path, "data-1.managed.blob");
+
+    ASSERT_OK_AND_ASSIGN(
+        std::optional<ManagedBlobReferenceFile::Reference> not_managed,
+        ManagedBlobReferenceFile::FromDescriptorUri("/warehouse/foo.db/bar/bucket-0/data-1.blob"));
+    EXPECT_FALSE(not_managed.has_value());
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestReferenceRejectsNestedRelativePath) {
+    // A nested path and a traversal are rejected as non-bare names; an empty part is a
+    // distinct failure, so each case must surface its own reason.
+    ASSERT_NOK_WITH_MSG(
+        ManagedBlobReferenceFile::Reference::Create("/warehouse", "a/b.managed.blob").status(),
+        "must be a bare file name");
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Reference::Create("/warehouse", "..").status(),
+                        "must be a bare file name");
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Reference::Create("", "a.managed.blob").status(),
+                        "must not be empty");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestSidecarPath) {
+    EXPECT_EQ(ManagedBlobReferenceFile::SidecarPath("/w/bucket-0/data-1.parquet"),
+              "/w/bucket-0/data-1.parquet.blobref");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/primary_key_blob_externalizer.cpp
+++ b/src/paimon/core/io/primary_key_blob_externalizer.cpp
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/primary_key_blob_externalizer.h"
+
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "fmt/format.h"
+#include "paimon/common/data/blob_defs.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/defs.h"
+#include "paimon/format/blob/blob_format_writer.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/file_format_factory.h"
+#include "paimon/format/format_writer.h"
+#include "paimon/format/writer_builder.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/bytes.h"
+
+namespace paimon {
+
+/// Rolls `.managed.blob` packs for one managed blob field. Each written value appends one blob
+/// format record to the current pack; the pack is sealed once it reaches the blob target file
+/// size. Descriptors point straight at the payload bytes inside the pack, so reading one back
+/// is a single ranged read that needs no pack footer.
+class PrimaryKeyBlobExternalizer::ManagedBlobPackWriter {
+ public:
+    ManagedBlobPackWriter(const CoreOptions& options, const std::shared_ptr<arrow::Field>& field,
+                          const std::shared_ptr<DataFilePathFactory>& path_factory,
+                          std::vector<std::string>* uncommitted_packs,
+                          const std::shared_ptr<MemoryPool>& pool)
+        : options_(options),
+          field_(field),
+          path_factory_(path_factory),
+          uncommitted_packs_(uncommitted_packs),
+          target_file_size_(options.GetBlobTargetFileSize()),
+          pool_(pool) {}
+
+    /// Copies row `row` of `column` into the current pack and returns the serialized
+    /// descriptor of the copied payload. The value may itself be a serialized descriptor; the
+    /// blob format writer then streams the referenced bytes in, re-materializing them.
+    Result<PAIMON_UNIQUE_PTR<Bytes>> Write(const std::shared_ptr<arrow::Array>& column,
+                                           int64_t row) {
+        if (writer_ == nullptr) {
+            PAIMON_RETURN_NOT_OK(OpenCurrent());
+        }
+
+        std::shared_ptr<arrow::Array> element = column->Slice(row, 1);
+        std::shared_ptr<arrow::Array> pack_row;
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(pack_row,
+                                          arrow::StructArray::Make({std::move(element)}, {field_}));
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*pack_row, &c_array));
+        PAIMON_RETURN_NOT_OK(writer_->AddBatch(&c_array));
+
+        // The blob format writer reports the payload bytes of the record it just stored, so
+        // the record layout stays inside the format (mirrors Java's descriptor callback).
+        // The "blob" format factory always builds a blob::BlobFormatWriter, and the accessor
+        // is inline, so the downcast never references the plugin library's symbols.
+        std::optional<std::pair<int64_t, int64_t>> payload_range =
+            static_cast<blob::BlobFormatWriter*>(writer_.get())->LastPayloadRange();
+        if (!payload_range) {
+            return Status::Invalid(fmt::format(
+                "Managed blob pack {} did not produce a payload record.", current_path_));
+        }
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<BlobDescriptor> descriptor,
+            BlobDescriptor::Create(current_path_, payload_range->first, payload_range->second));
+        PAIMON_UNIQUE_PTR<Bytes> serialized = descriptor->Serialize(pool_);
+
+        PAIMON_ASSIGN_OR_RAISE(
+            bool reach_target_size,
+            writer_->ReachTargetSize(/*suggested_check=*/true, target_file_size_));
+        if (reach_target_size) {
+            PAIMON_RETURN_NOT_OK(CloseCurrent());
+        }
+        return serialized;
+    }
+
+    /// Seals the current pack: writes the blob format footer and closes the stream. The
+    /// underlying stream is closed even when writing the footer fails, so a failed seal never
+    /// leaks the stream.
+    Status CloseCurrent() {
+        if (writer_ == nullptr) {
+            return Status::OK();
+        }
+        Status status = writer_->Finish();
+        Status close_status = out_->Close();
+        if (status.ok()) {
+            status = close_status;
+        }
+        writer_.reset();
+        out_.reset();
+        current_path_.clear();
+        return status;
+    }
+
+    /// Quietly drops the current pack writer; the file itself is removed through the
+    /// uncommitted pack list.
+    void AbortCurrent() {
+        if (out_) {
+            [[maybe_unused]] Status status = out_->Close();
+        }
+        writer_.reset();
+        out_.reset();
+        current_path_.clear();
+    }
+
+ private:
+    Status OpenCurrent() {
+        std::string path = path_factory_->NewManagedBlobPath();
+        uncommitted_packs_->push_back(path);
+        // The blob format lives in its own plugin library, so the writer is created through
+        // the format factory like every other core write path; core must not reference the
+        // plugin's out-of-line symbols directly.
+        std::map<std::string, std::string> format_options = options_.ToMap();
+        // Managed pack writes never convert fetch failures to NULL payloads and never
+        // interpret placeholder sentinels: strip the user-facing toggles so the format
+        // defaults (false) apply.
+        format_options.erase(Options::BLOB_WRITE_NULL_ON_MISSING_FILE);
+        format_options.erase(Options::BLOB_WRITE_NULL_ON_FETCH_FAILURE);
+        BlobDefs::EraseInternalPlaceholderOptions(&format_options);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileFormat> format,
+                               FileFormatFactory::Get("blob", format_options));
+        ::ArrowSchema c_schema;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(
+            arrow::ExportSchema(*arrow::schema(arrow::FieldVector{field_}), &c_schema));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<WriterBuilder> writer_builder,
+                               format->CreateWriterBuilder(&c_schema, /*batch_size=*/1));
+        writer_builder->WithMemoryPool(pool_);
+        if (auto* specific_fs_builder =
+                dynamic_cast<SpecificFSWriterBuilder*>(writer_builder.get())) {
+            specific_fs_builder->WithFileSystem(options_.GetFileSystem());
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<OutputStream> out,
+                               options_.GetFileSystem()->Create(path, /*overwrite=*/false));
+        out_ = std::move(out);
+        PAIMON_ASSIGN_OR_RAISE(writer_, writer_builder->Build(out_, /*compression=*/"none"));
+        current_path_ = path;
+        return Status::OK();
+    }
+
+    CoreOptions options_;
+    std::shared_ptr<arrow::Field> field_;
+    std::shared_ptr<DataFilePathFactory> path_factory_;
+    std::vector<std::string>* uncommitted_packs_;
+    int64_t target_file_size_;
+    std::shared_ptr<MemoryPool> pool_;
+
+    std::string current_path_;
+    std::shared_ptr<OutputStream> out_;
+    std::unique_ptr<FormatWriter> writer_;
+};
+
+Result<std::unique_ptr<PrimaryKeyBlobExternalizer>> PrimaryKeyBlobExternalizer::Create(
+    const CoreOptions& options, const std::shared_ptr<arrow::Schema>& value_schema,
+    const std::shared_ptr<DataFilePathFactory>& path_factory,
+    const std::shared_ptr<MemoryPool>& pool) {
+    std::vector<std::string> inline_field_names = options.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> managed_field_names =
+        BlobUtils::ManagedBlobFieldNames(value_schema, inline_fields);
+    if (managed_field_names.empty()) {
+        return std::unique_ptr<PrimaryKeyBlobExternalizer>();
+    }
+    // Guarded by SchemaValidation for tables created through the catalog; checked again here
+    // because pack rolling cannot work with a non-positive target size.
+    if (options.GetBlobTargetFileSize() <= 0) {
+        return Status::Invalid(
+            fmt::format("Managed blob target file size must be positive, "
+                        "but got {}.",
+                        options.GetBlobTargetFileSize()));
+    }
+    std::vector<int32_t> managed_field_indices;
+    managed_field_indices.reserve(managed_field_names.size());
+    for (const auto& field_name : managed_field_names) {
+        managed_field_indices.push_back(value_schema->GetFieldIndex(field_name));
+    }
+    auto value_type = arrow::struct_(value_schema->fields());
+    return std::unique_ptr<PrimaryKeyBlobExternalizer>(new PrimaryKeyBlobExternalizer(
+        options, value_type, std::move(managed_field_indices), path_factory, pool));
+}
+
+PrimaryKeyBlobExternalizer::PrimaryKeyBlobExternalizer(
+    const CoreOptions& options, const std::shared_ptr<arrow::DataType>& value_type,
+    std::vector<int32_t> managed_field_indices,
+    const std::shared_ptr<DataFilePathFactory>& path_factory,
+    const std::shared_ptr<MemoryPool>& pool)
+    : options_(options),
+      value_type_(value_type),
+      managed_field_indices_(std::move(managed_field_indices)),
+      path_factory_(path_factory),
+      pool_(pool),
+      arrow_pool_(GetArrowPool(pool)),
+      logger_(Logger::GetLogger("PrimaryKeyBlobExternalizer")) {
+    auto struct_type = std::static_pointer_cast<arrow::StructType>(value_type_);
+    pack_writers_.reserve(managed_field_indices_.size());
+    for (int32_t field_index : managed_field_indices_) {
+        pack_writers_.push_back(std::make_unique<ManagedBlobPackWriter>(
+            options_, struct_type->field(field_index), path_factory_, &uncommitted_packs_, pool_));
+    }
+}
+
+PrimaryKeyBlobExternalizer::~PrimaryKeyBlobExternalizer() {
+    Abort();
+}
+
+Result<std::unique_ptr<RecordBatch>> PrimaryKeyBlobExternalizer::Externalize(
+    std::unique_ptr<RecordBatch>&& moved_batch) {
+    std::unique_ptr<RecordBatch> batch = std::move(moved_batch);
+    Result<std::unique_ptr<RecordBatch>> result = [&]() -> Result<std::unique_ptr<RecordBatch>> {
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                          arrow::ImportArray(batch->GetData(), value_type_));
+        auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+        if (struct_array == nullptr) {
+            return Status::Invalid(
+                "PrimaryKeyBlobExternalizer expects a StructArray record batch.");
+        }
+        const std::vector<RecordBatch::RowKind>& row_kinds = batch->GetRowKind();
+        if (!row_kinds.empty() &&
+            static_cast<int64_t>(row_kinds.size()) != struct_array->length()) {
+            return Status::Invalid(
+                "PrimaryKeyBlobExternalizer batch row kinds do not match the row count.");
+        }
+        arrow::ArrayVector new_children = struct_array->fields();
+        for (size_t writer_index = 0; writer_index < managed_field_indices_.size();
+             writer_index++) {
+            int32_t field_index = managed_field_indices_[writer_index];
+            const auto& column = struct_array->field(field_index);
+            auto blob_column = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(column);
+            if (blob_column == nullptr) {
+                return Status::Invalid(
+                    fmt::format("PrimaryKeyBlobExternalizer expects managed blob column {} to be a "
+                                "LargeBinaryArray.",
+                                struct_array->struct_type()->field(field_index)->name()));
+            }
+            // The member pool, not a local one: these buffers enter the write buffer and
+            // must stay allocatable-from until the batch is flushed and released.
+            arrow::LargeBinaryBuilder builder(arrow_pool_.get());
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Reserve(blob_column->length()));
+            for (int64_t row = 0; row < blob_column->length(); row++) {
+                bool retract =
+                    !row_kinds.empty() && (row_kinds[row] == RecordBatch::RowKind::UPDATE_BEFORE ||
+                                           row_kinds[row] == RecordBatch::RowKind::DELETE);
+                // A retract row never keeps a payload: the managed value is dropped without
+                // writing anything to a pack.
+                if (retract || blob_column->IsNull(row)) {
+                    PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.AppendNull());
+                    continue;
+                }
+                PAIMON_ASSIGN_OR_RAISE(PAIMON_UNIQUE_PTR<Bytes> descriptor,
+                                       pack_writers_[writer_index]->Write(blob_column, row));
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Append(
+                    reinterpret_cast<const uint8_t*>(descriptor->data()), descriptor->size()));
+            }
+            std::shared_ptr<arrow::Array> descriptor_column;
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Finish(&descriptor_column));
+            new_children[field_index] = std::move(descriptor_column);
+        }
+
+        auto struct_type = std::static_pointer_cast<arrow::StructType>(value_type_);
+        std::shared_ptr<arrow::StructArray> externalized_array;
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            externalized_array, arrow::StructArray::Make(new_children, struct_type->fields()));
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*externalized_array, &c_array));
+        return std::make_unique<RecordBatch>(batch->GetPartition(), batch->GetBucket(), row_kinds,
+                                             &c_array);
+    }();
+    if (!result.ok()) {
+        Abort();
+    }
+    return result;
+}
+
+Status PrimaryKeyBlobExternalizer::CloseCurrentWriters() {
+    Status status = Status::OK();
+    for (const auto& pack_writer : pack_writers_) {
+        Status close_status = pack_writer->CloseCurrent();
+        if (status.ok() && !close_status.ok()) {
+            status = close_status;
+        }
+    }
+    return status;
+}
+
+Status PrimaryKeyBlobExternalizer::PrepareCommit() {
+    Status status = CloseCurrentWriters();
+    if (!status.ok()) {
+        Abort();
+        return status;
+    }
+    // The sealed packs are committed: this externalizer stops tracking them, and the data
+    // files' sidecars record which packs are referenced.
+    uncommitted_packs_.clear();
+    return Status::OK();
+}
+
+void PrimaryKeyBlobExternalizer::Abort() {
+    for (const auto& pack_writer : pack_writers_) {
+        pack_writer->AbortCurrent();
+    }
+    const auto& fs = options_.GetFileSystem();
+    for (const auto& path : uncommitted_packs_) {
+        Status status = fs->Delete(path);
+        // A pack that never came into existence (its create failed) is normal on this path;
+        // only a real cleanup failure is worth a warning (Java: deleteQuietly).
+        if (!status.ok() && !status.IsNotExist()) {
+            PAIMON_LOG_WARN(logger_, "Failed to delete uncommitted managed blob pack %s: %s",
+                            path.c_str(), status.ToString().c_str());
+        }
+    }
+    uncommitted_packs_.clear();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/primary_key_blob_externalizer.h
+++ b/src/paimon/core/io/primary_key_blob_externalizer.h
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/core/core_options.h"
+#include "paimon/logging.h"
+#include "paimon/record_batch.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class Field;
+class MemoryPool;
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+namespace blob {
+class BlobFormatWriter;
+}  // namespace blob
+
+class DataFilePathFactory;
+class MemoryPool;
+class OutputStream;
+
+/// Externalizes managed blob values of a primary-key table before they enter the merge-tree
+/// write buffer, mirroring Java's PrimaryKeyBlobExternalizer.
+///
+/// Only top-level scalar BLOB columns are managed. Java additionally externalizes
+/// `ARRAY<BLOB>` and `MAP<K, BLOB>` fields — expressible in Paimon C++'s type system, but
+/// not handled by the schema validation and the write/read paths yet — and can
+/// re-materialize descriptors through the source table's FileIO
+/// (`blob-descriptor.source-table`), while Paimon C++ always reads and copies through the
+/// table's own file system.
+///
+/// Each managed blob field owns a rolling pack writer producing `.managed.blob` files in the
+/// blob file format. Every non-null value of an insert row is copied into the current pack,
+/// even when the input already is a serialized descriptor (the payload is re-materialized into
+/// a pack this table owns), and the buffered column value becomes the serialized
+/// `BlobDescriptor` pointing at the copied payload. Retract rows never write a payload, their
+/// blob value is nulled out.
+///
+/// Packs created since the last `PrepareCommit` are uncommitted: `Abort` (and `Close` without
+/// a commit) deletes them, while `PrepareCommit` seals the current packs and stops tracking
+/// them; the committed data files' `.blobref` sidecars record which packs are referenced.
+class PrimaryKeyBlobExternalizer {
+ public:
+    /// Creates an externalizer for `value_schema`, or nullptr when the schema holds no managed
+    /// blob field.
+    static Result<std::unique_ptr<PrimaryKeyBlobExternalizer>> Create(
+        const CoreOptions& options, const std::shared_ptr<arrow::Schema>& value_schema,
+        const std::shared_ptr<DataFilePathFactory>& path_factory,
+        const std::shared_ptr<MemoryPool>& pool);
+
+    ~PrimaryKeyBlobExternalizer();
+
+    /// Rewrites the managed blob columns of `batch`: payloads move to pack files and the
+    /// columns hold serialized descriptors afterwards. On failure all uncommitted packs are
+    /// deleted and the error is returned.
+    Result<std::unique_ptr<RecordBatch>> Externalize(std::unique_ptr<RecordBatch>&& batch);
+
+    /// Seals the currently open packs and marks every pack written so far as committed, so a
+    /// later `Abort` or `Close` no longer deletes them. Call after the write buffer has been
+    /// flushed, right before the commit messages are handed out.
+    Status PrepareCommit();
+
+    /// Closes the open pack writers and deletes every uncommitted pack.
+    void Abort();
+
+ private:
+    /// A rolling writer for the packs of one managed blob field.
+    class ManagedBlobPackWriter;
+
+    PrimaryKeyBlobExternalizer(const CoreOptions& options,
+                               const std::shared_ptr<arrow::DataType>& value_type,
+                               std::vector<int32_t> managed_field_indices,
+                               const std::shared_ptr<DataFilePathFactory>& path_factory,
+                               const std::shared_ptr<MemoryPool>& pool);
+
+    Status CloseCurrentWriters();
+
+ private:
+    CoreOptions options_;
+    std::shared_ptr<arrow::DataType> value_type_;
+    std::vector<int32_t> managed_field_indices_;
+    std::shared_ptr<DataFilePathFactory> path_factory_;
+    std::shared_ptr<MemoryPool> pool_;
+    /// Allocates the descriptor columns of externalized batches. Those buffers flow into the
+    /// merge-tree write buffer, so the pool must live as long as the externalizer — the
+    /// owning writer keeps the externalizer alive until its buffered batches are released.
+    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+
+    std::unique_ptr<Logger> logger_;
+
+    /// One pack writer per managed field, aligned with managed_field_indices_.
+    std::vector<std::unique_ptr<ManagedBlobPackWriter>> pack_writers_;
+    /// Paths of packs not yet handed over by PrepareCommit; deleted on Abort.
+    std::vector<std::string> uncommitted_packs_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/primary_key_blob_externalizer_test.cpp
+++ b/src/paimon/core/io/primary_key_blob_externalizer_test.cpp
@@ -1,0 +1,569 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/primary_key_blob_externalizer.h"
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/factories/io_hook.h"
+#include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/data/blob.h"
+#include "paimon/defs.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/testing/utils/io_exception_helper.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+/// Wraps a local output stream so a test can observe the explicit Close() call and inject
+/// write failures at seal time. Only an explicit Close() is counted — the destructor would
+/// release the file anyway, which is exactly what must not mask a dropped Close in
+/// production code.
+class CloseTrackingOutputStream : public OutputStream {
+ public:
+    CloseTrackingOutputStream(std::unique_ptr<OutputStream> inner, const bool* fail_writes,
+                              int* close_count)
+        : inner_(std::move(inner)), fail_writes_(fail_writes), close_count_(close_count) {}
+
+    Result<int64_t> Write(const char* buffer, int64_t size) override {
+        if (*fail_writes_) {
+            return Status::IOError("injected write failure");
+        }
+        return inner_->Write(buffer, size);
+    }
+
+    Status Flush() override {
+        return inner_->Flush();
+    }
+
+    Result<int64_t> GetPos() const override {
+        return inner_->GetPos();
+    }
+
+    Result<std::string> GetUri() const override {
+        return inner_->GetUri();
+    }
+
+    Status Close() override {
+        (*close_count_)++;
+        return inner_->Close();
+    }
+
+ private:
+    std::unique_ptr<OutputStream> inner_;
+    const bool* fail_writes_;
+    int* close_count_;
+};
+
+/// A local file system whose output streams count explicit Close() calls and can start
+/// failing writes on demand.
+class CloseTrackingFileSystem : public LocalFileSystem {
+ public:
+    Result<std::unique_ptr<OutputStream>> Create(const std::string& path,
+                                                 bool overwrite) const override {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<OutputStream> inner,
+                               LocalFileSystem::Create(path, overwrite));
+        return std::make_unique<CloseTrackingOutputStream>(std::move(inner), &fail_writes_,
+                                                           &close_count_);
+    }
+
+    mutable bool fail_writes_ = false;
+    mutable int close_count_ = 0;
+};
+
+class PrimaryKeyBlobExternalizerTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        dir_ = UniqueTestDirectory::Create("local");
+        value_schema_ = arrow::schema(
+            {arrow::field("id", arrow::int32()), BlobUtils::ToArrowField("b", /*nullable=*/true)});
+        path_factory_ = std::make_shared<DataFilePathFactory>();
+        ASSERT_OK(path_factory_->Init(/*parent=*/dir_->Str(), /*format_identifier=*/"parquet",
+                                      /*data_file_prefix=*/"data-",
+                                      /*external_path_provider=*/nullptr));
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    CoreOptions CreateOptions(const std::string& blob_target_file_size) {
+        return CoreOptions::FromMap({{Options::FILE_SYSTEM, "local"},
+                                     {Options::BLOB_TARGET_FILE_SIZE, blob_target_file_size}})
+            .value();
+    }
+
+    /// An externalizer over the fixture's (id, blob) schema. The result is null when the
+    /// schema holds no managed blob field.
+    Result<std::unique_ptr<PrimaryKeyBlobExternalizer>> MakeExternalizer(
+        const std::string& blob_target_file_size) {
+        CoreOptions options = CreateOptions(blob_target_file_size);
+        return PrimaryKeyBlobExternalizer::Create(options, value_schema_, path_factory_,
+                                                  GetDefaultPool());
+    }
+
+    /// Builds a two-column (id, blob) record batch; a nullopt blob value is a null cell.
+    std::unique_ptr<RecordBatch> CreateBatch(
+        const std::vector<int32_t>& ids, const std::vector<std::optional<std::string>>& blob_values,
+        const std::vector<RecordBatch::RowKind>& row_kinds) {
+        arrow::Int32Builder id_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        for (size_t i = 0; i < ids.size(); i++) {
+            EXPECT_TRUE(id_builder.Append(ids[i]).ok());
+            if (blob_values[i]) {
+                EXPECT_TRUE(blob_builder.Append(blob_values[i].value()).ok());
+            } else {
+                EXPECT_TRUE(blob_builder.AppendNull().ok());
+            }
+        }
+        std::shared_ptr<arrow::Array> id_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(id_builder.Finish(&id_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        auto struct_array =
+            arrow::StructArray::Make({id_array, blob_array}, value_schema_->fields()).ValueOrDie();
+        ArrowArray c_array;
+        EXPECT_TRUE(arrow::ExportArray(*struct_array, &c_array).ok());
+        return std::make_unique<RecordBatch>(std::map<std::string, std::string>(), /*bucket=*/0,
+                                             row_kinds, &c_array);
+    }
+
+    /// Imports the batch and returns the blob column.
+    std::shared_ptr<arrow::LargeBinaryArray> BlobColumn(const RecordBatch& batch) {
+        auto arrow_array =
+            arrow::ImportArray(batch.GetData(), arrow::struct_(value_schema_->fields()))
+                .ValueOrDie();
+        auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+        EXPECT_TRUE(struct_array != nullptr);
+        if (struct_array == nullptr) {
+            return nullptr;
+        }
+        return std::dynamic_pointer_cast<arrow::LargeBinaryArray>(struct_array->field(1));
+    }
+
+    Result<std::string> ReadPayload(std::string_view descriptor_bytes, std::string* uri) {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<Blob> blob,
+            Blob::FromDescriptor(descriptor_bytes.data(), descriptor_bytes.size()));
+        *uri = blob->Uri();
+        PAIMON_ASSIGN_OR_RAISE(PAIMON_UNIQUE_PTR<Bytes> payload,
+                               blob->ToData(dir_->GetFileSystem(), GetDefaultPool()));
+        return std::string(payload->data(), payload->size());
+    }
+
+    bool FileExists(const std::string& path) {
+        return dir_->GetFileSystem()->GetFileStatus(path).ok();
+    }
+
+    std::unique_ptr<UniqueTestDirectory> dir_;
+    std::shared_ptr<arrow::Schema> value_schema_;
+    std::shared_ptr<DataFilePathFactory> path_factory_;
+};
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestCreateReturnsNullWithoutManagedFields) {
+    auto schema_without_blob = arrow::schema({arrow::field("id", arrow::int32())});
+    CoreOptions options = CreateOptions("1024");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         PrimaryKeyBlobExternalizer::Create(options, schema_without_blob,
+                                                            path_factory_, GetDefaultPool()));
+    ASSERT_TRUE(externalizer == nullptr);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestCreateRejectsNonPositiveTargetFileSize) {
+    // SchemaValidation guards catalog-created tables; the externalizer checks again because
+    // pack rolling cannot work with a non-positive target size.
+    ASSERT_NOK_WITH_MSG(MakeExternalizer("0").status(), "target file size must be positive");
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestExternalizeRejectsRowKindCountMismatch) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    // Two rows but one row kind: the externalizer cannot tell which rows retract.
+    auto batch =
+        CreateBatch({1, 2}, {std::string("a"), std::string("b")}, {RecordBatch::RowKind::INSERT});
+    ASSERT_NOK_WITH_MSG(externalizer->Externalize(std::move(batch)).status(),
+                        "row kinds do not match the row count");
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestExternalizeReplacesPayloadWithDescriptor) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch(
+        {1, 2, 3}, {std::string("hello"), std::nullopt, std::string("world")},
+        {RecordBatch::RowKind::INSERT, RecordBatch::RowKind::INSERT, RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    ASSERT_EQ(blob_column->length(), 3);
+    ASSERT_TRUE(blob_column->IsNull(1));
+
+    std::string uri0;
+    std::string_view value0 = blob_column->GetView(0);
+    ASSERT_OK_AND_ASSIGN(bool is_descriptor,
+                         BlobDescriptor::IsBlobDescriptor(value0.data(), value0.size()));
+    ASSERT_TRUE(is_descriptor);
+    ASSERT_OK_AND_ASSIGN(std::string payload0, ReadPayload(value0, &uri0));
+    EXPECT_EQ(payload0, "hello");
+
+    std::string uri2;
+    ASSERT_OK_AND_ASSIGN(std::string payload2, ReadPayload(blob_column->GetView(2), &uri2));
+    EXPECT_EQ(payload2, "world");
+    // Both payloads fit into one pack below the target size.
+    EXPECT_EQ(uri0, uri2);
+    EXPECT_TRUE(FileExists(uri0));
+
+    // Packs written before PrepareCommit are uncommitted: Abort removes them.
+    externalizer->Abort();
+    EXPECT_FALSE(FileExists(uri0));
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestEachManagedFieldOwnsItsPack) {
+    // Every managed blob column owns a pack writer, so two columns never share a pack even
+    // when their values are written in the same batch.
+    value_schema_ = arrow::schema({arrow::field("id", arrow::int32()),
+                                   BlobUtils::ToArrowField("b1", /*nullable=*/true),
+                                   BlobUtils::ToArrowField("b2", /*nullable=*/true)});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    arrow::Int32Builder id_builder;
+    arrow::LargeBinaryBuilder b1_builder;
+    arrow::LargeBinaryBuilder b2_builder;
+    ASSERT_TRUE(id_builder.Append(1).ok());
+    ASSERT_TRUE(id_builder.Append(2).ok());
+    ASSERT_TRUE(b1_builder.Append("first-column").ok());
+    ASSERT_TRUE(b1_builder.AppendNull().ok());
+    ASSERT_TRUE(b2_builder.Append("second-column").ok());
+    ASSERT_TRUE(b2_builder.Append("second-column-row-2").ok());
+    std::shared_ptr<arrow::Array> id_array;
+    std::shared_ptr<arrow::Array> b1_array;
+    std::shared_ptr<arrow::Array> b2_array;
+    ASSERT_TRUE(id_builder.Finish(&id_array).ok());
+    ASSERT_TRUE(b1_builder.Finish(&b1_array).ok());
+    ASSERT_TRUE(b2_builder.Finish(&b2_array).ok());
+    auto struct_array =
+        arrow::StructArray::Make({id_array, b1_array, b2_array}, value_schema_->fields())
+            .ValueOrDie();
+    ArrowArray c_array;
+    ASSERT_TRUE(arrow::ExportArray(*struct_array, &c_array).ok());
+    auto batch = std::make_unique<RecordBatch>(std::map<std::string, std::string>(), /*bucket=*/0,
+                                               std::vector<RecordBatch::RowKind>(), &c_array);
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    ASSERT_OK(externalizer->PrepareCommit());
+
+    auto resolved =
+        arrow::ImportArray(batch->GetData(), arrow::struct_(value_schema_->fields())).ValueOrDie();
+    auto resolved_struct = std::dynamic_pointer_cast<arrow::StructArray>(resolved);
+    ASSERT_TRUE(resolved_struct != nullptr);
+    auto b1_column = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved_struct->field(1));
+    auto b2_column = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved_struct->field(2));
+    ASSERT_TRUE(b1_column != nullptr);
+    ASSERT_TRUE(b2_column != nullptr);
+    // The null cell of the first column stays null and consumes no pack space.
+    EXPECT_TRUE(b1_column->IsNull(1));
+
+    std::string b1_uri;
+    std::string b2_uri;
+    ASSERT_OK_AND_ASSIGN(std::string b1_payload, ReadPayload(b1_column->GetView(0), &b1_uri));
+    ASSERT_OK_AND_ASSIGN(std::string b2_payload, ReadPayload(b2_column->GetView(0), &b2_uri));
+    EXPECT_EQ(b1_payload, "first-column");
+    EXPECT_EQ(b2_payload, "second-column");
+    EXPECT_NE(b1_uri, b2_uri);
+    EXPECT_TRUE(FileExists(b1_uri));
+    EXPECT_TRUE(FileExists(b2_uri));
+
+    // The second column's other row resolves out of that column's own pack.
+    std::string b2_row2_uri;
+    ASSERT_OK_AND_ASSIGN(std::string b2_row2_payload,
+                         ReadPayload(b2_column->GetView(1), &b2_row2_uri));
+    EXPECT_EQ(b2_row2_payload, "second-column-row-2");
+    EXPECT_EQ(b2_row2_uri, b2_uri);
+    EXPECT_NE(b2_row2_uri, b1_uri);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestRetractRowsDropPayload) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch(
+        {1, 2, 3}, {std::string("kept"), std::string("deleted"), std::string("update-before")},
+        {RecordBatch::RowKind::INSERT, RecordBatch::RowKind::DELETE,
+         RecordBatch::RowKind::UPDATE_BEFORE});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    EXPECT_FALSE(blob_column->IsNull(0));
+    EXPECT_TRUE(blob_column->IsNull(1));
+    EXPECT_TRUE(blob_column->IsNull(2));
+
+    std::string uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload, ReadPayload(blob_column->GetView(0), &uri));
+    EXPECT_EQ(payload, "kept");
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestRetractOnlyBatchOpensNoPack) {
+    // A batch holding nothing but retracts must not even open a pack: the previous test keeps
+    // an INSERT alongside them, so it cannot tell "no pack written" from "pack written and
+    // its descriptor dropped", which would leak storage and inflate the reference set.
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch({1, 2}, {std::string("deleted"), std::string("update-before")},
+                             {RecordBatch::RowKind::DELETE, RecordBatch::RowKind::UPDATE_BEFORE});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    EXPECT_TRUE(blob_column->IsNull(0));
+    EXPECT_TRUE(blob_column->IsNull(1));
+
+    std::vector<std::unique_ptr<BasicFileStatus>> statuses;
+    ASSERT_OK(dir_->GetFileSystem()->ListDir(dir_->Str(), &statuses));
+    EXPECT_TRUE(statuses.empty());
+
+    // Sealing and aborting an externalizer that never opened a pack stay no-ops.
+    ASSERT_OK(externalizer->PrepareCommit());
+    externalizer->Abort();
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestPrepareCommitHandsOverPacks) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch({1}, {std::string("payload")}, {RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    std::string uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload, ReadPayload(blob_column->GetView(0), &uri));
+    EXPECT_EQ(payload, "payload");
+
+    ASSERT_OK(externalizer->PrepareCommit());
+    // A committed pack survives both a later abort and the writer teardown.
+    externalizer->Abort();
+    EXPECT_TRUE(FileExists(uri));
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestSealFailureStillClosesPackStream) {
+    // A failing footer write must still close the pack stream exactly once. The wrapper counts
+    // only explicit Close() calls, so destructor cleanup cannot mask a Close dropped from
+    // CloseCurrent.
+    auto fs = std::make_shared<CloseTrackingFileSystem>();
+    ASSERT_OK_AND_ASSIGN(
+        CoreOptions options,
+        CoreOptions::FromMap(
+            {{Options::FILE_SYSTEM, "local"}, {Options::BLOB_TARGET_FILE_SIZE, "1024"}}, fs));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         PrimaryKeyBlobExternalizer::Create(options, value_schema_, path_factory_,
+                                                            GetDefaultPool()));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    std::unique_ptr<RecordBatch> batch =
+        CreateBatch({1}, {std::string("payload")}, /*row_kinds=*/{});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> externalized,
+                         externalizer->Externalize(std::move(batch)));
+    ASSERT_TRUE(externalized != nullptr);
+    // The pack is below the target size and stays open after the externalization.
+    ASSERT_EQ(fs->close_count_, 0);
+
+    // Every write fails from here on, so sealing the pack fails at the footer write.
+    fs->fail_writes_ = true;
+    Status seal_status = externalizer->PrepareCommit();
+    ASSERT_FALSE(seal_status.ok());
+    // The failed Finish() must not leak the stream: CloseCurrent closed it exactly once, and
+    // the abort path must not close it a second time.
+    ASSERT_EQ(fs->close_count_, 1);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestIOException) {
+    // IO-failure sweep in the repository's TestIOException convention: whichever IO
+    // operation of the externalize-and-seal cycle fails — including the footer write of
+    // PrepareCommit's seal — the failure must surface as the injected error without a crash
+    // or hang. Once no injection point is hit, the run completes and the sealed pack
+    // resolves. The explicit close guarantee is asserted separately above.
+    auto io_hook = IOHook::GetInstance();
+    bool run_complete = false;
+    for (size_t i = 0; i < 100; i++) {
+        auto dir = UniqueTestDirectory::Create("local");
+        ASSERT_TRUE(dir);
+        auto path_factory = std::make_shared<DataFilePathFactory>();
+        ASSERT_OK(path_factory->Init(dir->Str(), "parquet", "data-", nullptr));
+        CoreOptions options = CreateOptions("1024");
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                             PrimaryKeyBlobExternalizer::Create(options, value_schema_,
+                                                                path_factory, GetDefaultPool()));
+        ScopeGuard guard([&io_hook]() { io_hook->Clear(); });
+        io_hook->Reset(i, IOHook::Mode::RETURN_ERROR);
+
+        std::unique_ptr<RecordBatch> batch =
+            CreateBatch({1}, {std::string("seal-payload")}, /*row_kinds=*/{});
+        Result<std::unique_ptr<RecordBatch>> externalized =
+            externalizer->Externalize(std::move(batch));
+        CHECK_HOOK_STATUS(externalized.status(), i);
+        CHECK_HOOK_STATUS(externalizer->PrepareCommit(), i);
+
+        // No injection point was hit: the sealed pack must resolve to the payload.
+        io_hook->Clear();
+        std::shared_ptr<arrow::LargeBinaryArray> blob_column = BlobColumn(*externalized.value());
+        ASSERT_TRUE(blob_column != nullptr);
+        std::string pack_uri;
+        ASSERT_OK_AND_ASSIGN(std::string payload, ReadPayload(blob_column->GetView(0), &pack_uri));
+        ASSERT_EQ(payload, "seal-payload");
+        ASSERT_TRUE(FileExists(pack_uri));
+        run_complete = true;
+        break;
+    }
+    ASSERT_TRUE(run_complete);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestPacksRollByTargetFileSize) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch({1, 2}, {std::string("first"), std::string("second")},
+                             {RecordBatch::RowKind::INSERT, RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+
+    std::string uri0;
+    std::string uri1;
+    ASSERT_OK_AND_ASSIGN(std::string payload0, ReadPayload(blob_column->GetView(0), &uri0));
+    ASSERT_OK_AND_ASSIGN(std::string payload1, ReadPayload(blob_column->GetView(1), &uri1));
+    EXPECT_EQ(payload0, "first");
+    EXPECT_EQ(payload1, "second");
+    // A one-byte target size seals the pack after every value.
+    EXPECT_NE(uri0, uri1);
+
+    ASSERT_OK(externalizer->PrepareCommit());
+    EXPECT_TRUE(FileExists(uri0));
+    EXPECT_TRUE(FileExists(uri1));
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestInlineDescriptorFieldNotExternalized) {
+    // An inline blob field (blob-descriptor-field) keeps its caller-provided bytes; only the
+    // managed field is externalized.
+    auto schema_with_inline = arrow::schema({arrow::field("id", arrow::int32()),
+                                             BlobUtils::ToArrowField("b", /*nullable=*/true),
+                                             BlobUtils::ToArrowField("d", /*nullable=*/true)});
+    CoreOptions options = CoreOptions::FromMap({{Options::FILE_SYSTEM, "local"},
+                                                {Options::BLOB_TARGET_FILE_SIZE, "1024"},
+                                                {Options::BLOB_DESCRIPTOR_FIELD, "d"}})
+                              .value();
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         PrimaryKeyBlobExternalizer::Create(options, schema_with_inline,
+                                                            path_factory_, GetDefaultPool()));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    const std::string inline_bytes = "caller-provided-inline-bytes";
+    arrow::Int32Builder id_builder;
+    arrow::LargeBinaryBuilder managed_builder;
+    arrow::LargeBinaryBuilder inline_builder;
+    ASSERT_TRUE(id_builder.Append(1).ok());
+    ASSERT_TRUE(managed_builder.Append("managed-payload").ok());
+    ASSERT_TRUE(inline_builder.Append(inline_bytes).ok());
+    std::shared_ptr<arrow::Array> id_array;
+    std::shared_ptr<arrow::Array> managed_array;
+    std::shared_ptr<arrow::Array> inline_array;
+    ASSERT_TRUE(id_builder.Finish(&id_array).ok());
+    ASSERT_TRUE(managed_builder.Finish(&managed_array).ok());
+    ASSERT_TRUE(inline_builder.Finish(&inline_array).ok());
+    auto struct_array = arrow::StructArray::Make({id_array, managed_array, inline_array},
+                                                 schema_with_inline->fields())
+                            .ValueOrDie();
+    ArrowArray c_array;
+    ASSERT_TRUE(arrow::ExportArray(*struct_array, &c_array).ok());
+    auto batch = std::make_unique<RecordBatch>(std::map<std::string, std::string>(), /*bucket=*/0,
+                                               std::vector<RecordBatch::RowKind>(), &c_array);
+
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    auto result_array =
+        arrow::ImportArray(batch->GetData(), arrow::struct_(schema_with_inline->fields()))
+            .ValueOrDie();
+    auto result_struct = std::dynamic_pointer_cast<arrow::StructArray>(result_array);
+    ASSERT_TRUE(result_struct != nullptr);
+
+    auto managed_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(result_struct->GetFieldByName("b"));
+    ASSERT_TRUE(managed_column != nullptr);
+    std::string uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload, ReadPayload(managed_column->GetView(0), &uri));
+    EXPECT_EQ(payload, "managed-payload");
+
+    auto inline_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(result_struct->GetFieldByName("d"));
+    ASSERT_TRUE(inline_column != nullptr);
+    EXPECT_EQ(std::string(inline_column->GetView(0)), inline_bytes);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestRematerializesDescriptorInput) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    // First write produces a descriptor pointing at a pack.
+    auto batch = CreateBatch({1}, {std::string("original")}, {RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    std::string source_uri;
+    ASSERT_OK_AND_ASSIGN(std::string source_payload,
+                         ReadPayload(blob_column->GetView(0), &source_uri));
+    ASSERT_EQ(source_payload, "original");
+    ASSERT_OK(externalizer->PrepareCommit());
+
+    // Feeding that descriptor back in copies the payload into a fresh pack: the new
+    // descriptor points elsewhere but resolves to the same bytes.
+    std::string_view descriptor_bytes = blob_column->GetView(0);
+    auto second_batch =
+        CreateBatch({2}, {std::string(descriptor_bytes)}, {RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(second_batch, externalizer->Externalize(std::move(second_batch)));
+    auto second_column = BlobColumn(*second_batch);
+    ASSERT_TRUE(second_column != nullptr);
+    std::string second_uri;
+    ASSERT_OK_AND_ASSIGN(std::string second_payload,
+                         ReadPayload(second_column->GetView(0), &second_uri));
+    EXPECT_EQ(second_payload, "original");
+    EXPECT_NE(second_uri, source_uri);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/row_to_arrow_array_converter.h
+++ b/src/paimon/core/io/row_to_arrow_array_converter.h
@@ -150,6 +150,14 @@ Status RowToArrowArrayConverter<T, R>::Reserve(arrow::ArrayBuilder* array_builde
                 binary_builder->ReserveData(INFLATION_FACTOR * reserved_sizes_[(*idx)++]));
             break;
         }
+        case arrow::Type::type::LARGE_BINARY: {
+            // reserve large binary data buffer (managed blob descriptor columns)
+            PAIMON_ASSIGN_OR_RAISE(auto* large_binary_builder,
+                                   CastToTypedBuilder<arrow::LargeBinaryBuilder>(array_builder));
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                large_binary_builder->ReserveData(INFLATION_FACTOR * reserved_sizes_[(*idx)++]));
+            break;
+        }
         case arrow::Type::type::LIST: {
             PAIMON_ASSIGN_OR_RAISE(auto* list_builder,
                                    CastToTypedBuilder<arrow::ListBuilder>(array_builder));
@@ -216,6 +224,12 @@ Status RowToArrowArrayConverter<T, R>::Accumulate(const arrow::Array* array, int
             auto binary_array = checked_cast<const arrow::BinaryArray*>(array);
             // accumulate the bytes buffer size of binary
             UpdateAccumulatedVec(binary_array->value_data()->size(), idx);
+            break;
+        }
+        case arrow::Type::type::LARGE_BINARY: {
+            auto large_binary_array = checked_cast<const arrow::LargeBinaryArray*>(array);
+            // accumulate the bytes buffer size of large binary
+            UpdateAccumulatedVec(large_binary_array->value_data()->size(), idx);
             break;
         }
         case arrow::Type::type::LIST: {
@@ -366,6 +380,27 @@ RowToArrowArrayConverter<T, R>::AppendField(bool use_view, arrow::ArrayBuilder* 
             (*reserve_count)++;
             PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
                                    CastToTypedBuilder<arrow::BinaryBuilder>(array_builder));
+            if (use_view) {
+                return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                    [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                        CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                        auto view = data_getter.GetStringView(pos);
+                        return field_builder->Append(view.data(), view.size());
+                    });
+            }
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    auto bytes = data_getter.GetBinary(pos);
+                    assert(bytes);
+                    return field_builder->Append(bytes->data(), bytes->size());
+                });
+        }
+        case arrow::Type::type::LARGE_BINARY: {
+            // Managed blob descriptor columns of a primary-key table.
+            (*reserve_count)++;
+            PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
+                                   CastToTypedBuilder<arrow::LargeBinaryBuilder>(array_builder));
             if (use_view) {
                 return RowToArrowArrayConverter<T, R>::AppendValueFunc(
                     [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {

--- a/src/paimon/core/io/shredding_key_value_data_file_writer_factory.cpp
+++ b/src/paimon/core/io/shredding_key_value_data_file_writer_factory.cpp
@@ -84,12 +84,19 @@ ShreddingKeyValueDataFileWriterFactory::CreateShreddedWriter(
     };
     PAIMON_ASSIGN_OR_RAISE(WriterResources resources,
                            CreateWriterResources(*format, file_schema, create_stats_extractor_));
+    std::string path = path_factory_->NewPath();
     auto writer = std::make_unique<KeyValueDataFileWriter>(
         options_.GetWriteFileCompression(level_), std::move(batch_converter), schema_id_, level_,
         file_source_, primary_keys_, resources.stats_extractor, file_schema,
         path_factory_->IsExternalPath(), pool_);
-    PAIMON_RETURN_NOT_OK(
-        writer->Init(options_.GetFileSystem(), path_factory_->NewPath(), resources.writer_builder));
+    // The collector inspects the logical key-value batch (the factory's write schema), which
+    // is what Write() receives before the shredding conversion runs.
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ManagedBlobReferenceCollector> collector,
+                           CreateBlobReferenceCollector(path));
+    if (collector) {
+        writer->SetBlobReferenceCollector(std::move(collector));
+    }
+    PAIMON_RETURN_NOT_OK(writer->Init(options_.GetFileSystem(), path, resources.writer_builder));
     ShreddingWritePlanFactory::MetadataFinalizer finalizer =
         plan_factory_->CreateMetadataFinalizer(converter, options_.GetWriteFileCompression(level_));
     if (finalizer) {

--- a/src/paimon/core/io/single_file_writer.h
+++ b/src/paimon/core/io/single_file_writer.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "arrow/c/abi.h"
 #include "arrow/c/bridge.h"
@@ -60,17 +61,27 @@ class Metrics;
 template <typename T, typename R>
 class SingleFileWriter : public FileWriter<T, R> {
  public:
-    /// Abort executor to just have reference of path instead of whole writer.
+    /// Abort executor to just have reference of paths instead of whole writer. Besides the
+    /// data file itself it may carry companion files written next to it (e.g. a managed blob
+    /// reference sidecar), which an abort removes together.
     class AbortExecutor {
      public:
         AbortExecutor(const std::shared_ptr<FileSystem>& fs, const std::string& path)
-            : fs_(fs), path_(path), logger_(Logger::GetLogger("AbortExecutor")) {}
+            : AbortExecutor(fs, std::vector<std::string>{path}) {}
+
+        AbortExecutor(const std::shared_ptr<FileSystem>& fs, std::vector<std::string> paths)
+            : fs_(fs), paths_(std::move(paths)), logger_(Logger::GetLogger("AbortExecutor")) {}
 
         void Abort() {
-            if (fs_) {
-                auto status = fs_->Delete(path_);
-                if (!status.ok()) {
-                    PAIMON_LOG_WARN(logger_, "Exception occurs when deleting %s: %s", path_.c_str(),
+            if (!fs_) {
+                return;
+            }
+            for (const auto& path : paths_) {
+                auto status = fs_->Delete(path);
+                // A path already removed by another cleanup (e.g. the writer's own Abort) is
+                // fine; only a real failure is worth a warning.
+                if (!status.ok() && !status.IsNotExist()) {
+                    PAIMON_LOG_WARN(logger_, "Exception occurs when deleting %s: %s", path.c_str(),
                                     status.ToString().c_str());
                 }
             }
@@ -78,7 +89,7 @@ class SingleFileWriter : public FileWriter<T, R> {
 
      private:
         std::shared_ptr<FileSystem> fs_;
-        std::string path_;
+        std::vector<std::string> paths_;
         std::shared_ptr<Logger> logger_;
     };
 

--- a/src/paimon/core/mergetree/in_memory_sort_buffer.cpp
+++ b/src/paimon/core/mergetree/in_memory_sort_buffer.cpp
@@ -151,6 +151,14 @@ Result<int64_t> InMemorySortBuffer::EstimateMemoryUse(const std::shared_ptr<arro
             int64_t offset_length = array->length() * sizeof(int32_t);
             return null_bits_size_in_bytes + value_length + offset_length;
         }
+        case arrow::Type::type::LARGE_BINARY: {
+            // Managed blob columns of a primary-key table buffer their serialized
+            // descriptors as large binary.
+            auto large_binary_array = checked_cast<const arrow::LargeBinaryArray*>(array.get());
+            int64_t value_length = large_binary_array->total_values_length();
+            int64_t offset_length = array->length() * sizeof(int64_t);
+            return null_bits_size_in_bytes + value_length + offset_length;
+        }
         case arrow::Type::type::LIST: {
             auto list_array = checked_cast<const arrow::ListArray*>(array.get());
             PAIMON_ASSIGN_OR_RAISE(int64_t value_mem, EstimateMemoryUse(list_array->values()));

--- a/src/paimon/core/mergetree/merge_tree_writer.cpp
+++ b/src/paimon/core/mergetree/merge_tree_writer.cpp
@@ -40,6 +40,7 @@
 #include "paimon/core/io/key_value_data_file_writer_factory.h"
 #include "paimon/core/io/key_value_meta_projection_consumer.h"
 #include "paimon/core/io/key_value_record_reader.h"
+#include "paimon/core/io/primary_key_blob_externalizer.h"
 #include "paimon/core/io/row_to_arrow_array_converter.h"
 #include "paimon/core/io/shredding_key_value_data_file_writer_factory.h"
 #include "paimon/core/manifest/file_source.h"
@@ -67,10 +68,17 @@ Result<std::shared_ptr<MergeTreeWriter>> MergeTreeWriter::Create(
                             options.GetSequenceField(), key_comparator, user_defined_seq_comparator,
                             merge_function_wrapper, options, io_manager, enable_multi_thread_spill,
                             pool));
-    return std::shared_ptr<MergeTreeWriter>(
+    std::shared_ptr<MergeTreeWriter> writer(
         new MergeTreeWriter(trimmed_primary_keys, options, path_factory, key_comparator,
                             user_defined_seq_comparator, merge_function_wrapper, schema_id,
                             write_schema, compact_manager, std::move(write_buffer), pool));
+    // Managed blob payloads leave the row before it is buffered: they are externalized into
+    // pack files and the buffered value holds a descriptor, so the write buffer and any spill
+    // never carry the payload bytes.
+    PAIMON_ASSIGN_OR_RAISE(
+        writer->blob_externalizer_,
+        PrimaryKeyBlobExternalizer::Create(options, value_schema, path_factory, pool));
+    return writer;
 }
 
 MergeTreeWriter::MergeTreeWriter(
@@ -96,6 +104,11 @@ MergeTreeWriter::MergeTreeWriter(
       metrics_(std::make_shared<MetricsImpl>()) {}
 
 Status MergeTreeWriter::DoClose() {
+    // Uncommitted managed blob packs die with the writer, mirroring the temporary data file
+    // cleanup below; packs handed over by PrepareCommit are unaffected.
+    if (blob_externalizer_) {
+        blob_externalizer_->Abort();
+    }
     // Request cancellation and wait for running compaction to exit.
     // This avoids reusing cancellation state while an old task is still running.
     compact_manager_->CancelAndWaitCompaction();
@@ -119,8 +132,11 @@ Status MergeTreeWriter::DoClose() {
         }
     }
     for (const auto& file : delete_files) {
-        // Keep Java parity: temporary file cleanup is quiet.
-        [[maybe_unused]] auto s = options_.GetFileSystem()->Delete(path_factory_->ToPath(file));
+        // Keep Java parity: temporary file cleanup is quiet and removes the data file together
+        // with its companion files (e.g. the managed blob reference sidecar).
+        for (const auto& path : path_factory_->CollectFiles(file)) {
+            [[maybe_unused]] auto s = options_.GetFileSystem()->Delete(path);
+        }
     }
 
     write_buffer_->Clear();
@@ -146,6 +162,10 @@ Status MergeTreeWriter::FlushMemory() {
 }
 
 Status MergeTreeWriter::Write(std::unique_ptr<RecordBatch>&& moved_batch) {
+    if (blob_externalizer_) {
+        PAIMON_ASSIGN_OR_RAISE(moved_batch,
+                               blob_externalizer_->Externalize(std::move(moved_batch)));
+    }
     PAIMON_ASSIGN_OR_RAISE(bool has_remaining_quota, write_buffer_->Write(std::move(moved_batch)));
     if (!has_remaining_quota) {
         return FlushWriteBuffer(/*wait_for_latest_compaction=*/false,
@@ -201,7 +221,11 @@ Status MergeTreeWriter::UpdateCompactResult(const std::shared_ptr<CompactResult>
             if (!in_compact_before(file->file_name) &&
                 after_files.find(file->file_name) == after_files.end()) {
                 auto fs = options_.GetFileSystem();
-                [[maybe_unused]] auto s = fs->Delete(path_factory_->ToPath(file));
+                // An intermediate file's companion files (e.g. the managed blob reference
+                // sidecar) are no longer needed either.
+                for (const auto& path : path_factory_->CollectFiles(file)) {
+                    [[maybe_unused]] auto s = fs->Delete(path);
+                }
             }
         } else {
             compact_before_.push_back(file);
@@ -241,6 +265,12 @@ Result<CommitIncrement> MergeTreeWriter::PrepareCommit(bool wait_compaction) {
         wait_compaction = true;
     }
     PAIMON_RETURN_NOT_OK(TrySyncLatestCompaction(wait_compaction));
+    if (blob_externalizer_) {
+        // Seal the pack files the flushed data files reference and stop tracking them: this
+        // writer no longer deletes them on close, the committed files' sidecars record which
+        // packs are referenced.
+        PAIMON_RETURN_NOT_OK(blob_externalizer_->PrepareCommit());
+    }
     return DrainIncrement();
 }
 

--- a/src/paimon/core/mergetree/merge_tree_writer.h
+++ b/src/paimon/core/mergetree/merge_tree_writer.h
@@ -51,6 +51,7 @@ class IOManager;
 class FieldsComparator;
 class MemoryPool;
 class Metrics;
+class PrimaryKeyBlobExternalizer;
 template <typename T>
 class MergeFunctionWrapper;
 
@@ -128,6 +129,12 @@ class MergeTreeWriter : public BatchWriter {
     std::shared_ptr<arrow::Schema> write_schema_;
 
     std::shared_ptr<CompactManager> compact_manager_;
+
+    /// Externalizes managed blob payloads before buffering; null unless the table is a
+    /// primary-key managed blob table. Declared before the write buffer: buffered batches
+    /// hold descriptor columns allocated from the externalizer's pool, so the buffer must be
+    /// destroyed first.
+    std::unique_ptr<PrimaryKeyBlobExternalizer> blob_externalizer_;
 
     std::unique_ptr<WriteBuffer> write_buffer_;
 

--- a/src/paimon/core/mergetree/merge_tree_writer_test.cpp
+++ b/src/paimon/core/mergetree/merge_tree_writer_test.cpp
@@ -31,17 +31,20 @@
 #include "arrow/c/bridge.h"
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
+#include "paimon/common/data/blob_utils.h"
 #include "paimon/common/data/shredding/map_shared_shredding_utils.h"
 #include "paimon/common/factories/io_hook.h"
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/fields_comparator.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/common/utils/string_utils.h"
 #include "paimon/core/compact/noop_compact_manager.h"
 #include "paimon/core/disk/io_manager.h"
 #include "paimon/core/io/compact_increment.h"
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/io/data_increment.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
 #include "paimon/core/mergetree/compact/reducer_merge_function_wrapper.h"
@@ -209,6 +212,32 @@ class MergeTreeWriterTest : public ::testing::TestWithParam<bool> {
             last_sequence_number, primary_keys_, path_factory, key_comparator_,
             user_defined_seq_comparator, merge_function_wrapper_, schema_id, value_schema_, options,
             writer_compact_manager, io_manager, /*enable_multi_thread_spill=*/false, pool_);
+    }
+
+    /// Rebuilds the fixture schema as (f0 key, b managed blob) for the managed blob tests.
+    Status UseManagedBlobSchema() {
+        value_fields_ = {DataField(0, arrow::field("f0", arrow::utf8())),
+                         DataField(1, BlobUtils::ToArrowField("b", /*nullable=*/true))};
+        value_schema_ = DataField::ConvertDataFieldsToArrowSchema(value_fields_);
+        value_type_ = DataField::ConvertDataFieldsToArrowStructType(value_fields_);
+        PAIMON_ASSIGN_OR_RAISE(key_comparator_,
+                               FieldsComparator::Create({value_fields_[0]},
+                                                        /*is_ascending_order=*/true));
+        return Status::OK();
+    }
+
+    /// The single (key, payload) row the managed blob tests externalize.
+    std::shared_ptr<arrow::Array> ManagedBlobRow() const {
+        arrow::StringBuilder key_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        EXPECT_TRUE(key_builder.Append("Alice").ok());
+        EXPECT_TRUE(blob_builder.Append("blob-payload").ok());
+        std::shared_ptr<arrow::Array> key_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(key_builder.Finish(&key_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        return arrow::StructArray::Make({key_array, blob_array}, value_schema_->fields())
+            .ValueOrDie();
     }
 
  private:
@@ -1756,6 +1785,180 @@ TEST_F(MergeTreeWriterTest, TestSpillWithIOException) {
         ASSERT_EQ(1, commit_increment.value().GetNewFilesIncrement().NewFiles().size());
         ASSERT_EQ(5, commit_increment.value().GetNewFilesIncrement().NewFiles()[0]->row_count);
 
+        ASSERT_OK(merge_writer->Close());
+        run_complete = true;
+        break;
+    }
+    ASSERT_TRUE(run_complete);
+}
+
+TEST_P(MergeTreeWriterTest, TestManagedBlobSidecarKeptAfterCommit) {
+    // The flushed file carries a sidecar in its extra files, and closing the writer after
+    // PrepareCommit keeps the data file, the sidecar and the pack.
+    ASSERT_OK(UseManagedBlobSchema());
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    auto path_factory = std::make_shared<DataFilePathFactory>();
+    ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
+
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory,
+                                           /*schema_id=*/1, options));
+    WriteBatch(ManagedBlobRow(), /*row_kinds=*/{}, merge_writer.get());
+    ASSERT_OK_AND_ASSIGN(CommitIncrement commit_increment,
+                         merge_writer->PrepareCommit(/*wait_compaction=*/false));
+
+    ASSERT_EQ(1, commit_increment.GetNewFilesIncrement().NewFiles().size());
+    const auto& flushed_file = commit_increment.GetNewFilesIncrement().NewFiles()[0];
+    ASSERT_EQ(flushed_file->extra_files.size(), 1);
+    ASSERT_TRUE(flushed_file->extra_files[0].has_value());
+    ASSERT_EQ(flushed_file->extra_files[0].value(), flushed_file->file_name + ".blobref");
+    std::string data_path = dir->Str() + "/" + flushed_file->file_name;
+    std::string sidecar_path = data_path + ".blobref";
+
+    // The pack path is recorded in the sidecar, not assumed from naming.
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> references,
+                         ManagedBlobReferenceFile::Read(file_system_, sidecar_path));
+    ASSERT_EQ(references.size(), 1);
+    std::string pack_path = references[0].ToString();
+    ASSERT_TRUE(StringUtils::EndsWith(pack_path, ManagedBlobReferenceFile::kManagedBlobSuffix));
+
+    ASSERT_OK(merge_writer->Close());
+    EXPECT_TRUE(file_system_->GetFileStatus(data_path).ok());
+    EXPECT_TRUE(file_system_->GetFileStatus(sidecar_path).ok());
+    EXPECT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+}
+
+TEST_P(MergeTreeWriterTest, TestManagedBlobSidecarRemovedWithoutCommit) {
+    // Closing the writer without PrepareCommit removes the flushed data file together with its
+    // sidecar, and the externalizer deletes the uncommitted pack.
+    ASSERT_OK(UseManagedBlobSchema());
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    auto path_factory = std::make_shared<DataFilePathFactory>();
+    ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
+
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory,
+                                           /*schema_id=*/1, options));
+    WriteBatch(ManagedBlobRow(), /*row_kinds=*/{}, merge_writer.get());
+    // Force the buffer to flush without draining the increment.
+    ASSERT_OK(merge_writer->Compact(/*full_compaction=*/false));
+    ASSERT_EQ(1, merge_writer->new_files_.size());
+    const auto& flushed_file = merge_writer->new_files_[0];
+    ASSERT_EQ(flushed_file->extra_files.size(), 1);
+    ASSERT_TRUE(flushed_file->extra_files[0].has_value());
+    std::string data_path = dir->Str() + "/" + flushed_file->file_name;
+    std::string sidecar_path = dir->Str() + "/" + flushed_file->extra_files[0].value();
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> references,
+                         ManagedBlobReferenceFile::Read(file_system_, sidecar_path));
+    ASSERT_EQ(references.size(), 1);
+    std::string pack_path = references[0].ToString();
+    ASSERT_TRUE(file_system_->GetFileStatus(data_path).ok());
+    ASSERT_TRUE(file_system_->GetFileStatus(sidecar_path).ok());
+    ASSERT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+
+    ASSERT_OK(merge_writer->Close());
+    EXPECT_FALSE(file_system_->GetFileStatus(data_path).ok());
+    EXPECT_FALSE(file_system_->GetFileStatus(sidecar_path).ok());
+    EXPECT_FALSE(file_system_->GetFileStatus(pack_path).ok());
+}
+
+TEST_P(MergeTreeWriterTest, TestSharedShreddingKeepsManagedBlobSidecar) {
+    // A shredded map column and a managed blob column in one table. The reference collector
+    // reads the logical key-value batch, while the shredding conversion rewrites the batch into
+    // its physical layout afterwards, so the two must not disagree about column positions.
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({
+                             {Options::FILE_FORMAT, "orc"},
+                             {"fields.tags.map.storage-layout", "shared-shredding"},
+                             {"fields.tags.map.shared-shredding.max-columns", "3"},
+                             {"fields.tags.map.shared-shredding.column-placement-policy", "plain"},
+                         }));
+
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    auto path_factory = std::make_shared<DataFilePathFactory>();
+    ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
+
+    std::vector<DataField> value_fields = {
+        DataField(0, arrow::field("id", arrow::int32())),
+        DataField(1, arrow::field("tags", arrow::map(arrow::utf8(), arrow::int64()))),
+        DataField(2, BlobUtils::ToArrowField("b", /*nullable=*/true)),
+    };
+    auto value_schema = DataField::ConvertDataFieldsToArrowSchema(value_fields);
+    auto value_type = DataField::ConvertDataFieldsToArrowStructType(value_fields);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({value_fields[0]},
+                                                  /*is_ascending_order=*/true));
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(
+            /*last_sequence_number=*/-1, /*trimmed_primary_keys=*/{"id"}, path_factory,
+            key_comparator,
+            /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/1,
+            value_schema, options, noop_compact_manager_,
+            GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr,
+            /*enable_multi_thread_spill=*/false, pool_));
+
+    auto array = arrow::ipc::internal::json::ArrayFromJSON(value_type, R"([
+      [1, [["a", 10], ["b", 20]], "shredded-blob-payload"]
+    ])")
+                     .ValueOrDie();
+    WriteBatch(array, /*row_kinds=*/{}, merge_writer.get());
+
+    ASSERT_OK_AND_ASSIGN(CommitIncrement commit_increment,
+                         merge_writer->PrepareCommit(/*wait_compaction=*/false));
+    ASSERT_EQ(1, commit_increment.GetNewFilesIncrement().NewFiles().size());
+    const auto& flushed_file = commit_increment.GetNewFilesIncrement().NewFiles()[0];
+    ASSERT_EQ(flushed_file->extra_files.size(), 1);
+    ASSERT_TRUE(flushed_file->extra_files[0].has_value());
+
+    std::string sidecar_path = dir->Str() + "/" + flushed_file->extra_files[0].value();
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> references,
+                         ManagedBlobReferenceFile::Read(file_system_, sidecar_path));
+    ASSERT_EQ(references.size(), 1);
+    std::string pack_path = references[0].ToString();
+    EXPECT_TRUE(StringUtils::EndsWith(pack_path, ManagedBlobReferenceFile::kManagedBlobSuffix));
+    EXPECT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+    ASSERT_OK(merge_writer->Close());
+}
+
+TEST_P(MergeTreeWriterTest, TestManagedBlobIOException) {
+    // The TestIOException sweep on a managed blob schema: every injected failure must also
+    // tear down the blob reference collector, the sidecar (via the abort executor's extra
+    // paths) and the pack writers without a crash or hang, and the first clean run commits.
+    ASSERT_OK(UseManagedBlobSchema());
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
+
+    bool run_complete = false;
+    auto io_hook = IOHook::GetInstance();
+    for (size_t i = 0; i < 200; i++) {
+        auto dir = UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir);
+        ScopeGuard guard([&io_hook]() { io_hook->Clear(); });
+        io_hook->Reset(i, IOHook::Mode::RETURN_ERROR);
+        auto path_factory = std::make_shared<DataFilePathFactory>();
+        ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
+
+        auto merge_writer_result = CreateMergeWriter(
+            /*last_sequence_number=*/-1, dir->Str(), path_factory, /*schema_id=*/0, options);
+        CHECK_HOOK_STATUS(merge_writer_result.status(), i);
+        auto merge_writer = std::move(merge_writer_result).value();
+
+        ::ArrowArray c_array;
+        ASSERT_TRUE(arrow::ExportArray(*ManagedBlobRow(), &c_array).ok());
+        RecordBatchBuilder batch_builder(&c_array);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch, batch_builder.Finish());
+        CHECK_HOOK_STATUS(merge_writer->Write(std::move(batch)), i);
+        auto commit_increment = merge_writer->PrepareCommit(/*wait_compaction=*/false);
+        CHECK_HOOK_STATUS(commit_increment.status(), i);
+        ASSERT_FALSE(commit_increment.value().GetNewFilesIncrement().NewFiles().empty());
         ASSERT_OK(merge_writer->Close());
         run_complete = true;
         break;

--- a/src/paimon/core/operation/abstract_split_read.cpp
+++ b/src/paimon/core/operation/abstract_split_read.cpp
@@ -189,6 +189,17 @@ Result<std::unique_ptr<FileBatchReader>> AbstractSplitRead::CreateFieldMappingRe
                                               SpecialFields::ValueKind()};
         file_fields.insert(file_fields.end(), data_schema->Fields().begin(),
                            data_schema->Fields().end());
+        // Blob columns of a primary-key table are stored as plain bytes in the kv data
+        // files (managed columns hold serialized descriptors), and the format readers
+        // produce them as binary. Declare them as binary on the file side so the field
+        // mapping casts them back to the requested large_binary type.
+        std::vector<std::string> blob_field_names;
+        for (const auto& field : data_schema->Fields()) {
+            if (BlobUtils::IsBlobField(field.ArrowField())) {
+                blob_field_names.push_back(field.Name());
+            }
+        }
+        file_fields = BlobUtils::ConvertBlobInlineDataFields(file_fields, blob_field_names);
         PAIMON_ASSIGN_OR_RAISE(field_mapping,
                                field_mapping_builder->CreateFieldMapping(file_fields));
     } else {

--- a/src/paimon/core/operation/expire_snapshots.cpp
+++ b/src/paimon/core/operation/expire_snapshots.cpp
@@ -24,7 +24,9 @@
 #include <cstdint>
 #include <functional>
 #include <future>
+#include <map>
 #include <optional>
+#include <unordered_map>
 #include <utility>
 
 #include "fmt/format.h"
@@ -33,6 +35,7 @@
 #include "paimon/common/utils/date_time_utils.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/manifest/file_kind.h"
 #include "paimon/core/manifest/manifest_entry.h"
 #include "paimon/core/manifest/manifest_file.h"
@@ -277,14 +280,31 @@ Status ExpireSnapshots::CleanUnusedDataFiles(const std::string& manifest_list_na
             }
         }
 
+        // One data file path factory per (partition, bucket): creating one re-derives the
+        // partition path and external path provider, too heavy to repeat for every file.
+        std::unordered_map<BinaryRow, std::map<int32_t, std::shared_ptr<DataFilePathFactory>>>
+            data_file_path_factories;
         std::vector<std::future<void>> futures;
         ScopeGuard guard([&futures]() { Wait(futures); });
         for (const auto& [data_file_to_delete, entry] : data_files_to_delete) {
-            auto delete_file_path = data_file_to_delete;
-            futures.push_back(Via(executor_.get(), [this, delete_file_path]() {
-                auto status = fs_->Delete(delete_file_path);
-                // delete quietly will ignore any status error
-                (void)status;
+            // An expired data file takes its companion files with it (e.g. the managed blob
+            // reference sidecar). CollectFiles resolves their paths, honoring external data
+            // paths.
+            std::shared_ptr<DataFilePathFactory>& data_file_path_factory =
+                data_file_path_factories[entry.Partition()][entry.Bucket()];
+            if (data_file_path_factory == nullptr) {
+                PAIMON_ASSIGN_OR_RAISE(
+                    data_file_path_factory,
+                    path_factory_->CreateDataFilePathFactory(entry.Partition(), entry.Bucket()));
+            }
+            std::vector<std::string> delete_file_paths =
+                data_file_path_factory->CollectFiles(entry.File());
+            futures.push_back(Via(executor_.get(), [this, delete_file_paths]() {
+                for (const auto& delete_file_path : delete_file_paths) {
+                    auto status = fs_->Delete(delete_file_path);
+                    // delete quietly will ignore any status error
+                    (void)status;
+                }
             }));
             deletion_buckets_[entry.Partition()].insert(entry.Bucket());
         }
@@ -302,7 +322,6 @@ Status ExpireSnapshots::GetDataFilesToDelete(
         if (entry.Kind() == FileKind::Add()) {
             data_files_to_delete->erase(data_file_path);
         } else if (entry.Kind() == FileKind::Delete()) {
-            // TODO(jinli.zjw): do not support extra files
             data_files_to_delete->insert({data_file_path, entry});
         } else {
             return Status::Invalid(

--- a/src/paimon/core/operation/file_store_commit_impl.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl.cpp
@@ -81,6 +81,7 @@
 #include "paimon/core/utils/duration.h"
 #include "paimon/core/utils/file_store_path_factory.h"
 #include "paimon/core/utils/snapshot_manager.h"
+#include "paimon/defs.h"
 #include "paimon/file_store_write.h"
 #include "paimon/fs/file_system.h"
 #include "paimon/logging.h"
@@ -94,7 +95,6 @@ namespace {
 
 constexpr const char* kCommitStrictModeLastSafeSnapshot = "commit.strict-mode.last-safe-snapshot";
 constexpr const char* kSequenceSnapshotOrdering = "sequence.snapshot-ordering";
-constexpr const char* kPkClusteringOverride = "pk-clustering-override";
 
 bool MatchPartitionSpec(const std::map<std::string, std::string>& partition,
                         const std::map<std::string, std::string>& partition_spec) {
@@ -119,8 +119,9 @@ Status FileStoreCommitImpl::ValidateCommitOptions(const CoreOptions& options) {
     if (raw_options.find(kSequenceSnapshotOrdering) != raw_options.end()) {
         unsupported_options.emplace_back(kSequenceSnapshotOrdering);
     }
-    if (raw_options.find(kPkClusteringOverride) != raw_options.end()) {
-        unsupported_options.emplace_back(kPkClusteringOverride);
+    // Rejected by value, like Java: an explicit false equals the C++ behavior and is fine.
+    if (options.PkClusteringOverride()) {
+        unsupported_options.emplace_back(Options::PK_CLUSTERING_OVERRIDE);
     }
 
     if (!unsupported_options.empty()) {

--- a/src/paimon/core/operation/file_store_commit_impl_test.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl_test.cpp
@@ -2555,6 +2555,12 @@ TEST_F(FileStoreCommitImplTest, ValidateCommitOptionsRejectsUnsupportedOptions) 
     ASSERT_OK_AND_ASSIGN(CoreOptions ok_options,
                          CoreOptions::FromMap({{Options::FILE_SYSTEM, "local"}}));
     ASSERT_OK(FileStoreCommitImpl::ValidateCommitOptions(ok_options));
+
+    // 'pk-clustering-override' is rejected by value, like Java: an explicit false equals the
+    // C++ behavior and is allowed.
+    ASSERT_OK_AND_ASSIGN(CoreOptions pk_clustering_false,
+                         CoreOptions::FromMap({{Options::PK_CLUSTERING_OVERRIDE, "false"}}));
+    ASSERT_OK(FileStoreCommitImpl::ValidateCommitOptions(pk_clustering_false));
 }
 
 TEST_F(FileStoreCommitImplTest, ValidateCommitOptionsAllowsManifestDeleteFileDropStats) {

--- a/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
+++ b/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
@@ -31,6 +31,7 @@
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
 #include "paimon/common/utils/string_utils.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
 #include "paimon/core/manifest/manifest_entry.h"
 #include "paimon/core/manifest/manifest_file.h"
 #include "paimon/core/manifest/manifest_file_meta.h"
@@ -70,6 +71,13 @@ OrphanFilesCleanerImpl::OrphanFilesCleanerImpl(
       metrics_(std::make_shared<MetricsImpl>()) {}
 
 bool OrphanFilesCleanerImpl::SupportToClean(const std::string& file_name) {
+    // Managed blob packs may be shared by several data files and are referenced through
+    // `.blobref` sidecars the cleaner does not resolve, so they are never treated as orphans.
+    // Both blob rules are defensive today: the cleaner only supports append tables (see
+    // OrphanFilesCleaner), and managed blobs only exist in primary-key tables.
+    if (StringUtils::EndsWith(file_name, ManagedBlobReferenceFile::kManagedBlobSuffix)) {
+        return false;
+    }
     static std::vector<std::pair<std::string, std::string>> supported_pattern = {
         {"manifest-", ""}, {"manifest-list-", ""}, {".", ".tmp"}};
     for (const auto& pattern : supported_pattern) {
@@ -78,7 +86,10 @@ bool OrphanFilesCleanerImpl::SupportToClean(const std::string& file_name) {
             return true;
         }
     }
-    static std::vector<std::string> supported_formats = {".orc", ".parquet", ".avro"};
+    // Blob reference sidecars are cleanable: live ones are protected through the used-file
+    // set, which registers every manifest entry's extra files.
+    static std::vector<std::string> supported_formats = {
+        ".orc", ".parquet", ".avro", ManagedBlobReferenceFile::kReferenceFileSuffix};
     for (const auto& format : supported_formats) {
         if (StringUtils::StartsWith(file_name, "data-") &&
             StringUtils::EndsWith(file_name, format)) {
@@ -308,6 +319,13 @@ Result<std::set<std::string>> OrphanFilesCleanerImpl::GetUsedFilesBySnapshot(
             manifest.FileName(), /*filter=*/nullptr, &manifest_entries));
         for (const auto& manifest_entry : manifest_entries) {
             used_files.insert(manifest_entry.FileName());
+            // Extra files (e.g. managed blob reference sidecars) live and die with their data
+            // file and must never be treated as orphans while the data file is live.
+            for (const auto& extra_file : manifest_entry.File()->extra_files) {
+                if (extra_file) {
+                    used_files.insert(extra_file.value());
+                }
+            }
         }
     }
 

--- a/src/paimon/core/operation/orphan_files_cleaner_test.cpp
+++ b/src/paimon/core/operation/orphan_files_cleaner_test.cpp
@@ -47,6 +47,14 @@ TEST(OrphanFilesCleanerTest, TestSupportToClean) {
         "manifest-list-469f3a0f-f6f1-4027-91bf-d1e897e8ea23-1"));
     ASSERT_TRUE(OrphanFilesCleanerImpl::SupportToClean(
         ".snapshot-2.13c988c3-784d-493d-8884-016ddddb1fc2.tmp"));
+    // A blob reference sidecar is cleanable: a live one is protected through its data file's
+    // extra files, so an unreferenced one is genuinely orphaned.
+    ASSERT_TRUE(OrphanFilesCleanerImpl::SupportToClean(
+        "data-2d5ea1ea-77c1-47ff-bb87-19a509962a37-0.parquet.blobref"));
+    // A managed blob pack may be shared by several data files through sidecars the cleaner
+    // does not resolve, so it is never treated as an orphan.
+    ASSERT_FALSE(OrphanFilesCleanerImpl::SupportToClean(
+        "data-2d5ea1ea-77c1-47ff-bb87-19a509962a37-0.managed.blob"));
     ASSERT_FALSE(OrphanFilesCleanerImpl::SupportToClean("tmp"));
     ASSERT_FALSE(OrphanFilesCleanerImpl::SupportToClean("snapshot-1"));
     ASSERT_FALSE(OrphanFilesCleanerImpl::SupportToClean("schema-0"));

--- a/src/paimon/core/postpone/postpone_bucket_writer.cpp
+++ b/src/paimon/core/postpone/postpone_bucket_writer.cpp
@@ -44,6 +44,7 @@
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/io/data_increment.h"
 #include "paimon/core/io/key_value_data_file_writer_factory.h"
+#include "paimon/core/io/primary_key_blob_externalizer.h"
 #include "paimon/core/io/shredding_key_value_data_file_writer_factory.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/core/utils/commit_increment.h"
@@ -76,8 +77,14 @@ Result<std::unique_ptr<PostponeBucketWriter>> PostponeBucketWriter::Create(
     const std::shared_ptr<arrow::Schema>& value_schema, const CoreOptions& options,
     const std::shared_ptr<MemoryPool>& pool) {
     auto write_schema = BuildPostponeBucketWriteSchema(value_schema);
-    return std::unique_ptr<PostponeBucketWriter>(new PostponeBucketWriter(
+    std::unique_ptr<PostponeBucketWriter> writer(new PostponeBucketWriter(
         trimmed_primary_keys, path_factory, schema_id, value_schema, write_schema, options, pool));
+    // Managed blob payloads are externalized before buffering, exactly as in the merge-tree
+    // writer, so postpone-bucket files hold descriptors too. Null without managed blob fields.
+    PAIMON_ASSIGN_OR_RAISE(
+        writer->blob_externalizer_,
+        PrimaryKeyBlobExternalizer::Create(options, value_schema, path_factory, pool));
+    return writer;
 }
 
 PostponeBucketWriter::PostponeBucketWriter(const std::vector<std::string>& trimmed_primary_keys,
@@ -95,13 +102,17 @@ PostponeBucketWriter::PostponeBucketWriter(const std::vector<std::string>& trimm
       schema_id_(schema_id),
       value_type_(arrow::struct_(value_schema->fields())),
       write_schema_(write_schema),
-      metrics_(std::make_shared<MetricsImpl>()) {}
+      metrics_(std::make_shared<MetricsImpl>()),
+      logger_(Logger::GetLogger("PostponeBucketWriter")) {}
 
 Status PostponeBucketWriter::Write(std::unique_ptr<RecordBatch>&& moved_batch) {
     if (moved_batch->GetData()->length == 0) {
         return Status::OK();
     }
     std::unique_ptr<RecordBatch> batch = std::move(moved_batch);
+    if (blob_externalizer_) {
+        PAIMON_ASSIGN_OR_RAISE(batch, blob_externalizer_->Externalize(std::move(batch)));
+    }
     // check input array
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::StructArray> value_struct_array,
                            CheckAndCastValueArray(batch->GetData()));
@@ -147,6 +158,12 @@ Status PostponeBucketWriter::Write(std::unique_ptr<RecordBatch>&& moved_batch) {
 
 Result<CommitIncrement> PostponeBucketWriter::PrepareCommit(bool wait_compaction) {
     PAIMON_RETURN_NOT_OK(Flush());
+    if (blob_externalizer_) {
+        // Seal the pack files the flushed data files reference and stop tracking them: this
+        // writer no longer deletes them on close, the committed files' sidecars record which
+        // packs are referenced.
+        PAIMON_RETURN_NOT_OK(blob_externalizer_->PrepareCommit());
+    }
     return DrainIncrement();
 }
 

--- a/src/paimon/core/postpone/postpone_bucket_writer.h
+++ b/src/paimon/core/postpone/postpone_bucket_writer.h
@@ -30,10 +30,12 @@
 #include "paimon/core/core_options.h"
 #include "paimon/core/io/data_file_meta.h"
 #include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/core/io/primary_key_blob_externalizer.h"
 #include "paimon/core/io/rolling_file_writer.h"
 #include "paimon/core/key_value.h"
 #include "paimon/core/utils/batch_writer.h"
 #include "paimon/core/utils/commit_increment.h"
+#include "paimon/logging.h"
 #include "paimon/record_batch.h"
 #include "paimon/result.h"
 #include "paimon/status.h"
@@ -97,6 +99,23 @@ class PostponeBucketWriter : public BatchWriter {
 
  private:
     Status DoClose() {
+        // Uncommitted managed blob packs die with the writer; packs handed over by
+        // PrepareCommit are unaffected.
+        if (blob_externalizer_) {
+            blob_externalizer_->Abort();
+        }
+        // Flushed files not drained by PrepareCommit were never committed: remove them
+        // together with their companion files, mirroring the merge-tree writer cleanup.
+        for (const auto& file : new_files_) {
+            for (const auto& path : path_factory_->CollectFiles(file)) {
+                auto status = options_.GetFileSystem()->Delete(path);
+                if (!status.ok()) {
+                    PAIMON_LOG_WARN(logger_, "Failed to delete uncommitted postpone file %s: %s",
+                                    path.c_str(), status.ToString().c_str());
+                }
+            }
+        }
+        new_files_.clear();
         sequence_number_array_.reset();
         row_kind_array_.reset();
         if (writer_) {
@@ -142,6 +161,10 @@ class PostponeBucketWriter : public BatchWriter {
     std::shared_ptr<arrow::DataType> value_type_;
     std::shared_ptr<arrow::Schema> write_schema_;
     std::shared_ptr<Metrics> metrics_;
+    std::unique_ptr<Logger> logger_;
+    /// Externalizes managed blob payloads before buffering; null unless the table is a
+    /// primary-key managed blob table.
+    std::unique_ptr<PrimaryKeyBlobExternalizer> blob_externalizer_;
     std::vector<std::shared_ptr<DataFileMeta>> new_files_;
     std::unique_ptr<RollingFileWriter<KeyValueBatch, std::shared_ptr<DataFileMeta>>> writer_;
     std::shared_ptr<arrow::Array> sequence_number_array_;

--- a/src/paimon/core/postpone/postpone_bucket_writer_test.cpp
+++ b/src/paimon/core/postpone/postpone_bucket_writer_test.cpp
@@ -28,6 +28,7 @@
 #include "arrow/c/bridge.h"
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
+#include "paimon/common/data/blob_utils.h"
 #include "paimon/common/data/data_define.h"
 #include "paimon/common/data/shredding/map_shared_shredding_utils.h"
 #include "paimon/common/data/shredding/map_shredding_defs.h"
@@ -36,9 +37,11 @@
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/common/utils/string_utils.h"
 #include "paimon/core/io/compact_increment.h"
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/io/data_increment.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/core/stats/simple_stats.h"
 #include "paimon/core/utils/commit_increment.h"
@@ -80,6 +83,38 @@ class PostponeBucketWriterTest : public ::testing::Test,
         write_type_ = DataField::ConvertDataFieldsToArrowStructType(write_fields);
     }
     void TearDown() override {}
+
+    /// The (key, managed blob) schema shared by the managed blob writer tests.
+    static arrow::FieldVector ManagedBlobFields() {
+        return {arrow::field("key", arrow::utf8()),
+                BlobUtils::ToArrowField("b", /*nullable=*/true)};
+    }
+
+    /// A postpone writer over `ManagedBlobFields()` writing into `dir_path`.
+    Result<std::unique_ptr<PostponeBucketWriter>> CreateManagedBlobWriter(
+        const std::string& file_format, const std::string& dir_path) const {
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options,
+                               CoreOptions::FromMap({{Options::FILE_FORMAT, file_format}}));
+        auto path_factory = std::make_shared<DataFilePathFactory>();
+        PAIMON_RETURN_NOT_OK(
+            path_factory->Init(dir_path, file_format, options.DataFilePrefix(), nullptr));
+        return PostponeBucketWriter::Create(std::vector<std::string>{"key"}, path_factory,
+                                            /*schema_id=*/1, arrow::schema(ManagedBlobFields()),
+                                            options, pool_);
+    }
+
+    /// The single (key, payload) row the managed blob writer tests externalize.
+    static std::shared_ptr<arrow::Array> ManagedBlobBatch() {
+        arrow::StringBuilder key_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        EXPECT_TRUE(key_builder.Append("Lucy").ok());
+        EXPECT_TRUE(blob_builder.Append("postpone-payload").ok());
+        std::shared_ptr<arrow::Array> key_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(key_builder.Finish(&key_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        return arrow::StructArray::Make({key_array, blob_array}, ManagedBlobFields()).ValueOrDie();
+    }
 
     void WriteBatch(const std::shared_ptr<arrow::Array>& array,
                     const std::vector<RecordBatch::RowKind>& row_kinds,
@@ -762,6 +797,63 @@ TEST_P(PostponeBucketWriterTest, TestIOException) {
         break;
     }
     ASSERT_TRUE(run_complete);
+}
+
+TEST_P(PostponeBucketWriterTest, TestManagedBlobExternalizedWithSidecar) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PostponeBucketWriter> postpone_bucket_writer,
+                         CreateManagedBlobWriter(GetParam(), dir->Str()));
+    WriteBatch(ManagedBlobBatch(), /*row_kinds=*/{}, postpone_bucket_writer.get());
+
+    ASSERT_OK_AND_ASSIGN(CommitIncrement commit_increment,
+                         postpone_bucket_writer->PrepareCommit(/*wait_compaction=*/false));
+    ASSERT_EQ(1, commit_increment.GetNewFilesIncrement().NewFiles().size());
+    const auto& flushed_file = commit_increment.GetNewFilesIncrement().NewFiles()[0];
+
+    ASSERT_EQ(flushed_file->extra_files.size(), 1);
+    ASSERT_TRUE(flushed_file->extra_files[0].has_value());
+    ASSERT_EQ(flushed_file->extra_files[0].value(), flushed_file->file_name + ".blobref");
+    std::string sidecar_path = dir->Str() + "/" + flushed_file->extra_files[0].value();
+
+    // The pack path is recorded in the sidecar, not assumed from naming.
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> references,
+                         ManagedBlobReferenceFile::Read(file_system_, sidecar_path));
+    ASSERT_EQ(references.size(), 1);
+    std::string pack_path = references[0].ToString();
+    ASSERT_TRUE(StringUtils::EndsWith(pack_path, ManagedBlobReferenceFile::kManagedBlobSuffix));
+    ASSERT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+
+    // A committed pack survives the writer teardown.
+    ASSERT_OK(postpone_bucket_writer->Close());
+    ASSERT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+}
+
+TEST_P(PostponeBucketWriterTest, TestManagedBlobAbortedWithoutCommit) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PostponeBucketWriter> postpone_bucket_writer,
+                         CreateManagedBlobWriter(GetParam(), dir->Str()));
+    WriteBatch(ManagedBlobBatch(), /*row_kinds=*/{}, postpone_bucket_writer.get());
+
+    // Find the uncommitted pack by listing the directory rather than assuming its name.
+    std::vector<std::string> pack_paths;
+    {
+        std::vector<std::unique_ptr<BasicFileStatus>> statuses;
+        ASSERT_OK(file_system_->ListDir(dir->Str(), &statuses));
+        for (const auto& status : statuses) {
+            if (StringUtils::EndsWith(status->GetPath(),
+                                      ManagedBlobReferenceFile::kManagedBlobSuffix)) {
+                pack_paths.push_back(status->GetPath());
+            }
+        }
+    }
+    ASSERT_EQ(pack_paths.size(), 1);
+    ASSERT_TRUE(file_system_->GetFileStatus(pack_paths[0]).ok());
+
+    // Closing without PrepareCommit aborts the write: the uncommitted pack is removed.
+    ASSERT_OK(postpone_bucket_writer->Close());
+    ASSERT_FALSE(file_system_->GetFileStatus(pack_paths[0]).ok());
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/schema/schema_validation.cpp
+++ b/src/paimon/core/schema/schema_validation.cpp
@@ -43,6 +43,7 @@
 #include "paimon/common/utils/preconditions.h"
 #include "paimon/common/utils/string_utils.h"
 #include "paimon/core/core_options.h"
+#include "paimon/core/mergetree/compact/aggregate/field_last_value_agg.h"
 #include "paimon/core/options/changelog_producer.h"
 #include "paimon/core/options/expire_config.h"
 #include "paimon/core/options/map_storage_layout.h"
@@ -187,6 +188,8 @@ Status SchemaValidation::ValidateTableSchema(const TableSchema& schema) {
 
     PAIMON_RETURN_NOT_OK(ValidateRowTracking(schema, options));
     PAIMON_RETURN_NOT_OK(ValidateBlobFields(schema, options));
+    PAIMON_RETURN_NOT_OK(ValidatePrimaryKeyBlobConfiguration(schema, options));
+    PAIMON_RETURN_NOT_OK(ValidateSequenceGroupOrderingFields(schema, options));
     PAIMON_RETURN_NOT_OK(ValidateMapStorageLayout(schema, options));
     return Status::OK();
 }
@@ -497,13 +500,152 @@ Status SchemaValidation::ValidateRowTracking(const TableSchema& table_schema,
             }
         }
 
-        // Validate data evolution must be enabled when blob-field is configured
-        PAIMON_RETURN_NOT_OK(Preconditions::CheckState(
-            options.DataEvolutionEnabled(),
-            "Data evolution config must be enabled for table with BLOB type column."));
+        // A primary-key table manages its blob payloads itself (table-managed packs plus
+        // reference sidecars); only append tables need data evolution for BLOB columns.
+        bool primary_key_managed_blob = !table_schema.PrimaryKeys().empty();
+        if (!primary_key_managed_blob) {
+            PAIMON_RETURN_NOT_OK(Preconditions::CheckState(
+                options.DataEvolutionEnabled(),
+                "Data evolution config must be enabled for table with BLOB type column."));
+        }
         PAIMON_RETURN_NOT_OK(Preconditions::CheckState(
             table_schema.Fields().size() > blob_names.size(),
             "Table with BLOB type column must have other normal columns."));
+    }
+    return Status::OK();
+}
+
+Status SchemaValidation::ValidatePrimaryKeyBlobConfiguration(const TableSchema& table_schema,
+                                                             const CoreOptions& options) {
+    if (table_schema.PrimaryKeys().empty()) {
+        return Status::OK();
+    }
+    std::vector<std::string> inline_field_names = options.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> managed_blob_fields = BlobUtils::ManagedBlobFieldNames(
+        DataField::ConvertDataFieldsToArrowSchema(table_schema.Fields()), inline_fields);
+    if (managed_blob_fields.empty()) {
+        return Status::OK();
+    }
+
+    // Managed blob fields cannot serve as keys or ordering fields: the stored descriptor
+    // identifies where a payload lives, not a stable logical value — re-externalizing an
+    // equal payload yields different bytes (compaction itself rewrites descriptors
+    // verbatim).
+    for (const auto& field_name : managed_blob_fields) {
+        if (std::find(table_schema.PrimaryKeys().begin(), table_schema.PrimaryKeys().end(),
+                      field_name) != table_schema.PrimaryKeys().end()) {
+            return Status::Invalid(fmt::format(
+                "Managed BLOB field {} cannot be part of the primary key.", field_name));
+        }
+        if (std::find(table_schema.BucketKeys().begin(), table_schema.BucketKeys().end(),
+                      field_name) != table_schema.BucketKeys().end()) {
+            return Status::Invalid(
+                fmt::format("Managed BLOB field {} cannot be a bucket key.", field_name));
+        }
+        const auto& sequence_fields = options.GetSequenceField();
+        if (std::find(sequence_fields.begin(), sequence_fields.end(), field_name) !=
+            sequence_fields.end()) {
+            return Status::Invalid(
+                fmt::format("Managed BLOB field {} cannot be a sequence field.", field_name));
+        }
+    }
+
+    if (options.GetBlobTargetFileSize() <= 0) {
+        return Status::Invalid(
+            fmt::format("'{}' must be positive for tables with managed BLOB fields, but is {}.",
+                        Options::BLOB_TARGET_FILE_SIZE, options.GetBlobTargetFileSize()));
+    }
+    MergeEngine merge_engine = options.GetMergeEngine();
+    if (merge_engine != MergeEngine::DEDUPLICATE && merge_engine != MergeEngine::PARTIAL_UPDATE &&
+        merge_engine != MergeEngine::FIRST_ROW) {
+        return Status::Invalid(
+            "Primary-key tables with managed BLOB fields only support the deduplicate, "
+            "partial-update and first-row merge engines.");
+    }
+    if (options.GetChangelogProducer() != ChangelogProducer::NONE) {
+        return Status::Invalid(
+            "Primary-key tables with managed BLOB fields do not support changelog producers.");
+    }
+    // Mirror Java's `dataFileExternalPaths() == null` check on the raw option: resolving the
+    // paths would surface unrelated strategy errors instead of this rule, and configuring the
+    // option at all — even as an empty string — is rejected.
+    if (options.ToMap().count(Options::DATA_FILE_EXTERNAL_PATHS) != 0) {
+        return Status::Invalid(
+            "Primary-key tables with managed BLOB fields do not support data file external "
+            "paths.");
+    }
+    // Like Java, only an effective "true" is rejected; an explicit "false" equals the
+    // default behavior.
+    if (options.PkClusteringOverride()) {
+        return Status::Invalid(
+            fmt::format("Primary-key tables with managed BLOB fields do not support '{}'.",
+                        Options::PK_CLUSTERING_OVERRIDE));
+    }
+    // Java re-materializes descriptors through the source table's FileIO when this option is
+    // set; Paimon C++ always uses the table's own file system, so accepting the option would
+    // silently change credential semantics. Fail loudly until the capability is ported.
+    if (options.ToMap().count(Options::BLOB_DESCRIPTOR_SOURCE_TABLE) != 0) {
+        return Status::NotImplemented(
+            fmt::format("Paimon C++ does not support '{}' for primary-key tables with managed "
+                        "BLOB fields; descriptors are always read through the table's own file "
+                        "system.",
+                        Options::BLOB_DESCRIPTOR_SOURCE_TABLE));
+    }
+
+    // A retract row drops its managed BLOB payload, so an aggregate function that has to see
+    // the retracted value cannot protect a managed BLOB field through a sequence group.
+    if (merge_engine == MergeEngine::PARTIAL_UPDATE && !options.IgnoreDelete()) {
+        std::set<std::string> sequence_group_protected_fields;
+        for (const auto& [ordering_fields, protected_fields] : options.GetFieldsSequenceGroups()) {
+            for (const auto& protected_field :
+                 StringUtils::Split(protected_fields, Options::FIELDS_SEPARATOR)) {
+                sequence_group_protected_fields.insert(protected_field);
+            }
+        }
+        for (const auto& field_name : managed_blob_fields) {
+            if (sequence_group_protected_fields.count(field_name) == 0) {
+                continue;
+            }
+            PAIMON_ASSIGN_OR_RAISE(std::optional<std::string> aggregate_function,
+                                   options.GetFieldAggFunc(field_name));
+            if (!aggregate_function) {
+                aggregate_function = options.GetFieldsDefaultFunc();
+            }
+            PAIMON_ASSIGN_OR_RAISE(bool ignore_retract, options.FieldAggIgnoreRetract(field_name));
+            if (aggregate_function && aggregate_function.value() != FieldLastValueAgg::NAME &&
+                !ignore_retract) {
+                return Status::Invalid(fmt::format(
+                    "Managed BLOB field '{}' cannot use aggregate function '{}' because "
+                    "managed BLOB payloads are not retained in retract messages. Set "
+                    "'fields.{}.ignore-retract' to true to ignore retract messages.",
+                    field_name, aggregate_function.value(), field_name));
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaValidation::ValidateSequenceGroupOrderingFields(const TableSchema& table_schema,
+                                                             const CoreOptions& options) {
+    if (options.GetMergeEngine() != MergeEngine::PARTIAL_UPDATE) {
+        return Status::OK();
+    }
+    for (const auto& [ordering_fields, protected_fields] : options.GetFieldsSequenceGroups()) {
+        std::vector<std::string> ordering_field_names =
+            StringUtils::Split(ordering_fields, Options::FIELDS_SEPARATOR);
+        PAIMON_ASSIGN_OR_RAISE(std::vector<DataField> fields,
+                               table_schema.GetFields(ordering_field_names));
+        for (const auto& field : fields) {
+            // A BLOB value cannot order rows: for managed fields it is a storage descriptor,
+            // not a stable logical value.
+            if (BlobUtils::IsBlobField(field.ArrowField())) {
+                return Status::Invalid(fmt::format(
+                    "Field '{}' with BLOB type cannot be used as a sequence-group ordering "
+                    "field in option 'fields.{}.sequence-group'.",
+                    field.Name(), ordering_fields));
+            }
+        }
     }
     return Status::OK();
 }

--- a/src/paimon/core/schema/schema_validation.h
+++ b/src/paimon/core/schema/schema_validation.h
@@ -71,6 +71,19 @@ class SchemaValidation {
 
     static Status ValidateRowTracking(const TableSchema& table_schema, const CoreOptions& options);
 
+    /// Validates the managed BLOB configuration of a primary-key table: managed blob fields
+    /// cannot be key or ordering fields, only merge engines and options compatible with
+    /// externally stored payloads are allowed, a sequence-group-protected managed blob
+    /// field cannot use an aggregate function that needs the retracted payload, and the
+    /// capabilities Paimon C++ has not ported are rejected by value or presence
+    /// (`pk-clustering-override` set to true, `blob-descriptor.source-table`).
+    static Status ValidatePrimaryKeyBlobConfiguration(const TableSchema& table_schema,
+                                                      const CoreOptions& options);
+
+    /// Validates that no partial-update sequence-group ordering field is a BLOB column.
+    static Status ValidateSequenceGroupOrderingFields(const TableSchema& table_schema,
+                                                      const CoreOptions& options);
+
     static Status ValidateBlobFields(const TableSchema& schema, const CoreOptions& options);
 
     static Status ValidateMapStorageLayout(const TableSchema& schema, const CoreOptions& options);

--- a/src/paimon/core/schema/schema_validation_test.cpp
+++ b/src/paimon/core/schema/schema_validation_test.cpp
@@ -250,6 +250,263 @@ TEST(SchemaValidationTest, TestWithBlobField) {
     }
 }
 
+TEST(SchemaValidationTest, TestPrimaryKeyManagedBlob) {
+    auto f0 = arrow::field("f0", arrow::utf8(), /*nullable=*/false);
+    auto f1 = arrow::field("f1", arrow::int32());
+    std::shared_ptr<arrow::Field> f2 = BlobUtils::ToArrowField("f2", true);
+    arrow::FieldVector fields = {f0, f1, f2};
+    auto schema = arrow::schema(fields);
+    std::vector<std::string> primary_keys = {"f0"};
+    std::vector<std::string> partition_keys = {};
+    {
+        // A primary-key table manages its blob payloads itself: neither row tracking nor data
+        // evolution is required.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // first-row is an allowed merge engine for managed blob tables.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::MERGE_ENGINE, "first-row"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::MERGE_ENGINE, "aggregation"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "only support the deduplicate, partial-update and first-row merge "
+                            "engines");
+    }
+    {
+        // A managed blob descriptor is rewritten by compaction and cannot produce a changelog.
+        // The table-wide rule that Paimon C++ supports no changelog producer at all rejects
+        // this first; the managed blob rule behind it stays a second line of defence for when
+        // changelog producers arrive.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::CHANGELOG_PRODUCER, "input"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "keep changelog-producer as 'none'");
+    }
+    {
+        // An explicit "none" is the default behaviour and stays allowed, so neither rule can
+        // degrade into rejecting the option itself.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::CHANGELOG_PRODUCER, "none"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // Declaring every blob column inline leaves the table without managed blob fields, so
+        // none of the managed restrictions apply — here the otherwise rejected clustering
+        // override and source table are both accepted.
+        std::map<std::string, std::string> options = {
+            {Options::BUCKET, "2"},
+            {Options::BUCKET_KEY, "f0"},
+            {Options::BLOB_DESCRIPTOR_FIELD, "f2"},
+            {Options::PK_CLUSTERING_OVERRIDE, "true"},
+            {Options::BLOB_DESCRIPTOR_SOURCE_TABLE, "foo.bar"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // The blob target file size drives pack rolling and must be positive.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::BLOB_TARGET_FILE_SIZE, "0"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "must be positive for tables with managed BLOB fields");
+    }
+    {
+        // A managed blob field stores a storage descriptor, not a stable logical value, so
+        // it cannot identify a row.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"}};
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, partition_keys,
+                                                 /*primary_keys=*/{"f0", "f2"}, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot be part of the primary key");
+    }
+    {
+        // Nor can it order rows.
+        std::map<std::string, std::string> options = {
+            {Options::BUCKET, "2"}, {Options::BUCKET_KEY, "f0"}, {Options::SEQUENCE_FIELD, "f2"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot be a sequence field");
+    }
+    {
+        // Java would re-materialize descriptors through the source table's credentials;
+        // C++ rejects the option instead of silently using the table's own file system.
+        std::map<std::string, std::string> options = {
+            {Options::BUCKET, "2"},
+            {Options::BUCKET_KEY, "f0"},
+            {Options::BLOB_DESCRIPTOR_SOURCE_TABLE, "foo.bar"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "does not support 'blob-descriptor.source-table'");
+    }
+    {
+        // The unsupported clustering override is rejected by value, like Java: only "true"
+        // fails, an explicit "false" equals the default behavior.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::PK_CLUSTERING_OVERRIDE, "true"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "do not support 'pk-clustering-override'");
+
+        options[Options::PK_CLUSTERING_OVERRIDE] = "false";
+        ASSERT_OK_AND_ASSIGN(
+            table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // Managed packs stay in the default bucket directory; external data paths are
+        // rejected on the raw option, mirroring Java: configuring the option at all — even
+        // as an empty string — fails.
+        for (const std::string& external_paths : {std::string("file:///tmp/data"), std::string()}) {
+            std::map<std::string, std::string> options = {
+                {Options::BUCKET, "2"},
+                {Options::BUCKET_KEY, "f0"},
+                {Options::DATA_FILE_EXTERNAL_PATHS, external_paths}};
+            ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                                 TableSchema::Create(/*schema_id=*/0, schema, partition_keys,
+                                                     primary_keys, options));
+            ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                                "do not support data file external paths");
+        }
+    }
+}
+
+TEST(SchemaValidationTest, TestPrimaryKeyManagedBlobSequenceGroups) {
+    auto f0 = arrow::field("f0", arrow::utf8(), /*nullable=*/false);
+    auto f1 = arrow::field("f1", arrow::int32());
+    std::shared_ptr<arrow::Field> f2 = BlobUtils::ToArrowField("f2", true);
+    arrow::FieldVector fields = {f0, f1, f2};
+    auto schema = arrow::schema(fields);
+    std::vector<std::string> primary_keys = {"f0"};
+    std::map<std::string, std::string> base_options = {{Options::BUCKET, "2"},
+                                                       {Options::BUCKET_KEY, "f0"},
+                                                       {Options::MERGE_ENGINE, "partial-update"}};
+    {
+        // A sequence group may protect the managed blob field without an aggregate function.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // An aggregate function that needs the retracted value is rejected: retract rows drop
+        // the managed blob payload.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace("fields.f2.aggregate-function", "listagg");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot use aggregate function");
+    }
+    {
+        // With ignore-delete the retract messages never reach the merge function, so the
+        // payload can no longer be lost and the aggregate function is accepted.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace("fields.f2.aggregate-function", "listagg");
+        options.emplace(Options::IGNORE_DELETE, "true");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // last_value never needs the retracted value.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace("fields.f2.aggregate-function", "last_value");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // ignore-retract explicitly accepts the dropped payload.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace("fields.f2.aggregate-function", "listagg");
+        options.emplace("fields.f2.ignore-retract", "true");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // Without a per-field function the default aggregate function applies and is checked
+        // through the same rule.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace(Options::FIELDS_DEFAULT_AGG_FUNC, "listagg");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot use aggregate function");
+    }
+    {
+        // A last_value default aggregate function never needs the retracted value.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace(Options::FIELDS_DEFAULT_AGG_FUNC, "last_value");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // A BLOB column cannot order a sequence group.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f2.sequence-group", "f1");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot be used as a sequence-group ordering field");
+    }
+}
+
 TEST(SchemaValidationTest, TestDuplicateField) {
     auto f0 = arrow::field("f0", arrow::map(arrow::utf8(), arrow::int32()));
     auto f1 = arrow::field("f1", arrow::int32());

--- a/src/paimon/core/table/source/key_value_table_read.cpp
+++ b/src/paimon/core/table/source/key_value_table_read.cpp
@@ -19,8 +19,15 @@
 
 #include "paimon/core/table/source/key_value_table_read.h"
 
+#include <set>
+#include <string>
 #include <utility>
+#include <vector>
 
+#include "arrow/type.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/reader/managed_blob_resolving_batch_reader.h"
+#include "paimon/core/operation/internal_read_context.h"
 #include "paimon/core/operation/merge_file_split_read.h"
 #include "paimon/core/operation/raw_file_split_read.h"
 #include "paimon/core/table/source/data_split_impl.h"
@@ -81,10 +88,30 @@ Result<std::unique_ptr<BatchReader>> KeyValueTableRead::CreateReader(
     for (const auto& read : split_reads_) {
         PAIMON_ASSIGN_OR_RAISE(bool matched, read->Match(data_split, force_keep_delete_));
         if (matched) {
-            return read->CreateReader(data_split);
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> reader,
+                                   read->CreateReader(data_split));
+            return WrapWithManagedBlobResolverIfNeeded(std::move(reader));
         }
     }
     return Status::Invalid("create reader failed, not read match with data split.");
+}
+
+Result<std::unique_ptr<BatchReader>> KeyValueTableRead::WrapWithManagedBlobResolverIfNeeded(
+    std::unique_ptr<BatchReader>&& reader) const {
+    const CoreOptions& options = context_->GetCoreOptions();
+    // With blob-as-descriptor the caller wants the descriptors themselves.
+    if (options.BlobAsDescriptor()) {
+        return std::move(reader);
+    }
+    std::vector<std::string> inline_field_names = options.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> managed_fields =
+        BlobUtils::ManagedBlobFieldNames(context_->GetReadSchema(), inline_fields);
+    if (managed_fields.empty()) {
+        return std::move(reader);
+    }
+    return std::make_unique<ManagedBlobResolvingBatchReader>(
+        std::move(reader), std::move(managed_fields), options.GetFileSystem(), GetMemoryPool());
 }
 
 Result<std::unique_ptr<CountReader>> KeyValueTableRead::CreateCountReader(

--- a/src/paimon/core/table/source/key_value_table_read.h
+++ b/src/paimon/core/table/source/key_value_table_read.h
@@ -57,6 +57,11 @@ class KeyValueTableRead : public TableRead {
                       const std::shared_ptr<MemoryPool>& memory_pool,
                       const std::shared_ptr<Executor>& executor);
 
+    /// Wraps the split reader with the managed blob resolver when the read schema holds
+    /// managed blob fields and the read wants payload bytes rather than descriptors.
+    Result<std::unique_ptr<BatchReader>> WrapWithManagedBlobResolverIfNeeded(
+        std::unique_ptr<BatchReader>&& reader) const;
+
     std::vector<std::unique_ptr<SplitRead>> split_reads_;
     std::shared_ptr<FileStorePathFactory> path_factory_;
     std::shared_ptr<InternalReadContext> context_;

--- a/src/paimon/format/blob/blob_format_writer.cpp
+++ b/src/paimon/format/blob/blob_format_writer.cpp
@@ -19,11 +19,14 @@
 #include "paimon/format/blob/blob_format_writer.h"
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "arrow/api.h"
 #include "arrow/c/bridge.h"
+#include "fmt/format.h"
 #include "paimon/common/data/blob_defs.h"
 #include "paimon/common/data/blob_descriptor.h"
 #include "paimon/common/data/blob_utils.h"
@@ -33,6 +36,7 @@
 #include "paimon/common/utils/checked_cast.h"
 #include "paimon/common/utils/delta_varint_compressor.h"
 #include "paimon/data/blob.h"
+#include "paimon/defs.h"
 #include "paimon/fs/file_system.h"
 #include "paimon/io/byte_array_input_stream.h"
 #include "paimon/logging.h"
@@ -44,7 +48,8 @@ BlobFormatWriter::BlobFormatWriter(const std::shared_ptr<OutputStream>& out, con
                                    bool write_null_on_missing_file,
                                    bool write_null_on_fetch_failure, bool write_placeholder,
                                    const std::shared_ptr<FileSystem>& fs,
-                                   const std::shared_ptr<MemoryPool>& pool)
+                                   const std::shared_ptr<MemoryPool>& pool,
+                                   int64_t copy_buffer_size)
     : out_(out),
       uri_(uri),
       data_type_(data_type),
@@ -53,10 +58,11 @@ BlobFormatWriter::BlobFormatWriter(const std::shared_ptr<OutputStream>& out, con
       write_null_on_missing_file_(write_null_on_missing_file),
       write_null_on_fetch_failure_(write_null_on_fetch_failure),
       write_placeholder_(write_placeholder) {
-    // Create() has already checked that data_type has exactly one BLOB field.
+    // Create() has already checked that data_type has exactly one BLOB field and that
+    // copy_buffer_size is within range.
     blob_field_name_ = data_type_->field(0)->name();
     metrics_ = std::make_shared<MetricsImpl>();
-    tmp_buffer_ = Bytes::AllocateBytes(kTmpBufferSize, pool_.get());
+    tmp_buffer_ = Bytes::AllocateBytes(copy_buffer_size, pool_.get());
     magic_number_bytes_ = IntegerToLittleEndian<int32_t>(BlobDefs::kMagicNumber, pool_);
     logger_ = Logger::GetLogger("BlobFormatWriter");
 }
@@ -64,9 +70,16 @@ BlobFormatWriter::BlobFormatWriter(const std::shared_ptr<OutputStream>& out, con
 Result<std::unique_ptr<BlobFormatWriter>> BlobFormatWriter::Create(
     const std::shared_ptr<OutputStream>& out, const std::shared_ptr<arrow::DataType>& data_type,
     bool write_null_on_missing_file, bool write_null_on_fetch_failure, bool write_placeholder,
-    const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool) {
+    const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool,
+    int64_t copy_buffer_size) {
     if (out == nullptr) {
         return Status::Invalid("blob format writer create failed. out is nullptr");
+    }
+    // Mirror Java's checkedBlobCopyBufferSize bounds.
+    if (copy_buffer_size <= 0 || copy_buffer_size > std::numeric_limits<int32_t>::max()) {
+        return Status::Invalid(fmt::format(
+            "'{}' must be between 1 byte and {} bytes, but was {} bytes.",
+            Options::BLOB_COPY_BUFFER_SIZE, std::numeric_limits<int32_t>::max(), copy_buffer_size));
     }
     if (data_type == nullptr) {
         return Status::Invalid("blob format writer create failed. data_type is nullptr");
@@ -86,9 +99,9 @@ Result<std::unique_ptr<BlobFormatWriter>> BlobFormatWriter::Create(
             fmt::format("field {} is not BLOB", data_type->field(0)->ToString()));
     }
     PAIMON_ASSIGN_OR_RAISE(std::string uri, out->GetUri());
-    return std::unique_ptr<BlobFormatWriter>(
-        new BlobFormatWriter(out, uri, data_type, write_null_on_missing_file,
-                             write_null_on_fetch_failure, write_placeholder, fs, pool));
+    return std::unique_ptr<BlobFormatWriter>(new BlobFormatWriter(
+        out, uri, data_type, write_null_on_missing_file, write_null_on_fetch_failure,
+        write_placeholder, fs, pool, copy_buffer_size));
 }
 
 Status BlobFormatWriter::AddBatch(ArrowArray* batch) {
@@ -98,6 +111,9 @@ Status BlobFormatWriter::AddBatch(ArrowArray* batch) {
     if (batch->length != 1) {
         return Status::Invalid("BlobFormatWriter only supports batch with a row count of 1");
     }
+    // Only a record that stores payload bytes publishes a range; NULL and placeholder
+    // entries leave it empty.
+    last_payload_range_.reset();
     PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
                                       arrow::ImportArray(batch, data_type_));
 
@@ -161,6 +177,11 @@ Status BlobFormatWriter::Finish() {
 }
 
 Status BlobFormatWriter::WriteBlob(std::string_view blob_data) {
+    // Probe the output position before any stream is opened, so a probe failure has nothing
+    // to leak: from the moment the input stream exists, every path runs through the explicit
+    // Close below.
+    PAIMON_ASSIGN_OR_RAISE(int64_t previous_pos, out_->GetPos());
+
     // Open the blob input stream before writing any bytes, so that a failed fetch can be
     // converted to a NULL element without leaving partial data in the output stream.
     // Whether blob_data is a serialized BlobDescriptor is detected by its magic header rather
@@ -180,33 +201,43 @@ Status BlobFormatWriter::WriteBlob(std::string_view blob_data) {
     } else {
         in = std::make_unique<ByteArrayInputStream>(blob_data.data(), blob_data.size());
     }
-    PAIMON_ASSIGN_OR_RAISE(int64_t file_length, in->Length());
-
     crc32_ = 0;
-    PAIMON_ASSIGN_OR_RAISE(int64_t previous_pos, out_->GetPos());
 
-    // write magic number
-    PAIMON_RETURN_NOT_OK(WriteWithCrc32(magic_number_bytes_->data(), magic_number_bytes_->size()));
-    int64_t total_read_length = 0;
-    int64_t read_len = std::min(file_length, static_cast<int64_t>(tmp_buffer_->size()));
-    while (read_len > 0) {
-        PAIMON_ASSIGN_OR_RAISE(int64_t actual_read_len, in->Read(tmp_buffer_->data(), read_len));
-        if (actual_read_len != read_len) {
-            return Status::Invalid(
-                fmt::format("actual read length {}, not match with expect length {}",
-                            actual_read_len, read_len));
+    // Copy the payload; the source stream is closed on every path and a failed copy keeps its
+    // own error. Partial reads are legal for a file system and are simply continued.
+    Status copy_status = [&]() -> Status {
+        PAIMON_ASSIGN_OR_RAISE(int64_t file_length, in->Length());
+        // write magic number
+        PAIMON_RETURN_NOT_OK(
+            WriteWithCrc32(magic_number_bytes_->data(), magic_number_bytes_->size()));
+        int64_t total_read_length = 0;
+        while (total_read_length < file_length) {
+            int64_t read_len = std::min(file_length - total_read_length,
+                                        static_cast<int64_t>(tmp_buffer_->size()));
+            PAIMON_ASSIGN_OR_RAISE(int64_t actual_read_len,
+                                   in->Read(tmp_buffer_->data(), read_len));
+            if (actual_read_len <= 0 || actual_read_len > read_len) {
+                return Status::IOError(fmt::format("unexpected read length {} after {} of {} bytes",
+                                                   actual_read_len, total_read_length,
+                                                   file_length));
+            }
+            PAIMON_RETURN_NOT_OK(WriteWithCrc32(tmp_buffer_->data(), actual_read_len));
+            total_read_length += actual_read_len;
         }
-        PAIMON_RETURN_NOT_OK(WriteWithCrc32(tmp_buffer_->data(), actual_read_len));
-        total_read_length += actual_read_len;
-        read_len =
-            std::min(file_length - total_read_length, static_cast<int64_t>(tmp_buffer_->size()));
+        return Status::OK();
+    }();
+    Status in_close_status = in->Close();
+    if (copy_status.ok()) {
+        copy_status = in_close_status;
     }
+    PAIMON_RETURN_NOT_OK(copy_status);
 
     // write bin length
     PAIMON_ASSIGN_OR_RAISE(int64_t current_pos, out_->GetPos());
     /// magic number(4) + blob content(bin length - 16) + bin length(8) + crc32(4)
     /// ↑                                             ↑
     /// previous_pos                               current_pos
+    last_payload_range_ = std::make_pair(previous_pos + 4, current_pos - previous_pos - 4);
     int64_t bin_length = current_pos - previous_pos + 8 + 4;
     bin_lengths_.push_back(bin_length);
     PAIMON_UNIQUE_PTR<Bytes> bin_length_bytes = IntegerToLittleEndian<int64_t>(bin_length, pool_);
@@ -290,10 +321,16 @@ Result<std::unique_ptr<InputStream>> BlobFormatWriter::HandleFetchFailure(
 }
 
 Status BlobFormatWriter::WriteBytes(const char* data, int64_t length) {
-    PAIMON_ASSIGN_OR_RAISE(int64_t actual, out_->Write(data, length));
-    if (actual != length) {
-        return Status::Invalid(
-            fmt::format("unexpected actual length {} not match with expect {}", actual, length));
+    int64_t total_written = 0;
+    while (total_written < length) {
+        PAIMON_ASSIGN_OR_RAISE(int64_t actual,
+                               out_->Write(data + total_written, length - total_written));
+        // Like the read path, reject a backend claiming more than was requested.
+        if (actual <= 0 || actual > length - total_written) {
+            return Status::IOError(fmt::format("unexpected written length {} after {} of {} bytes",
+                                               actual, total_written, length));
+        }
+        total_written += actual;
     }
     return Status::OK();
 }

--- a/src/paimon/format/blob/blob_format_writer.h
+++ b/src/paimon/format/blob/blob_format_writer.h
@@ -21,12 +21,15 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "arrow/api.h"
 #include "arrow/util/crc32.h"
+#include "paimon/common/data/blob_defs.h"
 #include "paimon/format/format_writer.h"
 #include "paimon/logging.h"
 #include "paimon/memory/bytes.h"
@@ -76,10 +79,14 @@ class BlobFormatWriter : public FormatWriter {
     /// BlobDefs::kPlaceholderSentinel as a placeholder entry (bin_length -2, no data bytes);
     /// any other value is stored verbatim. When disabled, values are never interpreted and can
     /// never be turned into placeholder entries.
+    ///
+    /// `copy_buffer_size` is the payload copy buffer size in bytes (see
+    /// Options::BLOB_COPY_BUFFER_SIZE); production callers should pass the configured value.
     static Result<std::unique_ptr<BlobFormatWriter>> Create(
         const std::shared_ptr<OutputStream>& out, const std::shared_ptr<arrow::DataType>& data_type,
         bool write_null_on_missing_file, bool write_null_on_fetch_failure, bool write_placeholder,
-        const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool);
+        const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool,
+        int64_t copy_buffer_size = BlobDefs::kDefaultCopyBufferSize);
 
     Status AddBatch(ArrowArray* batch) override;
 
@@ -88,6 +95,14 @@ class BlobFormatWriter : public FormatWriter {
     Status Finish() override;
 
     Result<bool> ReachTargetSize(bool suggested_check, int64_t target_size) const override;
+
+    /// The (offset, length) of the payload bytes stored by the last AddBatch, or nullopt when
+    /// that record kept no payload (a NULL or placeholder entry). This is the byte range a
+    /// BlobDescriptor for the record must point at; exposing it here keeps the record layout
+    /// out of callers, mirroring Java's descriptor callback.
+    std::optional<std::pair<int64_t, int64_t>> LastPayloadRange() const {
+        return last_payload_range_;
+    }
 
     std::shared_ptr<Metrics> GetWriterMetrics() const override {
         return metrics_;
@@ -100,7 +115,7 @@ class BlobFormatWriter : public FormatWriter {
                      const std::shared_ptr<arrow::DataType>& data_type,
                      bool write_null_on_missing_file, bool write_null_on_fetch_failure,
                      bool write_placeholder, const std::shared_ptr<FileSystem>& fs,
-                     const std::shared_ptr<MemoryPool>& pool);
+                     const std::shared_ptr<MemoryPool>& pool, int64_t copy_buffer_size);
 
     Status WriteBlob(std::string_view blob_data);
 
@@ -127,8 +142,6 @@ class BlobFormatWriter : public FormatWriter {
                                                           const std::shared_ptr<MemoryPool>& pool);
 
  private:
-    static constexpr uint32_t kTmpBufferSize = 1024 * 1024;
-
     uint32_t crc32_ = 0;
     std::vector<int64_t> bin_lengths_;
     std::shared_ptr<OutputStream> out_;
@@ -144,6 +157,7 @@ class BlobFormatWriter : public FormatWriter {
     bool write_null_on_missing_file_ = false;
     bool write_null_on_fetch_failure_ = false;
     bool write_placeholder_ = false;
+    std::optional<std::pair<int64_t, int64_t>> last_payload_range_;
     uint64_t null_on_missing_file_count_ = 0;
     uint64_t null_on_fetch_failure_count_ = 0;
     std::unique_ptr<Logger> logger_;

--- a/src/paimon/format/blob/blob_format_writer_test.cpp
+++ b/src/paimon/format/blob/blob_format_writer_test.cpp
@@ -18,6 +18,7 @@
 
 #include "paimon/format/blob/blob_format_writer.h"
 
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -340,6 +341,20 @@ TEST_P(BlobFormatWriterTest, TestCreateWithInvalidParameters) {
                                                  /*write_null_on_fetch_failure=*/false,
                                                  /*write_placeholder=*/false, file_system_, pool_),
                         "field regular_col: binary is not BLOB");
+
+    // Test with out-of-range copy buffer sizes (mirrors Java's checkedBlobCopyBufferSize)
+    ASSERT_NOK_WITH_MSG(
+        BlobFormatWriter::Create(output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/false,
+                                 /*write_placeholder=*/false, file_system_, pool_,
+                                 /*copy_buffer_size=*/0),
+        "must be between 1 byte and");
+    ASSERT_NOK_WITH_MSG(
+        BlobFormatWriter::Create(output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/false,
+                                 /*write_placeholder=*/false, file_system_, pool_,
+                                 static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1),
+        "must be between 1 byte and");
 }
 
 TEST_P(BlobFormatWriterTest, TestInvalidCase) {
@@ -443,8 +458,8 @@ TEST_P(BlobFormatWriterTest, TestLargeBlob) {
     ASSERT_OK_AND_ASSIGN(auto large_file_stream,
                          file_system_->Create(large_file_path, /*overwrite=*/true));
 
-    // Write data larger than TMP_BUFFER_SIZE (1MB)
-    const size_t large_size = BlobFormatWriter::kTmpBufferSize * 2 + 1000;  // ~2MB
+    // Write data larger than the default copy buffer so the copy loops over several chunks
+    const size_t large_size = BlobDefs::kDefaultCopyBufferSize * 2 + 1000;  // ~9KB
     std::vector<char> large_data(large_size, 'A');
     ASSERT_OK_AND_ASSIGN(int64_t written, large_file_stream->Write(large_data.data(), large_size));
     ASSERT_EQ(written, large_size);
@@ -970,6 +985,31 @@ TEST_P(BlobFormatWriterTest, TestAddBatchWithZeroLengthBlob) {
 /// Placeholder tests always feed the sentinel bytes of the placeholder write protocol, so
 /// they do not depend on the blob_as_descriptor_ parameter and run once on the
 /// non-parameterized fixture.
+using BlobFormatWriterCopyBufferTest = BlobFormatWriterTestBase;
+
+TEST_F(BlobFormatWriterCopyBufferTest, TestTinyCopyBufferCopiesInChunks) {
+    // A one-byte copy buffer forces the payload copy to loop chunk by chunk; the record must
+    // still round-trip byte for byte.
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<BlobFormatWriter> writer,
+        BlobFormatWriter::Create(output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/false,
+                                 /*write_placeholder=*/false, file_system_, pool_,
+                                 /*copy_buffer_size=*/1));
+    const std::string payload = "tiny-buffer-payload";
+    ASSERT_OK_AND_ASSIGN(auto blob_array, MakeBlobArrayFromBytes(payload));
+    ASSERT_OK(AddBatchOnce(writer, blob_array));
+    ASSERT_OK(writer->Flush());
+    ASSERT_OK(writer->Finish());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> struct_array, ReadBackAsData());
+    ASSERT_EQ(struct_array->length(), 1);
+    auto binary_array =
+        arrow::internal::checked_pointer_cast<arrow::LargeBinaryArray>(struct_array->field(0));
+    ASSERT_FALSE(binary_array->IsNull(0));
+    ASSERT_EQ(binary_array->GetString(0), payload);
+}
+
 using BlobFormatWriterPlaceholderTest = BlobFormatWriterTestBase;
 
 std::string PlaceholderSentinelBytes() {

--- a/src/paimon/format/blob/blob_writer_builder.h
+++ b/src/paimon/format/blob/blob_writer_builder.h
@@ -27,6 +27,7 @@
 
 #include "arrow/api.h"
 #include "paimon/common/data/blob_defs.h"
+#include "paimon/common/options/memory_size.h"
 #include "paimon/common/utils/options_utils.h"
 #include "paimon/defs.h"
 #include "paimon/format/blob/blob_format_writer.h"
@@ -79,8 +80,15 @@ class BlobWriterBuilder : public SpecificFSWriterBuilder {
         PAIMON_ASSIGN_OR_RAISE(
             bool write_placeholder,
             OptionsUtils::GetValueFromMap<bool>(options_, BlobDefs::kWritePlaceholderKey, false));
+        int64_t copy_buffer_size = BlobDefs::kDefaultCopyBufferSize;
+        auto copy_buffer_iter = options_.find(Options::BLOB_COPY_BUFFER_SIZE);
+        if (copy_buffer_iter != options_.end()) {
+            PAIMON_ASSIGN_OR_RAISE(copy_buffer_size,
+                                   MemorySize::ParseBytes(copy_buffer_iter->second));
+        }
         return BlobFormatWriter::Create(out, data_type_, write_null_on_missing_file,
-                                        write_null_on_fetch_failure, write_placeholder, fs_, pool_);
+                                        write_null_on_fetch_failure, write_placeholder, fs_, pool_,
+                                        copy_buffer_size);
     }
 
  private:

--- a/src/paimon/format/blob/blob_writer_builder_test.cpp
+++ b/src/paimon/format/blob/blob_writer_builder_test.cpp
@@ -59,6 +59,24 @@ TEST_F(BlobWriterBuilderTest, TestSimple) {
     ASSERT_OK(builder.Build(output_stream_, "none"));
 }
 
+TEST_F(BlobWriterBuilderTest, TestCopyBufferSizeOption) {
+    // An out-of-range value fails the build: the option string reaches the writer's
+    // range validation.
+    BlobWriterBuilder invalid_builder(struct_type_, {{Options::BLOB_COPY_BUFFER_SIZE, "0"}});
+    invalid_builder.WithFileSystem(file_system_);
+    ASSERT_NOK_WITH_MSG(invalid_builder.Build(output_stream_, "none"),
+                        "must be between 1 byte and");
+
+    // A memory-size string parses and builds.
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<OutputStream> out,
+        file_system_->Create(dir_->Str() + "/file-copy-buffer.blob", /*overwrite=*/true));
+    BlobWriterBuilder builder(struct_type_, {{Options::BLOB_COPY_BUFFER_SIZE, "8 kb"}});
+    builder.WithFileSystem(file_system_);
+    ASSERT_OK(builder.Build(out, "none"));
+    ASSERT_OK(out->Close());
+}
+
 TEST_F(BlobWriterBuilderTest, TestWriteNullOptions) {
     auto prepare_batch = [&](const std::shared_ptr<Blob>& blob, ArrowArray* c_array) -> Status {
         PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> array,

--- a/test/inte/CMakeLists.txt
+++ b/test/inte/CMakeLists.txt
@@ -22,6 +22,13 @@ if(PAIMON_BUILD_TESTS)
                     test_utils_static
                     ${GTEST_LINK_TOOLCHAIN})
 
+    add_paimon_test(pk_blob_table_inte_test
+                    STATIC_LINK_LIBS
+                    paimon_shared
+                    ${TEST_STATIC_LINK_LIBS}
+                    test_utils_static
+                    ${GTEST_LINK_TOOLCHAIN})
+
     add_paimon_test(variant_table_inte_test
                     STATIC_LINK_LIBS
                     paimon_shared

--- a/test/inte/blob_table_inte_test.cpp
+++ b/test/inte/blob_table_inte_test.cpp
@@ -40,6 +40,7 @@
 #include "arrow/ipc/json_simple.h"
 #include "arrow/type.h"
 #include "gtest/gtest.h"
+#include "paimon/append/append_compact_coordinator.h"
 #include "paimon/commit_context.h"
 #include "paimon/common/data/binary_array_writer.h"
 #include "paimon/common/data/binary_row.h"
@@ -54,9 +55,12 @@
 #include "paimon/common/utils/checked_cast.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/common/utils/string_utils.h"
 #include "paimon/core/global_index/indexed_split_impl.h"
+#include "paimon/core/io/compact_increment.h"
 #include "paimon/core/snapshot.h"
 #include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
 #include "paimon/core/table/source/data_split_impl.h"
 #include "paimon/core/utils/file_utils.h"
 #include "paimon/core/utils/snapshot_manager.h"
@@ -670,6 +674,65 @@ TEST_P(BlobTableInteTest, TestAppendTableWriteWithBlobAsDescriptorFalse) {
 
     // BLOB_AS_DESCRIPTOR=false: blob data is stored inline, read result should match input
     ASSERT_OK(ScanAndRead(table_path, schema->field_names(), write_array));
+}
+
+TEST_P(BlobTableInteTest, TestDataEvolutionCompactionLeavesBlobFilesInPlace) {
+    CreateTable();
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    // Two commits build two evolved field groups over contiguous row ids; each write stores
+    // its blob column in a dedicated .blob file next to the normal data file.
+    auto array1 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [0, "blob-0", "s0"],
+        [1, "blob-1", "s1"]
+    ])")
+            .ValueOrDie());
+    auto array2 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [2, "blob-2", "s2"],
+        [3, "blob-3", "s3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs1,
+                         WriteArray(table_path, {}, schema->field_names(), {array1}));
+    ASSERT_OK(Commit(table_path, commit_msgs1));
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs2,
+                         WriteArray(table_path, {}, schema->field_names(), {array2}));
+    ASSERT_OK(Commit(table_path, commit_msgs2));
+
+    // The coordinator rewrites only the normal files; the dedicated blob files never enter
+    // the task and stay in place, still covering the rewritten file's row range.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), pool_));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 2);
+    for (const auto& file : compact_increment.CompactBefore()) {
+        ASSERT_FALSE(StringUtils::EndsWith(file->file_name, ".blob")) << file->file_name;
+    }
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    ASSERT_FALSE(StringUtils::EndsWith(compact_increment.CompactAfter()[0]->file_name, ".blob"));
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // The blob payloads still resolve after the rewrite: the read serves the normal columns
+    // from the compacted file and the blob column from the untouched .blob files.
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [0, "blob-0", "s0"],
+        [1, "blob-1", "s1"],
+        [2, "blob-2", "s2"],
+        [3, "blob-3", "s3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_array));
 }
 
 TEST_P(BlobTableInteTest, TestWriteNullOnMissingFile) {

--- a/test/inte/data_evolution_table_test.cpp
+++ b/test/inte/data_evolution_table_test.cpp
@@ -17,11 +17,14 @@
  * under the License.
  */
 #include <algorithm>
+#include <set>
 #include <tuple>
+#include <utility>
 
 #include "arrow/type.h"
 #include "fmt/format.h"
 #include "gtest/gtest.h"
+#include "paimon/append/append_compact_coordinator.h"
 #include "paimon/common/factories/io_hook.h"
 #include "paimon/common/io/cache/lru_cache.h"
 #include "paimon/common/table/special_fields.h"
@@ -2945,6 +2948,625 @@ TEST_P(DataEvolutionTableTest, TestLimitPushDownDisabledByRowRangeIndex) {
     ASSERT_EQ(limited.splits.size(), 2);
     ASSERT_OK_AND_ASSIGN(std::vector<int32_t> values, CollectF0Values(limited.rows));
     ASSERT_EQ(values, (std::vector<int32_t>{3, 101, 102}));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactAcrossEvolvedFieldGroups) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // Two evolved field groups (row id ranges [0, 1] and [2, 3]), each made of a full-column
+    // file and a newer partial f2 file over the exact same rows.
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4}));
+
+    // The coordinator merges the four contiguous files into one full-column file.
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 4);
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    const std::shared_ptr<DataFileMeta>& compacted_file = compact_increment.CompactAfter()[0];
+    // Row ids and the merged sequence number range of the inputs are preserved, so the rewrite
+    // does not disturb row tracking metadata.
+    ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id, compacted_file->NonNullFirstRowId());
+    ASSERT_EQ(compacted_first_row_id, 0);
+    ASSERT_EQ(compacted_file->row_count, 4);
+    ASSERT_EQ(compacted_file->min_sequence_number, 1);
+    ASSERT_EQ(compacted_file->max_sequence_number, 4);
+    ASSERT_TRUE(compacted_file->file_source.has_value());
+    ASSERT_EQ(compacted_file->file_source.value(), FileSource::Compact());
+    ASSERT_EQ(compacted_file->write_cols, std::nullopt);
+    // Java's contract for data-evolution compact messages: total buckets stay unset.
+    ASSERT_EQ(message_impl->TotalBuckets(), std::nullopt);
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // The merged rows keep the newest f2 values and their row ids. The read now serves from
+    // the single compacted file.
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [1, "a0", "y0", 0],
+        [2, "a1", "y1", 1],
+        [3, "a0", "y0", 2],
+        [4, "a1", "y1", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
+
+    // The compacted file carries the merged sequence range, so every row now reads the group
+    // maximum sequence number (4), where rows 0-1 read 2 before the compaction.
+    auto expected_sequence_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], SpecialFields::RowId().field_,
+                            SpecialFields::SequenceNumber().field_}),
+            R"([
+        [1, 0, 4],
+        [2, 1, 4],
+        [3, 2, 4],
+        [4, 3, 4]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(
+        ScanAndRead(table_path, {"f0", "_ROW_ID", "_SEQUENCE_NUMBER"}, expected_sequence_array));
+
+    // A second coordinator run finds a single file and plans nothing.
+    ASSERT_OK_AND_ASSIGN(messages, AppendCompactCoordinator::Run(
+                                       table_path, compact_options,
+                                       /*partitions=*/{}, dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_TRUE(messages.empty());
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactRejectsDeletionVectorTables) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    // Deletion vectors are keyed by the row range group's anchor file; without the DV
+    // migration of Java's DataEvolutionCompactDeletionVectorRewriter the coordinator keeps
+    // rejecting such tables instead of dropping the deletes.
+    ASSERT_NOK_WITH_MSG(AppendCompactCoordinator::Run(table_path, options, /*partitions=*/{},
+                                                      dir_->GetFileSystem(), GetDefaultPool())
+                            .status(),
+                        "does not support deletion vectors");
+
+    // Nor can the rejection be slipped past by overriding deletion vectors off — the rewrite
+    // neither reads nor migrates the deletion files, so the immutable-option guard fires
+    // first.
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::DELETION_VECTORS_ENABLED] = "false";
+    ASSERT_NOK_WITH_MSG(
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool())
+            .status(),
+        "immutable table options");
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactRejectsImmutableOptionOverrides) {
+    // Turning data evolution off at the compaction entry point would route the table into
+    // the plain append rewrite, which reorders row ids; the override is rejected before any
+    // scanning. The same guard covers the other path-deciding and layout options, checked
+    // here against the same table.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    const std::vector<std::pair<std::string, std::string>> overrides = {
+        {Options::DATA_EVOLUTION_ENABLED, "false"},
+        {Options::ROW_TRACKING_ENABLED, "false"},
+        {Options::BUCKET, "2"},
+        {Options::BLOB_FIELD, "f0"},
+    };
+    for (const auto& [key, value] : overrides) {
+        SCOPED_TRACE(key);
+        std::map<std::string, std::string> compact_options = options;
+        compact_options[key] = value;
+        ASSERT_NOK_WITH_MSG(
+            AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                          dir_->GetFileSystem(), GetDefaultPool())
+                .status(),
+            "immutable table options");
+    }
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactRejectsLegacyRewriteRowIdsOption) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    // The legacy row-id rewriting mode was removed in Java; the coordinator honors the same
+    // contract instead of silently ignoring the option.
+    std::map<std::string, std::string> compact_options = options;
+    compact_options.emplace("data-evolution.compaction.rewrite-row-ids", "true");
+    ASSERT_NOK_WITH_MSG(
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool())
+            .status(),
+        "no longer supported");
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactAcrossEvolvedFieldGroupsWithPartitions) {
+    CreateTable(/*partition_keys=*/{"f1"});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // One evolved field group per partition, each made of a full-column file and a newer
+    // partial f2 file over the same rows.
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2},
+                                  /*partition=*/{{"f1", "2024"}}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4},
+                                  /*partition=*/{{"f1", "2025"}}));
+
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    // Bins never span partitions: one task per partition, each merging the two files of its
+    // field group.
+    ASSERT_EQ(messages.size(), 2);
+    std::set<int64_t> compacted_first_row_ids;
+    for (const auto& message : messages) {
+        auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(message);
+        ASSERT_TRUE(message_impl);
+        const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+        ASSERT_EQ(compact_increment.CompactBefore().size(), 2);
+        ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+        ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id,
+                             compact_increment.CompactAfter()[0]->NonNullFirstRowId());
+        compacted_first_row_ids.insert(compacted_first_row_id);
+    }
+    ASSERT_EQ(compacted_first_row_ids, (std::set<int64_t>{0, 2}));
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // Split order across partitions does not follow row ids, so each partition is verified
+    // through its own partition predicate.
+    auto read_type =
+        arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_});
+    auto expected_2024 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "2024", "y0", 0],
+        [2, "2024", "y1", 1]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2024,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2024", 4))));
+    auto expected_2025 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [3, "2025", "y0", 2],
+        [4, "2025", "y1", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2025,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2025", 4))));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactWithPartitionFilter) {
+    CreateTable(/*partition_keys=*/{"f1"});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2},
+                                  /*partition=*/{{"f1", "2024"}}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4},
+                                  /*partition=*/{{"f1", "2025"}}));
+
+    // Only the selected partition is planned; the other partition's field group stays as it
+    // is and keeps serving reads from its original files.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> messages,
+                         AppendCompactCoordinator::Run(table_path, compact_options,
+                                                       /*partitions=*/{{{"f1", "2024"}}},
+                                                       dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 2);
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id,
+                         compact_increment.CompactAfter()[0]->NonNullFirstRowId());
+    ASSERT_EQ(compacted_first_row_id, 0);
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // Split order across partitions does not follow row ids, so each partition is verified
+    // through its own partition predicate: the compacted 2024 rows and the untouched 2025
+    // rows read back unchanged.
+    auto read_type =
+        arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_});
+    auto expected_2024 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "2024", "y0", 0],
+        [2, "2024", "y1", 1]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2024,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2024", 4))));
+    auto expected_2025 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [3, "2025", "y0", 2],
+        [4, "2025", "y1", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2025,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2025", 4))));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactAcrossSchemaEvolution) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // Schema 0: two full-row commits, row ids [0, 1] and [2, 3], sequence numbers 1 and 2.
+    for (const std::string& rows_json : {std::string(R"([[1, "a0", "x0"], [2, "a1", "x1"]])"),
+                                         std::string(R"([[3, "a2", "x2"], [4, "a3", "x3"]])")}) {
+        auto schema0_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), rows_json)
+                .ValueOrDie());
+        ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> schema0_msgs,
+                             WriteArray(table_path, {"f0", "f1", "f2"}, schema0_array));
+        ASSERT_OK(Commit(table_path, schema0_msgs));
+    }
+
+    // Evolve the schema: change f0 INT -> BIGINT (keeps field id 0, a type change) and add
+    // f3 INT with the fresh field id 3.
+    arrow::FieldVector evolved_fields = {
+        arrow::field("f0", arrow::int64()),
+        arrow::field("f1", arrow::utf8()),
+        arrow::field("f2", arrow::utf8()),
+        arrow::field("f3", arrow::int32()),
+    };
+    ASSERT_OK(TestHelper::WriteNextSchema(
+        dir_->GetFileSystem(), table_path,
+        {DataField(0, evolved_fields[0]), DataField(1, evolved_fields[1]),
+         DataField(2, evolved_fields[2]), DataField(3, evolved_fields[3])},
+        /*highest_field_id=*/3, options));
+
+    // Schema 1: two more full rows, row ids [4, 5], sequence number 3 (rows [2, 3] from the
+    // second schema-0 commit above stay untouched and keep their added f3 as NULL).
+    auto schema1_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(evolved_fields), R"([
+        [5, "a4", "x4", 50],
+        [6, "a5", "x5", 60]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> schema1_msgs,
+                         WriteArray(table_path, {"f0", "f1", "f2", "f3"}, schema1_array));
+    ASSERT_OK(Commit(table_path, schema1_msgs));
+
+    // A schema-1 partial write fills the added f3 for the first schema-0 rows: the [0, 1]
+    // field group now merges files written under different schema ids, sequence number 4.
+    auto f3_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({evolved_fields[3]}), R"([
+        [100],
+        [200]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> f3_msgs,
+                         WriteArray(table_path, {"f3"}, f3_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, f3_msgs);
+    ASSERT_OK(Commit(table_path, f3_msgs));
+
+    // Pre-compaction read through the latest schema: f0 is cast to BIGINT everywhere, the
+    // added f3 is NULL for the untouched schema-0 rows [2, 3] and filled through the
+    // cross-schema field group for rows [0, 1].
+    auto read_type =
+        arrow::struct_({evolved_fields[0], evolved_fields[1], evolved_fields[2], evolved_fields[3],
+                        SpecialFields::RowId().field_, SpecialFields::SequenceNumber().field_});
+    std::vector<std::string> read_names = {"f0", "f1", "f2", "f3", "_ROW_ID", "_SEQUENCE_NUMBER"};
+    auto expected_before = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "a0", "x0", 100, 0, 4],
+        [2, "a1", "x1", 200, 1, 4],
+        [3, "a2", "x2", null, 2, 2],
+        [4, "a3", "x3", null, 3, 2],
+        [5, "a4", "x4", 50, 4, 3],
+        [6, "a5", "x5", 60, 5, 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, read_names, expected_before));
+
+    // The coordinator merges all four files — schema-0, schema-1 and the cross-schema
+    // partial — into one file written with the latest schema.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 4);
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    const std::shared_ptr<DataFileMeta>& compacted_file = compact_increment.CompactAfter()[0];
+    // The rewritten file holds every column of the latest schema and carries its schema id;
+    // row ids and the merged sequence range of the inputs are preserved.
+    ASSERT_EQ(compacted_file->schema_id, 1);
+    ASSERT_EQ(compacted_file->write_cols, std::nullopt);
+    ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id, compacted_file->NonNullFirstRowId());
+    ASSERT_EQ(compacted_first_row_id, 0);
+    ASSERT_EQ(compacted_file->row_count, 6);
+    ASSERT_EQ(compacted_file->min_sequence_number, 1);
+    ASSERT_EQ(compacted_file->max_sequence_number, 4);
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // After the rewrite the merged values survive: the cast f0, the NULL-filled f3 and the
+    // cross-schema f3 fill are now materialized in the compacted file, and every row reads
+    // the group's maximum sequence number.
+    auto expected_after = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "a0", "x0", 100, 0, 4],
+        [2, "a1", "x1", 200, 1, 4],
+        [3, "a2", "x2", null, 2, 4],
+        [4, "a3", "x3", null, 3, 4],
+        [5, "a4", "x4", 50, 4, 4],
+        [6, "a5", "x5", 60, 5, 4]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, read_names, expected_after));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactAfterDropColumn) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // Schema 0: two full rows, row ids [0, 1], sequence number 1.
+    auto schema0_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a0", "x0"],
+        [2, "a1", "x1"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> schema0_msgs,
+                         WriteArray(table_path, {"f0", "f1", "f2"}, schema0_array));
+    ASSERT_OK(Commit(table_path, schema0_msgs));
+
+    // Drop f2. The surviving fields keep their ids, and the highest field id stays 2 so a
+    // later added column cannot recycle the dropped id.
+    ASSERT_OK(TestHelper::WriteNextSchema(dir_->GetFileSystem(), table_path,
+                                          {DataField(0, fields_[0]), DataField(1, fields_[1])},
+                                          /*highest_field_id=*/2, options));
+
+    // Schema 1: two more rows without f2, row ids [2, 3], sequence number 2.
+    arrow::FieldVector remaining_fields = {fields_[0], fields_[1]};
+    auto schema1_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(remaining_fields), R"([
+        [3, "a2"],
+        [4, "a3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> schema1_msgs,
+                         WriteArray(table_path, {"f0", "f1"}, schema1_array));
+    ASSERT_OK(Commit(table_path, schema1_msgs));
+
+    auto read_type =
+        arrow::struct_({remaining_fields[0], remaining_fields[1], SpecialFields::RowId().field_});
+    std::vector<std::string> read_names = {"f0", "f1", "_ROW_ID"};
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "a0", 0],
+        [2, "a1", 1],
+        [3, "a2", 2],
+        [4, "a3", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, read_names, expected_array));
+
+    // The rewrite reads the schema-0 file with the dropped column projected away and writes
+    // the latest two-column schema.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 2);
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    const std::shared_ptr<DataFileMeta>& compacted_file = compact_increment.CompactAfter()[0];
+    ASSERT_EQ(compacted_file->schema_id, 1);
+    ASSERT_EQ(compacted_file->write_cols, std::nullopt);
+    ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id, compacted_file->NonNullFirstRowId());
+    ASSERT_EQ(compacted_first_row_id, 0);
+    ASSERT_EQ(compacted_file->row_count, 4);
+
+    ASSERT_OK(Commit(table_path, messages));
+    ASSERT_OK(ScanAndRead(table_path, read_names, expected_array));
+}
+
+TEST_P(DataEvolutionTableTest, TestStaleCompactMessagePreservesConcurrentPartialUpdate) {
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // One evolved field group over rows [0, 1]: a full-column file and a newer partial f2
+    // file ("y0"/"y1").
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    // Plan and execute the compaction but hold its commit message back, so the commit below
+    // races it with a stale view of the files.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+
+    // A concurrent partial update lands on the same rows after the compaction has read its
+    // input.
+    auto concurrent_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields_[2]}), R"([
+        ["z0"],
+        ["z1"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> concurrent_msgs,
+                         WriteArray(table_path, {"f2"}, concurrent_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, concurrent_msgs);
+    ASSERT_OK(Commit(table_path, concurrent_msgs));
+
+    // The stale compact message still commits: its before-files are still live, and the
+    // rewritten file keeps the input group's sequence range, so the newer update stays on
+    // top instead of being swallowed. Mirrors Java's
+    // testCompactPreservesConcurrentPartialUpdateWithinCandidateRange.
+    ASSERT_OK(Commit(table_path, messages));
+
+    // f2 serves from the concurrent update (newest sequence), the other columns from the
+    // compacted file, and row ids are unchanged.
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [1, "a0", "z0", 0],
+        [2, "a1", "z1", 1]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
+}
+
+TEST_P(DataEvolutionTableTest, TestSmallFileCompactConflictsWithConcurrentPartialUpdate) {
+    // Mirrors Java's testSmallFileCompactConflictsWithConcurrentPartialUpdate: merging the
+    // groups [0, 0] and [1, 1] into one [0, 1] file moves the field group boundary, so a
+    // concurrent partial update aligned with the OLD boundary must conflict — committing the
+    // stale compact would leave the update's file misaligned with its new group.
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    for (const std::string& row_json :
+         {std::string(R"([[10, "a0", "b0"]])"), std::string(R"([[11, "a1", "b1"]])")}) {
+        auto row_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), row_json)
+                .ValueOrDie());
+        ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> row_msgs,
+                             WriteArray(table_path, {"f0", "f1", "f2"}, row_array));
+        ASSERT_OK(Commit(table_path, row_msgs));
+    }
+
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+
+    // The concurrent update lands on row 0 only, aligned with the pre-compaction boundary.
+    auto concurrent_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields_[2]}), R"([
+        ["upd0"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> concurrent_msgs,
+                         WriteArray(table_path, {"f2"}, concurrent_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, concurrent_msgs);
+    ASSERT_OK(Commit(table_path, concurrent_msgs));
+
+    // The compact-kind commit always runs the row range alignment check on data-evolution
+    // tables, so the stale message is rejected and the table keeps serving the update.
+    ASSERT_NOK_WITH_MSG(Commit(table_path, messages),
+                        "'COMPACT' operations have encountered conflicts");
+
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [10, "a0", "upd0", 0],
+        [11, "a1", "b1", 1]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactKeepsConcurrentAppendForNextSmallFileMerge) {
+    // Mirrors Java's testCompactKeepsConcurrentAppendForNextSmallFileMerge: an append outside
+    // the task's row id range neither conflicts with nor is consumed by the stale compact
+    // message; the next coordinator round merges it with the compacted file.
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    for (const std::string& row_json :
+         {std::string(R"([[10, "a0", "b0"]])"), std::string(R"([[11, "a1", "b1"]])")}) {
+        auto row_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), row_json)
+                .ValueOrDie());
+        ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> row_msgs,
+                             WriteArray(table_path, {"f0", "f1", "f2"}, row_array));
+        ASSERT_OK(Commit(table_path, row_msgs));
+    }
+
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+
+    // The concurrent append takes the next row id range [2, 2], outside the task's range.
+    auto append_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [12, "a2", "b2"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> append_msgs,
+                         WriteArray(table_path, {"f0", "f1", "f2"}, append_array));
+    ASSERT_OK(Commit(table_path, append_msgs));
+
+    // The stale compact message still commits: the appended range does not overlap the
+    // rewritten one.
+    ASSERT_OK(Commit(table_path, messages));
+
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [10, "a0", "b0", 0],
+        [11, "a1", "b1", 1],
+        [12, "a2", "b2", 2]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
+
+    // The next round packs the compacted file [0, 1] and the appended file [2, 2] — adjacent
+    // ranges — into one task and merges them.
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> next_messages,
+        AppendCompactCoordinator::Run(table_path, compact_options,
+                                      /*partitions=*/{}, dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(next_messages.size(), 1);
+    auto next_message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(next_messages[0]);
+    ASSERT_TRUE(next_message_impl);
+    const CompactIncrement& next_increment = next_message_impl->GetCompactIncrement();
+    ASSERT_EQ(next_increment.CompactBefore().size(), 2);
+    ASSERT_EQ(next_increment.CompactAfter().size(), 1);
+    ASSERT_OK_AND_ASSIGN(int64_t next_first_row_id,
+                         next_increment.CompactAfter()[0]->NonNullFirstRowId());
+    ASSERT_EQ(next_first_row_id, 0);
+    ASSERT_EQ(next_increment.CompactAfter()[0]->row_count, 3);
+    ASSERT_OK(Commit(table_path, next_messages));
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
 }
 
 std::vector<DataEvolutionTableParam> GetTestValuesForDataEvolutionTableTest() {

--- a/test/inte/pk_blob_table_inte_test.cpp
+++ b/test/inte/pk_blob_table_inte_test.cpp
@@ -1,0 +1,540 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/catalog/catalog.h"
+#include "paimon/commit_context.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/data/blob.h"
+#include "paimon/defs.h"
+#include "paimon/file_store_commit.h"
+#include "paimon/file_store_write.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/read_context.h"
+#include "paimon/record_batch.h"
+#include "paimon/result.h"
+#include "paimon/scan_context.h"
+#include "paimon/status.h"
+#include "paimon/table/source/startup_mode.h"
+#include "paimon/table/source/table_read.h"
+#include "paimon/table/source/table_scan.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+#include "paimon/write_context.h"
+
+namespace paimon::test {
+
+/// One read-back row of the (pk, v, b) table; nullopt marks a NULL cell.
+using PkBlobRow = std::tuple<std::string, std::optional<int32_t>, std::optional<std::string>>;
+
+/// End-to-end tests for table-managed BLOB storage in primary-key tables: payloads are
+/// externalized to `.managed.blob` packs at write time, data files carry `.blobref` sidecars,
+/// reads resolve descriptors back to payload bytes, and compaction rewrites descriptors
+/// verbatim while rebuilding the exact reference set of the surviving rows.
+class PkBlobTableInteTest : public ::testing::Test,
+                            public ::testing::WithParamInterface<std::string> {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+        dir_ = UniqueTestDirectory::Create("local");
+        fields_ = {arrow::field("pk", arrow::utf8(), /*nullable=*/false),
+                   arrow::field("v", arrow::int32()),
+                   BlobUtils::ToArrowField("b", /*nullable=*/true)};
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    std::string FileFormat() const {
+        return GetParam();
+    }
+
+    void CreateTable(const std::map<std::string, std::string>& extra_options) {
+        std::map<std::string, std::string> options = {{Options::FILE_FORMAT, FileFormat()},
+                                                      {Options::FILE_SYSTEM, "local"},
+                                                      {Options::BUCKET, "1"}};
+        options.insert(extra_options.begin(), extra_options.end());
+        auto schema = arrow::schema(fields_);
+        ::ArrowSchema c_schema;
+        ASSERT_TRUE(arrow::ExportSchema(*schema, &c_schema).ok());
+        ASSERT_OK_AND_ASSIGN(auto catalog, Catalog::Create(dir_->Str(), options));
+        ASSERT_OK(catalog->CreateDatabase("foo", {}, /*ignore_if_exists=*/false));
+        ASSERT_OK(catalog->CreateTable(Identifier("foo", "bar"), &c_schema,
+                                       /*partition_keys=*/{}, /*primary_keys=*/{"pk"}, options,
+                                       /*ignore_if_exists=*/false));
+    }
+
+    std::string TablePath() const {
+        return PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    }
+
+    std::string BucketPath() const {
+        return PathUtil::JoinPath(TablePath(), "bucket-0");
+    }
+
+    std::shared_ptr<arrow::Array> MakeArray(const std::vector<PkBlobRow>& rows) {
+        arrow::StringBuilder pk_builder;
+        arrow::Int32Builder v_builder;
+        arrow::LargeBinaryBuilder b_builder;
+        for (const auto& [pk, v, blob] : rows) {
+            EXPECT_TRUE(pk_builder.Append(pk).ok());
+            if (v) {
+                EXPECT_TRUE(v_builder.Append(v.value()).ok());
+            } else {
+                EXPECT_TRUE(v_builder.AppendNull().ok());
+            }
+            if (blob) {
+                EXPECT_TRUE(b_builder.Append(blob.value()).ok());
+            } else {
+                EXPECT_TRUE(b_builder.AppendNull().ok());
+            }
+        }
+        std::shared_ptr<arrow::Array> pk_array;
+        std::shared_ptr<arrow::Array> v_array;
+        std::shared_ptr<arrow::Array> b_array;
+        EXPECT_TRUE(pk_builder.Finish(&pk_array).ok());
+        EXPECT_TRUE(v_builder.Finish(&v_array).ok());
+        EXPECT_TRUE(b_builder.Finish(&b_array).ok());
+        return arrow::StructArray::Make({pk_array, v_array, b_array}, fields_).ValueOrDie();
+    }
+
+    Result<std::vector<std::shared_ptr<CommitMessage>>> WriteArray(
+        const std::shared_ptr<arrow::Array>& write_array, int64_t commit_identifier,
+        const std::vector<RecordBatch::RowKind>& row_kinds = {}) const {
+        WriteContextBuilder write_builder(TablePath(), "commit_user_1");
+        write_builder.WithStreamingMode(true)
+            .WithTempDirectory(PathUtil::JoinPath(dir_->Str(), "tmp"))
+            .AddOption(Options::WRITE_ONLY, "true");
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<WriteContext> write_context, write_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreWrite> file_store_write,
+                               FileStoreWrite::Create(std::move(write_context)));
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*write_array, &c_array));
+        auto record_batch = std::make_unique<RecordBatch>(std::map<std::string, std::string>(),
+                                                          /*bucket=*/0, row_kinds, &c_array);
+        PAIMON_RETURN_NOT_OK(file_store_write->Write(std::move(record_batch)));
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<CommitMessage>> commit_msgs,
+                               file_store_write->PrepareCommit(
+                                   /*wait_compaction=*/false, commit_identifier));
+        PAIMON_RETURN_NOT_OK(file_store_write->Close());
+        return commit_msgs;
+    }
+
+    Status Commit(const std::vector<std::shared_ptr<CommitMessage>>& commit_msgs) const {
+        CommitContextBuilder commit_builder(TablePath(), "commit_user_1");
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> commit_context,
+                               commit_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> file_store_commit,
+                               FileStoreCommit::Create(std::move(commit_context)));
+        return file_store_commit->Commit(commit_msgs);
+    }
+
+    Status WriteAndCommit(const std::vector<PkBlobRow>& rows, int64_t commit_identifier,
+                          const std::vector<RecordBatch::RowKind>& row_kinds = {}) {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<CommitMessage>> commit_msgs,
+                               WriteArray(MakeArray(rows), commit_identifier, row_kinds));
+        return Commit(commit_msgs);
+    }
+
+    Status FullCompactAndCommit(int64_t commit_identifier) {
+        WriteContextBuilder write_builder(TablePath(), "commit_user_1");
+        write_builder.WithStreamingMode(true).WithTempDirectory(
+            PathUtil::JoinPath(dir_->Str(), "tmp"));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<WriteContext> write_context, write_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreWrite> file_store_write,
+                               FileStoreWrite::Create(std::move(write_context)));
+        PAIMON_RETURN_NOT_OK(file_store_write->Compact(/*partition=*/{}, /*bucket=*/0,
+                                                       /*full_compaction=*/true));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<std::shared_ptr<CommitMessage>> commit_messages,
+            file_store_write->PrepareCommit(/*wait_compaction=*/true, commit_identifier));
+        PAIMON_RETURN_NOT_OK(file_store_write->Close());
+        return Commit(commit_messages);
+    }
+
+    /// Reads every row through the public read path (rows come back in key order within the
+    /// single bucket). With `blob_as_descriptor` the managed blob column holds the serialized
+    /// descriptors instead of the payload bytes.
+    void ReadRows(bool blob_as_descriptor, std::vector<PkBlobRow>* rows) {
+        rows->clear();
+        std::map<std::string, std::string> options = {{Options::FILE_SYSTEM, "local"}};
+        if (blob_as_descriptor) {
+            options.emplace(Options::BLOB_AS_DESCRIPTOR, "true");
+        }
+        ScanContextBuilder scan_context_builder(TablePath());
+        scan_context_builder.WithStreamingMode(false).SetOptions(options).AddOption(
+            Options::SCAN_MODE, StartupMode::LatestFull().ToString());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<ScanContext> scan_context,
+                             scan_context_builder.Finish());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableScan> table_scan,
+                             TableScan::Create(std::move(scan_context)));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> result_plan, table_scan->CreatePlan());
+
+        ReadContextBuilder read_context_builder(TablePath());
+        read_context_builder.SetOptions(options);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<ReadContext> read_context,
+                             read_context_builder.Finish());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableRead> table_read,
+                             TableRead::Create(std::move(read_context)));
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<BatchReader> batch_reader,
+                             table_read->CreateReader(result_plan->Splits()));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::ChunkedArray> result,
+                             ReadResultCollector::CollectResult(batch_reader.get()));
+        // The collector reports an empty read (no batches at all) as a null chunked array.
+        if (result == nullptr) {
+            return;
+        }
+        // Copy the cell values out while the reader that owns the buffers is still alive.
+        for (const std::shared_ptr<arrow::Array>& chunk : result->chunks()) {
+            auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(chunk);
+            ASSERT_TRUE(struct_array != nullptr);
+            auto pk_array =
+                std::dynamic_pointer_cast<arrow::StringArray>(struct_array->GetFieldByName("pk"));
+            auto v_array =
+                std::dynamic_pointer_cast<arrow::Int32Array>(struct_array->GetFieldByName("v"));
+            auto b_array = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(
+                struct_array->GetFieldByName("b"));
+            ASSERT_TRUE(pk_array != nullptr);
+            ASSERT_TRUE(v_array != nullptr);
+            ASSERT_TRUE(b_array != nullptr);
+            for (int64_t row = 0; row < struct_array->length(); row++) {
+                std::optional<int32_t> v;
+                if (!v_array->IsNull(row)) {
+                    v = v_array->Value(row);
+                }
+                std::optional<std::string> blob;
+                if (!b_array->IsNull(row)) {
+                    blob = std::string(b_array->GetView(row));
+                }
+                rows->emplace_back(std::string(pk_array->GetView(row)), v, std::move(blob));
+            }
+        }
+    }
+
+    /// The live data files of the single bucket, from a fresh scan.
+    void CollectDataFiles(std::vector<std::shared_ptr<DataFileMeta>>* files) {
+        files->clear();
+        std::map<std::string, std::string> options = {{Options::FILE_SYSTEM, "local"}};
+        ScanContextBuilder scan_context_builder(TablePath());
+        scan_context_builder.WithStreamingMode(false).SetOptions(options).AddOption(
+            Options::SCAN_MODE, StartupMode::LatestFull().ToString());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<ScanContext> scan_context,
+                             scan_context_builder.Finish());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableScan> table_scan,
+                             TableScan::Create(std::move(scan_context)));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> result_plan, table_scan->CreatePlan());
+        for (const auto& split : result_plan->Splits()) {
+            auto split_impl = dynamic_cast<DataSplitImpl*>(split.get());
+            ASSERT_TRUE(split_impl != nullptr);
+            files->insert(files->end(), split_impl->DataFiles().begin(),
+                          split_impl->DataFiles().end());
+        }
+    }
+
+    /// Reads the `.blobref` sidecar carried in `file`'s extra files.
+    void ReadSidecar(const std::shared_ptr<DataFileMeta>& file,
+                     std::vector<ManagedBlobReferenceFile::Reference>* references) {
+        references->clear();
+        ASSERT_EQ(file->extra_files.size(), 1);
+        ASSERT_TRUE(file->extra_files[0].has_value());
+        const std::string& sidecar_name = file->extra_files[0].value();
+        ASSERT_TRUE(
+            StringUtils::EndsWith(sidecar_name, ManagedBlobReferenceFile::kReferenceFileSuffix));
+        ASSERT_EQ(sidecar_name, file->file_name + ManagedBlobReferenceFile::kReferenceFileSuffix);
+        ASSERT_OK_AND_ASSIGN(*references, ManagedBlobReferenceFile::Read(
+                                              dir_->GetFileSystem(),
+                                              PathUtil::JoinPath(BucketPath(), sidecar_name)));
+    }
+
+    /// Asserts the bucket holds a single data file whose sidecar references exactly
+    /// `expected_packs`. Reads deduplicate, so the set is the full reference list.
+    void AssertSingleFileSidecar(const std::set<std::string>& expected_packs) {
+        std::vector<std::shared_ptr<DataFileMeta>> files;
+        CollectDataFiles(&files);
+        ASSERT_EQ(files.size(), 1);
+        std::vector<ManagedBlobReferenceFile::Reference> references;
+        ReadSidecar(files[0], &references);
+        std::set<std::string> referenced;
+        for (const auto& reference : references) {
+            referenced.insert(reference.ToString());
+        }
+        ASSERT_EQ(referenced, expected_packs);
+    }
+
+    bool FileExists(const std::string& path) {
+        return dir_->GetFileSystem()->GetFileStatus(path).ok();
+    }
+
+    /// Resolves serialized descriptor bytes to (payload, pack uri).
+    Result<std::string> ResolveDescriptor(const std::string& descriptor_bytes, std::string* uri) {
+        PAIMON_ASSIGN_OR_RAISE(
+            bool is_descriptor,
+            BlobDescriptor::IsBlobDescriptor(descriptor_bytes.data(), descriptor_bytes.size()));
+        if (!is_descriptor) {
+            return Status::Invalid("value is not a serialized blob descriptor");
+        }
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<Blob> blob,
+            Blob::FromDescriptor(descriptor_bytes.data(), descriptor_bytes.size()));
+        *uri = blob->Uri();
+        PAIMON_ASSIGN_OR_RAISE(PAIMON_UNIQUE_PTR<Bytes> payload,
+                               blob->ToData(dir_->GetFileSystem(), pool_));
+        return std::string(payload->data(), payload->size());
+    }
+
+ protected:
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<UniqueTestDirectory> dir_;
+    arrow::FieldVector fields_;
+};
+
+TEST_P(PkBlobTableInteTest, TestWriteAndReadManagedBlob) {
+    CreateTable({});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("payload-1")}, {"k2", 2, std::nullopt}},
+                             /*commit_identifier=*/0));
+
+    // The default read resolves the managed blob descriptors back to payload bytes.
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 1, std::string("payload-1")},
+                                       {"k2", 2, std::nullopt}};
+    ASSERT_EQ(rows, expected);
+
+    // With blob-as-descriptor the column holds serialized descriptors that resolve to the
+    // same payload through a ranged read of the pack.
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 2);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    std::string pack_uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload,
+                         ResolveDescriptor(std::get<2>(rows[0]).value(), &pack_uri));
+    ASSERT_EQ(payload, "payload-1");
+    ASSERT_TRUE(StringUtils::EndsWith(PathUtil::GetName(pack_uri),
+                                      ManagedBlobReferenceFile::kManagedBlobSuffix));
+    ASSERT_TRUE(FileExists(pack_uri));
+    ASSERT_FALSE(std::get<2>(rows[1]).has_value());
+
+    // The single data file carries a sidecar listing exactly the referenced pack.
+    AssertSingleFileSidecar({pack_uri});
+}
+
+TEST_P(PkBlobTableInteTest, TestCompactionRebuildsExactBlobReferences) {
+    // A one-byte blob target size seals a pack per value, so the reference sets of the
+    // surviving and the overwritten payloads are distinguishable.
+    CreateTable({{Options::BLOB_TARGET_FILE_SIZE, "1"}});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("v1-old")}}, /*commit_identifier=*/0));
+    ASSERT_OK(WriteAndCommit({{"k1", 2, std::string("v1-new")}, {"k2", 3, std::string("k2-val")}},
+                             /*commit_identifier=*/1));
+
+    // The merged pre-compaction descriptors: the newest version wins.
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 2);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    ASSERT_TRUE(std::get<2>(rows[1]).has_value());
+    std::string k1_descriptor_before = std::get<2>(rows[0]).value();
+
+    ASSERT_OK(FullCompactAndCommit(/*commit_identifier=*/2));
+
+    // The compacted file rewrites descriptors verbatim: same descriptor bytes, same pack.
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 2);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    ASSERT_EQ(std::get<2>(rows[0]).value(), k1_descriptor_before);
+    std::string k1_uri;
+    std::string k2_uri;
+    ASSERT_OK_AND_ASSIGN(std::string k1_payload,
+                         ResolveDescriptor(std::get<2>(rows[0]).value(), &k1_uri));
+    ASSERT_OK_AND_ASSIGN(std::string k2_payload,
+                         ResolveDescriptor(std::get<2>(rows[1]).value(), &k2_uri));
+    ASSERT_EQ(k1_payload, "v1-new");
+    ASSERT_EQ(k2_payload, "k2-val");
+
+    // The rebuilt sidecar lists exactly the packs of the surviving rows; the overwritten
+    // payload's pack is no longer referenced.
+    AssertSingleFileSidecar({k1_uri, k2_uri});
+
+    // The full read still resolves the payloads.
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 2, std::string("v1-new")},
+                                       {"k2", 3, std::string("k2-val")}};
+    ASSERT_EQ(rows, expected);
+}
+
+TEST_P(PkBlobTableInteTest, TestFirstRowManagedBlobKeepsFirstValue) {
+    CreateTable({{Options::MERGE_ENGINE, "first-row"}, {Options::BLOB_TARGET_FILE_SIZE, "1"}});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("first")}}, /*commit_identifier=*/0));
+    ASSERT_OK(WriteAndCommit({{"k1", 2, std::string("second")}}, /*commit_identifier=*/1));
+
+    // Batch reads of a first-row table only see compacted (level > 0) files, so the
+    // write-only level-0 commits are not visible yet.
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    ASSERT_TRUE(rows.empty());
+
+    ASSERT_OK(FullCompactAndCommit(/*commit_identifier=*/2));
+
+    // first-row keeps the first payload; the later write only produced an unused pack.
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 1, std::string("first")}};
+    ASSERT_EQ(rows, expected);
+
+    // After compaction the sidecar holds exactly the first payload's pack: the reference to
+    // the losing write's pack is gone.
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 1);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    std::string first_uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload,
+                         ResolveDescriptor(std::get<2>(rows[0]).value(), &first_uri));
+    ASSERT_EQ(payload, "first");
+    AssertSingleFileSidecar({first_uri});
+}
+
+TEST_P(PkBlobTableInteTest, TestPartialUpdateManagedBlob) {
+    CreateTable({{Options::MERGE_ENGINE, "partial-update"}});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("payload")}}, /*commit_identifier=*/0));
+    // Partial update: a NULL cell leaves the previous value in place, so the merged row keeps
+    // the descriptor externalized by the first write. The second write produces no pack.
+    ASSERT_OK(WriteAndCommit({{"k1", 2, std::nullopt}}, /*commit_identifier=*/1));
+
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 2, std::string("payload")}};
+    ASSERT_EQ(rows, expected);
+
+    ASSERT_OK(FullCompactAndCommit(/*commit_identifier=*/2));
+
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    ASSERT_EQ(rows, expected);
+
+    // The compacted file's sidecar lists exactly the surviving payload's pack.
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 1);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    std::string pack_uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload,
+                         ResolveDescriptor(std::get<2>(rows[0]).value(), &pack_uri));
+    ASSERT_EQ(payload, "payload");
+    AssertSingleFileSidecar({pack_uri});
+}
+
+TEST_P(PkBlobTableInteTest, TestSnapshotExpirationRemovesSidecar) {
+    CreateTable({});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("one")}}, /*commit_identifier=*/0));
+    ASSERT_OK(WriteAndCommit({{"k2", 2, std::string("two")}}, /*commit_identifier=*/1));
+
+    std::vector<std::shared_ptr<DataFileMeta>> files;
+    CollectDataFiles(&files);
+    ASSERT_EQ(files.size(), 2);
+    std::vector<std::string> old_data_paths;
+    std::vector<std::string> old_sidecar_paths;
+    std::set<std::string> pack_paths;
+    for (const auto& file : files) {
+        old_data_paths.push_back(PathUtil::JoinPath(BucketPath(), file->file_name));
+        std::vector<ManagedBlobReferenceFile::Reference> references;
+        ReadSidecar(file, &references);
+        // ReadSidecar's assertions only return from the helper, so stop here rather than
+        // dereference the extra file it just failed to validate.
+        ASSERT_FALSE(HasFatalFailure());
+        old_sidecar_paths.push_back(PathUtil::JoinPath(BucketPath(), file->extra_files[0].value()));
+        for (const auto& reference : references) {
+            pack_paths.insert(reference.ToString());
+        }
+    }
+    ASSERT_EQ(pack_paths.size(), 2);
+
+    // Rewrite both files into one; snapshot 3 marks the two originals as deleted.
+    ASSERT_OK(FullCompactAndCommit(/*commit_identifier=*/2));
+
+    CommitContextBuilder commit_builder(TablePath(), "commit_user_1");
+    commit_builder.SetOptions({{Options::FILE_SYSTEM, "local"},
+                               {Options::SNAPSHOT_NUM_RETAINED_MAX, "1"},
+                               {Options::SNAPSHOT_NUM_RETAINED_MIN, "1"}});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<CommitContext> commit_context, commit_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreCommit> file_store_commit,
+                         FileStoreCommit::Create(std::move(commit_context)));
+    ASSERT_OK_AND_ASSIGN(int32_t expired_snapshots, file_store_commit->Expire());
+    ASSERT_EQ(expired_snapshots, 2);
+
+    // The expired data files took their `.blobref` sidecars with them, while the shared packs
+    // are only referenced and never deleted by snapshot expiration: the compacted file still
+    // resolves its payloads from them.
+    for (const auto& path : old_data_paths) {
+        EXPECT_FALSE(FileExists(path));
+    }
+    for (const auto& path : old_sidecar_paths) {
+        EXPECT_FALSE(FileExists(path));
+    }
+    for (const auto& path : pack_paths) {
+        EXPECT_TRUE(FileExists(path));
+    }
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 1, std::string("one")},
+                                       {"k2", 2, std::string("two")}};
+    ASSERT_EQ(rows, expected);
+}
+
+TEST_P(PkBlobTableInteTest, TestDeleteDropsRow) {
+    CreateTable({});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("payload")}}, /*commit_identifier=*/0));
+
+    // A retract row never keeps a payload; the delete removes the key entirely on read.
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::nullopt}}, /*commit_identifier=*/1,
+                             {RecordBatch::RowKind::DELETE}));
+
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    ASSERT_TRUE(rows.empty());
+}
+
+std::vector<std::string> GetTestValuesForPkBlobTableInteTest() {
+    std::vector<std::string> values;
+    values.emplace_back("parquet");
+#ifdef PAIMON_ENABLE_ORC
+    values.emplace_back("orc");
+#endif
+    return values;
+}
+
+INSTANTIATE_TEST_SUITE_P(FileFormat, PkBlobTableInteTest,
+                         ::testing::ValuesIn(GetTestValuesForPkBlobTableInteTest()));
+
+}  // namespace paimon::test


### PR DESCRIPTION
### Purpose

Linked issue: close #204

Primary-key tables gain table-managed BLOB storage, and data-evolution tables gain normal-file compaction across evolved field groups — the two Java capabilities behind the roadmap item "Extend Data Evolution to primary-key tables and support compaction across evolved field groups" (#186).

The first half of that wording has no direct Java counterpart, which is worth stating up front: Java forbids row tracking, and with it data evolution, on a table that has primary keys (`SchemaValidation#validateRowTracking`). The capability the roadmap item names for primary-key tables is managed BLOB storage, so that is what is ported here.

1. **Managed BLOBs in primary-key tables** ([apache/paimon#8617](https://github.com/apache/paimon/pull/8617), [apache/paimon#9201](https://github.com/apache/paimon/pull/9201)). `PrimaryKeyBlobExternalizer` copies blob payloads into rolling `.managed.blob` packs before rows enter the merge-tree write buffer (sealed by `blob.target-file-size`, copied through the new `blob.copy-buffer-size` buffer), so data files and spills only hold small descriptors. Every data file carries a `.blobref` reference sidecar — byte-compatible with Java's `ManagedBlobReferenceFile` — in its extra files, written by `ManagedBlobReferenceCollector` and removed together with the data file everywhere companion files are collected (writer abort, uncommitted cleanup, snapshot expiration); a `.blobref` sidecar is itself cleanable while a live one is protected through its data file's extra files, and a `.managed.blob` pack is never deleted by table maintenance because several data files may reference one. Reads resolve descriptors back to payload bytes after merging via `ManagedBlobResolvingBatchReader` (`blob-as-descriptor` returns the raw descriptors). Schema validation enforces the `deduplicate`/`partial-update`/`first-row` merge engines, the managed-blob key/ordering/sequence-group rules, and rejects the unported capabilities (`data-file.external-paths`, `pk-clustering-override=true`, `blob-descriptor.source-table`). Postpone-bucket writers externalize the same way.

2. **Normal-file compaction across data-evolution field groups** ([apache/paimon#6828](https://github.com/apache/paimon/pull/6828), planning rules of [apache/paimon#9177](https://github.com/apache/paimon/pull/9177)). `DataEvolutionCompactCoordinator` groups files by exact row-id range into evolved field groups and packs contiguous runs into bins by `sum(max(file_size, source.split.open-file-cost))`; a bin becomes a task once its weight strictly exceeds `target-file-size`, a heavier-than-target group is compacted alone, a row-id gap cuts the bin, and `compaction.min.file-num` gates every task. `DataEvolutionNormalCompactTask` rewrites one run into exactly one file, preserving row ids and the merged `[min, max]` sequence-number range. `AppendCompactCoordinator::Run` routes data-evolution tables to this planner (scanning every live file instead of only small ones), rejects overrides of immutable options (row tracking, data evolution, deletion vectors, bucket, blob layout), keeps rejecting deletion-vector tables, and fails the removed legacy `data-evolution.compaction.rewrite-row-ids=true` mode like Java.

Design notes for review:

- The blob file format lives in the `paimon_blob_file_format` plugin library, so the managed pack writer obtains its `FormatWriter` through `FileFormatFactory::Get("blob", ...)` like every other core write path, and reads the last record's payload range through an inline accessor (`BlobFormatWriter::LastPayloadRange`, mirroring Java's descriptor callback) — core never references the plugin's out-of-line symbols.
- Descriptors are rewritten verbatim by compaction; the `.blobref` sidecar of a compacted file is rebuilt from the surviving rows, so it lists exactly the packs still referenced.
- A stale data-evolution compact message that races a concurrent commit follows Java: an append outside the rewritten range and an aligned partial update commit fine, while a partial update aligned with the old field-group boundary makes the compact-kind commit fail the row-range alignment check.

Known scope cuts against current Java are documented in the user guides and in #204: `ARRAY<BLOB>`/`MAP<K, BLOB>` fields, `blob-descriptor.source-table` re-materialization, deletion-vector rewrite/materialization, the projected-manifest candidate planning with ~100k-file batches and multi-round commits, dedicated blob pack compaction, and vector-store planning (tables holding vector-store files are rejected, where Java compacts their normal files).

Two behaviours differ from Java without being cuts, both documented in the compaction guide: the planning scan drops manifest statistics only when `manifest.delete-file-drop-stats` asks for it, while Java always drops them for that scan (identical plans, larger DELETE entries), and `blob-compaction.enabled` has no effect here whatever it is set to.

### Tests

Unit tests:

- `managed_blob_reference_file_test.cpp`: round trip with sort/dedup, Java golden-bytes interop (externally computed CRC32), and every rejection path of the reader — bad magic, unsupported version, negative and oversized count, checksum mismatch, trailing bytes, malformed low surrogate — plus descriptor-URI parsing and reference path validation.
- `managed_blob_reference_collector_test.cpp`: reference collection, collection restricted to the declared managed columns (an inline column pointing at a `.managed.blob` path is still skipped), non-descriptor values ignored, empty sidecar, abort, unknown field, and the closed-collector contracts (`Collect` after `Close`, `ResultFileName` before it).
- `primary_key_blob_externalizer_test.cpp`: descriptor replacement, one pack writer per managed column (two blob columns never share a pack), retract drops payload and a retract-only batch opens no pack at all, pack handover on `PrepareCommit`, rolling by target size, inline fields untouched, descriptor re-materialization, input validation (non-positive target size, row-kind/row-count mismatch), explicit close-on-seal-failure assertion via a close-tracking stream, `TestIOException` fault-injection sweep.
- `managed_blob_resolving_batch_reader_test.cpp`: descriptor resolution with nulls, non-descriptor rejection, pass-through.
- `data_evolution_compact_coordinator_test.cpp`: bin packing (target size boundary, open-file-cost weighting of tiny files, row-id gaps, heavy groups, min-file-num, per-partition planning) with the rewritten row ranges asserted, blob-file exclusion, vector-store rejection, mismatched-range rejection, and planner vs `Task::Create` input validation each asserting its own rejection reason.
- `schema_validation_test.cpp`: primary-key managed BLOB rules (merge engines, blob target size, primary/bucket-key/sequence-field/external-paths rejections incl. empty string, changelog producer, sequence groups and aggregate functions incl. the `ignore-delete` exemption, `pk-clustering-override` true/false, `blob-descriptor.source-table`), and a table whose blob columns are all inline, which none of the managed rules may constrain.
- `merge_tree_writer_test.cpp` / `postpone_bucket_writer_test.cpp`: sidecar lifecycle for committed and aborted flows, a shredded map column coexisting with a managed blob column (the collector reads the logical batch, the shredding conversion rewrites it afterwards), managed-blob `TestManagedBlobIOException` sweep.
- `orphan_files_cleaner_test.cpp`: a `.blobref` sidecar is classified as cleanable while a `.managed.blob` pack never is.
- `core_options_test.cpp`, `blob_format_writer_test.cpp`, `blob_writer_builder_test.cpp`, `file_store_commit_impl_test.cpp`: `blob.copy-buffer-size` parsing/bounds/pass-through/tiny-buffer chunked copy, `pk-clustering-override` commit semantics.

Integration tests:

- `pk_blob_table_inte_test.cpp` (new): write/read with payload and descriptor modes, compaction rebuilding exact blob references, first-row and partial-update merge engines, delete, snapshot expiration removing sidecars while shared packs survive.
- `data_evolution_table_test.cpp`: compaction across evolved field groups (single and multi-partition, partition filter), rejection paths (DV tables and DV override, immutable-option overrides, legacy rewrite-row-ids), compaction across real schema evolution (INT→BIGINT type change, added column with cross-schema partial fill, dropped column), the three Java concurrency scenarios (stale compact message preserving a concurrent partial update, small-file compact conflicting with a concurrent partial update, concurrent append kept for the next merge round).
- `blob_table_inte_test.cpp`: data-evolution compaction leaves dedicated `.blob` files in place and payloads readable.

### API and Format

- New public options in `include/paimon/defs.h`: `blob.copy-buffer-size` (default `4 kb`, Java-aligned; the previous fixed copy buffer was 1 MB), `pk-clustering-override` (only `true` is rejected now; an explicit `false` is accepted by the commit path), `blob-descriptor.source-table` (rejected for primary-key managed BLOB tables), `data-evolution.compaction.rewrite-row-ids` (rejected when `true`).
- `AppendCompactCoordinator::Run` (public API) now plans data-evolution tables across evolved field groups and rejects immutable-option overrides.
- Storage format: introduces the `.blobref` sidecar (byte-compatible with Java, locked by a golden-bytes test) carried in `DataFileMeta.extra_files`, and `.managed.blob` pack files in the blob file format. No existing format is changed.

### Documentation

- `docs/source/user_guide/primary_key_table.rst`: new "Managed BLOB Storage" section (behavior, restrictions, lifecycle, unsupported capabilities).
- `docs/source/user_guide/compaction.rst`: new "Data-Evolution Table Compaction" section (planning rules, row-id preservation, scope cuts against Java).
- `docs/source/user_guide/read.rst`: deletion-vector compaction note updated.

### Generative AI tooling

Generated-by: Claude Code (Claude Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


