### PR TITLE
feat(realtime): improve append table lifecycle and query support

### DIFF
--- a/include/paimon/api.h
+++ b/include/paimon/api.h
@@ -33,6 +33,7 @@
 #include "paimon/record_batch.h"             // IWYU pragma: export
 #include "paimon/result.h"                   // IWYU pragma: export
 #include "paimon/scan_context.h"             // IWYU pragma: export
+#include "paimon/statistics_mode.h"          // IWYU pragma: export
 #include "paimon/status.h"                   // IWYU pragma: export
 #include "paimon/table/source/table_read.h"  // IWYU pragma: export
 #include "paimon/table/source/table_scan.h"  // IWYU pragma: export

--- a/include/paimon/defs.h
+++ b/include/paimon/defs.h
@@ -544,6 +544,10 @@ struct PAIMON_EXPORT Options {
     /// before reader creation. Default value is "5 min".
     static const char REALTIME_READ_VIEW_TTL[];
 
+    /// "realtime.store.stats-mode" - Statistics collected by the default real-time store.
+    /// Supported values are "none" and "full". Default value is "none".
+    static const char REALTIME_STORE_STATS_MODE[];
+
     /// "scan.timestamp" - Optional timestamp string used in case of "from-timestamp" scan mode,
     /// as an alternative to "scan.timestamp-millis".
     /// It will be automatically converted to timestamp in unix milliseconds, using local time zone.

--- a/include/paimon/defs.h
+++ b/include/paimon/defs.h
@@ -540,6 +540,10 @@ struct PAIMON_EXPORT Options {
     /// "scan.timestamp" can be used as an alternative string input for the same mode.
     static const char SCAN_TIMESTAMP_MILLIS[];
 
+    /// "realtime.enabled" - Whether real-time write, commit, and read operations are enabled.
+    /// Default value is "false".
+    static const char REALTIME_ENABLED[];
+
     /// "realtime.read-view-ttl" - Lifetime of a real-time memory view pinned by scan planning
     /// before reader creation. Default value is "5 min".
     static const char REALTIME_READ_VIEW_TTL[];

--- a/include/paimon/file_store_commit.h
+++ b/include/paimon/file_store_commit.h
@@ -80,15 +80,16 @@ class PAIMON_EXPORT FileStoreCommit {
     /// snapshot atomically publishes the data files and the updated offset map.
     ///
     /// If this method returns an error, the caller may retry with the same arguments. Each call
-    /// reloads the latest committed state. A retry is treated as committed only when both its
-    /// commit identity (`commit_user`, `commit_identifier`) and its requested offset ranges
-    /// identify committed progress.
+    /// reloads the latest committed state. As in `FilterAndCommit`, a retry's identifier is
+    /// considered committed when it is not newer than the latest identifier for `commit_user`.
+    /// The requested offset ranges must also be covered by the latest committed progress.
     ///
     /// @param realtime_commits Commit messages and left-closed, right-open offset ranges to
     /// commit.
     /// @param commit_identifier Identifier of the streaming commit operation.
     /// @param watermark Optional event-time watermark.
-    /// @return The id of the final snapshot produced by this commit.
+    /// @return The id of the latest snapshot containing the committed progress. On retry, this may
+    /// be a snapshot produced by a later commit and is suitable for refreshing a real-time context.
     virtual Result<int64_t> CommitWithProgress(
         const std::vector<RealtimeCommitProgress>& realtime_commits, int64_t commit_identifier,
         std::optional<int64_t> watermark) = 0;

--- a/include/paimon/file_store_commit.h
+++ b/include/paimon/file_store_commit.h
@@ -79,6 +79,10 @@ class PAIMON_EXPORT FileStoreCommit {
     /// orders them by partition, bucket, and offset before validating continuity. The resulting
     /// snapshot atomically publishes the data files and the updated offset map.
     ///
+    /// If this method returns an error, the caller may retry with the same arguments. Each call
+    /// reloads the latest committed progress and treats ranges already covered by a committed
+    /// snapshot as successfully committed.
+    ///
     /// @param realtime_commits Commit messages and left-closed, right-open offset ranges to
     /// commit.
     /// @param commit_identifier Identifier of the streaming commit operation.

--- a/include/paimon/file_store_commit.h
+++ b/include/paimon/file_store_commit.h
@@ -122,6 +122,10 @@ class PAIMON_EXPORT FileStoreCommit {
     /// @param watermark An optional event-time watermark used to indicate the progress of data
     ///     processing. Default is std::nullopt.
     /// @return Result of the operation.
+    /// @note A full-table overwrite clears all committed real-time progress. A partition
+    ///     overwrite removes progress only for matching partitions. In either case, active
+    ///     real-time writers and their `RealtimeContext` instances must be recreated before
+    ///     further real-time operations.
     virtual Status Overwrite(const std::map<std::string, std::string>& partition,
                              const std::vector<std::shared_ptr<CommitMessage>>& commit_messages,
                              int64_t commit_identifier,
@@ -136,6 +140,10 @@ class PAIMON_EXPORT FileStoreCommit {
     /// @param watermark An optional event-time watermark used to indicate the progress of data
     ///     processing. Default is std::nullopt.
     /// @return Result of the operation.
+    /// @note A full-table overwrite clears all committed real-time progress. A partition
+    ///     overwrite removes progress only for matching partitions. In either case, active
+    ///     real-time writers and their `RealtimeContext` instances must be recreated before
+    ///     further real-time operations.
     virtual Result<int32_t> FilterAndOverwrite(
         const std::map<std::string, std::string>& partition,
         const std::vector<std::shared_ptr<CommitMessage>>& commit_messages,
@@ -162,6 +170,9 @@ class PAIMON_EXPORT FileStoreCommit {
     /// @param partitions A vector of partitions to be dropped.
     /// @param commit_identifier An identifier for the commit operation.
     /// @return Status indicating the success or failure of the drop partition operation.
+    /// @note A partition drop removes committed real-time progress only for matching partitions.
+    ///     Active real-time writers and their `RealtimeContext` instances must be recreated before
+    ///     further real-time operations.
     virtual Status DropPartition(const std::vector<std::map<std::string, std::string>>& partitions,
                                  int64_t commit_identifier) = 0;
 
@@ -170,6 +181,9 @@ class PAIMON_EXPORT FileStoreCommit {
     ///
     /// @param commit_identifier An identifier for the commit operation.
     /// @return Status indicating the success or failure of the truncate operation.
+    /// @note Truncation clears all committed real-time progress. Active real-time writers and
+    ///     their `RealtimeContext` instances must be recreated before further real-time
+    ///     operations.
     virtual Status TruncateTable(int64_t commit_identifier) = 0;
 
     /// Abort an unsuccessful commit. The data and index files described by the given commit
@@ -187,6 +201,9 @@ class PAIMON_EXPORT FileStoreCommit {
     /// @param target_snapshot_id The snapshot id to roll back to.
     /// @return Result<bool>; true if the atomic commit succeeded. Returns an error status if
     ///     there is no latest snapshot or the target snapshot does not exist.
+    /// @note Rollback restores the real-time progress recorded by the target snapshot. Active
+    ///     real-time writers and their `RealtimeContext` instances must be recreated before
+    ///     further real-time operations.
     virtual Result<bool> RollbackToAsLatest(int64_t target_snapshot_id) = 0;
 
     /// Configure row-id conflict checking from a specific snapshot id.

--- a/include/paimon/file_store_commit.h
+++ b/include/paimon/file_store_commit.h
@@ -80,8 +80,9 @@ class PAIMON_EXPORT FileStoreCommit {
     /// snapshot atomically publishes the data files and the updated offset map.
     ///
     /// If this method returns an error, the caller may retry with the same arguments. Each call
-    /// reloads the latest committed progress and treats ranges already covered by a committed
-    /// snapshot as successfully committed.
+    /// reloads the latest committed state. A retry is treated as committed only when both its
+    /// commit identity (`commit_user`, `commit_identifier`) and its requested offset ranges
+    /// identify committed progress.
     ///
     /// @param realtime_commits Commit messages and left-closed, right-open offset ranges to
     /// commit.

--- a/include/paimon/file_store_write.h
+++ b/include/paimon/file_store_write.h
@@ -107,6 +107,8 @@ class PAIMON_EXPORT FileStoreWrite {
     ///
     /// The writer loads the snapshot's partition-bucket offsets and releases sealed memory that is
     /// fully covered by disk. Calling this method on a non-real-time writer returns an error.
+    /// If the snapshot moves committed progress backwards, such as after a rollback, this method
+    /// returns an error and the caller must recreate the `RealtimeContext` and writer.
     virtual Status RefreshCommittedSnapshot(int64_t snapshot_id);
 
     virtual std::shared_ptr<Metrics> GetMetrics() const = 0;

--- a/include/paimon/file_store_write.h
+++ b/include/paimon/file_store_write.h
@@ -107,8 +107,12 @@ class PAIMON_EXPORT FileStoreWrite {
     ///
     /// The writer loads the snapshot's partition-bucket offsets and releases sealed memory that is
     /// fully covered by disk. Calling this method on a non-real-time writer returns an error.
-    /// If the snapshot moves committed progress backwards, such as after a rollback, this method
-    /// returns an error and the caller must recreate the `RealtimeContext` and writer.
+    /// If the snapshot overwrites table contents or moves committed progress backwards, such as
+    /// after a partition drop, overwrite, or rollback, this method returns an error and the caller
+    /// must recreate the `RealtimeContext` and writer. These operations are not fenced against an
+    /// active writer and do not clear its process-local state automatically. The caller must
+    /// coordinate them with active writers; skipping the resetting snapshot and continuing to use
+    /// an old context is unsupported.
     virtual Status RefreshCommittedSnapshot(int64_t snapshot_id);
 
     virtual std::shared_ptr<Metrics> GetMetrics() const = 0;

--- a/include/paimon/realtime/arrow_realtime_store_factory.h
+++ b/include/paimon/realtime/arrow_realtime_store_factory.h
@@ -28,7 +28,7 @@ class PAIMON_EXPORT ArrowRealtimeStoreFactory : public RealtimeStoreFactory {
  public:
     /// Creates an Arrow-backed store for one partition and bucket.
     Result<std::shared_ptr<RealtimeStore>> Create(
-        std::unique_ptr<::ArrowSchema> write_schema,
+        std::unique_ptr<::ArrowSchema> write_schema, StatisticsMode statistics_mode,
         const std::map<std::string, std::string>& options,
         const std::shared_ptr<MemoryPool>& memory_pool) override;
 };

--- a/include/paimon/realtime/realtime_context.h
+++ b/include/paimon/realtime/realtime_context.h
@@ -73,6 +73,11 @@ using RealtimeOffsetMap = std::map<RealtimePartitionBucket, int64_t>;
 /// reads. `RealtimeContext` itself is not a customization interface and must not be implemented by
 /// applications. Customize real-time storage and retrieval through `RealtimeStoreFactory` and
 /// `RealtimeStore` instead.
+///
+/// A context is valid only for one uninterrupted committed-progress history. Overwrite, truncate,
+/// partition drop, and rollback operations do not automatically clear process-local real-time
+/// state. Applications must coordinate these operations with active real-time writers and recreate
+/// the `RealtimeContext` and writers before continuing.
 class PAIMON_EXPORT RealtimeContext {
  public:
     /// Creates a context backed by Paimon's default in-memory Arrow `RealtimeStore`.

--- a/include/paimon/realtime/realtime_store.h
+++ b/include/paimon/realtime/realtime_store.h
@@ -31,6 +31,7 @@
 #include "paimon/realtime/offset_range.h"
 #include "paimon/record_batch.h"
 #include "paimon/result.h"
+#include "paimon/statistics_mode.h"
 #include "paimon/visibility.h"
 
 struct ArrowSchema;
@@ -39,14 +40,6 @@ namespace paimon {
 
 class MemoryPool;
 class Predicate;
-
-/// Statistics collected by a `RealtimeStore` for query predicate pushdown.
-enum class StatisticsMode {
-    /// Do not collect statistics.
-    NONE,
-    /// Collect statistics for all supported fields.
-    FULL,
-};
 
 /// A table record batch and its framework-assigned contiguous offset range.
 ///

--- a/include/paimon/realtime/realtime_store.h
+++ b/include/paimon/realtime/realtime_store.h
@@ -40,6 +40,14 @@ namespace paimon {
 class MemoryPool;
 class Predicate;
 
+/// Statistics collected by a `RealtimeStore` for query predicate pushdown.
+enum class StatisticsMode {
+    /// Do not collect statistics.
+    NONE,
+    /// Collect statistics for all supported fields.
+    FULL,
+};
+
 /// A table record batch and its framework-assigned contiguous offset range.
 ///
 /// The batch contains only table write fields. Row `i` is associated with
@@ -156,13 +164,14 @@ class PAIMON_EXPORT RealtimeStoreFactory {
  public:
     virtual ~RealtimeStoreFactory() = default;
 
-    /// Creates a store configured with the supplied schema, options, and memory pool.
+    /// Creates a store configured with the supplied schema, statistics, options, and memory pool.
     /// @param write_schema Complete table write schema whose ownership is transferred to the
     /// factory. The factory may consume it or retain it in the created store.
+    /// @param statistics_mode Framework-parsed statistics collection mode.
     /// @param options Effective table options available to the store.
     /// @param memory_pool Memory pool provided by the write context.
     virtual Result<std::shared_ptr<RealtimeStore>> Create(
-        std::unique_ptr<::ArrowSchema> write_schema,
+        std::unique_ptr<::ArrowSchema> write_schema, StatisticsMode statistics_mode,
         const std::map<std::string, std::string>& options,
         const std::shared_ptr<MemoryPool>& memory_pool) = 0;
 };

--- a/include/paimon/scan_context.h
+++ b/include/paimon/scan_context.h
@@ -170,7 +170,7 @@ class PAIMON_EXPORT ScanContextBuilder {
     ScanContextBuilder& SetGlobalIndexResult(
         const std::shared_ptr<GlobalIndexResult>& global_index_result);
 
-    /// Enables process-local union reads with the memory indexers owned by `realtime_context`.
+    /// Enables process-local union reads with the real-time stores owned by `realtime_context`.
     ScanContextBuilder& WithRealtimeContext(
         const std::shared_ptr<RealtimeContext>& realtime_context);
 

--- a/include/paimon/statistics_mode.h
+++ b/include/paimon/statistics_mode.h
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+namespace paimon {
+
+/// Controls the amount of statistics collected for metadata pruning.
+enum class StatisticsMode {
+    /// Do not collect statistics.
+    NONE,
+    /// Collect statistics for all supported fields.
+    FULL,
+};
+
+}  // namespace paimon

--- a/include/paimon/write_context.h
+++ b/include/paimon/write_context.h
@@ -218,7 +218,7 @@ class PAIMON_EXPORT WriteContextBuilder {
     WriteContextBuilder& WithFileSystem(const std::shared_ptr<FileSystem>& file_system);
 
     /// Enables the real-time write path with the provided shared context.
-    /// @param realtime_context Non-null context that owns the real-time indexers.
+    /// @param realtime_context Non-null context that owns the real-time stores.
     /// @return Reference to this builder for method chaining.
     WriteContextBuilder& WithRealtimeContext(
         const std::shared_ptr<RealtimeContext>& realtime_context);

--- a/src/paimon/CMakeLists.txt
+++ b/src/paimon/CMakeLists.txt
@@ -882,6 +882,7 @@ if(PAIMON_BUILD_TESTS)
                     core/utils/file_utils_test.cpp
                     core/utils/manifest_meta_reader_test.cpp
                     core/utils/offset_row_test.cpp
+                    core/utils/partition_utils_test.cpp
                     core/utils/partition_path_utils_test.cpp
                     core/utils/snapshot_manager_test.cpp
                     core/utils/tag_manager_test.cpp

--- a/src/paimon/common/defs.cpp
+++ b/src/paimon/common/defs.cpp
@@ -144,6 +144,7 @@ const char Options::TABLE_READ_SEQUENCE_NUMBER_ENABLED[] = "table-read.sequence-
 const char Options::KEY_VALUE_SEQUENCE_NUMBER_ENABLED[] = "key-value.sequence_number.enabled";
 const char Options::SCAN_TIMESTAMP_MILLIS[] = "scan.timestamp-millis";
 const char Options::REALTIME_READ_VIEW_TTL[] = "realtime.read-view-ttl";
+const char Options::REALTIME_STORE_STATS_MODE[] = "realtime.store.stats-mode";
 const char Options::SCAN_TIMESTAMP[] = "scan.timestamp";
 const char Options::SCAN_TAG_NAME[] = "scan.tag-name";
 const char Options::WRITE_ONLY[] = "write-only";

--- a/src/paimon/common/defs.cpp
+++ b/src/paimon/common/defs.cpp
@@ -143,6 +143,7 @@ const char Options::AGGREGATION_REMOVE_RECORD_ON_DELETE[] = "aggregation.remove-
 const char Options::TABLE_READ_SEQUENCE_NUMBER_ENABLED[] = "table-read.sequence-number.enabled";
 const char Options::KEY_VALUE_SEQUENCE_NUMBER_ENABLED[] = "key-value.sequence_number.enabled";
 const char Options::SCAN_TIMESTAMP_MILLIS[] = "scan.timestamp-millis";
+const char Options::REALTIME_ENABLED[] = "realtime.enabled";
 const char Options::REALTIME_READ_VIEW_TTL[] = "realtime.read-view-ttl";
 const char Options::REALTIME_STORE_STATS_MODE[] = "realtime.store.stats-mode";
 const char Options::SCAN_TIMESTAMP[] = "scan.timestamp";

--- a/src/paimon/common/utils/binary_row_partition_computer.cpp
+++ b/src/paimon/common/utils/binary_row_partition_computer.cpp
@@ -77,25 +77,38 @@ Result<std::unique_ptr<BinaryRowPartitionComputer>> BinaryRowPartitionComputer::
 
 Result<BinaryRow> BinaryRowPartitionComputer::ToBinaryRow(
     const std::map<std::string, std::string>& partition) const {
+    return ConvertToBinaryRow(partition, /*included_fields=*/nullptr);
+}
+
+Result<BinaryRow> BinaryRowPartitionComputer::ConvertToBinaryRow(
+    const std::map<std::string, std::string>& partition, std::vector<bool>* included_fields) const {
     BinaryRow binary_row(partition_converters_.size());
     BinaryRowWriter writer(&binary_row, /*initial_size=*/0, memory_pool_.get());
-    for (size_t field_idx = 0; field_idx < partition_converters_.size(); field_idx++) {
-        const auto& partition_extractor = partition_converters_[field_idx];
-        const auto& partition_key = partition_extractor.partition_key;
-        const auto& to_binary_row = partition_extractor.converter;
-        auto input_iter = partition.find(partition_key);
+    if (included_fields != nullptr) {
+        included_fields->assign(partition_converters_.size(), false);
+    }
+    for (size_t field_idx = 0; field_idx < partition_converters_.size(); ++field_idx) {
+        const PartitionConverter& partition_converter = partition_converters_[field_idx];
+        auto input_iter = partition.find(partition_converter.partition_key);
         if (input_iter == partition.end()) {
+            if (included_fields != nullptr) {
+                writer.SetNullAt(field_idx);
+                continue;
+            }
             return Status::Invalid(
                 fmt::format("can not find partition key '{}' in input partition '{}'",
-                            partition_key, partition));
+                            partition_converter.partition_key, partition));
         }
-        const auto& value_str = input_iter->second;
-        if (value_str == default_part_value_) {
+        if (included_fields != nullptr) {
+            (*included_fields)[field_idx] = true;
+        }
+        if (input_iter->second == default_part_value_) {
             // TODO(yonghao.fyh): when support decimal/ timestamp in partition, use
             // WriteTimestamp(null) for non compact precision
             writer.SetNullAt(field_idx);
         } else {
-            PAIMON_RETURN_NOT_OK(to_binary_row(value_str, field_idx, &writer));
+            PAIMON_RETURN_NOT_OK(
+                partition_converter.converter(input_iter->second, field_idx, &writer));
         }
     }
     writer.Complete();
@@ -112,26 +125,8 @@ Result<std::map<std::string, std::string>> BinaryRowPartitionComputer::Normalize
         }
     }
 
-    BinaryRow binary_row(partition_converters_.size());
-    BinaryRowWriter writer(&binary_row, /*initial_size=*/0, memory_pool_.get());
-    std::vector<bool> included_fields(partition_converters_.size(), false);
-    for (size_t field_idx = 0; field_idx < partition_converters_.size(); ++field_idx) {
-        const PartitionConverter& partition_converter = partition_converters_[field_idx];
-        auto input_iter = partition.find(partition_converter.partition_key);
-        if (input_iter == partition.end()) {
-            writer.SetNullAt(field_idx);
-            continue;
-        }
-
-        included_fields[field_idx] = true;
-        if (input_iter->second == default_part_value_) {
-            writer.SetNullAt(field_idx);
-        } else {
-            PAIMON_RETURN_NOT_OK(
-                partition_converter.converter(input_iter->second, field_idx, &writer));
-        }
-    }
-    writer.Complete();
+    std::vector<bool> included_fields;
+    PAIMON_ASSIGN_OR_RAISE(BinaryRow binary_row, ConvertToBinaryRow(partition, &included_fields));
 
     std::vector<std::pair<std::string, std::string>> normalized_values;
     PAIMON_ASSIGN_OR_RAISE(normalized_values, GeneratePartitionVector(binary_row));

--- a/src/paimon/common/utils/binary_row_partition_computer.cpp
+++ b/src/paimon/common/utils/binary_row_partition_computer.cpp
@@ -102,6 +102,48 @@ Result<BinaryRow> BinaryRowPartitionComputer::ToBinaryRow(
     return binary_row;
 }
 
+Result<std::map<std::string, std::string>> BinaryRowPartitionComputer::NormalizePartitionSpec(
+    const std::map<std::string, std::string>& partition) const {
+    for (const auto& [partition_key, _] : partition) {
+        if (std::find(partition_keys_.begin(), partition_keys_.end(), partition_key) ==
+            partition_keys_.end()) {
+            return Status::Invalid(
+                fmt::format("field {} does not exist in partition keys", partition_key));
+        }
+    }
+
+    BinaryRow binary_row(partition_converters_.size());
+    BinaryRowWriter writer(&binary_row, /*initial_size=*/0, memory_pool_.get());
+    std::vector<bool> included_fields(partition_converters_.size(), false);
+    for (size_t field_idx = 0; field_idx < partition_converters_.size(); ++field_idx) {
+        const PartitionConverter& partition_converter = partition_converters_[field_idx];
+        auto input_iter = partition.find(partition_converter.partition_key);
+        if (input_iter == partition.end()) {
+            writer.SetNullAt(field_idx);
+            continue;
+        }
+
+        included_fields[field_idx] = true;
+        if (input_iter->second == default_part_value_) {
+            writer.SetNullAt(field_idx);
+        } else {
+            PAIMON_RETURN_NOT_OK(
+                partition_converter.converter(input_iter->second, field_idx, &writer));
+        }
+    }
+    writer.Complete();
+
+    std::vector<std::pair<std::string, std::string>> normalized_values;
+    PAIMON_ASSIGN_OR_RAISE(normalized_values, GeneratePartitionVector(binary_row));
+    std::map<std::string, std::string> normalized_partition;
+    for (size_t field_idx = 0; field_idx < normalized_values.size(); ++field_idx) {
+        if (included_fields[field_idx]) {
+            normalized_partition.insert(normalized_values[field_idx]);
+        }
+    }
+    return normalized_partition;
+}
+
 Result<std::vector<std::pair<std::string, std::string>>>
 BinaryRowPartitionComputer::GeneratePartitionVector(const BinaryRow& partition) const {
     if (static_cast<size_t>(partition.GetFieldCount()) != partition_converters_.size()) {

--- a/src/paimon/common/utils/binary_row_partition_computer.h
+++ b/src/paimon/common/utils/binary_row_partition_computer.h
@@ -55,6 +55,8 @@ class BinaryRowPartitionComputer {
         bool legacy_partition_name_enabled, const std::shared_ptr<MemoryPool>& memory_pool);
 
     Result<BinaryRow> ToBinaryRow(const std::map<std::string, std::string>& partition) const;
+    Result<std::map<std::string, std::string>> NormalizePartitionSpec(
+        const std::map<std::string, std::string>& partition) const;
     Result<std::vector<std::pair<std::string, std::string>>> GeneratePartitionVector(
         const BinaryRow& partition) const;
     const std::vector<std::string>& GetPartitionKeys() const {

--- a/src/paimon/common/utils/binary_row_partition_computer.h
+++ b/src/paimon/common/utils/binary_row_partition_computer.h
@@ -75,6 +75,10 @@ class BinaryRowPartitionComputer {
                                const std::vector<PartitionConverter>& partition_converters,
                                const std::shared_ptr<MemoryPool>& memory_pool);
 
+    /// A non-null `included_fields` enables partial partitions and records present fields.
+    Result<BinaryRow> ConvertToBinaryRow(const std::map<std::string, std::string>& partition,
+                                         std::vector<bool>* included_fields) const;
+
     static Result<arrow::Type::type> GetTypeFromArrowSchema(
         const std::shared_ptr<arrow::Schema>& schema, const std::string& field_name);
 

--- a/src/paimon/common/utils/binary_row_partition_computer_test.cpp
+++ b/src/paimon/common/utils/binary_row_partition_computer_test.cpp
@@ -268,6 +268,36 @@ TEST(BinaryRowPartitionComputerTest, TestNullOrWhitespaceOnlyStr) {
     ASSERT_EQ(partition_key_values, expected);
 }
 
+TEST(BinaryRowPartitionComputerTest, TestNormalizePartialPartitionSpec) {
+    using PartitionSpec = std::map<std::string, std::string>;
+
+    std::shared_ptr<MemoryPool> pool = GetDefaultPool();
+    std::shared_ptr<arrow::Schema> schema =
+        arrow::schema({arrow::field("pt", arrow::date32()), arrow::field("region", arrow::utf8())});
+    std::vector<std::string> partition_keys = {"pt", "region"};
+
+    ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<BinaryRowPartitionComputer> legacy_computer,
+        BinaryRowPartitionComputer::Create(partition_keys, schema, "__DEFAULT_PARTITION__",
+                                           /*legacy_partition_name_enabled=*/true, pool));
+    ASSERT_OK_AND_ASSIGN(PartitionSpec legacy_partition,
+                         legacy_computer->NormalizePartitionSpec({{"pt", "2024-01-01"}}));
+    PartitionSpec expected_legacy_partition = {{"pt", "19723"}};
+    ASSERT_EQ(expected_legacy_partition, legacy_partition);
+
+    ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<BinaryRowPartitionComputer> non_legacy_computer,
+        BinaryRowPartitionComputer::Create(partition_keys, schema, "__DEFAULT_PARTITION__",
+                                           /*legacy_partition_name_enabled=*/false, pool));
+    ASSERT_OK_AND_ASSIGN(PartitionSpec non_legacy_partition,
+                         non_legacy_computer->NormalizePartitionSpec({{"pt", "2024-01-01"}}));
+    PartitionSpec expected_non_legacy_partition = {{"pt", "2024-01-01"}};
+    ASSERT_EQ(expected_non_legacy_partition, non_legacy_partition);
+
+    ASSERT_NOK_WITH_MSG(non_legacy_computer->NormalizePartitionSpec({{"unknown", "value"}}),
+                        "field unknown does not exist in partition keys");
+}
+
 TEST(BinaryRowPartitionComputerTest, TestPartToSimpleString) {
     auto pool = GetDefaultPool();
     {

--- a/src/paimon/core/core_options.cpp
+++ b/src/paimon/core/core_options.cpp
@@ -38,7 +38,7 @@
 #include "paimon/defs.h"
 #include "paimon/format/file_format.h"
 #include "paimon/format/file_format_factory.h"
-#include "paimon/realtime/realtime_store.h"
+#include "paimon/statistics_mode.h"
 #include "paimon/status.h"
 
 namespace paimon {
@@ -391,6 +391,7 @@ struct CoreOptions::Impl {
     int64_t commit_timeout = std::numeric_limits<int64_t>::max();
     int64_t commit_min_retry_wait = 10;
     int64_t commit_max_retry_wait = 10 * 1000;
+    bool realtime_enabled = false;
     int64_t realtime_read_view_ttl_millis = 5 * 60 * 1000;
     StatisticsMode realtime_store_statistics_mode = StatisticsMode::NONE;
 
@@ -850,6 +851,7 @@ struct CoreOptions::Impl {
 
     // Parse real-time write and read configurations.
     Status ParseRealtimeOptions(const ConfigParser& parser) {
+        PAIMON_RETURN_NOT_OK(parser.Parse<bool>(Options::REALTIME_ENABLED, &realtime_enabled));
         PAIMON_RETURN_NOT_OK(parser.ParseTimeDuration(Options::REALTIME_READ_VIEW_TTL,
                                                       &realtime_read_view_ttl_millis));
         if (realtime_read_view_ttl_millis <= 0) {
@@ -1180,6 +1182,10 @@ std::optional<int64_t> CoreOptions::GetScanSnapshotId() const {
 }
 std::optional<int64_t> CoreOptions::GetScanTimestampMillis() const {
     return impl_->scan_timestamp_millis;
+}
+
+bool CoreOptions::RealtimeEnabled() const {
+    return impl_->realtime_enabled;
 }
 
 int64_t CoreOptions::GetRealtimeReadViewTtlMillis() const {

--- a/src/paimon/core/core_options.cpp
+++ b/src/paimon/core/core_options.cpp
@@ -38,6 +38,7 @@
 #include "paimon/defs.h"
 #include "paimon/format/file_format.h"
 #include "paimon/format/file_format_factory.h"
+#include "paimon/realtime/realtime_store.h"
 #include "paimon/status.h"
 
 namespace paimon {
@@ -391,6 +392,7 @@ struct CoreOptions::Impl {
     int64_t commit_min_retry_wait = 10;
     int64_t commit_max_retry_wait = 10 * 1000;
     int64_t realtime_read_view_ttl_millis = 5 * 60 * 1000;
+    StatisticsMode realtime_store_statistics_mode = StatisticsMode::NONE;
 
     std::shared_ptr<FileFormat> file_format;
     std::shared_ptr<FileSystem> file_system;
@@ -803,12 +805,6 @@ struct CoreOptions::Impl {
         std::string scan_timestamp_str;
         PAIMON_RETURN_NOT_OK(parser.Parse(Options::SCAN_TIMESTAMP, &scan_timestamp_str));
         PAIMON_RETURN_NOT_OK(parser.Parse(Options::SCAN_TIMESTAMP_MILLIS, &scan_timestamp_millis));
-        PAIMON_RETURN_NOT_OK(parser.ParseTimeDuration(Options::REALTIME_READ_VIEW_TTL,
-                                                      &realtime_read_view_ttl_millis));
-        if (realtime_read_view_ttl_millis <= 0) {
-            return Status::Invalid(
-                fmt::format("{} must be positive", Options::REALTIME_READ_VIEW_TTL));
-        }
         if (scan_timestamp_millis != std::nullopt && !scan_timestamp_str.empty()) {
             return Status::Invalid(
                 "scan.timestamp-millis and scan.timestamp cannot be set at the same time");
@@ -834,6 +830,33 @@ struct CoreOptions::Impl {
         // Parse scan.tag-name - optional tag name for "from-snapshot" scan mode
         PAIMON_RETURN_NOT_OK(parser.Parse(Options::SCAN_TAG_NAME, &scan_tag_name));
         return Status::OK();
+    }
+
+    // Parse statistics collected by real-time stores.
+    Status ParseRealtimeStoreStatisticsMode(const ConfigParser& parser) {
+        std::string statistics_mode = "none";
+        PAIMON_RETURN_NOT_OK(parser.Parse(Options::REALTIME_STORE_STATS_MODE, &statistics_mode));
+        statistics_mode = StringUtils::ToLowerCase(statistics_mode);
+        if (statistics_mode == "none") {
+            realtime_store_statistics_mode = StatisticsMode::NONE;
+        } else if (statistics_mode == "full") {
+            realtime_store_statistics_mode = StatisticsMode::FULL;
+        } else {
+            return Status::Invalid(
+                fmt::format("{} must be 'none' or 'full'", Options::REALTIME_STORE_STATS_MODE));
+        }
+        return Status::OK();
+    }
+
+    // Parse real-time write and read configurations.
+    Status ParseRealtimeOptions(const ConfigParser& parser) {
+        PAIMON_RETURN_NOT_OK(parser.ParseTimeDuration(Options::REALTIME_READ_VIEW_TTL,
+                                                      &realtime_read_view_ttl_millis));
+        if (realtime_read_view_ttl_millis <= 0) {
+            return Status::Invalid(
+                fmt::format("{} must be positive", Options::REALTIME_READ_VIEW_TTL));
+        }
+        return ParseRealtimeStoreStatisticsMode(parser);
     }
 
     // Parse index-related configurations: file index, global index.
@@ -1046,6 +1069,7 @@ Result<CoreOptions> CoreOptions::FromMap(
     PAIMON_RETURN_NOT_OK(impl->ParseCommitOptions(parser));
     PAIMON_RETURN_NOT_OK(impl->ParseMergeAndSequenceOptions(parser));
     PAIMON_RETURN_NOT_OK(impl->ParseDeletionVectorOptions(parser));
+    PAIMON_RETURN_NOT_OK(impl->ParseRealtimeOptions(parser));
     PAIMON_RETURN_NOT_OK(impl->ParseScanAndBranchOptions(parser));
     PAIMON_RETURN_NOT_OK(impl->ParseIndexOptions(parser));
     PAIMON_RETURN_NOT_OK(impl->ParseCompactionOptions(parser));
@@ -1160,6 +1184,10 @@ std::optional<int64_t> CoreOptions::GetScanTimestampMillis() const {
 
 int64_t CoreOptions::GetRealtimeReadViewTtlMillis() const {
     return impl_->realtime_read_view_ttl_millis;
+}
+
+StatisticsMode CoreOptions::GetRealtimeStoreStatisticsMode() const {
+    return impl_->realtime_store_statistics_mode;
 }
 
 int32_t CoreOptions::GetScanManifestEntryCacheMaxSnapshots() const {

--- a/src/paimon/core/core_options.h
+++ b/src/paimon/core/core_options.h
@@ -40,6 +40,7 @@
 #include "paimon/format/file_format.h"
 #include "paimon/fs/file_system.h"
 #include "paimon/result.h"
+#include "paimon/statistics_mode.h"
 #include "paimon/table/source/startup_mode.h"
 #include "paimon/type_fwd.h"
 #include "paimon/visibility.h"
@@ -48,7 +49,6 @@ namespace paimon {
 
 class ExpireConfig;
 class Cache;
-enum class StatisticsMode;
 
 class PAIMON_EXPORT CoreOptions {
  public:
@@ -107,8 +107,9 @@ class PAIMON_EXPORT CoreOptions {
     int64_t GetSourceSplitOpenFileCost() const;
     std::optional<int64_t> GetScanSnapshotId() const;
     std::optional<int64_t> GetScanTimestampMillis() const;
+    bool RealtimeEnabled() const;
     int64_t GetRealtimeReadViewTtlMillis() const;
-    /// Returns the statistics mode used by real-time memory indexers.
+    /// Returns the statistics mode used by the real-time store.
     StatisticsMode GetRealtimeStoreStatisticsMode() const;
     int32_t GetScanManifestEntryCacheMaxSnapshots() const;
 

--- a/src/paimon/core/core_options.h
+++ b/src/paimon/core/core_options.h
@@ -48,6 +48,7 @@ namespace paimon {
 
 class ExpireConfig;
 class Cache;
+enum class StatisticsMode;
 
 class PAIMON_EXPORT CoreOptions {
  public:
@@ -107,6 +108,8 @@ class PAIMON_EXPORT CoreOptions {
     std::optional<int64_t> GetScanSnapshotId() const;
     std::optional<int64_t> GetScanTimestampMillis() const;
     int64_t GetRealtimeReadViewTtlMillis() const;
+    /// Returns the statistics mode used by real-time memory indexers.
+    StatisticsMode GetRealtimeStoreStatisticsMode() const;
     int32_t GetScanManifestEntryCacheMaxSnapshots() const;
 
     int64_t GetManifestTargetFileSize() const;

--- a/src/paimon/core/core_options_test.cpp
+++ b/src/paimon/core/core_options_test.cpp
@@ -29,6 +29,7 @@
 #include "paimon/core/options/expire_config.h"
 #include "paimon/defs.h"
 #include "paimon/fs/local/local_file_system.h"
+#include "paimon/realtime/realtime_store.h"
 #include "paimon/testing/mock/mock_file_system.h"
 #include "paimon/testing/utils/testharness.h"
 #include "paimon/testing/utils/timezone_guard.h"
@@ -54,6 +55,7 @@ TEST(CoreOptionsTest, TestDefaultValue) {
     ASSERT_EQ("__DEFAULT_PARTITION__", core_options.GetPartitionDefaultName());
     ASSERT_EQ(std::nullopt, core_options.GetScanSnapshotId());
     ASSERT_EQ(5 * 60 * 1000, core_options.GetRealtimeReadViewTtlMillis());
+    ASSERT_EQ(StatisticsMode::NONE, core_options.GetRealtimeStoreStatisticsMode());
     ASSERT_EQ("zstd", core_options.GetFileCompression());
     ASSERT_EQ("zstd", core_options.GetWriteFileCompression(0));
     ASSERT_EQ("zstd", core_options.GetWriteFileCompression(3));
@@ -802,6 +804,19 @@ TEST(CoreOptionsTest, TestRealtimeReadViewTtlMillis) {
     ASSERT_EQ(1234, core_options.GetRealtimeReadViewTtlMillis());
     ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::REALTIME_READ_VIEW_TTL, "0 ms"}}),
                         "realtime.read-view-ttl must be positive");
+}
+
+TEST(CoreOptionsTest, TestRealtimeStoreStatisticsMode) {
+    ASSERT_OK_AND_ASSIGN(CoreOptions full_options,
+                         CoreOptions::FromMap({{Options::REALTIME_STORE_STATS_MODE, "full"}}));
+    ASSERT_EQ(StatisticsMode::FULL, full_options.GetRealtimeStoreStatisticsMode());
+
+    ASSERT_OK_AND_ASSIGN(CoreOptions none_options,
+                         CoreOptions::FromMap({{Options::REALTIME_STORE_STATS_MODE, "none"}}));
+    ASSERT_EQ(StatisticsMode::NONE, none_options.GetRealtimeStoreStatisticsMode());
+
+    ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::REALTIME_STORE_STATS_MODE, "invalid"}}),
+                        "realtime.store.stats-mode must be 'none' or 'full'");
 }
 
 TEST(CoreOptionsTest, TestScanTimestampMillisExplicitMode) {

--- a/src/paimon/core/core_options_test.cpp
+++ b/src/paimon/core/core_options_test.cpp
@@ -29,7 +29,7 @@
 #include "paimon/core/options/expire_config.h"
 #include "paimon/defs.h"
 #include "paimon/fs/local/local_file_system.h"
-#include "paimon/realtime/realtime_store.h"
+#include "paimon/statistics_mode.h"
 #include "paimon/testing/mock/mock_file_system.h"
 #include "paimon/testing/utils/testharness.h"
 #include "paimon/testing/utils/timezone_guard.h"
@@ -55,6 +55,7 @@ TEST(CoreOptionsTest, TestDefaultValue) {
     ASSERT_EQ("__DEFAULT_PARTITION__", core_options.GetPartitionDefaultName());
     ASSERT_EQ(std::nullopt, core_options.GetScanSnapshotId());
     ASSERT_EQ(5 * 60 * 1000, core_options.GetRealtimeReadViewTtlMillis());
+    ASSERT_FALSE(core_options.RealtimeEnabled());
     ASSERT_EQ(StatisticsMode::NONE, core_options.GetRealtimeStoreStatisticsMode());
     ASSERT_EQ("zstd", core_options.GetFileCompression());
     ASSERT_EQ("zstd", core_options.GetWriteFileCompression(0));
@@ -306,6 +307,7 @@ TEST(CoreOptionsTest, TestFromMap) {
         {Options::LOOKUP_REMOTE_LEVEL_THRESHOLD, "2"},
         {Options::TABLE_READ_SEQUENCE_NUMBER_ENABLED, "true"},
         {Options::KEY_VALUE_SEQUENCE_NUMBER_ENABLED, "true"},
+        {Options::REALTIME_ENABLED, "true"},
         {Options::BUCKET_FUNCTION_TYPE, "mod"},
         {"fields.metrics.map.storage-layout", "shared-shredding"},
         {"fields.metrics.map.shared-shredding.max-columns", "128"},
@@ -465,6 +467,7 @@ TEST(CoreOptionsTest, TestFromMap) {
     ASSERT_EQ(10L * 1024 * 1024 * 1024, core_options.GetLookupCacheMaxDiskSize());
     ASSERT_TRUE(core_options.TableReadSequenceNumberEnabled());
     ASSERT_TRUE(core_options.KeyValueSequenceNumberEnabled());
+    ASSERT_TRUE(core_options.RealtimeEnabled());
     ASSERT_TRUE(core_options.LookupRemoteFileEnabled());
     ASSERT_EQ(core_options.GetLookupRemoteLevelThreshold(), 2);
     ASSERT_EQ(BucketFunctionType::MOD, core_options.GetBucketFunctionType());
@@ -494,6 +497,7 @@ TEST(CoreOptionsTest, TestInvalidCase) {
                         "invalid lookup mode: invalid");
     ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::LOOKUP_COMPACT_MAX_INTERVAL, "invalid"}}),
                         "Invalid Config [lookup-compact.max-interval: invalid]");
+    ASSERT_NOK(CoreOptions::FromMap({{Options::REALTIME_ENABLED, "invalid"}}));
     ASSERT_NOK_WITH_MSG(
         CoreOptions::FromMap({{Options::SCAN_MANIFEST_ENTRY_CACHE_MAX_SNAPSHOTS, "-1"}}),
         "scan.manifest-entry-cache.max-snapshots must be non-negative");

--- a/src/paimon/core/operation/append_only_file_store_write.cpp
+++ b/src/paimon/core/operation/append_only_file_store_write.cpp
@@ -106,6 +106,10 @@ Status AppendOnlyFileStoreWrite::RefreshCommittedSnapshot(int64_t snapshot_id) {
         return Status::Invalid("refresh committed snapshot requires a real-time writer");
     }
     PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, snapshot_manager_->LoadSnapshot(snapshot_id));
+    if (snapshot.GetCommitKind() == Snapshot::CommitKind::Overwrite()) {
+        return Status::Invalid(
+            "real-time committed progress was reset by overwrite; recreate RealtimeContext");
+    }
     PAIMON_ASSIGN_OR_RAISE(
         RealtimeOffsetMap committed_offsets,
         RealtimeCommitProperties::ReadOffsets(std::optional<Snapshot>(std::move(snapshot)),

--- a/src/paimon/core/operation/append_only_file_store_write.cpp
+++ b/src/paimon/core/operation/append_only_file_store_write.cpp
@@ -106,10 +106,6 @@ Status AppendOnlyFileStoreWrite::RefreshCommittedSnapshot(int64_t snapshot_id) {
         return Status::Invalid("refresh committed snapshot requires a real-time writer");
     }
     PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, snapshot_manager_->LoadSnapshot(snapshot_id));
-    if (snapshot.GetCommitKind() == Snapshot::CommitKind::Overwrite()) {
-        return Status::Invalid(
-            "real-time committed progress was reset by overwrite; recreate RealtimeContext");
-    }
     PAIMON_ASSIGN_OR_RAISE(
         RealtimeOffsetMap committed_offsets,
         RealtimeCommitProperties::ReadOffsets(std::optional<Snapshot>(std::move(snapshot)),

--- a/src/paimon/core/operation/append_only_file_store_write.cpp
+++ b/src/paimon/core/operation/append_only_file_store_write.cpp
@@ -254,9 +254,9 @@ Result<std::shared_ptr<BatchWriter>> AppendOnlyFileStoreWrite::CreateWriter(
                                                      partition_values.end());
     auto c_write_schema = std::make_unique<ArrowSchema>();
     PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportSchema(*write_schema_, c_write_schema.get()));
-    return RealtimeAppendOnlyWriter::Create(partition_map, bucket, std::move(c_write_schema),
-                                            realtime_context_, writer, write_schema_,
-                                            options_.ToMap(), pool_);
+    return RealtimeAppendOnlyWriter::Create(
+        partition_map, bucket, std::move(c_write_schema), realtime_context_, writer, write_schema_,
+        options_.GetRealtimeStoreStatisticsMode(), options_.ToMap(), pool_);
 }
 
 Result<AppendOnlyFileStoreWrite::WriterFactory> AppendOnlyFileStoreWrite::GetDataFileWriterFactory(

--- a/src/paimon/core/operation/append_only_file_store_write_test.cpp
+++ b/src/paimon/core/operation/append_only_file_store_write_test.cpp
@@ -273,6 +273,7 @@ TEST_F(AppendOnlyFileStoreWriteTest, TestRealtimeWriteTracksInternalOffsetRange)
         {"write-only", "true"},
         {"bucket", "1"},
         {"bucket-key", "id"},
+        {Options::REALTIME_ENABLED, "true"},
     };
     auto logical_schema =
         arrow::schema({arrow::field("id", arrow::int32()), arrow::field("name", arrow::utf8())});

--- a/src/paimon/core/operation/commit/commit_scanner.cpp
+++ b/src/paimon/core/operation/commit/commit_scanner.cpp
@@ -38,6 +38,7 @@
 #include "paimon/core/operation/commit/overwrite_changes_provider.h"
 #include "paimon/core/operation/file_store_scan.h"
 #include "paimon/core/table/bucket_mode.h"
+#include "paimon/core/utils/partition_utils.h"
 #include "paimon/scan_context.h"
 
 namespace paimon {
@@ -183,14 +184,9 @@ Result<std::vector<IndexManifestEntry>> CommitScanner::ReadAllIndexEntriesFromPa
         }
 
         for (const auto& partition_spec : partitions) {
-            bool matched = true;
-            for (const auto& [key, value] : partition_spec) {
-                auto iter = partition.find(key);
-                if (iter == partition.end() || iter->second != value) {
-                    matched = false;
-                    break;
-                }
-            }
+            PAIMON_ASSIGN_OR_RAISE(bool matched,
+                                   PartitionUtils::MatchPartitionSpec(partition, partition_spec,
+                                                                      *partition_computer_));
             if (matched) {
                 return true;
             }

--- a/src/paimon/core/operation/commit/realtime_commit_properties.cpp
+++ b/src/paimon/core/operation/commit/realtime_commit_properties.cpp
@@ -31,22 +31,12 @@
 #include "paimon/common/utils/rapidjson_util.h"
 #include "paimon/common/utils/uuid.h"
 #include "paimon/core/utils/branch_manager.h"
+#include "paimon/core/utils/partition_utils.h"
 #include "paimon/fs/file_system.h"
 #include "paimon/macros.h"
 
 namespace paimon {
 namespace {
-
-bool MatchPartitionSpec(const std::map<std::string, std::string>& partition,
-                        const std::map<std::string, std::string>& partition_spec) {
-    for (const auto& [key, value] : partition_spec) {
-        auto iter = partition.find(key);
-        if (iter == partition.end() || iter->second != value) {
-            return false;
-        }
-    }
-    return true;
-}
 
 class OffsetEntryJson : public Jsonizable<OffsetEntryJson> {
  public:
@@ -247,6 +237,7 @@ Result<std::map<std::string, std::string>> RealtimeCommitProperties::Build(
     const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
     bool reset_all_realtime_progress,
     const std::vector<std::map<std::string, std::string>>& removed_realtime_partitions,
+    const BinaryRowPartitionComputer& partition_computer,
     const std::shared_ptr<FileSystem>& file_system, const std::string& table_root,
     const std::string& branch) {
     std::map<std::string, std::string> merged_properties = properties;
@@ -269,11 +260,15 @@ Result<std::map<std::string, std::string>> RealtimeCommitProperties::Build(
         RealtimeOffsetMap merged_offsets,
         ReadOffsets(reset_all_realtime_progress ? std::nullopt : latest_snapshot, file_system));
     for (auto iter = merged_offsets.begin(); iter != merged_offsets.end();) {
-        bool removed =
-            std::any_of(removed_realtime_partitions.begin(), removed_realtime_partitions.end(),
-                        [&iter](const std::map<std::string, std::string>& partition_spec) {
-                            return MatchPartitionSpec(iter->first.partition, partition_spec);
-                        });
+        bool removed = false;
+        for (const auto& partition_spec : removed_realtime_partitions) {
+            PAIMON_ASSIGN_OR_RAISE(
+                removed, PartitionUtils::MatchPartitionSpec(iter->first.partition, partition_spec,
+                                                            partition_computer));
+            if (removed) {
+                break;
+            }
+        }
         if (removed) {
             iter = merged_offsets.erase(iter);
         } else {

--- a/src/paimon/core/operation/commit/realtime_commit_properties.cpp
+++ b/src/paimon/core/operation/commit/realtime_commit_properties.cpp
@@ -159,22 +159,69 @@ std::string RealtimeCommitProperties::OffsetsDirectory(const std::string& table_
     return PathUtil::JoinPath(BranchManager::BranchPath(table_root, branch), "metadata");
 }
 
-Result<RealtimeOffsetMap> RealtimeCommitProperties::ReadOffsets(
-    const std::optional<Snapshot>& snapshot, const std::shared_ptr<FileSystem>& file_system) {
-    if (!snapshot || !snapshot->Properties()) {
-        return RealtimeOffsetMap{};
+std::optional<std::string> RealtimeCommitProperties::GetOffsetsPath(const Snapshot& snapshot) {
+    if (!snapshot.Properties()) {
+        return std::nullopt;
     }
-    const std::map<std::string, std::string>& properties = snapshot->Properties().value();
+    const std::map<std::string, std::string>& properties = snapshot.Properties().value();
     auto iter = properties.find(kOffsetsKey);
     if (iter == properties.end()) {
+        return std::nullopt;
+    }
+    return iter->second;
+}
+
+Result<RealtimeOffsetMap> RealtimeCommitProperties::ReadOffsets(
+    const std::optional<Snapshot>& snapshot, const std::shared_ptr<FileSystem>& file_system) {
+    if (!snapshot) {
+        return RealtimeOffsetMap{};
+    }
+    std::optional<std::string> offsets_path = GetOffsetsPath(snapshot.value());
+    if (!offsets_path) {
         return RealtimeOffsetMap{};
     }
     if (file_system == nullptr) {
         return Status::Invalid("file system is null when reading real-time offsets");
     }
     std::string content;
-    PAIMON_RETURN_NOT_OK(file_system->ReadFile(iter->second, &content));
+    PAIMON_RETURN_NOT_OK(file_system->ReadFile(offsets_path.value(), &content));
     return ParseOffsets(content);
+}
+
+Result<bool> RealtimeCommitProperties::AreRangesCommitted(
+    const RealtimeOffsetMap& committed_offsets,
+    const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges) {
+    std::optional<bool> all_committed;
+    for (const auto& [partition_bucket, offset_range] : realtime_ranges) {
+        if (partition_bucket.bucket < 0) {
+            return Status::Invalid(
+                fmt::format("real-time commit bucket {} is invalid", partition_bucket.bucket));
+        }
+        if (offset_range.begin < 0 || offset_range.begin >= offset_range.end) {
+            return Status::Invalid("real-time commit offset range is invalid");
+        }
+
+        auto offset_iter = committed_offsets.find(partition_bucket);
+        int64_t committed_end_offset =
+            offset_iter == committed_offsets.end() ? 0 : offset_iter->second;
+        bool range_committed = offset_range.end <= committed_end_offset;
+        if (!range_committed && offset_range.begin < committed_end_offset) {
+            return Status::Invalid(fmt::format(
+                "real-time commit offset range partially overlaps committed offset for bucket {}",
+                partition_bucket.bucket));
+        }
+        if (!range_committed && offset_range.begin != committed_end_offset) {
+            return Status::Invalid(
+                fmt::format("real-time commit offsets for bucket {} are not contiguous",
+                            partition_bucket.bucket));
+        }
+        if (all_committed && all_committed.value() != range_committed) {
+            return Status::Invalid(
+                "real-time commit ranges are only partially covered by committed offsets");
+        }
+        all_committed = range_committed;
+    }
+    return all_committed.value_or(false);
 }
 
 Result<std::string> RealtimeCommitProperties::SerializeOffsets(const RealtimeOffsetMap& offsets) {

--- a/src/paimon/core/operation/commit/realtime_commit_properties.cpp
+++ b/src/paimon/core/operation/commit/realtime_commit_properties.cpp
@@ -37,6 +37,17 @@
 namespace paimon {
 namespace {
 
+bool MatchPartitionSpec(const std::map<std::string, std::string>& partition,
+                        const std::map<std::string, std::string>& partition_spec) {
+    for (const auto& [key, value] : partition_spec) {
+        auto iter = partition.find(key);
+        if (iter == partition.end() || iter->second != value) {
+            return false;
+        }
+    }
+    return true;
+}
+
 class OffsetEntryJson : public Jsonizable<OffsetEntryJson> {
  public:
     OffsetEntryJson() = default;
@@ -234,11 +245,16 @@ Result<std::map<std::string, std::string>> RealtimeCommitProperties::Build(
     const std::map<std::string, std::string>& properties,
     const std::optional<Snapshot>& latest_snapshot,
     const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
+    bool reset_all_realtime_progress,
+    const std::vector<std::map<std::string, std::string>>& removed_realtime_partitions,
     const std::shared_ptr<FileSystem>& file_system, const std::string& table_root,
     const std::string& branch) {
     std::map<std::string, std::string> merged_properties = properties;
-    if (realtime_ranges.empty()) {
-        if (latest_snapshot && latest_snapshot->Properties()) {
+    if (reset_all_realtime_progress || !removed_realtime_partitions.empty()) {
+        merged_properties.erase(kOffsetsKey);
+    }
+    if (realtime_ranges.empty() && removed_realtime_partitions.empty()) {
+        if (!reset_all_realtime_progress && latest_snapshot && latest_snapshot->Properties()) {
             const std::map<std::string, std::string>& latest_properties =
                 latest_snapshot->Properties().value();
             auto offsets_iter = latest_properties.find(kOffsetsKey);
@@ -249,8 +265,21 @@ Result<std::map<std::string, std::string>> RealtimeCommitProperties::Build(
         return merged_properties;
     }
 
-    PAIMON_ASSIGN_OR_RAISE(RealtimeOffsetMap merged_offsets,
-                           ReadOffsets(latest_snapshot, file_system));
+    PAIMON_ASSIGN_OR_RAISE(
+        RealtimeOffsetMap merged_offsets,
+        ReadOffsets(reset_all_realtime_progress ? std::nullopt : latest_snapshot, file_system));
+    for (auto iter = merged_offsets.begin(); iter != merged_offsets.end();) {
+        bool removed =
+            std::any_of(removed_realtime_partitions.begin(), removed_realtime_partitions.end(),
+                        [&iter](const std::map<std::string, std::string>& partition_spec) {
+                            return MatchPartitionSpec(iter->first.partition, partition_spec);
+                        });
+        if (removed) {
+            iter = merged_offsets.erase(iter);
+        } else {
+            ++iter;
+        }
+    }
     for (const auto& [partition_bucket, offset_range] : realtime_ranges) {
         if (partition_bucket.bucket < 0) {
             return Status::Invalid(
@@ -267,6 +296,10 @@ Result<std::map<std::string, std::string>> RealtimeCommitProperties::Build(
                             partition_bucket.bucket));
         }
         merged_offsets[partition_bucket] = offset_range.end;
+    }
+    if (merged_offsets.empty()) {
+        merged_properties.erase(kOffsetsKey);
+        return merged_properties;
     }
     PAIMON_ASSIGN_OR_RAISE(
         merged_properties[kOffsetsKey],

--- a/src/paimon/core/operation/commit/realtime_commit_properties.h
+++ b/src/paimon/core/operation/commit/realtime_commit_properties.h
@@ -46,8 +46,19 @@ class RealtimeCommitProperties {
 
     static std::string OffsetsDirectory(const std::string& table_root, const std::string& branch);
 
+    /// Returns the offset file referenced by `snapshot`, if present.
+    static std::optional<std::string> GetOffsetsPath(const Snapshot& snapshot);
+
     static Result<RealtimeOffsetMap> ReadOffsets(const std::optional<Snapshot>& snapshot,
                                                  const std::shared_ptr<FileSystem>& file_system);
+
+    /// Returns whether all ranges are already covered by committed offsets.
+    ///
+    /// Ranges must either all immediately follow committed offsets or all be fully covered.
+    /// Mixed states, gaps, and partial overlaps are rejected.
+    static Result<bool> AreRangesCommitted(
+        const RealtimeOffsetMap& committed_offsets,
+        const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges);
 
     static Result<std::string> SerializeOffsets(const RealtimeOffsetMap& offsets);
 

--- a/src/paimon/core/operation/commit/realtime_commit_properties.h
+++ b/src/paimon/core/operation/commit/realtime_commit_properties.h
@@ -63,10 +63,17 @@ class RealtimeCommitProperties {
     static Result<std::string> SerializeOffsets(const RealtimeOffsetMap& offsets);
 
     /// Builds snapshot properties against `latest_snapshot` and applies real-time progress.
+    ///
+    /// A full-table replacement sets `reset_all_realtime_progress`. A partition overwrite or
+    /// drop lists only the affected partition specs in `removed_realtime_partitions`; offsets for
+    /// all other partitions are retained. The two reset forms are independent of the snapshot's
+    /// commit kind because an ordinary commit may also use `OVERWRITE` for conflict handling.
     static Result<std::map<std::string, std::string>> Build(
         const std::map<std::string, std::string>& properties,
         const std::optional<Snapshot>& latest_snapshot,
         const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
+        bool reset_all_realtime_progress,
+        const std::vector<std::map<std::string, std::string>>& removed_realtime_partitions,
         const std::shared_ptr<FileSystem>& file_system, const std::string& table_root,
         const std::string& branch);
 

--- a/src/paimon/core/operation/commit/realtime_commit_properties.h
+++ b/src/paimon/core/operation/commit/realtime_commit_properties.h
@@ -33,6 +33,7 @@
 
 namespace paimon {
 
+class BinaryRowPartitionComputer;
 class FileSystem;
 
 class RealtimeCommitProperties {
@@ -74,6 +75,7 @@ class RealtimeCommitProperties {
         const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
         bool reset_all_realtime_progress,
         const std::vector<std::map<std::string, std::string>>& removed_realtime_partitions,
+        const BinaryRowPartitionComputer& partition_computer,
         const std::shared_ptr<FileSystem>& file_system, const std::string& table_root,
         const std::string& branch);
 

--- a/src/paimon/core/operation/commit/realtime_commit_properties_test.cpp
+++ b/src/paimon/core/operation/commit/realtime_commit_properties_test.cpp
@@ -256,6 +256,52 @@ TEST_F(RealtimeCommitPropertiesTest, SortProgress) {
     ASSERT_EQ(OffsetRange(5, 7), commits[2].offset_range);
 }
 
+TEST_F(RealtimeCommitPropertiesTest, CheckRangesCommitted) {
+    RealtimePartitionBucket bucket0({{"dt", "2"}}, /*bucket=*/0);
+    RealtimePartitionBucket bucket1({{"dt", "2"}}, /*bucket=*/1);
+    RealtimeOffsetMap committed_offsets = {{bucket0, 4}, {bucket1, 9}};
+
+    std::map<RealtimePartitionBucket, OffsetRange> pending = {{bucket0, OffsetRange(4, 6)},
+                                                              {bucket1, OffsetRange(9, 11)}};
+    ASSERT_OK_AND_ASSIGN(bool pending_committed,
+                         RealtimeCommitProperties::AreRangesCommitted(committed_offsets, pending));
+    ASSERT_FALSE(pending_committed);
+
+    std::map<RealtimePartitionBucket, OffsetRange> covered = {{bucket0, OffsetRange(0, 4)},
+                                                              {bucket1, OffsetRange(5, 8)}};
+    ASSERT_OK_AND_ASSIGN(bool covered_committed,
+                         RealtimeCommitProperties::AreRangesCommitted(committed_offsets, covered));
+    ASSERT_TRUE(covered_committed);
+
+    std::map<RealtimePartitionBucket, OffsetRange> single_bucket_covered = {
+        {bucket0, OffsetRange(0, 4)}};
+    ASSERT_OK_AND_ASSIGN(
+        bool single_bucket_covered_committed,
+        RealtimeCommitProperties::AreRangesCommitted(committed_offsets, single_bucket_covered));
+    ASSERT_TRUE(single_bucket_covered_committed);
+
+    std::map<RealtimePartitionBucket, OffsetRange> single_bucket_pending = {
+        {bucket1, OffsetRange(9, 11)}};
+    ASSERT_OK_AND_ASSIGN(
+        bool single_bucket_pending_committed,
+        RealtimeCommitProperties::AreRangesCommitted(committed_offsets, single_bucket_pending));
+    ASSERT_FALSE(single_bucket_pending_committed);
+
+    std::map<RealtimePartitionBucket, OffsetRange> partial_overlap = {{bucket0, OffsetRange(3, 5)}};
+    ASSERT_NOK_WITH_MSG(
+        RealtimeCommitProperties::AreRangesCommitted(committed_offsets, partial_overlap),
+        "partially overlaps");
+
+    std::map<RealtimePartitionBucket, OffsetRange> gap = {{bucket0, OffsetRange(5, 7)}};
+    ASSERT_NOK_WITH_MSG(RealtimeCommitProperties::AreRangesCommitted(committed_offsets, gap),
+                        "are not contiguous");
+
+    std::map<RealtimePartitionBucket, OffsetRange> mixed = {{bucket0, OffsetRange(0, 4)},
+                                                            {bucket1, OffsetRange(9, 11)}};
+    ASSERT_NOK_WITH_MSG(RealtimeCommitProperties::AreRangesCommitted(committed_offsets, mixed),
+                        "only partially covered");
+}
+
 TEST_F(RealtimeCommitPropertiesTest, BuildRejectsInvalidProgress) {
     RealtimePartitionBucket bucket0({{"dt", "2"}}, /*bucket=*/0);
     RealtimeOffsetMap committed_offsets = {{bucket0, 1}};

--- a/src/paimon/core/operation/commit/realtime_commit_properties_test.cpp
+++ b/src/paimon/core/operation/commit/realtime_commit_properties_test.cpp
@@ -311,18 +311,24 @@ TEST_F(RealtimeCommitPropertiesTest, BuildRejectsInvalidProgress) {
         {RealtimePartitionBucket({{"dt", "2"}}, /*bucket=*/-1), OffsetRange(0, 1)}};
     ASSERT_NOK_WITH_MSG(
         RealtimeCommitProperties::Build(/*properties=*/{}, /*latest_snapshot=*/std::nullopt,
-                                        invalid_bucket, file_system_, directory_->Str(), "main"),
+                                        invalid_bucket, /*reset_all_realtime_progress=*/false,
+                                        /*removed_realtime_partitions=*/{}, file_system_,
+                                        directory_->Str(), "main"),
         "bucket -1 is invalid");
 
     std::map<RealtimePartitionBucket, OffsetRange> gap = {
         {RealtimePartitionBucket({{"dt", "2"}}, /*bucket=*/0), OffsetRange(3, 5)}};
     ASSERT_NOK_WITH_MSG(RealtimeCommitProperties::Build(/*properties=*/{}, latest_snapshot, gap,
+                                                        /*reset_all_realtime_progress=*/false,
+                                                        /*removed_realtime_partitions=*/{},
                                                         file_system_, directory_->Str(), "main"),
                         "are not contiguous");
 
     std::map<RealtimePartitionBucket, OffsetRange> overlap = {
         {RealtimePartitionBucket({{"dt", "2"}}, /*bucket=*/0), OffsetRange(0, 2)}};
     ASSERT_NOK_WITH_MSG(RealtimeCommitProperties::Build(/*properties=*/{}, latest_snapshot, overlap,
+                                                        /*reset_all_realtime_progress=*/false,
+                                                        /*removed_realtime_partitions=*/{},
                                                         file_system_, directory_->Str(), "main"),
                         "are not contiguous");
 
@@ -333,7 +339,9 @@ TEST_F(RealtimeCommitPropertiesTest, BuildRejectsInvalidProgress) {
          OffsetRange(std::numeric_limits<int64_t>::max(), std::numeric_limits<int64_t>::max())}};
     ASSERT_NOK_WITH_MSG(
         RealtimeCommitProperties::Build(/*properties=*/{}, exhausted_snapshot, after_max,
-                                        file_system_, directory_->Str(), "main"),
+                                        /*reset_all_realtime_progress=*/false,
+                                        /*removed_realtime_partitions=*/{}, file_system_,
+                                        directory_->Str(), "main"),
         "offset range is invalid");
 }
 
@@ -346,16 +354,53 @@ TEST_F(RealtimeCommitPropertiesTest, BuildWithoutProgress) {
     ASSERT_OK_AND_ASSIGN(Properties inherited,
                          RealtimeCommitProperties::Build(
                              properties, std::optional<Snapshot>(MakeSnapshot(latest_properties)),
-                             /*realtime_ranges=*/{}, /*file_system=*/nullptr,
+                             /*realtime_ranges=*/{}, /*reset_all_realtime_progress=*/false,
+                             /*removed_realtime_partitions=*/{},
+                             /*file_system=*/nullptr,
                              /*table_root=*/"", /*branch=*/"main"));
     ASSERT_EQ("value", inherited.at("custom"));
     ASSERT_EQ(latest_offsets_path, inherited.at(RealtimeCommitProperties::kOffsetsKey));
 
     ASSERT_OK_AND_ASSIGN(Properties unchanged, RealtimeCommitProperties::Build(
                                                    properties, /*latest_snapshot=*/std::nullopt,
-                                                   /*realtime_ranges=*/{}, /*file_system=*/nullptr,
+                                                   /*realtime_ranges=*/{},
+                                                   /*reset_all_realtime_progress=*/false,
+                                                   /*removed_realtime_partitions=*/{},
+                                                   /*file_system=*/nullptr,
                                                    /*table_root=*/"", /*branch=*/"main"));
     ASSERT_EQ(properties, unchanged);
+
+    Properties properties_with_stale_offset = properties;
+    properties_with_stale_offset[RealtimeCommitProperties::kOffsetsKey] = "stale.offsets";
+    ASSERT_OK_AND_ASSIGN(
+        Properties overwritten,
+        RealtimeCommitProperties::Build(
+            properties_with_stale_offset, std::optional<Snapshot>(MakeSnapshot(latest_properties)),
+            /*realtime_ranges=*/{}, /*reset_all_realtime_progress=*/true,
+            /*removed_realtime_partitions=*/{},
+            /*file_system=*/nullptr, /*table_root=*/"", /*branch=*/"main"));
+    ASSERT_EQ("value", overwritten.at("custom"));
+    ASSERT_EQ(0, overwritten.count(RealtimeCommitProperties::kOffsetsKey));
+}
+
+TEST_F(RealtimeCommitPropertiesTest, BuildRemovesOnlyOverwrittenPartitions) {
+    RealtimePartitionBucket dt2_bucket0({{"dt", "2"}}, /*bucket=*/0);
+    RealtimePartitionBucket dt2_bucket1({{"dt", "2"}}, /*bucket=*/1);
+    RealtimePartitionBucket dt3_bucket0({{"dt", "3"}}, /*bucket=*/0);
+    RealtimeOffsetMap committed_offsets = {{dt2_bucket0, 3}, {dt2_bucket1, 4}, {dt3_bucket0, 5}};
+    ASSERT_OK_AND_ASSIGN(Snapshot latest_snapshot, MakeSnapshotWithOffsets(committed_offsets));
+    std::vector<std::map<std::string, std::string>> removed_partitions = {{{"dt", "2"}}};
+
+    ASSERT_OK_AND_ASSIGN(Properties properties,
+                         RealtimeCommitProperties::Build(
+                             /*properties=*/{}, latest_snapshot, /*realtime_ranges=*/{},
+                             /*reset_all_realtime_progress=*/false, removed_partitions,
+                             file_system_, directory_->Str(), "main"));
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap actual,
+                         RealtimeCommitProperties::ReadOffsets(
+                             std::optional<Snapshot>(MakeSnapshot(properties)), file_system_));
+    RealtimeOffsetMap expected = {{dt3_bucket0, 5}};
+    ASSERT_EQ(expected, actual);
 }
 
 TEST_F(RealtimeCommitPropertiesTest, BuildWritesMergedProgress) {
@@ -368,10 +413,12 @@ TEST_F(RealtimeCommitPropertiesTest, BuildWritesMergedProgress) {
         {RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0), OffsetRange(7, 9)}};
     std::map<std::string, std::string> properties = {{"custom", "value"}};
 
-    ASSERT_OK_AND_ASSIGN(Properties merged,
-                         RealtimeCommitProperties::Build(
-                             properties, std::optional<Snapshot>(MakeSnapshot(latest_properties)),
-                             ranges, file_system_, directory_->Str(), "main"));
+    ASSERT_OK_AND_ASSIGN(
+        Properties merged,
+        RealtimeCommitProperties::Build(
+            properties, std::optional<Snapshot>(MakeSnapshot(latest_properties)), ranges,
+            /*reset_all_realtime_progress=*/false,
+            /*removed_realtime_partitions=*/{}, file_system_, directory_->Str(), "main"));
     ASSERT_EQ("value", merged.at("custom"));
     ASSERT_NE(latest_offsets_path, merged.at(RealtimeCommitProperties::kOffsetsKey));
 
@@ -388,10 +435,12 @@ TEST_F(RealtimeCommitPropertiesTest, BuildWritesMergedProgress) {
 TEST_F(RealtimeCommitPropertiesTest, BuildRequiresFileSystem) {
     std::map<RealtimePartitionBucket, OffsetRange> ranges = {
         {RealtimePartitionBucket({{"dt", "2"}}, /*bucket=*/0), OffsetRange(0, 2)}};
-    ASSERT_NOK_WITH_MSG(RealtimeCommitProperties::Build(
-                            /*properties=*/{}, /*latest_snapshot=*/std::nullopt, ranges,
-                            /*file_system=*/nullptr, directory_->Str(), "main"),
-                        "file system is null");
+    ASSERT_NOK_WITH_MSG(
+        RealtimeCommitProperties::Build(
+            /*properties=*/{}, /*latest_snapshot=*/std::nullopt, ranges,
+            /*reset_all_realtime_progress=*/false,
+            /*removed_realtime_partitions=*/{}, /*file_system=*/nullptr, directory_->Str(), "main"),
+        "file system is null");
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/operation/commit/realtime_commit_properties_test.cpp
+++ b/src/paimon/core/operation/commit/realtime_commit_properties_test.cpp
@@ -28,9 +28,12 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/type.h"
 #include "gtest/gtest.h"
+#include "paimon/common/utils/binary_row_partition_computer.h"
 #include "paimon/fs/file_system.h"
 #include "paimon/macros.h"
+#include "paimon/memory/memory_pool.h"
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
@@ -71,6 +74,13 @@ class RealtimeCommitPropertiesTest : public testing::Test {
         ASSERT_NE(nullptr, directory_);
         file_system_ = directory_->GetFileSystem();
         ASSERT_NE(nullptr, file_system_);
+        std::shared_ptr<arrow::Schema> schema = arrow::schema(
+            {arrow::field("dt", arrow::utf8()), arrow::field("region", arrow::utf8())});
+        ASSERT_OK_AND_ASSIGN(partition_computer_,
+                             BinaryRowPartitionComputer::Create(
+                                 /*partition_keys=*/{"dt", "region"}, schema,
+                                 /*default_part_value=*/"__DEFAULT_PARTITION__",
+                                 /*legacy_partition_name_enabled=*/true, GetDefaultPool()));
     }
 
     Snapshot MakeSnapshot(
@@ -120,6 +130,7 @@ class RealtimeCommitPropertiesTest : public testing::Test {
 
     std::unique_ptr<UniqueTestDirectory> directory_;
     std::shared_ptr<FileSystem> file_system_;
+    std::unique_ptr<BinaryRowPartitionComputer> partition_computer_;
     int32_t next_file_id_ = 0;
 };
 
@@ -312,25 +323,27 @@ TEST_F(RealtimeCommitPropertiesTest, BuildRejectsInvalidProgress) {
     ASSERT_NOK_WITH_MSG(
         RealtimeCommitProperties::Build(/*properties=*/{}, /*latest_snapshot=*/std::nullopt,
                                         invalid_bucket, /*reset_all_realtime_progress=*/false,
-                                        /*removed_realtime_partitions=*/{}, file_system_,
-                                        directory_->Str(), "main"),
+                                        /*removed_realtime_partitions=*/{}, *partition_computer_,
+                                        file_system_, directory_->Str(), "main"),
         "bucket -1 is invalid");
 
     std::map<RealtimePartitionBucket, OffsetRange> gap = {
         {RealtimePartitionBucket({{"dt", "2"}}, /*bucket=*/0), OffsetRange(3, 5)}};
-    ASSERT_NOK_WITH_MSG(RealtimeCommitProperties::Build(/*properties=*/{}, latest_snapshot, gap,
-                                                        /*reset_all_realtime_progress=*/false,
-                                                        /*removed_realtime_partitions=*/{},
-                                                        file_system_, directory_->Str(), "main"),
-                        "are not contiguous");
+    ASSERT_NOK_WITH_MSG(
+        RealtimeCommitProperties::Build(/*properties=*/{}, latest_snapshot, gap,
+                                        /*reset_all_realtime_progress=*/false,
+                                        /*removed_realtime_partitions=*/{}, *partition_computer_,
+                                        file_system_, directory_->Str(), "main"),
+        "are not contiguous");
 
     std::map<RealtimePartitionBucket, OffsetRange> overlap = {
         {RealtimePartitionBucket({{"dt", "2"}}, /*bucket=*/0), OffsetRange(0, 2)}};
-    ASSERT_NOK_WITH_MSG(RealtimeCommitProperties::Build(/*properties=*/{}, latest_snapshot, overlap,
-                                                        /*reset_all_realtime_progress=*/false,
-                                                        /*removed_realtime_partitions=*/{},
-                                                        file_system_, directory_->Str(), "main"),
-                        "are not contiguous");
+    ASSERT_NOK_WITH_MSG(
+        RealtimeCommitProperties::Build(/*properties=*/{}, latest_snapshot, overlap,
+                                        /*reset_all_realtime_progress=*/false,
+                                        /*removed_realtime_partitions=*/{}, *partition_computer_,
+                                        file_system_, directory_->Str(), "main"),
+        "are not contiguous");
 
     RealtimeOffsetMap exhausted_offsets = {{bucket0, std::numeric_limits<int64_t>::max()}};
     ASSERT_OK_AND_ASSIGN(Snapshot exhausted_snapshot, MakeSnapshotWithOffsets(exhausted_offsets));
@@ -340,8 +353,8 @@ TEST_F(RealtimeCommitPropertiesTest, BuildRejectsInvalidProgress) {
     ASSERT_NOK_WITH_MSG(
         RealtimeCommitProperties::Build(/*properties=*/{}, exhausted_snapshot, after_max,
                                         /*reset_all_realtime_progress=*/false,
-                                        /*removed_realtime_partitions=*/{}, file_system_,
-                                        directory_->Str(), "main"),
+                                        /*removed_realtime_partitions=*/{}, *partition_computer_,
+                                        file_system_, directory_->Str(), "main"),
         "offset range is invalid");
 }
 
@@ -355,19 +368,20 @@ TEST_F(RealtimeCommitPropertiesTest, BuildWithoutProgress) {
                          RealtimeCommitProperties::Build(
                              properties, std::optional<Snapshot>(MakeSnapshot(latest_properties)),
                              /*realtime_ranges=*/{}, /*reset_all_realtime_progress=*/false,
-                             /*removed_realtime_partitions=*/{},
+                             /*removed_realtime_partitions=*/{}, *partition_computer_,
                              /*file_system=*/nullptr,
                              /*table_root=*/"", /*branch=*/"main"));
     ASSERT_EQ("value", inherited.at("custom"));
     ASSERT_EQ(latest_offsets_path, inherited.at(RealtimeCommitProperties::kOffsetsKey));
 
-    ASSERT_OK_AND_ASSIGN(Properties unchanged, RealtimeCommitProperties::Build(
-                                                   properties, /*latest_snapshot=*/std::nullopt,
-                                                   /*realtime_ranges=*/{},
-                                                   /*reset_all_realtime_progress=*/false,
-                                                   /*removed_realtime_partitions=*/{},
-                                                   /*file_system=*/nullptr,
-                                                   /*table_root=*/"", /*branch=*/"main"));
+    ASSERT_OK_AND_ASSIGN(
+        Properties unchanged,
+        RealtimeCommitProperties::Build(properties, /*latest_snapshot=*/std::nullopt,
+                                        /*realtime_ranges=*/{},
+                                        /*reset_all_realtime_progress=*/false,
+                                        /*removed_realtime_partitions=*/{}, *partition_computer_,
+                                        /*file_system=*/nullptr,
+                                        /*table_root=*/"", /*branch=*/"main"));
     ASSERT_EQ(properties, unchanged);
 
     Properties properties_with_stale_offset = properties;
@@ -377,7 +391,7 @@ TEST_F(RealtimeCommitPropertiesTest, BuildWithoutProgress) {
         RealtimeCommitProperties::Build(
             properties_with_stale_offset, std::optional<Snapshot>(MakeSnapshot(latest_properties)),
             /*realtime_ranges=*/{}, /*reset_all_realtime_progress=*/true,
-            /*removed_realtime_partitions=*/{},
+            /*removed_realtime_partitions=*/{}, *partition_computer_,
             /*file_system=*/nullptr, /*table_root=*/"", /*branch=*/"main"));
     ASSERT_EQ("value", overwritten.at("custom"));
     ASSERT_EQ(0, overwritten.count(RealtimeCommitProperties::kOffsetsKey));
@@ -395,7 +409,7 @@ TEST_F(RealtimeCommitPropertiesTest, BuildRemovesOnlyOverwrittenPartitions) {
                          RealtimeCommitProperties::Build(
                              /*properties=*/{}, latest_snapshot, /*realtime_ranges=*/{},
                              /*reset_all_realtime_progress=*/false, removed_partitions,
-                             file_system_, directory_->Str(), "main"));
+                             *partition_computer_, file_system_, directory_->Str(), "main"));
     ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap actual,
                          RealtimeCommitProperties::ReadOffsets(
                              std::optional<Snapshot>(MakeSnapshot(properties)), file_system_));
@@ -418,7 +432,8 @@ TEST_F(RealtimeCommitPropertiesTest, BuildWritesMergedProgress) {
         RealtimeCommitProperties::Build(
             properties, std::optional<Snapshot>(MakeSnapshot(latest_properties)), ranges,
             /*reset_all_realtime_progress=*/false,
-            /*removed_realtime_partitions=*/{}, file_system_, directory_->Str(), "main"));
+            /*removed_realtime_partitions=*/{}, *partition_computer_, file_system_,
+            directory_->Str(), "main"));
     ASSERT_EQ("value", merged.at("custom"));
     ASSERT_NE(latest_offsets_path, merged.at(RealtimeCommitProperties::kOffsetsKey));
 
@@ -435,12 +450,12 @@ TEST_F(RealtimeCommitPropertiesTest, BuildWritesMergedProgress) {
 TEST_F(RealtimeCommitPropertiesTest, BuildRequiresFileSystem) {
     std::map<RealtimePartitionBucket, OffsetRange> ranges = {
         {RealtimePartitionBucket({{"dt", "2"}}, /*bucket=*/0), OffsetRange(0, 2)}};
-    ASSERT_NOK_WITH_MSG(
-        RealtimeCommitProperties::Build(
-            /*properties=*/{}, /*latest_snapshot=*/std::nullopt, ranges,
-            /*reset_all_realtime_progress=*/false,
-            /*removed_realtime_partitions=*/{}, /*file_system=*/nullptr, directory_->Str(), "main"),
-        "file system is null");
+    ASSERT_NOK_WITH_MSG(RealtimeCommitProperties::Build(
+                            /*properties=*/{}, /*latest_snapshot=*/std::nullopt, ranges,
+                            /*reset_all_realtime_progress=*/false,
+                            /*removed_realtime_partitions=*/{}, *partition_computer_,
+                            /*file_system=*/nullptr, directory_->Str(), "main"),
+                        "file system is null");
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/operation/expire_snapshots.cpp
+++ b/src/paimon/core/operation/expire_snapshots.cpp
@@ -51,13 +51,14 @@ ExpireSnapshots::ExpireSnapshots(const std::shared_ptr<SnapshotManager>& snapsho
                                  const std::shared_ptr<ManifestList>& manifest_list,
                                  const std::shared_ptr<ManifestFile>& manifest_file,
                                  const std::shared_ptr<FileSystem>& fs, const ExpireConfig& config,
-                                 const std::shared_ptr<Executor>& executor)
+                                 bool realtime_enabled, const std::shared_ptr<Executor>& executor)
     : snapshot_manager_(snapshot_manager),
       path_factory_(path_factory),
       manifest_list_(manifest_list),
       manifest_file_(manifest_file),
       fs_(fs),
       config_(config),
+      realtime_enabled_(realtime_enabled),
       executor_(executor),
       logger_(Logger::GetLogger("ExpireSnapshots")) {}
 
@@ -159,16 +160,18 @@ Result<int32_t> ExpireSnapshots::ExpireUntil(int64_t earliest_snapshot_id,
     PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, snapshot_manager_->LoadSnapshot(end_exclusive_id));
     retained_snapshots.push_back(snapshot);
     std::set<std::string> retained_offset_files;
-    PAIMON_ASSIGN_OR_RAISE(std::vector<Snapshot> all_snapshots,
-                           snapshot_manager_->GetAllSnapshots());
-    for (const Snapshot& retained_snapshot : all_snapshots) {
-        if (retained_snapshot.Id() < end_exclusive_id) {
-            continue;
-        }
-        std::optional<std::string> offsets_path =
-            RealtimeCommitProperties::GetOffsetsPath(retained_snapshot);
-        if (offsets_path) {
-            retained_offset_files.insert(offsets_path.value());
+    if (realtime_enabled_) {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<Snapshot> all_snapshots,
+                               snapshot_manager_->GetAllSnapshots());
+        for (const Snapshot& retained_snapshot : all_snapshots) {
+            if (retained_snapshot.Id() < end_exclusive_id) {
+                continue;
+            }
+            std::optional<std::string> offsets_path =
+                RealtimeCommitProperties::GetOffsetsPath(retained_snapshot);
+            if (offsets_path) {
+                retained_offset_files.insert(offsets_path.value());
+            }
         }
     }
     std::set<std::string> skipping_sets;
@@ -184,10 +187,12 @@ Result<int32_t> ExpireSnapshots::ExpireUntil(int64_t earliest_snapshot_id,
         PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, snapshot_manager_->LoadSnapshot(id));
         PAIMON_RETURN_NOT_OK(CleanUnusedManifests(snapshot.BaseManifestList(), skipping_sets));
         PAIMON_RETURN_NOT_OK(CleanUnusedManifests(snapshot.DeltaManifestList(), skipping_sets));
-        std::optional<std::string> offsets_path =
-            RealtimeCommitProperties::GetOffsetsPath(snapshot);
-        if (offsets_path) {
-            expired_offset_files.insert(offsets_path.value());
+        if (realtime_enabled_) {
+            std::optional<std::string> offsets_path =
+                RealtimeCommitProperties::GetOffsetsPath(snapshot);
+            if (offsets_path) {
+                expired_offset_files.insert(offsets_path.value());
+            }
         }
         auto status = fs_->Delete(snapshot_manager_->SnapshotPath(id));
         // delete quietly will ignore any status error

--- a/src/paimon/core/operation/expire_snapshots.cpp
+++ b/src/paimon/core/operation/expire_snapshots.cpp
@@ -38,6 +38,7 @@
 #include "paimon/core/manifest/manifest_file.h"
 #include "paimon/core/manifest/manifest_file_meta.h"
 #include "paimon/core/manifest/manifest_list.h"
+#include "paimon/core/operation/commit/realtime_commit_properties.h"
 #include "paimon/core/snapshot.h"
 #include "paimon/core/utils/file_store_path_factory.h"
 #include "paimon/core/utils/snapshot_manager.h"
@@ -157,8 +158,22 @@ Result<int32_t> ExpireSnapshots::ExpireUntil(int64_t earliest_snapshot_id,
     std::vector<Snapshot> retained_snapshots;
     PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, snapshot_manager_->LoadSnapshot(end_exclusive_id));
     retained_snapshots.push_back(snapshot);
+    std::set<std::string> retained_offset_files;
+    PAIMON_ASSIGN_OR_RAISE(std::vector<Snapshot> all_snapshots,
+                           snapshot_manager_->GetAllSnapshots());
+    for (const Snapshot& retained_snapshot : all_snapshots) {
+        if (retained_snapshot.Id() < end_exclusive_id) {
+            continue;
+        }
+        std::optional<std::string> offsets_path =
+            RealtimeCommitProperties::GetOffsetsPath(retained_snapshot);
+        if (offsets_path) {
+            retained_offset_files.insert(offsets_path.value());
+        }
+    }
     std::set<std::string> skipping_sets;
     PAIMON_RETURN_NOT_OK(GetManifestSkippingSet(retained_snapshots, &skipping_sets));
+    std::set<std::string> expired_offset_files;
     for (int64_t id = begin_inclusive_id; id < end_exclusive_id; id++) {
         PAIMON_LOG_DEBUG(logger_, "Ready to delete manifests in snapshot #%ld", id);
         PAIMON_ASSIGN_OR_RAISE(bool exist, snapshot_manager_->SnapshotExists(id));
@@ -169,9 +184,21 @@ Result<int32_t> ExpireSnapshots::ExpireUntil(int64_t earliest_snapshot_id,
         PAIMON_ASSIGN_OR_RAISE(Snapshot snapshot, snapshot_manager_->LoadSnapshot(id));
         PAIMON_RETURN_NOT_OK(CleanUnusedManifests(snapshot.BaseManifestList(), skipping_sets));
         PAIMON_RETURN_NOT_OK(CleanUnusedManifests(snapshot.DeltaManifestList(), skipping_sets));
+        std::optional<std::string> offsets_path =
+            RealtimeCommitProperties::GetOffsetsPath(snapshot);
+        if (offsets_path) {
+            expired_offset_files.insert(offsets_path.value());
+        }
         auto status = fs_->Delete(snapshot_manager_->SnapshotPath(id));
         // delete quietly will ignore any status error
         (void)status;
+    }
+    for (const std::string& offsets_path : expired_offset_files) {
+        if (retained_offset_files.count(offsets_path) == 0) {
+            auto status = fs_->Delete(offsets_path);
+            // Orphan cleanup can retry offset files that fail to delete here.
+            (void)status;
+        }
     }
     PAIMON_RETURN_NOT_OK(snapshot_manager_->CommitEarliestHint(end_exclusive_id));
     return end_exclusive_id - begin_inclusive_id;

--- a/src/paimon/core/operation/expire_snapshots.h
+++ b/src/paimon/core/operation/expire_snapshots.h
@@ -51,7 +51,7 @@ class ExpireSnapshots {
                     const std::shared_ptr<ManifestList>& manifest_list,
                     const std::shared_ptr<ManifestFile>& manifest_file,
                     const std::shared_ptr<FileSystem>& fs, const ExpireConfig& config,
-                    const std::shared_ptr<Executor>& executor);
+                    bool realtime_enabled, const std::shared_ptr<Executor>& executor);
 
     Result<int32_t> Expire();
 
@@ -74,6 +74,7 @@ class ExpireSnapshots {
     std::shared_ptr<ManifestFile> manifest_file_;
     std::shared_ptr<FileSystem> fs_;
     ExpireConfig config_;
+    bool realtime_enabled_;
     std::shared_ptr<Executor> executor_;
     std::unordered_map<BinaryRow, std::set<std::int32_t>> deletion_buckets_;
 

--- a/src/paimon/core/operation/expire_snapshots_test.cpp
+++ b/src/paimon/core/operation/expire_snapshots_test.cpp
@@ -170,7 +170,7 @@ TEST_F(ExpireSnapshotsTest, TestInvalidInput) {
     {
         ASSERT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap({}));
         ExpireSnapshots expire(mgr, path_factory_, manifest_list_, manifest_file_, fs_,
-                               options.GetExpireConfig(), executor_);
+                               options.GetExpireConfig(), options.RealtimeEnabled(), executor_);
         ASSERT_OK_AND_ASSIGN(int32_t count, expire.Expire());
         ASSERT_EQ(count, 0);
     }
@@ -178,7 +178,7 @@ TEST_F(ExpireSnapshotsTest, TestInvalidInput) {
         ASSERT_OK_AND_ASSIGN(CoreOptions options,
                              CoreOptions::FromMap({{Options::SNAPSHOT_NUM_RETAINED_MIN, "0"}}));
         ExpireSnapshots expire(mgr, path_factory_, manifest_list_, manifest_file_, fs_,
-                               options.GetExpireConfig(), executor_);
+                               options.GetExpireConfig(), options.RealtimeEnabled(), executor_);
         ASSERT_NOK(expire.Expire());
     }
     {
@@ -186,7 +186,7 @@ TEST_F(ExpireSnapshotsTest, TestInvalidInput) {
                              CoreOptions::FromMap({{Options::SNAPSHOT_NUM_RETAINED_MIN, "10"},
                                                    {Options::SNAPSHOT_NUM_RETAINED_MAX, "9"}}));
         ExpireSnapshots expire(mgr, path_factory_, manifest_list_, manifest_file_, fs_,
-                               options.GetExpireConfig(), executor_);
+                               options.GetExpireConfig(), options.RealtimeEnabled(), executor_);
         ASSERT_NOK(expire.Expire());
     }
     {
@@ -194,7 +194,7 @@ TEST_F(ExpireSnapshotsTest, TestInvalidInput) {
                              CoreOptions::FromMap({{Options::SNAPSHOT_NUM_RETAINED_MIN, "10"},
                                                    {Options::SNAPSHOT_NUM_RETAINED_MAX, "10"}}));
         ExpireSnapshots expire(mgr, path_factory_, manifest_list_, manifest_file_, fs_,
-                               options.GetExpireConfig(), executor_);
+                               options.GetExpireConfig(), options.RealtimeEnabled(), executor_);
         ASSERT_OK_AND_ASSIGN(int32_t count, expire.Expire());
         ASSERT_EQ(count, 0);
     }
@@ -204,7 +204,7 @@ TEST_F(ExpireSnapshotsTest, TestInvalidInput) {
                                                    {Options::SNAPSHOT_NUM_RETAINED_MIN, "10"},
                                                    {Options::SNAPSHOT_NUM_RETAINED_MAX, "10"}}));
         ExpireSnapshots expire(mgr, path_factory_, manifest_list_, manifest_file_, fs_,
-                               options.GetExpireConfig(), executor_);
+                               options.GetExpireConfig(), options.RealtimeEnabled(), executor_);
         ASSERT_NOK(expire.Expire());
     }
     {
@@ -212,7 +212,7 @@ TEST_F(ExpireSnapshotsTest, TestInvalidInput) {
                              CoreOptions::FromMap({{Options::SNAPSHOT_NUM_RETAINED_MIN, "10"},
                                                    {Options::SNAPSHOT_NUM_RETAINED_MAX, "10"}}));
         ExpireSnapshots expire(nullptr, path_factory_, manifest_list_, manifest_file_, fs_,
-                               options.GetExpireConfig(), executor_);
+                               options.GetExpireConfig(), options.RealtimeEnabled(), executor_);
         ASSERT_NOK(expire.Expire());
     }
 }
@@ -222,7 +222,7 @@ TEST_F(ExpireSnapshotsTest, TestGetDataFileToDelete) {
     ASSERT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap({}));
     {
         ExpireSnapshots expire(mgr, path_factory_, manifest_list_, manifest_file_, fs_,
-                               options.GetExpireConfig(), executor_);
+                               options.GetExpireConfig(), options.RealtimeEnabled(), executor_);
         std::map<std::string, ManifestEntry> data_file_to_delete;
         std::vector<ManifestEntry> data_file_entries;
         data_file_entries.push_back(CreateManifestEntry("file1", /*bucket=*/0, FileKind::Delete()));
@@ -237,7 +237,7 @@ TEST_F(ExpireSnapshotsTest, TestGetDataFileToDelete) {
     }
     {
         ExpireSnapshots expire(mgr, path_factory_, manifest_list_, manifest_file_, fs_,
-                               options.GetExpireConfig(), executor_);
+                               options.GetExpireConfig(), options.RealtimeEnabled(), executor_);
         std::map<std::string, ManifestEntry> data_file_to_delete;
         std::vector<ManifestEntry> data_file_entries;
         data_file_entries.push_back(CreateManifestEntry("file1", /*bucket=*/0, FileKind::Add()));

--- a/src/paimon/core/operation/file_store_commit.cpp
+++ b/src/paimon/core/operation/file_store_commit.cpp
@@ -175,7 +175,7 @@ Result<std::unique_ptr<FileStoreCommit>> FileStoreCommit::Create(
 
     auto expire_snapshots = std::make_shared<ExpireSnapshots>(
         snapshot_manager, path_factory, manifest_list, manifest_file, options.GetFileSystem(),
-        options.GetExpireConfig(), ctx->GetExecutor());
+        options.GetExpireConfig(), options.RealtimeEnabled(), ctx->GetExecutor());
 
     CommitScanner::ScanSupplier scan_supplier;
     if (table_schema.value()->PrimaryKeys().empty()) {

--- a/src/paimon/core/operation/file_store_commit_impl.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl.cpp
@@ -929,6 +929,19 @@ Result<int64_t> FileStoreCommitImpl::CommitWithProgress(
         commit_messages.push_back(realtime_commit.commit_message);
     }
 
+    PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> latest_snapshot,
+                           snapshot_manager_->LatestSnapshot());
+    PAIMON_ASSIGN_OR_RAISE(RealtimeOffsetMap committed_offsets,
+                           RealtimeCommitProperties::ReadOffsets(latest_snapshot, fs_));
+    PAIMON_ASSIGN_OR_RAISE(bool ranges_committed, RealtimeCommitProperties::AreRangesCommitted(
+                                                      committed_offsets, realtime_ranges));
+    if (ranges_committed) {
+        if (!latest_snapshot) {
+            return Status::Invalid("real-time commit ranges are covered without a snapshot");
+        }
+        return latest_snapshot->Id();
+    }
+
     std::shared_ptr<ManifestCommittable> committable =
         CreateManifestCommittable(identifier, commit_messages, watermark, /*properties=*/{});
     const int64_t previous_snapshot_id = last_committed_snapshot_id_;

--- a/src/paimon/core/operation/file_store_commit_impl.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl.cpp
@@ -80,6 +80,7 @@
 #include "paimon/core/table/sink/commit_message_impl.h"
 #include "paimon/core/utils/duration.h"
 #include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/core/utils/partition_utils.h"
 #include "paimon/core/utils/snapshot_manager.h"
 #include "paimon/file_store_write.h"
 #include "paimon/fs/file_system.h"
@@ -95,17 +96,6 @@ namespace {
 constexpr const char* kCommitStrictModeLastSafeSnapshot = "commit.strict-mode.last-safe-snapshot";
 constexpr const char* kSequenceSnapshotOrdering = "sequence.snapshot-ordering";
 constexpr const char* kPkClusteringOverride = "pk-clustering-override";
-
-bool MatchPartitionSpec(const std::map<std::string, std::string>& partition,
-                        const std::map<std::string, std::string>& partition_spec) {
-    for (const auto& [key, value] : partition_spec) {
-        auto iter = partition.find(key);
-        if (iter == partition.end() || iter->second != value) {
-            return false;
-        }
-    }
-    return true;
-}
 
 }  // namespace
 
@@ -667,7 +657,10 @@ Status FileStoreCommitImpl::ExecuteOverwrite(
             PAIMON_ASSIGN_OR_RAISE(partition_map, PartitionToMap(entry.Partition()));
             bool belongs_to_overwrite_partition = false;
             for (const auto& partition_spec : partitions) {
-                if (MatchPartitionSpec(partition_map, partition_spec)) {
+                PAIMON_ASSIGN_OR_RAISE(
+                    bool matched, PartitionUtils::MatchPartitionSpec(partition_map, partition_spec,
+                                                                     *partition_computer_));
+                if (matched) {
                     belongs_to_overwrite_partition = true;
                     break;
                 }
@@ -1009,9 +1002,10 @@ Result<int32_t> FileStoreCommitImpl::TryCommit(
         using SnapshotProperties = std::map<std::string, std::string>;
         PAIMON_ASSIGN_OR_RAISE(
             SnapshotProperties snapshot_properties,
-            RealtimeCommitProperties::Build(
-                properties, latest_snapshot, realtime_ranges, reset_all_realtime_progress,
-                removed_realtime_partitions, fs_, root_path_, snapshot_manager_->Branch()));
+            RealtimeCommitProperties::Build(properties, latest_snapshot, realtime_ranges,
+                                            reset_all_realtime_progress,
+                                            removed_realtime_partitions, *partition_computer_, fs_,
+                                            root_path_, snapshot_manager_->Branch()));
         PAIMON_ASSIGN_OR_RAISE(
             bool commit_success,
             TryCommitOnce(commit_changes->delta_files, commit_changes->changelog_files,

--- a/src/paimon/core/operation/file_store_commit_impl.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl.cpp
@@ -337,7 +337,6 @@ Result<bool> FileStoreCommitImpl::RollbackToAsLatest(int64_t target_snapshot_id)
     // snapshots between the target and the previous latest, breaking the global uniqueness of
     // _ROW_ID. Keep the larger of the previous latest and the target nextRowId.
     std::optional<int64_t> next_row_id = std::max(latest.NextRowId(), target_snapshot.NextRowId());
-
     int64_t delta_record_count =
         ManifestEntry::RecordCountAdd(delta_files) - ManifestEntry::RecordCountDelete(delta_files);
     Snapshot new_snapshot(
@@ -708,6 +707,8 @@ Status FileStoreCommitImpl::ExecuteOverwrite(
                                          changes->compact_index_files, identifier, watermark,
                                          committable->Properties(), /*realtime_ranges=*/{},
                                          Snapshot::CommitKind::Compact(),
+                                         /*reset_all_realtime_progress=*/false,
+                                         /*removed_realtime_partitions=*/{},
                                          /*detect_conflicts=*/true,
                                          /*retry_on_conflict=*/true));
         *attempt += cnt;
@@ -809,8 +810,12 @@ Result<int32_t> FileStoreCommitImpl::TryOverwrite(
     const std::map<std::string, std::string>& properties) {
     std::shared_ptr<CommitChangesProvider> changes_provider =
         commit_scanner_->OverwriteChangesProvider(partitions, changes, index_entries);
+    // ExecuteOverwrite has already resolved dynamic overwrite to the concrete affected
+    // partitions. Only an empty final partition list denotes a full-table replacement.
+    const bool reset_all_realtime_progress = partitions.empty();
     return TryCommit(changes_provider, commit_identifier, watermark, properties,
                      /*realtime_ranges=*/{}, Snapshot::CommitKind::Overwrite(),
+                     reset_all_realtime_progress, partitions,
                      /*detect_conflicts=*/true,
                      /*retry_on_conflict=*/true);
 }
@@ -859,7 +864,9 @@ Status FileStoreCommitImpl::Commit(
             TryCommit(changes.append_table_files, changes.append_changelog,
                       changes.append_index_files, committable->Identifier(),
                       committable->Watermark(), committable->Properties(), realtime_ranges,
-                      commit_kind, check_append_files, retry_on_conflict));
+                      commit_kind,
+                      /*reset_all_realtime_progress=*/false,
+                      /*removed_realtime_partitions=*/{}, check_append_files, retry_on_conflict));
         attempt += cnt;
         generated_snapshot += 1;
     }
@@ -870,6 +877,8 @@ Status FileStoreCommitImpl::Commit(
                                          changes.compact_index_files, committable->Identifier(),
                                          committable->Watermark(), committable->Properties(),
                                          /*realtime_ranges=*/{}, Snapshot::CommitKind::Compact(),
+                                         /*reset_all_realtime_progress=*/false,
+                                         /*removed_realtime_partitions=*/{},
                                          /*detect_conflicts=*/true, retry_on_conflict));
         attempt += cnt;
         generated_snapshot += 1;
@@ -973,18 +982,23 @@ Result<int32_t> FileStoreCommitImpl::TryCommit(
     const std::vector<IndexManifestEntry>& index_entries, int64_t identifier,
     std::optional<int64_t> watermark, const std::map<std::string, std::string>& properties,
     const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
-    Snapshot::CommitKind commit_kind, bool detect_conflicts, bool retry_on_conflict) {
+    Snapshot::CommitKind commit_kind, bool reset_all_realtime_progress,
+    const std::vector<std::map<std::string, std::string>>& removed_realtime_partitions,
+    bool detect_conflicts, bool retry_on_conflict) {
     std::shared_ptr<CommitChangesProvider> changes_provider =
         CommitChangesProvider::Provider(delta_files, changelog_files, index_entries);
     return TryCommit(changes_provider, identifier, watermark, properties, realtime_ranges,
-                     commit_kind, detect_conflicts, retry_on_conflict);
+                     commit_kind, reset_all_realtime_progress, removed_realtime_partitions,
+                     detect_conflicts, retry_on_conflict);
 }
 
 Result<int32_t> FileStoreCommitImpl::TryCommit(
     const std::shared_ptr<CommitChangesProvider>& changes_provider, int64_t identifier,
     std::optional<int64_t> watermark, const std::map<std::string, std::string>& properties,
     const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
-    Snapshot::CommitKind commit_kind, bool detect_conflicts, bool retry_on_conflict) {
+    Snapshot::CommitKind commit_kind, bool reset_all_realtime_progress,
+    const std::vector<std::map<std::string, std::string>>& removed_realtime_partitions,
+    bool detect_conflicts, bool retry_on_conflict) {
     int32_t retry_count = 0;
     int64_t start_millis = DateTimeUtils::GetCurrentUTCTimeUs() / 1000;
     while (true) {
@@ -995,8 +1009,9 @@ Result<int32_t> FileStoreCommitImpl::TryCommit(
         using SnapshotProperties = std::map<std::string, std::string>;
         PAIMON_ASSIGN_OR_RAISE(
             SnapshotProperties snapshot_properties,
-            RealtimeCommitProperties::Build(properties, latest_snapshot, realtime_ranges, fs_,
-                                            root_path_, snapshot_manager_->Branch()));
+            RealtimeCommitProperties::Build(
+                properties, latest_snapshot, realtime_ranges, reset_all_realtime_progress,
+                removed_realtime_partitions, fs_, root_path_, snapshot_manager_->Branch()));
         PAIMON_ASSIGN_OR_RAISE(
             bool commit_success,
             TryCommitOnce(commit_changes->delta_files, commit_changes->changelog_files,

--- a/src/paimon/core/operation/file_store_commit_impl.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl.cpp
@@ -889,6 +889,9 @@ Status FileStoreCommitImpl::Commit(
 Result<int64_t> FileStoreCommitImpl::CommitWithProgress(
     const std::vector<RealtimeCommitProgress>& realtime_commits, int64_t identifier,
     std::optional<int64_t> watermark) {
+    if (!options_.RealtimeEnabled()) {
+        return Status::Invalid("CommitWithProgress requires realtime.enabled=true");
+    }
     if (realtime_commits.empty()) {
         return Status::Invalid("real-time commits must not be empty");
     }
@@ -929,12 +932,24 @@ Result<int64_t> FileStoreCommitImpl::CommitWithProgress(
         commit_messages.push_back(realtime_commit.commit_message);
     }
 
+    std::shared_ptr<ManifestCommittable> committable =
+        CreateManifestCommittable(identifier, commit_messages, watermark, /*properties=*/{});
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<ManifestCommittable>> pending_committables,
+                           FilterCommitted({committable}));
+    const bool identifier_committed = pending_committables.empty();
+
     PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> latest_snapshot,
                            snapshot_manager_->LatestSnapshot());
     PAIMON_ASSIGN_OR_RAISE(RealtimeOffsetMap committed_offsets,
                            RealtimeCommitProperties::ReadOffsets(latest_snapshot, fs_));
     PAIMON_ASSIGN_OR_RAISE(bool ranges_committed, RealtimeCommitProperties::AreRangesCommitted(
                                                       committed_offsets, realtime_ranges));
+    if (ranges_committed != identifier_committed) {
+        return Status::Invalid(
+            ranges_committed
+                ? "real-time offset ranges were committed by another commit user or identifier"
+                : "real-time commit identifier was committed without the requested offset ranges");
+    }
     if (ranges_committed) {
         if (!latest_snapshot) {
             return Status::Invalid("real-time commit ranges are covered without a snapshot");
@@ -942,8 +957,7 @@ Result<int64_t> FileStoreCommitImpl::CommitWithProgress(
         return latest_snapshot->Id();
     }
 
-    std::shared_ptr<ManifestCommittable> committable =
-        CreateManifestCommittable(identifier, commit_messages, watermark, /*properties=*/{});
+    PAIMON_RETURN_NOT_OK(CheckFilesExistence(pending_committables));
     const int64_t previous_snapshot_id = last_committed_snapshot_id_;
     PAIMON_RETURN_NOT_OK(Commit(committable, /*check_append_files=*/false,
                                 /*retry_on_conflict=*/false, realtime_ranges));

--- a/src/paimon/core/operation/file_store_commit_impl.h
+++ b/src/paimon/core/operation/file_store_commit_impl.h
@@ -185,21 +185,23 @@ class FileStoreCommitImpl : public FileStoreCommit {
     void ReportCommit(const ManifestEntryChanges& changes, int64_t commit_duration,
                       int32_t generated_snapshot, int32_t attempt);
 
-    Result<int32_t> TryCommit(const std::vector<ManifestEntry>& delta_files,
-                              const std::vector<ManifestEntry>& changelog_files,
-                              const std::vector<IndexManifestEntry>& index_entries,
-                              int64_t identifier, std::optional<int64_t> watermark,
-                              const std::map<std::string, std::string>& properties,
-                              const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
-                              Snapshot::CommitKind commit_kind, bool detect_conflicts,
-                              bool retry_on_conflict);
+    Result<int32_t> TryCommit(
+        const std::vector<ManifestEntry>& delta_files,
+        const std::vector<ManifestEntry>& changelog_files,
+        const std::vector<IndexManifestEntry>& index_entries, int64_t identifier,
+        std::optional<int64_t> watermark, const std::map<std::string, std::string>& properties,
+        const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
+        Snapshot::CommitKind commit_kind, bool reset_all_realtime_progress,
+        const std::vector<std::map<std::string, std::string>>& removed_realtime_partitions,
+        bool detect_conflicts, bool retry_on_conflict);
 
-    Result<int32_t> TryCommit(const std::shared_ptr<CommitChangesProvider>& changes_provider,
-                              int64_t identifier, std::optional<int64_t> watermark,
-                              const std::map<std::string, std::string>& properties,
-                              const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
-                              Snapshot::CommitKind commit_kind, bool detect_conflicts,
-                              bool retry_on_conflict);
+    Result<int32_t> TryCommit(
+        const std::shared_ptr<CommitChangesProvider>& changes_provider, int64_t identifier,
+        std::optional<int64_t> watermark, const std::map<std::string, std::string>& properties,
+        const std::map<RealtimePartitionBucket, OffsetRange>& realtime_ranges,
+        Snapshot::CommitKind commit_kind, bool reset_all_realtime_progress,
+        const std::vector<std::map<std::string, std::string>>& removed_realtime_partitions,
+        bool detect_conflicts, bool retry_on_conflict);
 
     Result<bool> TryCommitOnce(const std::vector<ManifestEntry>& delta_files,
                                const std::vector<ManifestEntry>& changelog_files,

--- a/src/paimon/core/operation/file_store_write.cpp
+++ b/src/paimon/core/operation/file_store_write.cpp
@@ -120,6 +120,9 @@ Result<std::unique_ptr<FileStoreWrite>> FileStoreWrite::Create(std::unique_ptr<W
     }
 
     bool ignore_previous_files = ctx->IgnorePreviousFiles();
+    if (ctx->GetRealtimeContext() && !options.RealtimeEnabled()) {
+        return Status::Invalid("real-time write requires realtime.enabled=true");
+    }
     if (schema->PrimaryKeys().empty()) {
         // append table
         bool need_dv_maintainer_factory = options.DeletionVectorsEnabled();

--- a/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
+++ b/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
@@ -157,8 +157,10 @@ Result<std::set<std::string>> OrphanFilesCleanerImpl::ListPaimonFileDirs() const
     std::set<std::string> paimon_file_dirs;
     paimon_file_dirs.insert(snapshot_manager_->SnapshotDirectory());
     paimon_file_dirs.insert(FileStorePathFactory::ManifestPath(root_path_));
-    paimon_file_dirs.insert(
-        RealtimeCommitProperties::OffsetsDirectory(root_path_, options_.GetBranch()));
+    if (options_.RealtimeEnabled()) {
+        paimon_file_dirs.insert(
+            RealtimeCommitProperties::OffsetsDirectory(root_path_, options_.GetBranch()));
+    }
     // TODO(jinli.zjw): support clean index, stats, changelog in the future
     // paimon_file_dirs.insert(FileStorePathFactory::IndexPath(root_path_));
     // paimon_file_dirs.insert(FileStorePathFactory::StatisticsPath(root_path_));
@@ -297,9 +299,12 @@ Result<std::set<std::string>> OrphanFilesCleanerImpl::GetUsedFilesBySnapshot(
     used_files.insert(SnapshotManager::SNAPSHOT_PREFIX + std::to_string(snapshot.Id()));
     used_files.insert(snapshot.BaseManifestList());
     used_files.insert(snapshot.DeltaManifestList());
-    std::optional<std::string> offsets_path = RealtimeCommitProperties::GetOffsetsPath(snapshot);
-    if (offsets_path) {
-        used_files.insert(PathUtil::GetName(offsets_path.value()));
+    if (options_.RealtimeEnabled()) {
+        std::optional<std::string> offsets_path =
+            RealtimeCommitProperties::GetOffsetsPath(snapshot);
+        if (offsets_path) {
+            used_files.insert(PathUtil::GetName(offsets_path.value()));
+        }
     }
     std::vector<ManifestFileMeta> manifests;
     PAIMON_RETURN_NOT_OK(manifest_list_->ReadIfFileExist(snapshot.BaseManifestList(),

--- a/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
+++ b/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
@@ -35,6 +35,7 @@
 #include "paimon/core/manifest/manifest_file.h"
 #include "paimon/core/manifest/manifest_file_meta.h"
 #include "paimon/core/manifest/manifest_list.h"
+#include "paimon/core/operation/commit/realtime_commit_properties.h"
 #include "paimon/core/operation/metrics/clean_metrics.h"
 #include "paimon/core/snapshot.h"
 #include "paimon/core/utils/duration.h"
@@ -85,7 +86,7 @@ bool OrphanFilesCleanerImpl::SupportToClean(const std::string& file_name) {
             return true;
         }
     }
-    return false;
+    return StringUtils::EndsWith(file_name, ".offsets");
 }
 
 Result<std::set<std::string>> OrphanFilesCleanerImpl::Clean() {
@@ -156,6 +157,8 @@ Result<std::set<std::string>> OrphanFilesCleanerImpl::ListPaimonFileDirs() const
     std::set<std::string> paimon_file_dirs;
     paimon_file_dirs.insert(snapshot_manager_->SnapshotDirectory());
     paimon_file_dirs.insert(FileStorePathFactory::ManifestPath(root_path_));
+    paimon_file_dirs.insert(
+        RealtimeCommitProperties::OffsetsDirectory(root_path_, options_.GetBranch()));
     // TODO(jinli.zjw): support clean index, stats, changelog in the future
     // paimon_file_dirs.insert(FileStorePathFactory::IndexPath(root_path_));
     // paimon_file_dirs.insert(FileStorePathFactory::StatisticsPath(root_path_));
@@ -294,6 +297,10 @@ Result<std::set<std::string>> OrphanFilesCleanerImpl::GetUsedFilesBySnapshot(
     used_files.insert(SnapshotManager::SNAPSHOT_PREFIX + std::to_string(snapshot.Id()));
     used_files.insert(snapshot.BaseManifestList());
     used_files.insert(snapshot.DeltaManifestList());
+    std::optional<std::string> offsets_path = RealtimeCommitProperties::GetOffsetsPath(snapshot);
+    if (offsets_path) {
+        used_files.insert(PathUtil::GetName(offsets_path.value()));
+    }
     std::vector<ManifestFileMeta> manifests;
     PAIMON_RETURN_NOT_OK(manifest_list_->ReadIfFileExist(snapshot.BaseManifestList(),
                                                          /*filter=*/nullptr, &manifests));

--- a/src/paimon/core/realtime/arrow_realtime_store.cpp
+++ b/src/paimon/core/realtime/arrow_realtime_store.cpp
@@ -221,7 +221,8 @@ class ArrowRealtimeStore::QueryBatchReader : public BatchReader {
             if (stored.offset_range.end <= offset_begin_) {
                 continue;
             }
-            if (!MayMatch(stored)) {
+            PAIMON_ASSIGN_OR_RAISE(bool may_match, MayMatch(stored));
+            if (!may_match) {
                 continue;
             }
             int64_t begin = std::max<int64_t>(0, offset_begin_ - stored.offset_range.begin);
@@ -248,7 +249,7 @@ class ArrowRealtimeStore::QueryBatchReader : public BatchReader {
     }
 
  private:
-    bool MayMatch(const StoredBatch& stored) const {
+    Result<bool> MayMatch(const StoredBatch& stored) const {
         if (!predicate_filter_ || !stored.statistics) {
             return true;
         }
@@ -263,12 +264,8 @@ class ArrowRealtimeStore::QueryBatchReader : public BatchReader {
             std::make_shared<ColumnarArray>(statistics.null_counts.get(), memory_pool_,
                                             /*offset=*/0, statistics.null_counts->length());
         ProjectedArray projected_null_counts(null_counts, statistics_mapping_);
-        Result<bool> result =
-            predicate_filter_->Test(read_schema_, stored.data->length(), projected_min,
-                                    projected_max, projected_null_counts);
-        // Statistics are only an optional pruning aid. An unsupported predicate or incomplete
-        // statistic must retain the batch to avoid false negatives.
-        return !result.ok() || result.value();
+        return predicate_filter_->Test(read_schema_, stored.data->length(), projected_min,
+                                       projected_max, projected_null_counts);
     }
 
     Result<std::shared_ptr<arrow::StructArray>> BuildOutput(const StoredBatch& stored) {

--- a/src/paimon/core/realtime/arrow_realtime_store.cpp
+++ b/src/paimon/core/realtime/arrow_realtime_store.cpp
@@ -25,12 +25,18 @@
 
 #include "arrow/api.h"
 #include "arrow/c/bridge.h"
+#include "arrow/compute/api_aggregate.h"
+#include "paimon/common/data/columnar/columnar_array.h"
+#include "paimon/common/data/columnar/columnar_row.h"
 #include "paimon/common/metrics/metrics_impl.h"
+#include "paimon/common/predicate/predicate_filter.h"
 #include "paimon/common/reader/complete_row_kind_batch_reader.h"
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/row_kind.h"
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/common/utils/checked_cast.h"
+#include "paimon/common/utils/projected_array.h"
+#include "paimon/common/utils/projected_row.h"
 #include "paimon/core/utils/nested_projection_utils.h"
 #include "paimon/macros.h"
 
@@ -51,6 +57,26 @@ uint64_t GetArrayMemoryUsage(const std::shared_ptr<arrow::ArrayData>& data) {
         result += GetArrayMemoryUsage(data->dictionary);
     }
     return result;
+}
+
+bool SupportsMinMax(const std::shared_ptr<arrow::DataType>& type) {
+    switch (type->id()) {
+        case arrow::Type::BOOL:
+        case arrow::Type::INT8:
+        case arrow::Type::INT16:
+        case arrow::Type::INT32:
+        case arrow::Type::INT64:
+        case arrow::Type::FLOAT:
+        case arrow::Type::DOUBLE:
+        case arrow::Type::STRING:
+        case arrow::Type::BINARY:
+        case arrow::Type::DATE32:
+        case arrow::Type::TIMESTAMP:
+        case arrow::Type::DECIMAL128:
+            return true;
+        default:
+            return false;
+    }
 }
 
 }  // namespace
@@ -165,11 +191,17 @@ class ArrowRealtimeStore::QueryBatchReader : public BatchReader {
  public:
     QueryBatchReader(const ReadView* view, int64_t offset_begin,
                      const std::shared_ptr<arrow::Schema>& read_schema,
-                     const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
+                     const std::shared_ptr<PredicateFilter>& predicate_filter,
+                     std::vector<int32_t>&& statistics_mapping,
+                     const std::shared_ptr<arrow::MemoryPool>& arrow_pool,
+                     const std::shared_ptr<MemoryPool>& memory_pool)
         : view_(view),
           offset_begin_(offset_begin),
           read_schema_(read_schema),
           arrow_pool_(arrow_pool),
+          memory_pool_(memory_pool),
+          predicate_filter_(predicate_filter),
+          statistics_mapping_(std::move(statistics_mapping)),
           metrics_(std::make_shared<MetricsImpl>()) {}
 
     Result<ReadBatch> NextBatch() override {
@@ -187,6 +219,9 @@ class ArrowRealtimeStore::QueryBatchReader : public BatchReader {
         while (view_ && next_batch_ < view_->GetBatches().size()) {
             const StoredBatch& stored = view_->GetBatches()[next_batch_++];
             if (stored.offset_range.end <= offset_begin_) {
+                continue;
+            }
+            if (!MayMatch(stored)) {
                 continue;
             }
             int64_t begin = std::max<int64_t>(0, offset_begin_ - stored.offset_range.begin);
@@ -213,6 +248,29 @@ class ArrowRealtimeStore::QueryBatchReader : public BatchReader {
     }
 
  private:
+    bool MayMatch(const StoredBatch& stored) const {
+        if (!predicate_filter_ || !stored.statistics) {
+            return true;
+        }
+        const BatchStatistics& statistics = stored.statistics.value();
+        std::shared_ptr<InternalRow> min_row = std::make_shared<ColumnarRow>(
+            statistics.min_values, statistics.min_values->fields(), memory_pool_, /*row_id=*/0);
+        std::shared_ptr<InternalRow> max_row = std::make_shared<ColumnarRow>(
+            statistics.max_values, statistics.max_values->fields(), memory_pool_, /*row_id=*/0);
+        ProjectedRow projected_min(min_row, statistics_mapping_);
+        ProjectedRow projected_max(max_row, statistics_mapping_);
+        std::shared_ptr<InternalArray> null_counts =
+            std::make_shared<ColumnarArray>(statistics.null_counts.get(), memory_pool_,
+                                            /*offset=*/0, statistics.null_counts->length());
+        ProjectedArray projected_null_counts(null_counts, statistics_mapping_);
+        Result<bool> result =
+            predicate_filter_->Test(read_schema_, stored.data->length(), projected_min,
+                                    projected_max, projected_null_counts);
+        // Statistics are only an optional pruning aid. An unsupported predicate or incomplete
+        // statistic must retain the batch to avoid false negatives.
+        return !result.ok() || result.value();
+    }
+
     Result<std::shared_ptr<arrow::StructArray>> BuildOutput(const StoredBatch& stored) {
         PAIMON_ASSIGN_OR_RAISE(
             std::shared_ptr<arrow::Array> projected,
@@ -231,14 +289,81 @@ class ArrowRealtimeStore::QueryBatchReader : public BatchReader {
     int64_t offset_begin_;
     std::shared_ptr<arrow::Schema> read_schema_;
     std::shared_ptr<arrow::MemoryPool> arrow_pool_;
+    std::shared_ptr<MemoryPool> memory_pool_;
+    std::shared_ptr<PredicateFilter> predicate_filter_;
+    std::vector<int32_t> statistics_mapping_;
     std::shared_ptr<Metrics> metrics_;
     size_t next_batch_ = 0;
 };
 
 ArrowRealtimeStore::ArrowRealtimeStore(const std::shared_ptr<arrow::Schema>& write_schema,
+                                       StatisticsMode statistics_mode,
                                        const std::shared_ptr<MemoryPool>& memory_pool,
                                        const std::shared_ptr<arrow::MemoryPool>& arrow_pool)
-    : write_schema_(write_schema), memory_pool_(memory_pool), arrow_pool_(arrow_pool) {}
+    : write_schema_(write_schema),
+      memory_pool_(memory_pool),
+      arrow_pool_(arrow_pool),
+      statistics_mode_(statistics_mode) {}
+
+Result<std::optional<ArrowRealtimeStore::BatchStatistics>> ArrowRealtimeStore::CollectStatistics(
+    const std::shared_ptr<arrow::StructArray>& data) const {
+    if (statistics_mode_ == StatisticsMode::NONE) {
+        return std::optional<BatchStatistics>();
+    }
+
+    arrow::ArrayVector min_values;
+    arrow::ArrayVector max_values;
+    min_values.reserve(data->num_fields());
+    max_values.reserve(data->num_fields());
+    arrow::Int64Builder null_count_builder(arrow_pool_.get());
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(null_count_builder.Reserve(data->num_fields()));
+    arrow::compute::ScalarAggregateOptions aggregate_options;
+    aggregate_options.skip_nulls = true;
+    aggregate_options.min_count = 1;
+    arrow::compute::ExecContext exec_context(arrow_pool_.get());
+
+    for (const std::shared_ptr<arrow::Array>& field : data->fields()) {
+        null_count_builder.UnsafeAppend(field->null_count());
+        if (!SupportsMinMax(field->type())) {
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                std::shared_ptr<arrow::Array> min_value,
+                arrow::MakeArrayOfNull(field->type(), /*length=*/1, arrow_pool_.get()));
+            PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+                std::shared_ptr<arrow::Array> max_value,
+                arrow::MakeArrayOfNull(field->type(), /*length=*/1, arrow_pool_.get()));
+            min_values.push_back(std::move(min_value));
+            max_values.push_back(std::move(max_value));
+            continue;
+        }
+
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            arrow::Datum min_max, arrow::compute::MinMax(field, aggregate_options, &exec_context));
+        std::shared_ptr<arrow::StructScalar> min_max_scalar =
+            std::dynamic_pointer_cast<arrow::StructScalar>(min_max.scalar());
+        if (!min_max_scalar || min_max_scalar->value.size() != 2) {
+            return Status::Invalid("Arrow min_max did not produce min and max scalars");
+        }
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            std::shared_ptr<arrow::Array> min_value,
+            arrow::MakeArrayFromScalar(*min_max_scalar->value[0], /*length=*/1, arrow_pool_.get()));
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            std::shared_ptr<arrow::Array> max_value,
+            arrow::MakeArrayFromScalar(*min_max_scalar->value[1], /*length=*/1, arrow_pool_.get()));
+        min_values.push_back(std::move(min_value));
+        max_values.push_back(std::move(max_value));
+    }
+
+    std::shared_ptr<arrow::Array> null_counts_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(null_count_builder.Finish(&null_counts_array));
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+        std::shared_ptr<arrow::StructArray> min_values_struct,
+        arrow::StructArray::Make(min_values, write_schema_->fields()));
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+        std::shared_ptr<arrow::StructArray> max_values_struct,
+        arrow::StructArray::Make(max_values, write_schema_->fields()));
+    return std::optional<BatchStatistics>(BatchStatistics{
+        std::move(min_values_struct), std::move(max_values_struct), std::move(null_counts_array)});
+}
 
 Status ArrowRealtimeStore::Write(RealtimeWriteBatch&& write_batch) {
     if (!write_batch.batch) {
@@ -264,16 +389,23 @@ Status ArrowRealtimeStore::Write(RealtimeWriteBatch&& write_batch) {
     }
     std::shared_ptr<arrow::StructArray> struct_array =
         checked_pointer_cast<arrow::StructArray>(data);
+    PAIMON_ASSIGN_OR_RAISE(std::optional<BatchStatistics> statistics,
+                           CollectStatistics(struct_array));
 
     std::lock_guard<std::mutex> lock(mutex_);
     if (building_range_ && write_batch.offset_range.begin != building_range_->end) {
         return Status::Invalid("real-time offset ranges must be contiguous");
     }
     uint64_t memory_usage = GetArrayMemoryUsage(struct_array->data());
+    if (statistics) {
+        memory_usage += GetArrayMemoryUsage(statistics->min_values->data()) +
+                        GetArrayMemoryUsage(statistics->max_values->data()) +
+                        GetArrayMemoryUsage(statistics->null_counts->data());
+    }
     building_memory_usage_ += memory_usage;
-    building_batches_.push_back(StoredBatch{std::move(struct_array),
-                                            write_batch.batch->GetRowKind(),
-                                            write_batch.offset_range, memory_usage});
+    building_batches_.push_back(
+        StoredBatch{std::move(struct_array), write_batch.batch->GetRowKind(),
+                    write_batch.offset_range, std::move(statistics), memory_usage});
     if (!building_range_) {
         building_range_ = write_batch.offset_range;
     } else {
@@ -329,13 +461,20 @@ Result<std::vector<std::unique_ptr<BatchReader>>> ArrowRealtimeStore::CreateQuer
     }
     PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Schema> read_schema,
                                       arrow::ImportSchema(context.read_schema));
-    // TODO(xinyu.lxy): Support predicate pushdown after adding batch statistics or index metadata.
-    // The default Arrow store currently ignores context.predicate and
-    // context.enable_predicate_pushdown, and returns all offset-matching rows as candidates.
+    std::shared_ptr<PredicateFilter> predicate_filter;
+    if (context.enable_predicate_pushdown && context.predicate) {
+        predicate_filter = std::dynamic_pointer_cast<PredicateFilter>(context.predicate);
+    }
+    std::vector<int32_t> statistics_mapping;
+    statistics_mapping.reserve(read_schema->num_fields());
+    for (const std::shared_ptr<arrow::Field>& field : read_schema->fields()) {
+        statistics_mapping.push_back(write_schema_->GetFieldIndex(field->name()));
+    }
     std::vector<std::unique_ptr<BatchReader>> readers;
     if (arrow_view->GetOffsetRange() && arrow_view->GetOffsetRange()->end > offset_begin) {
         std::unique_ptr<BatchReader> reader = std::make_unique<QueryBatchReader>(
-            arrow_view.get(), offset_begin, read_schema, arrow_pool_);
+            arrow_view.get(), offset_begin, read_schema, predicate_filter,
+            std::move(statistics_mapping), arrow_pool_, memory_pool_);
         reader = std::make_unique<CompleteRowKindBatchReader>(std::move(reader), memory_pool_);
         readers.push_back(std::move(reader));
     }

--- a/src/paimon/core/realtime/arrow_realtime_store.h
+++ b/src/paimon/core/realtime/arrow_realtime_store.h
@@ -28,6 +28,7 @@
 #include "paimon/realtime/realtime_store.h"
 
 namespace arrow {
+class Array;
 class MemoryPool;
 class Schema;
 class StructArray;
@@ -40,6 +41,7 @@ class MemoryPool;
 class ArrowRealtimeStore : public RealtimeStore {
  public:
     ArrowRealtimeStore(const std::shared_ptr<arrow::Schema>& write_schema,
+                       StatisticsMode statistics_mode,
                        const std::shared_ptr<MemoryPool>& memory_pool,
                        const std::shared_ptr<arrow::MemoryPool>& arrow_pool);
 
@@ -61,10 +63,17 @@ class ArrowRealtimeStore : public RealtimeStore {
     uint64_t GetMemoryUsage() const override;
 
  private:
+    struct BatchStatistics {
+        std::shared_ptr<arrow::StructArray> min_values;
+        std::shared_ptr<arrow::StructArray> max_values;
+        std::shared_ptr<arrow::Array> null_counts;
+    };
+
     struct StoredBatch {
         std::shared_ptr<arrow::StructArray> data;
         std::vector<RecordBatch::RowKind> row_kinds;
         OffsetRange offset_range;
+        std::optional<BatchStatistics> statistics;
         uint64_t memory_usage;
     };
 
@@ -73,9 +82,13 @@ class ArrowRealtimeStore : public RealtimeStore {
     class CommitBatchReader;
     class QueryBatchReader;
 
+    Result<std::optional<BatchStatistics>> CollectStatistics(
+        const std::shared_ptr<arrow::StructArray>& data) const;
+
     std::shared_ptr<arrow::Schema> write_schema_;
     std::shared_ptr<MemoryPool> memory_pool_;
     std::shared_ptr<arrow::MemoryPool> arrow_pool_;
+    StatisticsMode statistics_mode_;
     mutable std::mutex mutex_;
     std::vector<StoredBatch> building_batches_;
     std::vector<std::shared_ptr<Segment>> sealed_segments_;

--- a/src/paimon/core/realtime/arrow_realtime_store_factory.cpp
+++ b/src/paimon/core/realtime/arrow_realtime_store_factory.cpp
@@ -30,8 +30,8 @@
 namespace paimon {
 
 Result<std::shared_ptr<RealtimeStore>> ArrowRealtimeStoreFactory::Create(
-    std::unique_ptr<ArrowSchema> write_schema, const std::map<std::string, std::string>&,
-    const std::shared_ptr<MemoryPool>& memory_pool) {
+    std::unique_ptr<ArrowSchema> write_schema, StatisticsMode statistics_mode,
+    const std::map<std::string, std::string>&, const std::shared_ptr<MemoryPool>& memory_pool) {
     if (!write_schema || !write_schema->release) {
         return Status::Invalid("real-time store write schema is null");
     }
@@ -42,7 +42,8 @@ Result<std::shared_ptr<RealtimeStore>> ArrowRealtimeStoreFactory::Create(
     PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Schema> imported_schema,
                                       arrow::ImportSchema(write_schema.get()));
     std::shared_ptr<arrow::MemoryPool> arrow_pool = GetArrowPool(memory_pool);
-    return std::make_shared<ArrowRealtimeStore>(imported_schema, memory_pool, arrow_pool);
+    return std::make_shared<ArrowRealtimeStore>(imported_schema, statistics_mode, memory_pool,
+                                                arrow_pool);
 }
 
 }  // namespace paimon

--- a/src/paimon/core/realtime/arrow_realtime_store_test.cpp
+++ b/src/paimon/core/realtime/arrow_realtime_store_test.cpp
@@ -29,6 +29,7 @@
 #include "arrow/c/bridge.h"
 #include "arrow/ipc/json_simple.h"
 #include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/checked_cast.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/predicate/literal.h"
 #include "paimon/predicate/predicate_builder.h"
@@ -98,9 +99,9 @@ class ArrowRealtimeStoreTest : public testing::Test {
         std::shared_ptr<arrow::Array> array =
             arrow::ImportArray(batch.first.first.get(), batch.first.second.get()).ValueOrDie();
         std::shared_ptr<arrow::StructArray> struct_array =
-            std::static_pointer_cast<arrow::StructArray>(array);
+            checked_pointer_cast<arrow::StructArray>(array);
         std::shared_ptr<arrow::Int64Array> ids =
-            std::static_pointer_cast<arrow::Int64Array>(struct_array->field(/*id=*/1));
+            checked_pointer_cast<arrow::Int64Array>(struct_array->field(/*pos=*/1));
         std::vector<int64_t> result;
         for (RoaringBitmap32::Iterator iter = batch.second.Begin(); iter != batch.second.End();
              ++iter) {

--- a/src/paimon/core/realtime/arrow_realtime_store_test.cpp
+++ b/src/paimon/core/realtime/arrow_realtime_store_test.cpp
@@ -19,6 +19,7 @@
 
 #include "paimon/core/realtime/arrow_realtime_store.h"
 
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -29,6 +30,9 @@
 #include "arrow/ipc/json_simple.h"
 #include "paimon/common/utils/arrow/mem_utils.h"
 #include "paimon/memory/memory_pool.h"
+#include "paimon/predicate/literal.h"
+#include "paimon/predicate/predicate_builder.h"
+#include "paimon/realtime/arrow_realtime_store_factory.h"
 #include "paimon/record_batch.h"
 #include "paimon/testing/utils/testharness.h"
 
@@ -56,7 +60,11 @@ class ArrowRealtimeStoreTest : public testing::Test {
             {arrow::field("id", arrow::int64()), arrow::field("value", arrow::utf8())});
         pool_ = GetDefaultPool();
         arrow_pool_ = GetArrowPool(pool_);
-        store_ = std::make_shared<ArrowRealtimeStore>(schema_, pool_, arrow_pool_);
+        store_ = CreateStore(StatisticsMode::NONE);
+    }
+
+    std::shared_ptr<ArrowRealtimeStore> CreateStore(StatisticsMode statistics_mode) const {
+        return std::make_shared<ArrowRealtimeStore>(schema_, statistics_mode, pool_, arrow_pool_);
     }
 
     std::unique_ptr<RecordBatch> MakeBatch(const std::string& json) const {
@@ -84,6 +92,21 @@ class ArrowRealtimeStoreTest : public testing::Test {
         auto c_schema = std::make_unique<ArrowSchema>();
         EXPECT_TRUE(arrow::ExportSchema(*schema, c_schema.get()).ok());
         return c_schema;
+    }
+
+    std::vector<int64_t> ReadIds(const BatchReader::ReadBatchWithBitmap& batch) const {
+        std::shared_ptr<arrow::Array> array =
+            arrow::ImportArray(batch.first.first.get(), batch.first.second.get()).ValueOrDie();
+        std::shared_ptr<arrow::StructArray> struct_array =
+            std::static_pointer_cast<arrow::StructArray>(array);
+        std::shared_ptr<arrow::Int64Array> ids =
+            std::static_pointer_cast<arrow::Int64Array>(struct_array->field(/*id=*/1));
+        std::vector<int64_t> result;
+        for (RoaringBitmap32::Iterator iter = batch.second.Begin(); iter != batch.second.End();
+             ++iter) {
+            result.push_back(ids->Value(*iter));
+        }
+        return result;
     }
 
  protected:
@@ -203,6 +226,66 @@ TEST_F(ArrowRealtimeStoreTest, TestCommitReaderPreservesSlicedBatch) {
             .ValueOrDie();
     ASSERT_TRUE(actual_array->Equals(*expected_array))
         << "expected: " << expected_array->ToString() << ", actual: " << actual_array->ToString();
+}
+
+TEST_F(ArrowRealtimeStoreTest, TestFullStatisticsPrunesNonMatchingBatch) {
+    ArrowRealtimeStoreFactory factory;
+    std::unique_ptr<ArrowSchema> write_schema = MakeReadSchema(schema_);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeStore> realtime_store,
+                         factory.Create(std::move(write_schema), StatisticsMode::FULL, {}, pool_));
+    std::shared_ptr<ArrowRealtimeStore> store =
+        std::dynamic_pointer_cast<ArrowRealtimeStore>(realtime_store);
+    ASSERT_NE(nullptr, store);
+    ASSERT_OK(
+        store->Write(RealtimeWriteBatch{MakeBatch(R"([[0, "a"], [1, "b"]])"), OffsetRange(0, 2)}));
+    ASSERT_OK(store->Write(
+        RealtimeWriteBatch{MakeBatch(R"([[10, "c"], [11, "d"]])"), OffsetRange(2, 4)}));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeReadView> view, store->AcquireReadView());
+
+    std::unique_ptr<ArrowSchema> read_schema = MakeReadSchema(schema_);
+    std::shared_ptr<Predicate> predicate = PredicateBuilder::GreaterThan(
+        /*field_index=*/0, /*field_name=*/"id", FieldType::BIGINT, Literal(int64_t{5}));
+    RealtimeQueryContext context{read_schema.get(), predicate, /*enable_predicate_pushdown=*/true};
+    ASSERT_OK_AND_ASSIGN(std::vector<std::unique_ptr<BatchReader>> readers,
+                         store->CreateQueryReaders(view, /*offset_begin=*/0, context));
+    ASSERT_EQ(1, readers.size());
+
+    ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatchWithBitmap batch, readers[0]->NextBatchWithBitmap());
+    ASSERT_FALSE(BatchReader::IsEofBatch(batch));
+    ASSERT_EQ(std::vector<int64_t>({10, 11}), ReadIds(batch));
+    ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatchWithBitmap eof, readers[0]->NextBatchWithBitmap());
+    ASSERT_TRUE(BatchReader::IsEofBatch(eof));
+
+    std::unique_ptr<ArrowSchema> unfiltered_read_schema = MakeReadSchema(schema_);
+    RealtimeQueryContext unfiltered_context{unfiltered_read_schema.get(), predicate,
+                                            /*enable_predicate_pushdown=*/false};
+    ASSERT_OK_AND_ASSIGN(std::vector<std::unique_ptr<BatchReader>> unfiltered_readers,
+                         store->CreateQueryReaders(view, /*offset_begin=*/0, unfiltered_context));
+    ASSERT_EQ(1, unfiltered_readers.size());
+    ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatchWithBitmap unfiltered_batch,
+                         unfiltered_readers[0]->NextBatchWithBitmap());
+    ASSERT_EQ(std::vector<int64_t>({0, 1}), ReadIds(unfiltered_batch));
+}
+
+TEST_F(ArrowRealtimeStoreTest, TestMissingStatisticsRetainsNonMatchingBatch) {
+    ASSERT_OK(
+        store_->Write(RealtimeWriteBatch{MakeBatch(R"([[0, "a"], [1, "b"]])"), OffsetRange(0, 2)}));
+    ASSERT_OK(store_->Write(
+        RealtimeWriteBatch{MakeBatch(R"([[10, "c"], [11, "d"]])"), OffsetRange(2, 4)}));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeReadView> view, store_->AcquireReadView());
+
+    std::unique_ptr<ArrowSchema> read_schema = MakeReadSchema(schema_);
+    std::shared_ptr<Predicate> predicate = PredicateBuilder::GreaterThan(
+        /*field_index=*/0, /*field_name=*/"id", FieldType::BIGINT, Literal(int64_t{5}));
+    RealtimeQueryContext context{read_schema.get(), predicate,
+                                 /*enable_predicate_pushdown=*/true};
+    ASSERT_OK_AND_ASSIGN(std::vector<std::unique_ptr<BatchReader>> readers,
+                         store_->CreateQueryReaders(view, /*offset_begin=*/0, context));
+    ASSERT_EQ(1, readers.size());
+
+    ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatchWithBitmap batch, readers[0]->NextBatchWithBitmap());
+    ASSERT_FALSE(BatchReader::IsEofBatch(batch));
+    ASSERT_EQ(std::vector<int64_t>({0, 1}), ReadIds(batch));
 }
 
 TEST_F(ArrowRealtimeStoreTest, TestRejectsHandlesFromAnotherStoreImplementation) {

--- a/src/paimon/core/realtime/realtime_append_only_writer.cpp
+++ b/src/paimon/core/realtime/realtime_append_only_writer.cpp
@@ -47,7 +47,7 @@ Result<std::shared_ptr<RealtimeAppendOnlyWriter>> RealtimeAppendOnlyWriter::Crea
     std::unique_ptr<::ArrowSchema> write_schema,
     const std::shared_ptr<RealtimeContext>& realtime_context,
     const std::shared_ptr<AppendOnlyWriter>& file_writer,
-    const std::shared_ptr<arrow::Schema>& input_schema,
+    const std::shared_ptr<arrow::Schema>& input_schema, StatisticsMode statistics_mode,
     const std::map<std::string, std::string>& options,
     const std::shared_ptr<MemoryPool>& memory_pool) {
     if (!realtime_context) {
@@ -55,9 +55,10 @@ Result<std::shared_ptr<RealtimeAppendOnlyWriter>> RealtimeAppendOnlyWriter::Crea
     }
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RealtimeContextImpl> realtime_context_impl,
                            RealtimeContextImpl::Cast(realtime_context));
-    PAIMON_ASSIGN_OR_RAISE(RealtimeStoreState store_state,
-                           realtime_context_impl->GetOrCreateRealtimeStore(
-                               partition, bucket, std::move(write_schema), options, memory_pool));
+    PAIMON_ASSIGN_OR_RAISE(
+        RealtimeStoreState store_state,
+        realtime_context_impl->GetOrCreateRealtimeStore(partition, bucket, std::move(write_schema),
+                                                        statistics_mode, options, memory_pool));
     return std::shared_ptr<RealtimeAppendOnlyWriter>(new RealtimeAppendOnlyWriter(
         store_state.store, file_writer, input_schema, store_state.initial_offset, memory_pool));
 }

--- a/src/paimon/core/realtime/realtime_append_only_writer.h
+++ b/src/paimon/core/realtime/realtime_append_only_writer.h
@@ -47,7 +47,7 @@ class RealtimeAppendOnlyWriter : public BatchWriter {
         std::unique_ptr<::ArrowSchema> write_schema,
         const std::shared_ptr<RealtimeContext>& realtime_context,
         const std::shared_ptr<AppendOnlyWriter>& file_writer,
-        const std::shared_ptr<arrow::Schema>& input_schema,
+        const std::shared_ptr<arrow::Schema>& input_schema, StatisticsMode statistics_mode,
         const std::map<std::string, std::string>& options,
         const std::shared_ptr<MemoryPool>& memory_pool);
 

--- a/src/paimon/core/realtime/realtime_context_impl.cpp
+++ b/src/paimon/core/realtime/realtime_context_impl.cpp
@@ -231,18 +231,27 @@ Status RealtimeContextImpl::AdvanceCommittedProgress(int64_t snapshot_id,
                 return Status::Invalid("invalid partition-bucket committed offset");
             }
         }
-        // Reclaimed segments cannot be restored in place. A rollback therefore requires the
-        // caller to discard this context and rebuild it from the rolled-back snapshot.
-        for (const auto& [partition_bucket, previous_offset] : committed_offsets_) {
+        // Only stores created by this context can contain state which cannot be restored in
+        // place. Offsets for other partition-buckets are reference state for lazy store creation
+        // and may be removed or rolled back without rebuilding the context.
+        std::lock_guard<std::mutex> registry_lock(mutex_);
+        for (const auto& store_entry : stores_) {
+            const RealtimePartitionBucket& partition_bucket = store_entry.first;
+            auto previous_iter = committed_offsets_.find(partition_bucket);
+            if (previous_iter == committed_offsets_.end()) {
+                continue;
+            }
+
             auto current_iter = committed_offsets.find(partition_bucket);
             if (current_iter == committed_offsets.end()) {
                 return Status::Invalid(
-                    "real-time committed progress removed a partition-bucket; recreate "
+                    "real-time committed progress removed an active partition-bucket; recreate "
                     "RealtimeContext");
             }
-            if (current_iter->second < previous_offset) {
+            if (current_iter->second < previous_iter->second) {
                 return Status::Invalid(
-                    "real-time committed offset moved backwards; recreate RealtimeContext");
+                    "real-time committed offset moved backwards for an active partition-bucket; "
+                    "recreate RealtimeContext");
             }
         }
         committed_offsets_ = committed_offsets;

--- a/src/paimon/core/realtime/realtime_context_impl.cpp
+++ b/src/paimon/core/realtime/realtime_context_impl.cpp
@@ -79,7 +79,8 @@ Status RealtimeContextImpl::Start() {
 
 Result<RealtimeStoreState> RealtimeContextImpl::GetOrCreateRealtimeStore(
     const std::map<std::string, std::string>& partition, int32_t bucket,
-    std::unique_ptr<ArrowSchema> write_schema, const std::map<std::string, std::string>& options,
+    std::unique_ptr<ArrowSchema> write_schema, StatisticsMode statistics_mode,
+    const std::map<std::string, std::string>& options,
     const std::shared_ptr<MemoryPool>& memory_pool) {
     std::lock_guard<std::mutex> progress_lock(progress_mutex_);
     std::lock_guard<std::mutex> registry_lock(mutex_);
@@ -118,9 +119,9 @@ Result<RealtimeStoreState> RealtimeContextImpl::GetOrCreateRealtimeStore(
         }
         return RealtimeStoreState{iter->second, initial_offset};
     }
-    Result<std::shared_ptr<RealtimeStore>> store_result =
-        factory_->Create(std::move(write_schema), options, memory_pool);
-    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RealtimeStore> store, std::move(store_result));
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<RealtimeStore> store,
+        factory_->Create(std::move(write_schema), statistics_mode, options, memory_pool));
     stores_.emplace(key, store);
     if (offset_iter != committed_offsets_.end()) {
         reclaimed_offsets_.emplace(key, offset_iter->second);
@@ -229,12 +230,19 @@ Status RealtimeContextImpl::AdvanceCommittedProgress(int64_t snapshot_id,
             if (partition_bucket.bucket < 0 || committed_end_offset < 0) {
                 return Status::Invalid("invalid partition-bucket committed offset");
             }
-            auto previous_iter = committed_offsets_.find(partition_bucket);
-            if (previous_iter != committed_offsets_.end()) {
-                if (committed_end_offset < previous_iter->second) {
-                    return Status::Invalid(
-                        "real-time partition-bucket committed offset cannot move backwards");
-                }
+        }
+        // Reclaimed segments cannot be restored in place. A rollback therefore requires the
+        // caller to discard this context and rebuild it from the rolled-back snapshot.
+        for (const auto& [partition_bucket, previous_offset] : committed_offsets_) {
+            auto current_iter = committed_offsets.find(partition_bucket);
+            if (current_iter == committed_offsets.end()) {
+                return Status::Invalid(
+                    "real-time committed progress removed a partition-bucket; recreate "
+                    "RealtimeContext");
+            }
+            if (current_iter->second < previous_offset) {
+                return Status::Invalid(
+                    "real-time committed offset moved backwards; recreate RealtimeContext");
             }
         }
         committed_offsets_ = committed_offsets;

--- a/src/paimon/core/realtime/realtime_context_impl.h
+++ b/src/paimon/core/realtime/realtime_context_impl.h
@@ -33,6 +33,7 @@
 
 #include "paimon/realtime/realtime_context.h"
 #include "paimon/result.h"
+#include "paimon/statistics_mode.h"
 #include "paimon/visibility.h"
 
 struct ArrowSchema;
@@ -42,7 +43,6 @@ namespace paimon {
 class RealtimeStore;
 class RealtimeReadView;
 class MemoryPool;
-enum class StatisticsMode;
 
 struct RealtimeStoreState {
     std::shared_ptr<RealtimeStore> store;

--- a/src/paimon/core/realtime/realtime_context_impl.h
+++ b/src/paimon/core/realtime/realtime_context_impl.h
@@ -79,8 +79,9 @@ class PAIMON_EXPORT RealtimeContextImpl final : public RealtimeContext {
 
     Status ReleaseReadView(const std::string& opaque_ticket);
 
-    // Returns an error requiring a new context if a newer snapshot moves committed progress
-    // backwards, because segments reclaimed by this context cannot be restored in place.
+    // Returns an error requiring a new context if a newer snapshot removes or moves committed
+    // progress backwards for a store created by this context. Progress for inactive stores is
+    // only reference state and can be replaced in place.
     Status AdvanceCommittedProgress(int64_t snapshot_id,
                                     const RealtimeOffsetMap& committed_offsets);
 
@@ -102,7 +103,9 @@ class PAIMON_EXPORT RealtimeContextImpl final : public RealtimeContext {
     std::mutex mutex_;
     std::mutex progress_mutex_;
     std::map<RealtimePartitionBucket, std::shared_ptr<RealtimeStore>> stores_;
+    // Full-table progress used as the initial offset when a store is created lazily.
     RealtimeOffsetMap committed_offsets_;
+    // Progress already reflected in stores owned by this context.
     RealtimeOffsetMap reclaimed_offsets_;
     std::optional<int64_t> last_refreshed_snapshot_id_;
     std::mutex read_views_mutex_;

--- a/src/paimon/core/realtime/realtime_context_impl.h
+++ b/src/paimon/core/realtime/realtime_context_impl.h
@@ -42,6 +42,7 @@ namespace paimon {
 class RealtimeStore;
 class RealtimeReadView;
 class MemoryPool;
+enum class StatisticsMode;
 
 struct RealtimeStoreState {
     std::shared_ptr<RealtimeStore> store;
@@ -66,7 +67,7 @@ class PAIMON_EXPORT RealtimeContextImpl final : public RealtimeContext {
 
     Result<RealtimeStoreState> GetOrCreateRealtimeStore(
         const std::map<std::string, std::string>& partition, int32_t bucket,
-        std::unique_ptr<::ArrowSchema> write_schema,
+        std::unique_ptr<::ArrowSchema> write_schema, StatisticsMode statistics_mode,
         const std::map<std::string, std::string>& options,
         const std::shared_ptr<MemoryPool>& memory_pool);
 
@@ -78,6 +79,8 @@ class PAIMON_EXPORT RealtimeContextImpl final : public RealtimeContext {
 
     Status ReleaseReadView(const std::string& opaque_ticket);
 
+    // Returns an error requiring a new context if a newer snapshot moves committed progress
+    // backwards, because segments reclaimed by this context cannot be restored in place.
     Status AdvanceCommittedProgress(int64_t snapshot_id,
                                     const RealtimeOffsetMap& committed_offsets);
 

--- a/src/paimon/core/realtime/realtime_context_test.cpp
+++ b/src/paimon/core/realtime/realtime_context_test.cpp
@@ -92,6 +92,7 @@ class TestingRealtimeStore : public RealtimeStore {
 class TestingRealtimeStoreFactory : public RealtimeStoreFactory {
  public:
     Result<std::shared_ptr<RealtimeStore>> Create(std::unique_ptr<ArrowSchema> write_schema,
+                                                  StatisticsMode,
                                                   const std::map<std::string, std::string>&,
                                                   const std::shared_ptr<MemoryPool>&) override {
         if (!write_schema || !write_schema->release) {
@@ -121,18 +122,20 @@ Result<std::shared_ptr<RealtimeContextImpl>> CreateContext(
     return RealtimeContextImpl::Cast(context);
 }
 
-TEST(RealtimeContextTest, TestReusesIndexerAndCapturesRegisteredViews) {
+TEST(RealtimeContextTest, TestReusesStoreAndCapturesRegisteredViews) {
     auto factory = std::make_shared<TestingRealtimeStoreFactory>();
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContextImpl> context, CreateContext(factory));
     std::shared_ptr<MemoryPool> pool = GetDefaultPool();
 
-    ASSERT_OK_AND_ASSIGN(RealtimeStoreState first_state,
-                         context->GetOrCreateRealtimeStore({{"dt", "2026-08-02"}}, 0,
-                                                           MakeWriteSchema(), {{"k", "v"}}, pool));
+    ASSERT_OK_AND_ASSIGN(
+        RealtimeStoreState first_state,
+        context->GetOrCreateRealtimeStore({{"dt", "2026-08-02"}}, 0, MakeWriteSchema(),
+                                          StatisticsMode::NONE, {{"k", "v"}}, pool));
     ASSERT_EQ(0, first_state.initial_offset);
     ASSERT_OK_AND_ASSIGN(
         RealtimeStoreState first_again_state,
-        context->GetOrCreateRealtimeStore({{"dt", "2026-08-02"}}, 0, MakeWriteSchema(), {}, pool));
+        context->GetOrCreateRealtimeStore({{"dt", "2026-08-02"}}, 0, MakeWriteSchema(),
+                                          StatisticsMode::NONE, {}, pool));
     ASSERT_EQ(first_state.store, first_again_state.store);
     ASSERT_EQ(0, first_again_state.initial_offset);
     ASSERT_EQ(1, factory->stores.size());
@@ -140,10 +143,12 @@ TEST(RealtimeContextTest, TestReusesIndexerAndCapturesRegisteredViews) {
 
     ASSERT_OK_AND_ASSIGN(
         RealtimeStoreState second_state,
-        context->GetOrCreateRealtimeStore({{"dt", "2026-08-02"}}, 1, MakeWriteSchema(), {}, pool));
+        context->GetOrCreateRealtimeStore({{"dt", "2026-08-02"}}, 1, MakeWriteSchema(),
+                                          StatisticsMode::NONE, {}, pool));
     ASSERT_OK_AND_ASSIGN(
         RealtimeStoreState third_state,
-        context->GetOrCreateRealtimeStore({{"dt", "2026-08-03"}}, 0, MakeWriteSchema(), {}, pool));
+        context->GetOrCreateRealtimeStore({{"dt", "2026-08-03"}}, 0, MakeWriteSchema(),
+                                          StatisticsMode::NONE, {}, pool));
     ASSERT_NE(first_state.store, second_state.store);
     ASSERT_NE(first_state.store, third_state.store);
     ASSERT_EQ(3, factory->stores.size());
@@ -166,8 +171,10 @@ TEST(RealtimeContextTest, TestCommittedProgressIsMonotonicAndSelective) {
     std::shared_ptr<MemoryPool> pool = GetDefaultPool();
     const std::map<std::string, std::string> partition = {{"dt", "2026-08-02"}};
 
-    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 0, MakeWriteSchema(), {}, pool));
-    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 1, MakeWriteSchema(), {}, pool));
+    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 0, MakeWriteSchema(),
+                                                StatisticsMode::NONE, {}, pool));
+    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 1, MakeWriteSchema(),
+                                                StatisticsMode::NONE, {}, pool));
     ASSERT_EQ(2, factory->stores.size());
 
     ASSERT_NOK_WITH_MSG(context->AdvanceCommittedProgress(-1, {}),
@@ -186,7 +193,8 @@ TEST(RealtimeContextTest, TestCommittedProgressIsMonotonicAndSelective) {
 
     ASSERT_OK_AND_ASSIGN(
         RealtimeStoreState restored_state,
-        context->GetOrCreateRealtimeStore({{"dt", "unknown"}}, 0, MakeWriteSchema(), {}, pool));
+        context->GetOrCreateRealtimeStore({{"dt", "unknown"}}, 0, MakeWriteSchema(),
+                                          StatisticsMode::NONE, {}, pool));
     ASSERT_EQ(9, restored_state.initial_offset);
 
     ASSERT_OK(context->AdvanceCommittedProgress(
@@ -209,9 +217,12 @@ TEST(RealtimeContextTest, TestRetriesOnlyIncompleteReclamation) {
     std::shared_ptr<MemoryPool> pool = GetDefaultPool();
     const std::map<std::string, std::string> partition = {{"dt", "2026-08-02"}};
 
-    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 0, MakeWriteSchema(), {}, pool));
-    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 1, MakeWriteSchema(), {}, pool));
-    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 2, MakeWriteSchema(), {}, pool));
+    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 0, MakeWriteSchema(),
+                                                StatisticsMode::NONE, {}, pool));
+    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 1, MakeWriteSchema(),
+                                                StatisticsMode::NONE, {}, pool));
+    ASSERT_OK(context->GetOrCreateRealtimeStore(partition, 2, MakeWriteSchema(),
+                                                StatisticsMode::NONE, {}, pool));
     ASSERT_EQ(3, factory->stores.size());
     factory->stores[1]->fail_next_advance = true;
 
@@ -225,9 +236,9 @@ TEST(RealtimeContextTest, TestRetriesOnlyIncompleteReclamation) {
     ASSERT_TRUE(factory->stores[1]->committed_offsets.empty());
     ASSERT_EQ(std::vector<int64_t>({9}), factory->stores[2]->committed_offsets);
 
-    ASSERT_OK_AND_ASSIGN(
-        RealtimeStoreState failed_store_state,
-        context->GetOrCreateRealtimeStore(partition, 1, MakeWriteSchema(), {}, pool));
+    ASSERT_OK_AND_ASSIGN(RealtimeStoreState failed_store_state,
+                         context->GetOrCreateRealtimeStore(partition, 1, MakeWriteSchema(),
+                                                           StatisticsMode::NONE, {}, pool));
     ASSERT_EQ(8, failed_store_state.initial_offset);
 
     ASSERT_OK(context->AdvanceCommittedProgress(5, committed_offsets));
@@ -237,11 +248,45 @@ TEST(RealtimeContextTest, TestRetriesOnlyIncompleteReclamation) {
     ASSERT_EQ(std::vector<int64_t>({8}), factory->stores[1]->committed_offsets);
 }
 
+TEST(RealtimeContextTest, TestRequiresReopenWhenCommittedProgressMovesBackwards) {
+    auto factory = std::make_shared<TestingRealtimeStoreFactory>();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContextImpl> context, CreateContext(factory));
+    std::shared_ptr<MemoryPool> pool = GetDefaultPool();
+    const std::map<std::string, std::string> first_partition = {{"dt", "2026-08-02"}};
+    const std::map<std::string, std::string> second_partition = {{"dt", "2026-08-03"}};
+    const RealtimePartitionBucket first_partition_bucket(first_partition, /*bucket=*/0);
+    const RealtimePartitionBucket second_partition_bucket(second_partition, /*bucket=*/0);
+
+    ASSERT_OK(context->GetOrCreateRealtimeStore(first_partition, 0, MakeWriteSchema(),
+                                                StatisticsMode::NONE, {}, pool));
+    ASSERT_OK(context->GetOrCreateRealtimeStore(second_partition, 0, MakeWriteSchema(),
+                                                StatisticsMode::NONE, {}, pool));
+    ASSERT_OK(context->AdvanceCommittedProgress(
+        5, {{first_partition_bucket, /*offset=*/7}, {second_partition_bucket, /*offset=*/9}}));
+    ASSERT_EQ(std::vector<int64_t>({7}), factory->stores[0]->committed_offsets);
+    ASSERT_EQ(std::vector<int64_t>({9}), factory->stores[1]->committed_offsets);
+
+    ASSERT_NOK_WITH_MSG(
+        context->AdvanceCommittedProgress(
+            6, {{first_partition_bucket, /*offset=*/6}, {second_partition_bucket, /*offset=*/10}}),
+        "recreate RealtimeContext");
+    ASSERT_NOK_WITH_MSG(
+        context->AdvanceCommittedProgress(6, {{first_partition_bucket, /*offset=*/10}}),
+        "recreate RealtimeContext");
+    ASSERT_EQ(std::vector<int64_t>({7}), factory->stores[0]->committed_offsets);
+    ASSERT_EQ(std::vector<int64_t>({9}), factory->stores[1]->committed_offsets);
+
+    ASSERT_OK(context->AdvanceCommittedProgress(
+        6, {{first_partition_bucket, /*offset=*/10}, {second_partition_bucket, /*offset=*/11}}));
+    ASSERT_EQ(std::vector<int64_t>({7, 10}), factory->stores[0]->committed_offsets);
+    ASSERT_EQ(std::vector<int64_t>({9, 11}), factory->stores[1]->committed_offsets);
+}
+
 TEST(RealtimeContextTest, TestPinsResolvesAndReleasesReadViewTicket) {
     auto factory = std::make_shared<TestingRealtimeStoreFactory>();
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContextImpl> context, CreateContext(factory));
     ASSERT_OK(context->GetOrCreateRealtimeStore(/*partition=*/{}, /*bucket=*/0, MakeWriteSchema(),
-                                                {}, GetDefaultPool()));
+                                                StatisticsMode::NONE, {}, GetDefaultPool()));
     ASSERT_OK_AND_ASSIGN(std::vector<RealtimePartitionBucketView> views,
                          context->AcquireReadViews());
     ASSERT_EQ(1, views.size());
@@ -265,7 +310,7 @@ TEST(RealtimeContextTest, TestExpiresAbandonedReadViewTicket) {
     auto factory = std::make_shared<TestingRealtimeStoreFactory>();
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContextImpl> context, CreateContext(factory));
     ASSERT_OK(context->GetOrCreateRealtimeStore(/*partition=*/{}, /*bucket=*/0, MakeWriteSchema(),
-                                                {}, GetDefaultPool()));
+                                                StatisticsMode::NONE, {}, GetDefaultPool()));
     ASSERT_OK_AND_ASSIGN(std::vector<RealtimePartitionBucketView> views,
                          context->AcquireReadViews());
     ASSERT_EQ(1, views.size());

--- a/src/paimon/core/realtime/realtime_context_test.cpp
+++ b/src/paimon/core/realtime/realtime_context_test.cpp
@@ -211,6 +211,29 @@ TEST(RealtimeContextTest, TestCommittedProgressIsMonotonicAndSelective) {
     ASSERT_EQ(std::vector<int64_t>({8}), factory->stores[1]->committed_offsets);
 }
 
+TEST(RealtimeContextTest, TestRemovedInactivePartitionDoesNotRequireReopen) {
+    auto factory = std::make_shared<TestingRealtimeStoreFactory>();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContextImpl> context, CreateContext(factory));
+    std::shared_ptr<MemoryPool> pool = GetDefaultPool();
+    const std::map<std::string, std::string> active_partition = {{"dt", "2026-08-02"}};
+    const std::map<std::string, std::string> inactive_partition = {{"dt", "2026-08-03"}};
+    const RealtimePartitionBucket active_partition_bucket(active_partition, /*bucket=*/0);
+    const RealtimePartitionBucket inactive_partition_bucket(inactive_partition, /*bucket=*/0);
+
+    ASSERT_OK(context->AdvanceCommittedProgress(
+        5, {{active_partition_bucket, /*offset=*/7}, {inactive_partition_bucket, /*offset=*/9}}));
+    ASSERT_OK_AND_ASSIGN(RealtimeStoreState active_state,
+                         context->GetOrCreateRealtimeStore(active_partition, 0, MakeWriteSchema(),
+                                                           StatisticsMode::NONE, {}, pool));
+    ASSERT_EQ(7, active_state.initial_offset);
+
+    ASSERT_OK(context->AdvanceCommittedProgress(6, {{active_partition_bucket, /*offset=*/7}}));
+    ASSERT_OK_AND_ASSIGN(RealtimeStoreState inactive_state,
+                         context->GetOrCreateRealtimeStore(inactive_partition, 0, MakeWriteSchema(),
+                                                           StatisticsMode::NONE, {}, pool));
+    ASSERT_EQ(0, inactive_state.initial_offset);
+}
+
 TEST(RealtimeContextTest, TestRetriesOnlyIncompleteReclamation) {
     auto factory = std::make_shared<TestingRealtimeStoreFactory>();
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContextImpl> context, CreateContext(factory));

--- a/src/paimon/core/table/source/append_count_reader.cpp
+++ b/src/paimon/core/table/source/append_count_reader.cpp
@@ -38,13 +38,6 @@ Result<int64_t> AppendCountReader::CountRows() {
 Result<int64_t> AppendCountReader::CountSingleSplit(const std::shared_ptr<Split>& split) const {
     std::shared_ptr<RealtimeSplit> realtime_split = std::dynamic_pointer_cast<RealtimeSplit>(split);
     if (realtime_split) {
-        if (realtime_split->Version() != RealtimeSplit::kCurrentVersion) {
-            return Status::Invalid("unsupported real-time split version");
-        }
-        if (realtime_split->MemoryEndOffset() < realtime_split->CommittedEndOffset()) {
-            return Status::Invalid("real-time memory upper offset is behind committed offset");
-        }
-
         int64_t total = realtime_split->MemoryEndOffset() - realtime_split->CommittedEndOffset();
         for (const std::shared_ptr<Split>& disk_split : realtime_split->DiskSplits()) {
             PAIMON_ASSIGN_OR_RAISE(int64_t disk_count, CountSingleSplit(disk_split));

--- a/src/paimon/core/table/source/append_count_reader.cpp
+++ b/src/paimon/core/table/source/append_count_reader.cpp
@@ -21,6 +21,7 @@
 
 #include "paimon/core/deletionvectors/deletion_vector.h"
 #include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/core/table/source/realtime_split.h"
 #include "paimon/status.h"
 
 namespace paimon {
@@ -35,6 +36,23 @@ Result<int64_t> AppendCountReader::CountRows() {
 }
 
 Result<int64_t> AppendCountReader::CountSingleSplit(const std::shared_ptr<Split>& split) const {
+    std::shared_ptr<RealtimeSplit> realtime_split = std::dynamic_pointer_cast<RealtimeSplit>(split);
+    if (realtime_split) {
+        if (realtime_split->Version() != RealtimeSplit::kCurrentVersion) {
+            return Status::Invalid("unsupported real-time split version");
+        }
+        if (realtime_split->MemoryEndOffset() < realtime_split->CommittedEndOffset()) {
+            return Status::Invalid("real-time memory upper offset is behind committed offset");
+        }
+
+        int64_t total = realtime_split->MemoryEndOffset() - realtime_split->CommittedEndOffset();
+        for (const std::shared_ptr<Split>& disk_split : realtime_split->DiskSplits()) {
+            PAIMON_ASSIGN_OR_RAISE(int64_t disk_count, CountSingleSplit(disk_split));
+            total += disk_count;
+        }
+        return total;
+    }
+
     auto data_split = std::dynamic_pointer_cast<DataSplitImpl>(split);
     if (!data_split) {
         return Status::Invalid("split cannot be cast to DataSplitImpl");

--- a/src/paimon/core/table/source/append_only_table_read.cpp
+++ b/src/paimon/core/table/source/append_only_table_read.cpp
@@ -183,15 +183,52 @@ Result<std::unique_ptr<BatchReader>> AppendOnlyTableRead::CreateDiskReader(
 
 Result<std::unique_ptr<CountReader>> AppendOnlyTableRead::CreateCountReader(
     const std::vector<std::shared_ptr<Split>>& splits) {
-    for (const std::shared_ptr<Split>& split : splits) {
-        if (std::dynamic_pointer_cast<RealtimeSplit>(split)) {
-            return Status::NotImplemented(
-                "CreateCountReader does not support process-local real-time splits");
-        }
-    }
     if (context_->GetPredicate() != nullptr) {
         return Status::NotImplemented(
             "CreateCountReader with predicate pushdown is not supported yet");
+    }
+
+    std::vector<std::shared_ptr<RealtimeSplit>> realtime_splits;
+    for (const std::shared_ptr<Split>& split : splits) {
+        std::shared_ptr<RealtimeSplit> realtime_split =
+            std::dynamic_pointer_cast<RealtimeSplit>(split);
+        if (realtime_split) {
+            realtime_splits.push_back(std::move(realtime_split));
+        }
+    }
+    if (!realtime_splits.empty()) {
+        const std::shared_ptr<RealtimeContext> realtime_context = context_->GetRealtimeContext();
+        if (!realtime_context) {
+            return Status::Invalid("reading a real-time split requires a real-time context");
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RealtimeContextImpl> realtime_context_impl,
+                               RealtimeContextImpl::Cast(realtime_context));
+        for (const std::shared_ptr<RealtimeSplit>& realtime_split : realtime_splits) {
+            if (realtime_split->Version() != RealtimeSplit::kCurrentVersion) {
+                return Status::Invalid("unsupported real-time split version");
+            }
+            if (realtime_split->MemoryEndOffset() < realtime_split->CommittedEndOffset()) {
+                return Status::Invalid("real-time memory upper offset is behind committed offset");
+            }
+            PAIMON_ASSIGN_OR_RAISE(
+                RealtimePartitionBucketView memory,
+                realtime_context_impl->ResolveReadView(realtime_split->OpaqueTicket()));
+            const RealtimePartitionBucket expected_partition_bucket(realtime_split->Partition(),
+                                                                    realtime_split->Bucket());
+            if (memory.partition_bucket != expected_partition_bucket) {
+                return Status::Invalid(
+                    "real-time read-view ticket belongs to another partition-bucket");
+            }
+            const std::optional<OffsetRange> memory_range = memory.read_view->GetOffsetRange();
+            if (!memory_range || memory_range->end != realtime_split->MemoryEndOffset()) {
+                return Status::Invalid(
+                    "real-time read-view ticket does not match the split offset range");
+            }
+        }
+        for (const std::shared_ptr<RealtimeSplit>& realtime_split : realtime_splits) {
+            PAIMON_RETURN_NOT_OK(
+                realtime_context_impl->ReleaseReadView(realtime_split->OpaqueTicket()));
+        }
     }
 
     return std::make_unique<AppendCountReader>(splits, context_->GetCoreOptions().GetFileSystem(),

--- a/src/paimon/core/table/source/realtime_split.h
+++ b/src/paimon/core/table/source/realtime_split.h
@@ -31,7 +31,10 @@
 
 namespace paimon {
 
-/// Split combining committed disk splits and a ticket for one immutable memory view.
+/// Split combining disk splits and one immutable memory view.
+///
+/// Append scans keep earlier disk splits independently schedulable and place only the tail disk
+/// split in this wrapper. Other table semantics may choose a different disk grouping policy.
 ///
 /// `committed_end_offset` and `memory_end_offset` are exclusive bounds. Disk covers the committed
 /// prefix and memory readers return the remaining `[committed_end_offset, memory_end_offset)`

--- a/src/paimon/core/table/source/realtime_table_scan.cpp
+++ b/src/paimon/core/table/source/realtime_table_scan.cpp
@@ -19,6 +19,7 @@
 
 #include "paimon/core/table/source/realtime_table_scan.h"
 
+#include <iterator>
 #include <map>
 #include <optional>
 #include <utility>
@@ -119,7 +120,6 @@ Result<std::vector<std::shared_ptr<Split>>> RealtimeTableScan::CreateRealtimeSpl
             .push_back(split);
     }
 
-    // TODO(xinyu.lxy): Support splitting one partition-bucket into multiple real-time splits.
     std::vector<std::shared_ptr<Split>> result;
     std::vector<std::string> pinned_tickets;
     ScopeGuard ticket_guard([this, &pinned_tickets]() {
@@ -151,9 +151,17 @@ Result<std::vector<std::shared_ptr<Split>>> RealtimeTableScan::CreateRealtimeSpl
             result.insert(result.end(), grouped_disk_splits.begin(), grouped_disk_splits.end());
             continue;
         }
+
+        // Append tables can schedule all but the tail disk split independently. The tail split
+        // carries the immutable memory view so disk and memory are still concatenated by one
+        // RealtimeSplit without collapsing the whole partition-bucket into one scheduling unit.
+        auto tail_disk_split = std::prev(grouped_disk_splits.end());
+        result.insert(result.end(), grouped_disk_splits.begin(), tail_disk_split);
+        std::vector<std::shared_ptr<Split>> realtime_disk_splits;
+        realtime_disk_splits.push_back(std::move(*tail_disk_split));
         RealtimePartitionBucketView& memory = memory_iter->second;
         PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Split> realtime_split,
-                               create_realtime_split(key, std::move(grouped_disk_splits), memory));
+                               create_realtime_split(key, std::move(realtime_disk_splits), memory));
         result.push_back(std::move(realtime_split));
         active_memory.erase(memory_iter);
     }

--- a/src/paimon/core/table/source/table_read.cpp
+++ b/src/paimon/core/table/source/table_read.cpp
@@ -90,6 +90,9 @@ Result<std::unique_ptr<TableRead>> CreateTableRead(
     const std::shared_ptr<MemoryPool>& memory_pool, const std::shared_ptr<Executor>& executor) {
     const auto& core_options = internal_context->GetCoreOptions();
     const auto& table_schema = internal_context->GetTableSchema();
+    if (internal_context->GetRealtimeContext() && !core_options.RealtimeEnabled()) {
+        return Status::Invalid("real-time read requires realtime.enabled=true");
+    }
     auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
     PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> external_paths,
                            core_options.CreateExternalPaths());

--- a/src/paimon/core/table/source/table_scan.cpp
+++ b/src/paimon/core/table/source/table_scan.cpp
@@ -220,6 +220,9 @@ Status ValidateRealtimeScan(const TableSchema& table_schema, const CoreOptions& 
     if (!context.GetRealtimeContext()) {
         return Status::OK();
     }
+    if (!core_options.RealtimeEnabled()) {
+        return Status::Invalid("real-time scan requires realtime.enabled=true");
+    }
     if (!table_schema.PrimaryKeys().empty()) {
         return Status::Invalid("real-time union read currently supports append tables only");
     }

--- a/src/paimon/core/utils/partition_utils.h
+++ b/src/paimon/core/utils/partition_utils.h
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "paimon/common/utils/binary_row_partition_computer.h"
+#include "paimon/result.h"
+
+namespace paimon {
+
+class PartitionUtils {
+ public:
+    PartitionUtils() = delete;
+    ~PartitionUtils() = delete;
+
+    static Result<bool> MatchPartitionSpec(const std::map<std::string, std::string>& partition,
+                                           const std::map<std::string, std::string>& partition_spec,
+                                           const BinaryRowPartitionComputer& partition_computer) {
+        for (const auto& entry : partition_spec) {
+            if (partition.find(entry.first) == partition.end()) {
+                return false;
+            }
+        }
+        // Dynamic overwrite already supplies canonical partition values. Avoid trying to parse
+        // legacy DATE names such as "19723" as user-facing DATE literals again.
+        if (MatchNormalizedPartitionSpec(partition, partition_spec)) {
+            return true;
+        }
+        std::map<std::string, std::string> normalized_partition_spec;
+        PAIMON_ASSIGN_OR_RAISE(normalized_partition_spec,
+                               partition_computer.NormalizePartitionSpec(partition_spec));
+        return MatchNormalizedPartitionSpec(partition, normalized_partition_spec);
+    }
+
+    static bool MatchNormalizedPartitionSpec(
+        const std::map<std::string, std::string>& partition,
+        const std::map<std::string, std::string>& normalized_partition_spec) {
+        for (const auto& [key, value] : normalized_partition_spec) {
+            auto iter = partition.find(key);
+            if (iter == partition.end() || iter->second != value) {
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+}  // namespace paimon

--- a/src/paimon/core/utils/partition_utils_test.cpp
+++ b/src/paimon/core/utils/partition_utils_test.cpp
@@ -34,7 +34,8 @@ namespace paimon::test {
 TEST(PartitionUtilsTest, MatchNormalizedPartitionSpec) {
     const std::map<std::string, std::string> partition = {{"dt", "2026-08-21"}, {"region", "cn"}};
 
-    ASSERT_TRUE(PartitionUtils::MatchNormalizedPartitionSpec(partition, /*partition_spec=*/{}));
+    ASSERT_TRUE(
+        PartitionUtils::MatchNormalizedPartitionSpec(partition, /*normalized_partition_spec=*/{}));
     ASSERT_TRUE(PartitionUtils::MatchNormalizedPartitionSpec(partition, {{"dt", "2026-08-21"}}));
     ASSERT_TRUE(PartitionUtils::MatchNormalizedPartitionSpec(
         partition, {{"dt", "2026-08-21"}, {"region", "cn"}}));

--- a/src/paimon/core/utils/partition_utils_test.cpp
+++ b/src/paimon/core/utils/partition_utils_test.cpp
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/utils/partition_utils.h"
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/common/utils/binary_row_partition_computer.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+TEST(PartitionUtilsTest, MatchNormalizedPartitionSpec) {
+    const std::map<std::string, std::string> partition = {{"dt", "2026-08-21"}, {"region", "cn"}};
+
+    ASSERT_TRUE(PartitionUtils::MatchNormalizedPartitionSpec(partition, /*partition_spec=*/{}));
+    ASSERT_TRUE(PartitionUtils::MatchNormalizedPartitionSpec(partition, {{"dt", "2026-08-21"}}));
+    ASSERT_TRUE(PartitionUtils::MatchNormalizedPartitionSpec(
+        partition, {{"dt", "2026-08-21"}, {"region", "cn"}}));
+    ASSERT_FALSE(PartitionUtils::MatchNormalizedPartitionSpec(partition, {{"dt", "2026-08-22"}}));
+    ASSERT_FALSE(PartitionUtils::MatchNormalizedPartitionSpec(partition, {{"hour", "12"}}));
+}
+
+TEST(PartitionUtilsTest, MatchPartitionSpecNormalizesPartialSpec) {
+    std::shared_ptr<arrow::Schema> schema =
+        arrow::schema({arrow::field("dt", arrow::date32()), arrow::field("region", arrow::utf8())});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<BinaryRowPartitionComputer> partition_computer,
+                         BinaryRowPartitionComputer::Create(
+                             /*partition_keys=*/{"dt", "region"}, schema,
+                             /*default_part_value=*/"__DEFAULT_PARTITION__",
+                             /*legacy_partition_name_enabled=*/true, GetDefaultPool()));
+    const std::map<std::string, std::string> partition = {{"dt", "19723"}, {"region", "cn"}};
+    ASSERT_OK_AND_ASSIGN(
+        bool raw_spec_matches,
+        PartitionUtils::MatchPartitionSpec(partition, {{"dt", "2024-01-01"}}, *partition_computer));
+    ASSERT_TRUE(raw_spec_matches);
+
+    ASSERT_OK_AND_ASSIGN(
+        bool normalized_spec_matches,
+        PartitionUtils::MatchPartitionSpec(partition, {{"dt", "19723"}}, *partition_computer));
+    ASSERT_TRUE(normalized_spec_matches);
+
+    ASSERT_OK_AND_ASSIGN(bool unknown_key_matches,
+                         PartitionUtils::MatchPartitionSpec(
+                             partition, {{"unknown_partition_key", "value"}}, *partition_computer));
+    ASSERT_FALSE(unknown_key_matches);
+}
+
+}  // namespace paimon::test

--- a/test/inte/realtime_write_inte_test.cpp
+++ b/test/inte/realtime_write_inte_test.cpp
@@ -260,6 +260,16 @@ class RealtimeWriteInteTest : public ::testing::Test {
         return builder.SetBucket(bucket).Finish();
     }
 
+    Result<std::unique_ptr<RecordBatch>> MakeUnpartitionedBatchFromJson(
+        const std::string& json) const {
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            std::shared_ptr<arrow::Array> array,
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), json));
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*array, &c_array));
+        return RecordBatchBuilder(&c_array).SetBucket(/*bucket=*/0).Finish();
+    }
+
     static std::vector<Row> MakeRows(int64_t first_id, int64_t count,
                                      const std::string& partition) {
         std::vector<Row> rows;
@@ -280,6 +290,16 @@ class RealtimeWriteInteTest : public ::testing::Test {
                                FileStoreCommit::Create(std::move(context)));
         return commit->CommitWithProgress(realtime_commits, commit_identifier,
                                           /*watermark=*/std::nullopt);
+    }
+
+    Status DropPartition(const std::map<std::string, std::string>& partition,
+                         int64_t commit_identifier) const {
+        CommitContextBuilder builder(table_path_, commit_user_);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> context,
+                               builder.SetOptions(options_).Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> commit,
+                               FileStoreCommit::Create(std::move(context)));
+        return commit->DropPartition({partition}, commit_identifier);
     }
 
     Result<int64_t> RollbackToAsLatest(int64_t target_snapshot_id) const {
@@ -1387,6 +1407,67 @@ TEST_F(RealtimeWriteInteTest, TestMemoryBatchStatisticsPredicatePushdownWithDisk
     ASSERT_OK(writer->Close());
 }
 
+TEST_F(RealtimeWriteInteTest, TestNullPredicateForMemoryAndDisk) {
+    options_[Options::FILE_FORMAT] = "parquet";
+    options_[Options::WRITE_BATCH_SIZE] = "1";
+    options_[Options::REALTIME_STORE_STATS_MODE] = "full";
+    options_["parquet.page.size"] = "1";
+    options_["parquet.enable-dictionary"] = "false";
+    options_["parquet.write.enable-page-index"] = "true";
+    options_["parquet.write.max-row-group-length"] = "1";
+    options_["parquet.read.enable-page-index-filter"] = "true";
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> disk_batch,
+                         MakeUnpartitionedBatchFromJson(R"([
+                             [0, null, "p0"],
+                             [1, "disk-value", "p0"]
+                         ])"));
+    ASSERT_OK(writer->Write(std::move(disk_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> disk_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK(Commit(disk_commits, /*commit_identifier=*/0));
+
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> non_null_memory_batch,
+                         MakeUnpartitionedBatchFromJson(R"([
+                             [2, "memory-value-2", "p0"],
+                             [3, "memory-value-3", "p0"]
+                         ])"));
+    ASSERT_OK(writer->Write(std::move(non_null_memory_batch)));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> nullable_memory_batch,
+                         MakeUnpartitionedBatchFromJson(R"([
+                             [4, null, "p0"],
+                             [5, "memory-value-5", "p0"]
+                         ])"));
+    ASSERT_OK(writer->Write(std::move(nullable_memory_batch)));
+
+    std::shared_ptr<Predicate> predicate = PredicateBuilder::IsNull(
+        /*field_index=*/1, /*field_name=*/"payload", FieldType::STRING);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> plan, CreatePlan(realtime_context, predicate));
+    ASSERT_OK_AND_ASSIGN(CollectedReadResult result,
+                         ReadPlan(plan, realtime_context, {"id", "payload", "pt"}, predicate,
+                                  /*enable_predicate_filter=*/false));
+
+    std::shared_ptr<arrow::DataType> result_type = arrow::struct_(
+        {arrow::field("_VALUE_KIND", arrow::int8()), arrow::field("id", arrow::int64()),
+         arrow::field("payload", arrow::utf8()), arrow::field("pt", arrow::utf8())});
+    std::shared_ptr<arrow::Array> expected =
+        arrow::ipc::internal::json::ArrayFromJSON(result_type, R"([
+            [0, 0, null, "p0"],
+            [0, 4, null, "p0"],
+            [0, 5, "memory-value-5", "p0"]
+        ])")
+            .ValueOrDie();
+    ASSERT_NE(nullptr, result.data);
+    ASSERT_TRUE(std::make_shared<arrow::ChunkedArray>(expected)->Equals(*result.data))
+        << result.data->ToString();
+    ASSERT_OK(writer->Close());
+}
+
 TEST_F(RealtimeWriteInteTest, TestUnionReadAfterColumnRename) {
     CreateTable(/*partition_keys=*/{});
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> first_context, RealtimeContext::Create());
@@ -1619,6 +1700,47 @@ TEST_F(RealtimeWriteInteTest, TestRepeatedCommitReadAndRefresh) {
                              GetRealtimeMemoryUsage(realtime_context));
         ASSERT_EQ(0, memory_usage_after_refresh);
     }
+    ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestRefreshLatestSnapshotReclaimsMultipleCommittedSegments) {
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+    constexpr int64_t kSnapshotCount = 3;
+    constexpr int64_t kRowsPerSnapshot = 2;
+    std::vector<Row> expected_rows;
+    int64_t latest_snapshot_id = -1;
+    for (int64_t snapshot_index = 0; snapshot_index < kSnapshotCount; ++snapshot_index) {
+        std::vector<Row> rows =
+            MakeRows(snapshot_index * kRowsPerSnapshot, kRowsPerSnapshot, /*partition=*/"p0");
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                             MakeBatch(rows, /*partitioned=*/false));
+        ASSERT_OK(writer->Write(std::move(batch)));
+        ASSERT_OK_AND_ASSIGN(
+            std::vector<RealtimeCommitProgress> commits,
+            writer->PrepareCommitWithProgress(/*commit_identifier=*/snapshot_index));
+        ASSERT_EQ(1, commits.size());
+        ASSERT_OK_AND_ASSIGN(latest_snapshot_id,
+                             Commit(commits, /*commit_identifier=*/snapshot_index));
+        expected_rows.insert(expected_rows.end(), rows.begin(), rows.end());
+    }
+
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> rows_before_refresh, ReadRows(realtime_context));
+    ASSERT_EQ(expected_rows, rows_before_refresh);
+    ASSERT_OK_AND_ASSIGN(uint64_t memory_usage_before_refresh,
+                         GetRealtimeMemoryUsage(realtime_context));
+    ASSERT_GT(memory_usage_before_refresh, 0);
+
+    ASSERT_OK(writer->RefreshCommittedSnapshot(latest_snapshot_id));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> rows_after_refresh, ReadRows(realtime_context));
+    ASSERT_EQ(rows_before_refresh, rows_after_refresh);
+    ASSERT_OK_AND_ASSIGN(uint64_t memory_usage_after_refresh,
+                         GetRealtimeMemoryUsage(realtime_context));
+    ASSERT_EQ(0, memory_usage_after_refresh);
     ASSERT_OK(writer->Close());
 }
 
@@ -1966,6 +2088,52 @@ TEST_F(RealtimeWriteInteTest, TestMultiplePartitions) {
     ASSERT_OK(writer->RefreshCommittedSnapshot(final_snapshot_id));
     ASSERT_OK_AND_ASSIGN(std::vector<Row> committed_rows, ReadRows(realtime_context));
     ASSERT_EQ(expected_rows, committed_rows);
+    ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestDropPartitionKeepsUncommittedRealtimeRows) {
+    CreateTable(/*partition_keys=*/{"pt"});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+
+    std::vector<Row> disk_rows = MakeRows(/*first_id=*/0, /*count=*/3, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> disk_batch,
+                         MakeBatch(disk_rows, /*partitioned=*/true));
+    ASSERT_OK(writer->Write(std::move(disk_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> disk_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK_AND_ASSIGN(int64_t disk_snapshot_id, Commit(disk_commits, /*commit_identifier=*/0));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(disk_snapshot_id));
+
+    std::vector<Row> memory_rows = MakeRows(/*first_id=*/3, /*count=*/2, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> memory_batch,
+                         MakeBatch(memory_rows, /*partitioned=*/true));
+    ASSERT_OK(writer->Write(std::move(memory_batch)));
+    std::vector<Row> rows_before_drop = disk_rows;
+    rows_before_drop.insert(rows_before_drop.end(), memory_rows.begin(), memory_rows.end());
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> actual_rows_before_drop, ReadRows(realtime_context));
+    ASSERT_EQ(rows_before_drop, actual_rows_before_drop);
+
+    ASSERT_OK(DropPartition({{"pt", "p0"}}, /*commit_identifier=*/1));
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> rows_after_drop, ReadRows(realtime_context));
+    ASSERT_EQ(memory_rows, rows_after_drop);
+    RealtimePartitionBucket partition_bucket({{"pt", "p0"}}, /*bucket=*/0);
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap offsets_after_drop, ReadCommittedOffsets());
+    ASSERT_EQ(3, offsets_after_drop.at(partition_bucket));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> memory_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/2));
+    ASSERT_OK_AND_ASSIGN(int64_t memory_snapshot_id,
+                         Commit(memory_commits, /*commit_identifier=*/2));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(memory_snapshot_id));
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> rows_after_memory_commit, ReadRows(realtime_context));
+    ASSERT_EQ(memory_rows, rows_after_memory_commit);
+    ASSERT_OK_AND_ASSIGN(uint64_t final_memory_usage, GetRealtimeMemoryUsage(realtime_context));
+    ASSERT_EQ(0, final_memory_usage);
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap final_offsets, ReadCommittedOffsets());
+    ASSERT_EQ(5, final_offsets.at(partition_bucket));
     ASSERT_OK(writer->Close());
 }
 

--- a/test/inte/realtime_write_inte_test.cpp
+++ b/test/inte/realtime_write_inte_test.cpp
@@ -402,6 +402,36 @@ class RealtimeWriteInteTest : public ::testing::Test {
         return CollectedReadResult{std::move(reader), std::move(result)};
     }
 
+    void ReadPlanWithSchemaAndCheck(const std::shared_ptr<Plan>& plan,
+                                    const std::shared_ptr<RealtimeContext>& realtime_context,
+                                    const std::shared_ptr<arrow::Schema>& read_schema,
+                                    const std::string& expected_json) const {
+        std::unique_ptr<ArrowSchema> c_read_schema = std::make_unique<ArrowSchema>();
+        ASSERT_TRUE(arrow::ExportSchema(*read_schema, c_read_schema.get()).ok());
+        ReadContextBuilder read_builder(table_path_);
+        read_builder.SetOptions(options_)
+            .SetReadSchema(std::move(c_read_schema))
+            .WithRealtimeContext(realtime_context)
+            .WithMemoryPool(pool_);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<ReadContext> read_context, read_builder.Finish());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableRead> table_read,
+                             TableRead::Create(std::move(read_context)));
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<BatchReader> reader,
+                             table_read->CreateReader(plan->Splits()));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::ChunkedArray> result,
+                             ReadResultCollector::CollectResult(reader.get()));
+
+        arrow::FieldVector result_fields = {arrow::field("_VALUE_KIND", arrow::int8())};
+        result_fields.insert(result_fields.end(), read_schema->fields().begin(),
+                             read_schema->fields().end());
+        std::shared_ptr<arrow::Array> expected =
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(result_fields), expected_json)
+                .ValueOrDie();
+        ASSERT_NE(nullptr, result);
+        ASSERT_TRUE(std::make_shared<arrow::ChunkedArray>(expected)->Equals(*result))
+            << result->ToString();
+    }
+
     Result<std::vector<Row>> ReadRows(
         const std::shared_ptr<RealtimeContext>& realtime_context) const {
         PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Plan> plan,
@@ -1520,6 +1550,56 @@ TEST_F(RealtimeWriteInteTest, TestUnionReadAfterColumnRename) {
     ASSERT_TRUE(std::make_shared<arrow::ChunkedArray>(expected)->Equals(*result.data))
         << result.data->ToString();
     ASSERT_OK(second_writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestUnionReadWithNestedStructProjection) {
+    std::shared_ptr<arrow::DataType> address_type =
+        arrow::struct_({arrow::field("city", arrow::utf8()), arrow::field("zip", arrow::int64())});
+    std::shared_ptr<arrow::DataType> profile_type = arrow::struct_(
+        {arrow::field("name", arrow::utf8()), arrow::field("address", address_type)});
+    fields_ = {arrow::field("id", arrow::int64()), arrow::field("profile", profile_type),
+               arrow::field("pt", arrow::utf8())};
+    schema_ = arrow::schema(fields_);
+    CreateTable(/*partition_keys=*/{});
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> disk_batch,
+                         MakeUnpartitionedBatchFromJson(R"([
+                             [0, ["disk-0", ["hangzhou", 310000]], "p0"],
+                             [1, ["disk-1", ["shanghai", 200000]], "p0"]
+                         ])"));
+    ASSERT_OK(writer->Write(std::move(disk_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> disk_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK_AND_ASSIGN(int64_t disk_snapshot_id, Commit(disk_commits, /*commit_identifier=*/0));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(disk_snapshot_id));
+
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> memory_batch,
+                         MakeUnpartitionedBatchFromJson(R"([
+                             [2, ["memory-2", ["beijing", 100000]], "p0"],
+                             [3, ["memory-3", ["shenzhen", 518000]], "p0"]
+                         ])"));
+    ASSERT_OK(writer->Write(std::move(memory_batch)));
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> plan,
+                         CreatePlan(realtime_context, /*predicate=*/nullptr));
+    std::shared_ptr<arrow::DataType> projected_address_type =
+        arrow::struct_({arrow::field("city", arrow::utf8())});
+    std::shared_ptr<arrow::DataType> projected_profile_type =
+        arrow::struct_({arrow::field("address", projected_address_type)});
+    std::shared_ptr<arrow::Schema> projected_schema = arrow::schema(
+        {arrow::field("id", arrow::int64()), arrow::field("profile", projected_profile_type),
+         arrow::field("pt", arrow::utf8())});
+    ReadPlanWithSchemaAndCheck(plan, realtime_context, projected_schema, R"([
+        [0, 0, [["hangzhou"]], "p0"],
+        [0, 1, [["shanghai"]], "p0"],
+        [0, 2, [["beijing"]], "p0"],
+        [0, 3, [["shenzhen"]], "p0"]
+    ])");
+    ASSERT_OK(writer->Close());
 }
 
 TEST_F(RealtimeWriteInteTest, TestRefreshCommittedSnapshotReclaimsMemory) {

--- a/test/inte/realtime_write_inte_test.cpp
+++ b/test/inte/realtime_write_inte_test.cpp
@@ -836,7 +836,7 @@ TEST_F(RealtimeWriteInteTest, TestCommitOrdersPreparedOffsetRanges) {
     ASSERT_EQ(expected_rows, actual_rows);
 }
 
-TEST_F(RealtimeWriteInteTest, TestCommitWithProgressRetryIsIdempotent) {
+TEST_F(RealtimeWriteInteTest, TestCommitWithProgressRetryReturnsLatestSnapshot) {
     CreateTable(/*partition_keys=*/{});
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer, CreateRealtimeWriter());
     std::vector<Row> expected_rows = MakeRows(/*first_id=*/0, /*count=*/3, /*partition=*/"p0");
@@ -849,9 +849,24 @@ TEST_F(RealtimeWriteInteTest, TestCommitWithProgressRetryIsIdempotent) {
     ASSERT_OK_AND_ASSIGN(int64_t first_snapshot_id, Commit(commits, /*commit_identifier=*/0));
     ASSERT_OK_AND_ASSIGN(int64_t retry_snapshot_id, Commit(commits, /*commit_identifier=*/0));
     ASSERT_EQ(first_snapshot_id, retry_snapshot_id);
-    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap committed_offsets, ReadCommittedOffsets());
-    ASSERT_EQ(3, committed_offsets.at(RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0)));
 
+    ASSERT_OK(writer->RefreshCommittedSnapshot(first_snapshot_id));
+    std::vector<Row> second_rows = MakeRows(/*first_id=*/3, /*count=*/2, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> second_batch,
+                         MakeBatch(second_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(second_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> second_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/1));
+    ASSERT_OK_AND_ASSIGN(int64_t second_snapshot_id,
+                         Commit(second_commits, /*commit_identifier=*/1));
+
+    ASSERT_OK_AND_ASSIGN(retry_snapshot_id, Commit(commits, /*commit_identifier=*/0));
+    ASSERT_EQ(second_snapshot_id, retry_snapshot_id);
+    ASSERT_NE(first_snapshot_id, retry_snapshot_id);
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap committed_offsets, ReadCommittedOffsets());
+    ASSERT_EQ(5, committed_offsets.at(RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0)));
+
+    expected_rows.insert(expected_rows.end(), second_rows.begin(), second_rows.end());
     ASSERT_OK_AND_ASSIGN(std::vector<Row> actual_rows, ReadRows());
     ASSERT_EQ(expected_rows, actual_rows);
     ASSERT_OK(writer->Close());

--- a/test/inte/realtime_write_inte_test.cpp
+++ b/test/inte/realtime_write_inte_test.cpp
@@ -72,6 +72,14 @@
 
 namespace paimon::test {
 
+namespace {
+
+constexpr char kDropPartitionCommitUser[] = "drop_partition_commit_user";
+constexpr char kRollbackCommitUser[] = "rollback_commit_user";
+constexpr char kTruncateCommitUser[] = "truncate_commit_user";
+
+}  // namespace
+
 class UnsupportedFunction : public Function {
  public:
     Type GetType() const override {
@@ -293,18 +301,43 @@ class RealtimeWriteInteTest : public ::testing::Test {
                                           /*watermark=*/std::nullopt);
     }
 
-    Status DropPartition(const std::map<std::string, std::string>& partition,
-                         int64_t commit_identifier) const {
-        CommitContextBuilder builder(table_path_, commit_user_);
+    Result<int64_t> DropPartition(const std::map<std::string, std::string>& partition,
+                                  int64_t commit_identifier) const {
+        CommitContextBuilder builder(table_path_, kDropPartitionCommitUser);
         PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> context,
                                builder.SetOptions(options_).Finish());
         PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> commit,
                                FileStoreCommit::Create(std::move(context)));
-        return commit->DropPartition({partition}, commit_identifier);
+        PAIMON_RETURN_NOT_OK(commit->DropPartition({partition}, commit_identifier));
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options, CoreOptions::FromMap(options_));
+        SnapshotManager snapshot_manager(options.GetFileSystem(), table_path_);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> latest_snapshot,
+                               snapshot_manager.LatestSnapshot());
+        if (!latest_snapshot) {
+            return Status::Invalid("drop partition did not produce a snapshot");
+        }
+        return latest_snapshot->Id();
+    }
+
+    Result<int64_t> TruncateTable(int64_t commit_identifier) const {
+        CommitContextBuilder builder(table_path_, kTruncateCommitUser);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> context,
+                               builder.SetOptions(options_).Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> commit,
+                               FileStoreCommit::Create(std::move(context)));
+        PAIMON_RETURN_NOT_OK(commit->TruncateTable(commit_identifier));
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options, CoreOptions::FromMap(options_));
+        SnapshotManager snapshot_manager(options.GetFileSystem(), table_path_);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> latest_snapshot,
+                               snapshot_manager.LatestSnapshot());
+        if (!latest_snapshot) {
+            return Status::Invalid("truncate did not produce a snapshot");
+        }
+        return latest_snapshot->Id();
     }
 
     Result<int64_t> RollbackToAsLatest(int64_t target_snapshot_id) const {
-        CommitContextBuilder builder(table_path_, commit_user_);
+        CommitContextBuilder builder(table_path_, kRollbackCommitUser);
         PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> context,
                                builder.SetOptions(options_).Finish());
         PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> commit,
@@ -1935,6 +1968,64 @@ TEST_F(RealtimeWriteInteTest, TestRefreshLatestSnapshotReclaimsMultipleCommitted
     ASSERT_OK(writer->Close());
 }
 
+TEST_F(RealtimeWriteInteTest, TestOverwriteRequiresReopenRealtimeContext) {
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+
+    std::vector<Row> committed_rows = MakeRows(/*first_id=*/0, /*count=*/3, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> committed_batch,
+                         MakeBatch(committed_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(committed_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK_AND_ASSIGN(int64_t committed_snapshot_id, Commit(commits, /*commit_identifier=*/0));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(committed_snapshot_id));
+
+    std::vector<Row> building_rows = MakeRows(/*first_id=*/3, /*count=*/2, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> building_batch,
+                         MakeBatch(building_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(building_batch)));
+    ASSERT_OK_AND_ASSIGN(uint64_t memory_usage_before_overwrite,
+                         GetRealtimeMemoryUsage(realtime_context));
+    ASSERT_GT(memory_usage_before_overwrite, 0);
+
+    ASSERT_OK_AND_ASSIGN(int64_t overwrite_snapshot_id, TruncateTable(/*commit_identifier=*/1));
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options_));
+    SnapshotManager snapshot_manager(core_options.GetFileSystem(), table_path_);
+    ASSERT_OK_AND_ASSIGN(Snapshot overwrite_snapshot,
+                         snapshot_manager.LoadSnapshot(overwrite_snapshot_id));
+    ASSERT_EQ(Snapshot::CommitKind::Overwrite(), overwrite_snapshot.GetCommitKind());
+    ASSERT_FALSE(RealtimeCommitProperties::GetOffsetsPath(overwrite_snapshot));
+
+    ASSERT_NOK_WITH_MSG(writer->RefreshCommittedSnapshot(overwrite_snapshot_id),
+                        "recreate RealtimeContext");
+    ASSERT_OK_AND_ASSIGN(uint64_t memory_usage_after_failed_refresh,
+                         GetRealtimeMemoryUsage(realtime_context));
+    ASSERT_EQ(memory_usage_before_overwrite, memory_usage_after_failed_refresh);
+    ASSERT_OK(writer->Close());
+    writer.reset();
+    realtime_context.reset();
+
+    ASSERT_OK_AND_ASSIGN(realtime_context, RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(writer, CreateRealtimeWriter(realtime_context));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> replay_batch,
+                         MakeBatch(building_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(replay_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> replay_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/2));
+    ASSERT_EQ(1, replay_commits.size());
+    ASSERT_EQ(OffsetRange(0, 2), replay_commits[0].offset_range);
+    ASSERT_OK_AND_ASSIGN(int64_t replay_snapshot_id,
+                         Commit(replay_commits, /*commit_identifier=*/2));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(replay_snapshot_id));
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> replayed_rows, ReadRows(realtime_context));
+    ASSERT_EQ(building_rows, replayed_rows);
+    ASSERT_OK(writer->Close());
+}
+
 TEST_F(RealtimeWriteInteTest, TestReopenRealtimeContextAfterRollback) {
     CreateTable(/*partition_keys=*/{});
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
@@ -1962,24 +2053,27 @@ TEST_F(RealtimeWriteInteTest, TestReopenRealtimeContextAfterRollback) {
     ASSERT_OK(writer->RefreshCommittedSnapshot(second_snapshot_id));
 
     ASSERT_OK_AND_ASSIGN(int64_t rollback_snapshot_id, RollbackToAsLatest(first_snapshot_id));
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap rollback_offsets, ReadCommittedOffsets());
+    ASSERT_EQ(1, rollback_offsets.size());
+    ASSERT_EQ(3, rollback_offsets.at(RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0)));
     ASSERT_NOK_WITH_MSG(writer->RefreshCommittedSnapshot(rollback_snapshot_id),
                         "recreate RealtimeContext");
     ASSERT_OK(writer->Close());
     writer.reset();
     realtime_context.reset();
 
-    // A rollback can only restore reclaimed ranges by rebuilding the context and replaying input.
-    commit_user_ = "realtime_commit_user_after_rollback";
+    // Reopen the same real-time writer identity from the target snapshot's progress and replay
+    // input after that restored boundary.
     ASSERT_OK_AND_ASSIGN(realtime_context, RealtimeContext::Create());
     ASSERT_OK_AND_ASSIGN(writer, CreateRealtimeWriter(realtime_context));
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> replay_batch,
                          MakeBatch(second_rows, /*partitioned=*/false));
     ASSERT_OK(writer->Write(std::move(replay_batch)));
     ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> replay_commits,
-                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/2));
     ASSERT_EQ(1, replay_commits.size());
     ASSERT_EQ(OffsetRange(3, 5), replay_commits[0].offset_range);
-    ASSERT_OK(Commit(replay_commits, /*commit_identifier=*/0));
+    ASSERT_OK(Commit(replay_commits, /*commit_identifier=*/2));
 
     std::vector<Row> expected_rows = first_rows;
     expected_rows.insert(expected_rows.end(), second_rows.begin(), second_rows.end());
@@ -2282,7 +2376,7 @@ TEST_F(RealtimeWriteInteTest, TestMultiplePartitions) {
     ASSERT_OK(writer->Close());
 }
 
-TEST_F(RealtimeWriteInteTest, TestDropPartitionKeepsUncommittedRealtimeRows) {
+TEST_F(RealtimeWriteInteTest, TestDropPartitionRequiresReopenRealtimeContext) {
     CreateTable(/*partition_keys=*/{"pt"});
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
                          RealtimeContext::Create());
@@ -2293,6 +2387,11 @@ TEST_F(RealtimeWriteInteTest, TestDropPartitionKeepsUncommittedRealtimeRows) {
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> disk_batch,
                          MakeBatch(disk_rows, /*partitioned=*/true));
     ASSERT_OK(writer->Write(std::move(disk_batch)));
+    std::vector<Row> retained_disk_rows =
+        MakeRows(/*first_id=*/10, /*count=*/3, /*partition=*/"p1");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> retained_disk_batch,
+                         MakeBatch(retained_disk_rows, /*partitioned=*/true));
+    ASSERT_OK(writer->Write(std::move(retained_disk_batch)));
     ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> disk_commits,
                          writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
     ASSERT_OK_AND_ASSIGN(int64_t disk_snapshot_id, Commit(disk_commits, /*commit_identifier=*/0));
@@ -2304,27 +2403,61 @@ TEST_F(RealtimeWriteInteTest, TestDropPartitionKeepsUncommittedRealtimeRows) {
     ASSERT_OK(writer->Write(std::move(memory_batch)));
     std::vector<Row> rows_before_drop = disk_rows;
     rows_before_drop.insert(rows_before_drop.end(), memory_rows.begin(), memory_rows.end());
+    rows_before_drop.insert(rows_before_drop.end(), retained_disk_rows.begin(),
+                            retained_disk_rows.end());
     ASSERT_OK_AND_ASSIGN(std::vector<Row> actual_rows_before_drop, ReadRows(realtime_context));
     ASSERT_EQ(rows_before_drop, actual_rows_before_drop);
 
-    ASSERT_OK(DropPartition({{"pt", "p0"}}, /*commit_identifier=*/1));
-    ASSERT_OK_AND_ASSIGN(std::vector<Row> rows_after_drop, ReadRows(realtime_context));
-    ASSERT_EQ(memory_rows, rows_after_drop);
+    ASSERT_OK_AND_ASSIGN(int64_t drop_snapshot_id,
+                         DropPartition({{"pt", "p0"}}, /*commit_identifier=*/1));
     RealtimePartitionBucket partition_bucket({{"pt", "p0"}}, /*bucket=*/0);
+    RealtimePartitionBucket retained_partition_bucket({{"pt", "p1"}}, /*bucket=*/0);
     ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap offsets_after_drop, ReadCommittedOffsets());
-    ASSERT_EQ(3, offsets_after_drop.at(partition_bucket));
+    ASSERT_EQ(1, offsets_after_drop.size());
+    ASSERT_EQ(3, offsets_after_drop.at(retained_partition_bucket));
+    ASSERT_EQ(offsets_after_drop.end(), offsets_after_drop.find(partition_bucket));
+    ASSERT_OK_AND_ASSIGN(uint64_t memory_usage_before_refresh,
+                         GetRealtimeMemoryUsage(realtime_context));
+    ASSERT_NOK_WITH_MSG(writer->RefreshCommittedSnapshot(drop_snapshot_id),
+                        "recreate RealtimeContext");
+    ASSERT_OK_AND_ASSIGN(uint64_t memory_usage_after_refresh,
+                         GetRealtimeMemoryUsage(realtime_context));
+    ASSERT_EQ(memory_usage_before_refresh, memory_usage_after_refresh);
+    ASSERT_OK(writer->Close());
+    writer.reset();
+    realtime_context.reset();
+
+    // Reopen with p1's retained progress and replay p0 input that existed only in the old context.
+    ASSERT_OK_AND_ASSIGN(realtime_context, RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(writer, CreateRealtimeWriter(realtime_context));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> replay_batch,
+                         MakeBatch(memory_rows, /*partitioned=*/true));
+    ASSERT_OK(writer->Write(std::move(replay_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> replayed_rows, ReadRows(realtime_context));
+    // The retained p1 disk split is read before the tail real-time split containing p0.
+    std::vector<Row> expected_replayed_rows = retained_disk_rows;
+    expected_replayed_rows.insert(expected_replayed_rows.end(), memory_rows.begin(),
+                                  memory_rows.end());
+    ASSERT_EQ(expected_replayed_rows, replayed_rows);
 
     ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> memory_commits,
                          writer->PrepareCommitWithProgress(/*commit_identifier=*/2));
+    ASSERT_EQ(1, memory_commits.size());
+    ASSERT_EQ(OffsetRange(0, 2), memory_commits[0].offset_range);
     ASSERT_OK_AND_ASSIGN(int64_t memory_snapshot_id,
                          Commit(memory_commits, /*commit_identifier=*/2));
     ASSERT_OK(writer->RefreshCommittedSnapshot(memory_snapshot_id));
     ASSERT_OK_AND_ASSIGN(std::vector<Row> rows_after_memory_commit, ReadRows(realtime_context));
-    ASSERT_EQ(memory_rows, rows_after_memory_commit);
+    std::vector<Row> expected_committed_rows = memory_rows;
+    expected_committed_rows.insert(expected_committed_rows.end(), retained_disk_rows.begin(),
+                                   retained_disk_rows.end());
+    ASSERT_EQ(expected_committed_rows, rows_after_memory_commit);
     ASSERT_OK_AND_ASSIGN(uint64_t final_memory_usage, GetRealtimeMemoryUsage(realtime_context));
     ASSERT_EQ(0, final_memory_usage);
     ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap final_offsets, ReadCommittedOffsets());
-    ASSERT_EQ(5, final_offsets.at(partition_bucket));
+    ASSERT_EQ(2, final_offsets.size());
+    ASSERT_EQ(2, final_offsets.at(partition_bucket));
+    ASSERT_EQ(3, final_offsets.at(retained_partition_bucket));
     ASSERT_OK(writer->Close());
 }
 

--- a/test/inte/realtime_write_inte_test.cpp
+++ b/test/inte/realtime_write_inte_test.cpp
@@ -269,6 +269,33 @@ class RealtimeWriteInteTest : public ::testing::Test {
         return builder.SetBucket(bucket).Finish();
     }
 
+    Result<std::unique_ptr<RecordBatch>> MakeDatePartitionBatch(
+        int64_t first_id, int64_t count, int32_t date, const std::string& partition) const {
+        if (count <= 0) {
+            return Status::Invalid("cannot create an empty test batch");
+        }
+        std::string json = "[";
+        for (int64_t i = 0; i < count; ++i) {
+            if (i > 0) {
+                json += ",";
+            }
+            int64_t id = first_id + i;
+            json += "[" + std::to_string(id) + ",\"value-" + std::to_string(id) + "\"," +
+                    std::to_string(date) + "]";
+        }
+        json += "]";
+
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            std::shared_ptr<arrow::Array> array,
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), json));
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*array, &c_array));
+        return RecordBatchBuilder(&c_array)
+            .SetPartition({{"pt", partition}})
+            .SetBucket(/*bucket=*/0)
+            .Finish();
+    }
+
     Result<std::unique_ptr<RecordBatch>> MakeUnpartitionedBatchFromJson(
         const std::string& json) const {
         PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
@@ -591,6 +618,52 @@ class RealtimeWriteInteTest : public ::testing::Test {
 
         ASSERT_OK_AND_ASSIGN(std::vector<Row> actual_rows, ReadRows());
         ASSERT_EQ(expected_rows, actual_rows);
+    }
+
+    void CheckDropDatePartitionRemovesOffset(bool legacy_partition_name_enabled) {
+        fields_ = {arrow::field("id", arrow::int64()), arrow::field("payload", arrow::utf8()),
+                   arrow::field("pt", arrow::date32())};
+        schema_ = arrow::schema(fields_);
+        options_[Options::PARTITION_GENERATE_LEGACY_NAME] =
+            legacy_partition_name_enabled ? "true" : "false";
+        CreateTable(/*partition_keys=*/{"pt"});
+
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                             RealtimeContext::Create());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                             CreateRealtimeWriter(realtime_context));
+        constexpr int32_t kDate = 19723;
+        constexpr int64_t kRowCount = 3;
+        const std::string partition = "2024-01-01";
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                             MakeDatePartitionBatch(/*first_id=*/0, kRowCount, kDate, partition));
+        ASSERT_OK(writer->Write(std::move(batch)));
+        ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> commits,
+                             writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+        ASSERT_EQ(1, commits.size());
+        ASSERT_OK(Commit(commits, /*commit_identifier=*/0));
+
+        const std::string normalized_partition =
+            legacy_partition_name_enabled ? std::to_string(kDate) : partition;
+        RealtimePartitionBucket partition_bucket({{"pt", normalized_partition}}, /*bucket=*/0);
+        ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap offsets_before_drop, ReadCommittedOffsets());
+        ASSERT_EQ(1, offsets_before_drop.size());
+        ASSERT_EQ(kRowCount, offsets_before_drop.at(partition_bucket));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> plan_before_drop,
+                             CreatePlan(/*realtime_context=*/nullptr, /*predicate=*/nullptr));
+        ASSERT_OK_AND_ASSIGN(int64_t rows_before_drop,
+                             CountRows(plan_before_drop, /*realtime_context=*/nullptr));
+        ASSERT_EQ(kRowCount, rows_before_drop);
+
+        ASSERT_OK(DropPartition({{"pt", partition}}, /*commit_identifier=*/1));
+        ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap offsets_after_drop, ReadCommittedOffsets());
+        ASSERT_TRUE(offsets_after_drop.empty());
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> plan_after_drop,
+                             CreatePlan(/*realtime_context=*/nullptr, /*predicate=*/nullptr));
+        ASSERT_OK_AND_ASSIGN(int64_t rows_after_drop,
+                             CountRows(plan_after_drop, /*realtime_context=*/nullptr));
+        ASSERT_EQ(0, rows_after_drop);
+        ASSERT_OK(writer->Close());
     }
 
     std::unique_ptr<UniqueTestDirectory> dir_;
@@ -2459,6 +2532,72 @@ TEST_F(RealtimeWriteInteTest, TestDropPartitionRequiresReopenRealtimeContext) {
     ASSERT_EQ(2, final_offsets.at(partition_bucket));
     ASSERT_EQ(3, final_offsets.at(retained_partition_bucket));
     ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestDropInactivePartitionDoesNotRequireReopenRealtimeContext) {
+    CreateTable(/*partition_keys=*/{"pt"});
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> seed_context, RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> seed_writer,
+                         CreateRealtimeWriter(seed_context));
+    for (int64_t partition_index = 0; partition_index < 2; ++partition_index) {
+        std::string partition = "p" + std::to_string(partition_index);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                             MakeBatch(MakeRows(partition_index * 10, /*count=*/3, partition),
+                                       /*partitioned=*/true));
+        ASSERT_OK(seed_writer->Write(std::move(batch)));
+    }
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> seed_commits,
+                         seed_writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_EQ(2, seed_commits.size());
+    ASSERT_OK(Commit(seed_commits, /*commit_identifier=*/0));
+    ASSERT_OK(seed_writer->Close());
+    seed_writer.reset();
+    seed_context.reset();
+
+    // The new context loads offsets for both partitions, but creates a store only for p0.
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> p0_batch,
+                         MakeBatch(MakeRows(/*first_id=*/20, /*count=*/1, /*partition=*/"p0"),
+                                   /*partitioned=*/true));
+    ASSERT_OK(writer->Write(std::move(p0_batch)));
+
+    ASSERT_OK_AND_ASSIGN(int64_t drop_snapshot_id,
+                         DropPartition({{"pt", "p1"}}, /*commit_identifier=*/1));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(drop_snapshot_id));
+    const RealtimePartitionBucket p0_partition_bucket({{"pt", "p0"}}, /*bucket=*/0);
+    const RealtimePartitionBucket p1_partition_bucket({{"pt", "p1"}}, /*bucket=*/0);
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap offsets_after_drop, ReadCommittedOffsets());
+    ASSERT_EQ(1, offsets_after_drop.size());
+    ASSERT_EQ(3, offsets_after_drop.at(p0_partition_bucket));
+    ASSERT_EQ(offsets_after_drop.end(), offsets_after_drop.find(p1_partition_bucket));
+
+    // Since p1 was never active in this context, writing it after the drop starts from zero.
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> p1_batch,
+                         MakeBatch(MakeRows(/*first_id=*/30, /*count=*/2, /*partition=*/"p1"),
+                                   /*partitioned=*/true));
+    ASSERT_OK(writer->Write(std::move(p1_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/2));
+    ASSERT_EQ(2, commits.size());
+    auto p1_commit =
+        std::find_if(commits.begin(), commits.end(), [&](const RealtimeCommitProgress& commit) {
+            return commit.partition_bucket == p1_partition_bucket;
+        });
+    ASSERT_NE(commits.end(), p1_commit);
+    ASSERT_EQ(OffsetRange(0, 2), p1_commit->offset_range);
+    ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestDropDatePartitionRemovesOffsetWithLegacyPartitionName) {
+    CheckDropDatePartitionRemovesOffset(/*legacy_partition_name_enabled=*/true);
+}
+
+TEST_F(RealtimeWriteInteTest, TestDropDatePartitionRemovesOffsetWithoutLegacyPartitionName) {
+    CheckDropDatePartitionRemovesOffset(/*legacy_partition_name_enabled=*/false);
 }
 
 TEST_F(RealtimeWriteInteTest, TestMultipleBucketsRestoreIndependentOffsets) {

--- a/test/inte/realtime_write_inte_test.cpp
+++ b/test/inte/realtime_write_inte_test.cpp
@@ -24,9 +24,11 @@
 #include <cstdint>
 #include <deque>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <thread>
 #include <tuple>
@@ -51,10 +53,12 @@
 #include "paimon/file_store_commit.h"
 #include "paimon/file_store_write.h"
 #include "paimon/memory/memory_pool.h"
+#include "paimon/orphan_files_cleaner.h"
 #include "paimon/predicate/function.h"
 #include "paimon/predicate/predicate.h"
 #include "paimon/predicate/predicate_builder.h"
 #include "paimon/read_context.h"
+#include "paimon/reader/count_reader.h"
 #include "paimon/realtime/realtime_context.h"
 #include "paimon/realtime/realtime_store.h"
 #include "paimon/record_batch.h"
@@ -62,6 +66,7 @@
 #include "paimon/table/source/table_read.h"
 #include "paimon/table/source/table_scan.h"
 #include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/test_helper.h"
 #include "paimon/testing/utils/testharness.h"
 #include "paimon/write_context.h"
 
@@ -277,6 +282,69 @@ class RealtimeWriteInteTest : public ::testing::Test {
                                           /*watermark=*/std::nullopt);
     }
 
+    Result<int64_t> RollbackToAsLatest(int64_t target_snapshot_id) const {
+        CommitContextBuilder builder(table_path_, commit_user_);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> context,
+                               builder.SetOptions(options_).Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> commit,
+                               FileStoreCommit::Create(std::move(context)));
+        PAIMON_ASSIGN_OR_RAISE(bool rolled_back, commit->RollbackToAsLatest(target_snapshot_id));
+        if (!rolled_back) {
+            return Status::Invalid("failed to commit rollback snapshot");
+        }
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options, CoreOptions::FromMap(options_));
+        SnapshotManager snapshot_manager(options.GetFileSystem(), table_path_);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> latest_snapshot,
+                               snapshot_manager.LatestSnapshot());
+        if (!latest_snapshot) {
+            return Status::Invalid("rollback did not produce a snapshot");
+        }
+        return latest_snapshot->Id();
+    }
+
+    Result<Snapshot> CompactAndCommit(const std::map<std::string, std::string>& partition,
+                                      int32_t bucket, int64_t commit_identifier) const {
+        WriteContextBuilder write_builder(table_path_, commit_user_);
+        write_builder.SetOptions(options_).WithStreamingMode(true);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<WriteContext> write_context, write_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreWrite> compaction_writer,
+                               FileStoreWrite::Create(std::move(write_context)));
+        PAIMON_RETURN_NOT_OK(compaction_writer->Compact(partition, bucket,
+                                                        /*full_compaction=*/true));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<std::shared_ptr<CommitMessage>> compaction_messages,
+            compaction_writer->PrepareCommit(/*wait_compaction=*/true, commit_identifier));
+        if (compaction_messages.empty()) {
+            return Status::Invalid("compaction did not produce a commit message");
+        }
+
+        CommitContextBuilder commit_builder(table_path_, commit_user_);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> commit_context,
+                               commit_builder.SetOptions(options_).Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> compaction_commit,
+                               FileStoreCommit::Create(std::move(commit_context)));
+        PAIMON_RETURN_NOT_OK(compaction_commit->Commit(compaction_messages, commit_identifier));
+        PAIMON_RETURN_NOT_OK(compaction_writer->Close());
+
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions core_options, CoreOptions::FromMap(options_));
+        SnapshotManager snapshot_manager(core_options.GetFileSystem(), table_path_);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> compact_snapshot,
+                               snapshot_manager.LatestSnapshot());
+        if (!compact_snapshot) {
+            return Status::Invalid("compaction did not produce a snapshot");
+        }
+        return compact_snapshot.value();
+    }
+
+    Result<int32_t> ExpireSnapshots() const {
+        CommitContextBuilder builder(table_path_, commit_user_);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> context,
+                               builder.SetOptions(options_).Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> commit,
+                               FileStoreCommit::Create(std::move(context)));
+        return commit->Expire();
+    }
+
     Result<std::shared_ptr<Plan>> CreatePlan(
         const std::shared_ptr<RealtimeContext>& realtime_context,
         const std::shared_ptr<Predicate>& predicate) const {
@@ -365,6 +433,20 @@ class RealtimeWriteInteTest : public ::testing::Test {
 
     Result<std::vector<Row>> ReadRows() const {
         return ReadRows(/*realtime_context=*/nullptr);
+    }
+
+    Result<int64_t> CountRows(const std::shared_ptr<Plan>& plan,
+                              const std::shared_ptr<RealtimeContext>& realtime_context) const {
+        ReadContextBuilder read_builder(table_path_);
+        read_builder.SetOptions(options_)
+            .WithRealtimeContext(realtime_context)
+            .WithMemoryPool(pool_);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ReadContext> read_context, read_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<TableRead> table_read,
+                               TableRead::Create(std::move(read_context)));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CountReader> count_reader,
+                               table_read->CreateCountReader(plan->Splits()));
+        return count_reader->CountRows();
     }
 
     Result<uint64_t> GetRealtimeMemoryUsage(
@@ -478,6 +560,52 @@ TEST_F(RealtimeWriteInteTest, TestRollingFilesPreserveProgress) {
     ASSERT_EQ(expected_rows, actual_rows);
 }
 
+TEST_F(RealtimeWriteInteTest, TestAppendScanKeepsDiskSplitsIndependent) {
+    options_[Options::TARGET_FILE_ROW_NUM] = "2";
+    options_[Options::SOURCE_SPLIT_OPEN_FILE_COST] = "1";
+    options_[Options::SOURCE_SPLIT_TARGET_SIZE] = "1";
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+
+    std::vector<Row> expected_rows;
+    for (int64_t first_id = 0; first_id < 6; first_id += 2) {
+        std::vector<Row> rows = MakeRows(first_id, /*count=*/2, /*partition=*/"p0");
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                             MakeBatch(rows, /*partitioned=*/false));
+        ASSERT_OK(writer->Write(std::move(batch)));
+        expected_rows.insert(expected_rows.end(), rows.begin(), rows.end());
+    }
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK_AND_ASSIGN(int64_t snapshot_id, Commit(commits, /*commit_identifier=*/0));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(snapshot_id));
+
+    std::vector<Row> memory_rows = MakeRows(/*first_id=*/6, /*count=*/2, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> memory_batch,
+                         MakeBatch(memory_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(memory_batch)));
+    expected_rows.insert(expected_rows.end(), memory_rows.begin(), memory_rows.end());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> plan,
+                         CreatePlan(realtime_context, /*predicate=*/nullptr));
+    ASSERT_EQ(3, plan->Splits().size());
+    ASSERT_EQ(nullptr, std::dynamic_pointer_cast<RealtimeSplit>(plan->Splits()[0]));
+    ASSERT_EQ(nullptr, std::dynamic_pointer_cast<RealtimeSplit>(plan->Splits()[1]));
+    std::shared_ptr<RealtimeSplit> realtime_split =
+        std::dynamic_pointer_cast<RealtimeSplit>(plan->Splits()[2]);
+    ASSERT_NE(nullptr, realtime_split);
+    ASSERT_EQ(1, realtime_split->DiskSplits().size());
+    ASSERT_EQ(6, realtime_split->CommittedEndOffset());
+    ASSERT_EQ(8, realtime_split->MemoryEndOffset());
+
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> actual_rows, ReadRows(plan, realtime_context));
+    ASSERT_EQ(expected_rows, actual_rows);
+    ASSERT_OK(writer->Close());
+}
+
 TEST_F(RealtimeWriteInteTest, TestCommitOrdersPreparedOffsetRanges) {
     CreateTable(/*partition_keys=*/{});
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer, CreateRealtimeWriter());
@@ -511,6 +639,160 @@ TEST_F(RealtimeWriteInteTest, TestCommitOrdersPreparedOffsetRanges) {
     expected_rows.insert(expected_rows.end(), second_rows.begin(), second_rows.end());
     ASSERT_OK_AND_ASSIGN(std::vector<Row> actual_rows, ReadRows());
     ASSERT_EQ(expected_rows, actual_rows);
+}
+
+TEST_F(RealtimeWriteInteTest, TestCommitWithProgressRetryIsIdempotent) {
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer, CreateRealtimeWriter());
+    std::vector<Row> expected_rows = MakeRows(/*first_id=*/0, /*count=*/3, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                         MakeBatch(expected_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+
+    ASSERT_OK_AND_ASSIGN(int64_t first_snapshot_id, Commit(commits, /*commit_identifier=*/0));
+    ASSERT_OK_AND_ASSIGN(int64_t retry_snapshot_id, Commit(commits, /*commit_identifier=*/0));
+    ASSERT_EQ(first_snapshot_id, retry_snapshot_id);
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap committed_offsets, ReadCommittedOffsets());
+    ASSERT_EQ(3, committed_offsets.at(RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0)));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> actual_rows, ReadRows());
+    ASSERT_EQ(expected_rows, actual_rows);
+    ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestRealtimeWriteAcrossAppendCompaction) {
+    options_[Options::TARGET_FILE_ROW_NUM] = "2";
+    options_[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+
+    std::vector<Row> first_rows;
+    for (int64_t first_id = 0; first_id < 5; first_id += 2) {
+        std::vector<Row> rows =
+            MakeRows(first_id, std::min<int64_t>(2, 5 - first_id), /*partition=*/"p0");
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                             MakeBatch(rows, /*partitioned=*/false));
+        ASSERT_OK(writer->Write(std::move(batch)));
+        first_rows.insert(first_rows.end(), rows.begin(), rows.end());
+    }
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> first_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_EQ(1, first_commits.size());
+    ASSERT_EQ(OffsetRange(0, 5), first_commits[0].offset_range);
+    std::shared_ptr<CommitMessageImpl> first_commit_message =
+        std::dynamic_pointer_cast<CommitMessageImpl>(first_commits[0].commit_message);
+    ASSERT_NE(nullptr, first_commit_message);
+    ASSERT_EQ(3, first_commit_message->GetNewFilesIncrement().NewFiles().size());
+    ASSERT_OK_AND_ASSIGN(int64_t first_snapshot_id, Commit(first_commits, /*commit_identifier=*/0));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(first_snapshot_id));
+
+    ASSERT_OK_AND_ASSIGN(Snapshot compact_snapshot, CompactAndCommit(/*partition=*/{}, /*bucket=*/0,
+                                                                     /*commit_identifier=*/1));
+    ASSERT_EQ(Snapshot::CommitKind::Compact(), compact_snapshot.GetCommitKind());
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap compacted_offsets, ReadCommittedOffsets());
+    ASSERT_EQ(5, compacted_offsets.at(RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0)));
+
+    ASSERT_OK(writer->RefreshCommittedSnapshot(compact_snapshot.Id()));
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> rows_after_compaction, ReadRows(realtime_context));
+    ASSERT_EQ(first_rows, rows_after_compaction);
+
+    std::vector<Row> second_rows = MakeRows(/*first_id=*/5, /*count=*/2, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> second_batch,
+                         MakeBatch(second_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(second_batch)));
+    std::vector<Row> expected_rows = first_rows;
+    expected_rows.insert(expected_rows.end(), second_rows.begin(), second_rows.end());
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> rows_with_building_memory, ReadRows(realtime_context));
+    ASSERT_EQ(expected_rows, rows_with_building_memory);
+
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> second_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/2));
+    ASSERT_EQ(1, second_commits.size());
+    ASSERT_EQ(OffsetRange(5, 7), second_commits[0].offset_range);
+    ASSERT_OK_AND_ASSIGN(int64_t final_snapshot_id,
+                         Commit(second_commits, /*commit_identifier=*/2));
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap final_offsets, ReadCommittedOffsets());
+    ASSERT_EQ(7, final_offsets.at(RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0)));
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> final_rows_before_refresh, ReadRows(realtime_context));
+    ASSERT_EQ(expected_rows, final_rows_before_refresh);
+    ASSERT_OK(writer->RefreshCommittedSnapshot(final_snapshot_id));
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> final_rows_after_refresh, ReadRows(realtime_context));
+    ASSERT_EQ(expected_rows, final_rows_after_refresh);
+    ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestRealtimeOffsetFileLifecycle) {
+    options_[Options::SNAPSHOT_NUM_RETAINED_MIN] = "1";
+    options_[Options::SNAPSHOT_NUM_RETAINED_MAX] = "1";
+    options_[Options::SNAPSHOT_TIME_RETAINED] = "1ms";
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer, CreateRealtimeWriter());
+
+    std::vector<Row> first_rows = MakeRows(/*first_id=*/0, /*count=*/3, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> first_batch,
+                         MakeBatch(first_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(first_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> first_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK_AND_ASSIGN(int64_t first_snapshot_id, Commit(first_commits, /*commit_identifier=*/0));
+
+    std::vector<Row> second_rows = MakeRows(/*first_id=*/3, /*count=*/2, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> second_batch,
+                         MakeBatch(second_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(second_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> second_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/1));
+    ASSERT_OK_AND_ASSIGN(int64_t second_snapshot_id,
+                         Commit(second_commits, /*commit_identifier=*/1));
+
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options_));
+    std::shared_ptr<FileSystem> file_system = core_options.GetFileSystem();
+    SnapshotManager snapshot_manager(file_system, table_path_);
+    ASSERT_OK_AND_ASSIGN(Snapshot first_snapshot, snapshot_manager.LoadSnapshot(first_snapshot_id));
+    ASSERT_OK_AND_ASSIGN(Snapshot second_snapshot,
+                         snapshot_manager.LoadSnapshot(second_snapshot_id));
+    std::optional<std::string> first_offsets_path =
+        RealtimeCommitProperties::GetOffsetsPath(first_snapshot);
+    std::optional<std::string> second_offsets_path =
+        RealtimeCommitProperties::GetOffsetsPath(second_snapshot);
+    ASSERT_TRUE(first_offsets_path);
+    ASSERT_TRUE(second_offsets_path);
+    ASSERT_NE(first_offsets_path, second_offsets_path);
+
+    std::string orphan_offsets_path = PathUtil::JoinPath(
+        RealtimeCommitProperties::OffsetsDirectory(table_path_, core_options.GetBranch()),
+        "orphan.offsets");
+    ASSERT_OK(file_system->WriteFile(orphan_offsets_path, "orphan", /*overwrite=*/false));
+    CleanContextBuilder clean_builder(table_path_);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<CleanContext> clean_context,
+                         clean_builder.WithFileSystem(file_system)
+                             .WithOlderThanMs(std::numeric_limits<int64_t>::max())
+                             .Finish());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<OrphanFilesCleaner> cleaner,
+                         OrphanFilesCleaner::Create(std::move(clean_context)));
+    ASSERT_OK_AND_ASSIGN(std::set<std::string> cleaned_paths, cleaner->Clean());
+    ASSERT_EQ(std::set<std::string>({orphan_offsets_path}), cleaned_paths);
+    ASSERT_OK_AND_ASSIGN(bool first_offsets_exist, file_system->Exists(first_offsets_path.value()));
+    ASSERT_TRUE(first_offsets_exist);
+    ASSERT_OK_AND_ASSIGN(bool second_offsets_exist,
+                         file_system->Exists(second_offsets_path.value()));
+    ASSERT_TRUE(second_offsets_exist);
+
+    ASSERT_OK_AND_ASSIGN(int32_t expired_snapshots, ExpireSnapshots());
+    ASSERT_EQ(1, expired_snapshots);
+    ASSERT_OK_AND_ASSIGN(first_offsets_exist, file_system->Exists(first_offsets_path.value()));
+    ASSERT_FALSE(first_offsets_exist);
+    ASSERT_OK_AND_ASSIGN(second_offsets_exist, file_system->Exists(second_offsets_path.value()));
+    ASSERT_TRUE(second_offsets_exist);
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap committed_offsets,
+                         RealtimeCommitProperties::ReadOffsets(second_snapshot, file_system));
+    ASSERT_EQ(5, committed_offsets.at(RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0)));
+    ASSERT_OK(writer->Close());
 }
 
 TEST_F(RealtimeWriteInteTest, TestReadMemoryBeforePrepareCommit) {
@@ -816,6 +1098,44 @@ TEST_F(RealtimeWriteInteTest, TestReadCommittedDiskAndBuildingMemory) {
     ASSERT_OK(writer->Close());
 }
 
+TEST_F(RealtimeWriteInteTest, TestCountMemoryAndDiskAcrossRefresh) {
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+
+    std::vector<Row> disk_rows = MakeRows(/*first_id=*/0, /*count=*/3, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> disk_batch,
+                         MakeBatch(disk_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(disk_batch)));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> memory_plan,
+                         CreatePlan(realtime_context, /*predicate=*/nullptr));
+    ASSERT_OK_AND_ASSIGN(int64_t memory_count, CountRows(memory_plan, realtime_context));
+    ASSERT_EQ(3, memory_count);
+
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> disk_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK_AND_ASSIGN(int64_t committed_snapshot_id,
+                         Commit(disk_commits, /*commit_identifier=*/0));
+    std::vector<Row> memory_rows = MakeRows(/*first_id=*/3, /*count=*/2, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> memory_batch,
+                         MakeBatch(memory_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(memory_batch)));
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> union_plan,
+                         CreatePlan(realtime_context, /*predicate=*/nullptr));
+    ASSERT_OK_AND_ASSIGN(int64_t union_count, CountRows(union_plan, realtime_context));
+    ASSERT_EQ(5, union_count);
+
+    ASSERT_OK(writer->RefreshCommittedSnapshot(committed_snapshot_id));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> refreshed_plan,
+                         CreatePlan(realtime_context, /*predicate=*/nullptr));
+    ASSERT_OK_AND_ASSIGN(int64_t refreshed_count, CountRows(refreshed_plan, realtime_context));
+    ASSERT_EQ(union_count, refreshed_count);
+    ASSERT_OK(writer->Close());
+}
+
 TEST_F(RealtimeWriteInteTest, TestProjectionAndPredicateForMemoryAndDisk) {
     CreateTable(/*partition_keys=*/{});
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
@@ -926,6 +1246,199 @@ TEST_F(RealtimeWriteInteTest, TestDiskPredicatePushdownWithoutMemoryFiltering) {
     ASSERT_TRUE(std::make_shared<arrow::ChunkedArray>(expected)->Equals(*result.data))
         << result.data->ToString();
     ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestMemoryBatchStatisticsPredicatePushdown) {
+    CreateTable(/*partition_keys=*/{});
+    std::shared_ptr<arrow::DataType> result_type = arrow::struct_(
+        {arrow::field("_VALUE_KIND", arrow::int8()), arrow::field("id", arrow::int64()),
+         arrow::field("payload", arrow::utf8()), arrow::field("pt", arrow::utf8())});
+    auto make_expected = [&](const std::string& json) {
+        std::shared_ptr<arrow::Array> array =
+            arrow::ipc::internal::json::ArrayFromJSON(result_type, json).ValueOrDie();
+        return std::make_shared<arrow::ChunkedArray>(array);
+    };
+    std::vector<std::shared_ptr<Predicate>> predicates = {
+        PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"id", FieldType::BIGINT,
+                                      Literal(static_cast<int64_t>(100))),
+        PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"id", FieldType::BIGINT,
+                                      Literal(static_cast<int64_t>(5))),
+        PredicateBuilder::Equal(/*field_index=*/0, /*field_name=*/"id", FieldType::BIGINT,
+                                Literal(static_cast<int64_t>(10))),
+    };
+
+    auto check_candidates =
+        [&](const std::string& statistics_mode,
+            const std::vector<std::shared_ptr<arrow::ChunkedArray>>& expected) -> Status {
+        if (expected.size() != predicates.size()) {
+            return Status::Invalid("unexpected real-time candidate result count");
+        }
+        options_[Options::REALTIME_STORE_STATS_MODE] = statistics_mode;
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<RealtimeContext> realtime_context,
+                               RealtimeContext::Create());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreWrite> writer,
+                               CreateRealtimeWriter(realtime_context));
+        for (int64_t first_id : {0, 10, 20}) {
+            std::vector<Row> rows = MakeRows(first_id, /*count=*/3, /*partition=*/"p0");
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<RecordBatch> batch,
+                                   MakeBatch(rows, /*partitioned=*/false));
+            PAIMON_RETURN_NOT_OK(writer->Write(std::move(batch)));
+        }
+
+        for (size_t i = 0; i < predicates.size(); ++i) {
+            const std::shared_ptr<Predicate>& predicate = predicates[i];
+            PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Plan> plan,
+                                   CreatePlan(realtime_context, predicate));
+            PAIMON_ASSIGN_OR_RAISE(
+                CollectedReadResult result,
+                ReadPlan(plan, realtime_context, {"id", "payload", "pt"}, predicate,
+                         /*enable_predicate_filter=*/false));
+            std::shared_ptr<arrow::ChunkedArray> actual =
+                result.data ? result.data : make_expected("[]");
+            if (!expected[i]->Equals(*actual)) {
+                return Status::Invalid("unexpected real-time candidate rows: " +
+                                       actual->ToString());
+            }
+        }
+        PAIMON_RETURN_NOT_OK(writer->Close());
+        return Status::OK();
+    };
+
+    std::shared_ptr<arrow::ChunkedArray> all_rows = make_expected(R"([
+        [0, 0, "value-0", "p0"],
+        [0, 1, "value-1", "p0"],
+        [0, 2, "value-2", "p0"],
+        [0, 10, "value-10", "p0"],
+        [0, 11, "value-11", "p0"],
+        [0, 12, "value-12", "p0"],
+        [0, 20, "value-20", "p0"],
+        [0, 21, "value-21", "p0"],
+        [0, 22, "value-22", "p0"]
+    ])");
+    ASSERT_OK(check_candidates("none", {all_rows, all_rows, all_rows}));
+
+    std::shared_ptr<arrow::ChunkedArray> partially_filtered = make_expected(R"([
+        [0, 10, "value-10", "p0"],
+        [0, 11, "value-11", "p0"],
+        [0, 12, "value-12", "p0"],
+        [0, 20, "value-20", "p0"],
+        [0, 21, "value-21", "p0"],
+        [0, 22, "value-22", "p0"]
+    ])");
+    std::shared_ptr<arrow::ChunkedArray> matching_batch = make_expected(R"([
+        [0, 10, "value-10", "p0"],
+        [0, 11, "value-11", "p0"],
+        [0, 12, "value-12", "p0"]
+    ])");
+    ASSERT_OK(check_candidates("full", {make_expected("[]"), partially_filtered, matching_batch}));
+}
+
+TEST_F(RealtimeWriteInteTest, TestMemoryBatchStatisticsPredicatePushdownWithDisk) {
+    options_[Options::FILE_FORMAT] = "parquet";
+    options_[Options::WRITE_BATCH_SIZE] = "1";
+    options_[Options::REALTIME_STORE_STATS_MODE] = "full";
+    options_["parquet.page.size"] = "1";
+    options_["parquet.enable-dictionary"] = "false";
+    options_["parquet.write.enable-page-index"] = "true";
+    options_["parquet.read.enable-page-index-filter"] = "true";
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+
+    std::vector<Row> disk_rows = MakeRows(/*first_id=*/0, /*count=*/6, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> disk_batch,
+                         MakeBatch(disk_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(disk_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> disk_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK(Commit(disk_commits, /*commit_identifier=*/0));
+
+    for (int64_t first_id : {0, 10}) {
+        std::vector<Row> rows = MakeRows(first_id, /*count=*/3, /*partition=*/"p0");
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                             MakeBatch(rows, /*partitioned=*/false));
+        ASSERT_OK(writer->Write(std::move(batch)));
+    }
+    std::shared_ptr<Predicate> predicate =
+        PredicateBuilder::GreaterThan(/*field_index=*/0, /*field_name=*/"id", FieldType::BIGINT,
+                                      Literal(static_cast<int64_t>(3)));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> plan, CreatePlan(realtime_context, predicate));
+    ASSERT_OK_AND_ASSIGN(CollectedReadResult result,
+                         ReadPlan(plan, realtime_context, {"id", "payload", "pt"}, predicate,
+                                  /*enable_predicate_filter=*/false));
+
+    std::shared_ptr<arrow::DataType> result_type = arrow::struct_(
+        {arrow::field("_VALUE_KIND", arrow::int8()), arrow::field("id", arrow::int64()),
+         arrow::field("payload", arrow::utf8()), arrow::field("pt", arrow::utf8())});
+    std::shared_ptr<arrow::Array> expected =
+        arrow::ipc::internal::json::ArrayFromJSON(result_type, R"([
+            [0, 4, "value-4", "p0"],
+            [0, 5, "value-5", "p0"],
+            [0, 10, "value-10", "p0"],
+            [0, 11, "value-11", "p0"],
+            [0, 12, "value-12", "p0"]
+        ])")
+            .ValueOrDie();
+    ASSERT_NE(nullptr, result.data);
+    ASSERT_TRUE(std::make_shared<arrow::ChunkedArray>(expected)->Equals(*result.data))
+        << result.data->ToString();
+    ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestUnionReadAfterColumnRename) {
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> first_context, RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> first_writer,
+                         CreateRealtimeWriter(first_context));
+    std::vector<Row> disk_rows = MakeRows(/*first_id=*/0, /*count=*/3, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> disk_batch,
+                         MakeBatch(disk_rows, /*partitioned=*/false));
+    ASSERT_OK(first_writer->Write(std::move(disk_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> disk_commits,
+                         first_writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK(Commit(disk_commits, /*commit_identifier=*/0));
+    ASSERT_OK(first_writer->Close());
+
+    std::shared_ptr<arrow::Field> renamed_payload = arrow::field("renamed_payload", arrow::utf8());
+    ASSERT_OK(TestHelper::WriteNextSchema(
+        dir_->GetFileSystem(), table_path_,
+        {DataField(0, fields_[0]), DataField(1, renamed_payload), DataField(2, fields_[2])},
+        /*highest_field_id=*/2, options_));
+    fields_[1] = renamed_payload;
+    schema_ = arrow::schema(fields_);
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> second_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> second_writer,
+                         CreateRealtimeWriter(second_context));
+    std::vector<Row> memory_rows = MakeRows(/*first_id=*/3, /*count=*/2, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> memory_batch,
+                         MakeBatch(memory_rows, /*partitioned=*/false));
+    ASSERT_OK(second_writer->Write(std::move(memory_batch)));
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> plan,
+                         CreatePlan(second_context, /*predicate=*/nullptr));
+    ASSERT_OK_AND_ASSIGN(CollectedReadResult result,
+                         ReadPlan(plan, second_context, {"id", "renamed_payload", "pt"},
+                                  /*predicate=*/nullptr, /*enable_predicate_filter=*/false));
+    std::shared_ptr<arrow::DataType> result_type = arrow::struct_(
+        {arrow::field("_VALUE_KIND", arrow::int8()), arrow::field("id", arrow::int64()),
+         renamed_payload, arrow::field("pt", arrow::utf8())});
+    std::shared_ptr<arrow::Array> expected =
+        arrow::ipc::internal::json::ArrayFromJSON(result_type, R"([
+            [0, 0, "value-0", "p0"],
+            [0, 1, "value-1", "p0"],
+            [0, 2, "value-2", "p0"],
+            [0, 3, "value-3", "p0"],
+            [0, 4, "value-4", "p0"]
+        ])")
+            .ValueOrDie();
+    ASSERT_NE(nullptr, result.data);
+    ASSERT_TRUE(std::make_shared<arrow::ChunkedArray>(expected)->Equals(*result.data))
+        << result.data->ToString();
+    ASSERT_OK(second_writer->Close());
 }
 
 TEST_F(RealtimeWriteInteTest, TestRefreshCommittedSnapshotReclaimsMemory) {
@@ -1106,6 +1619,59 @@ TEST_F(RealtimeWriteInteTest, TestRepeatedCommitReadAndRefresh) {
                              GetRealtimeMemoryUsage(realtime_context));
         ASSERT_EQ(0, memory_usage_after_refresh);
     }
+    ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestReopenRealtimeContextAfterRollback) {
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer,
+                         CreateRealtimeWriter(realtime_context));
+
+    std::vector<Row> first_rows = MakeRows(/*first_id=*/0, /*count=*/3, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> first_batch,
+                         MakeBatch(first_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(first_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> first_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK_AND_ASSIGN(int64_t first_snapshot_id, Commit(first_commits, /*commit_identifier=*/0));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(first_snapshot_id));
+
+    std::vector<Row> second_rows = MakeRows(/*first_id=*/3, /*count=*/2, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> second_batch,
+                         MakeBatch(second_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(second_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> second_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/1));
+    ASSERT_OK_AND_ASSIGN(int64_t second_snapshot_id,
+                         Commit(second_commits, /*commit_identifier=*/1));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(second_snapshot_id));
+
+    ASSERT_OK_AND_ASSIGN(int64_t rollback_snapshot_id, RollbackToAsLatest(first_snapshot_id));
+    ASSERT_NOK_WITH_MSG(writer->RefreshCommittedSnapshot(rollback_snapshot_id),
+                        "recreate RealtimeContext");
+    ASSERT_OK(writer->Close());
+    writer.reset();
+    realtime_context.reset();
+
+    // A rollback can only restore reclaimed ranges by rebuilding the context and replaying input.
+    commit_user_ = "realtime_commit_user_after_rollback";
+    ASSERT_OK_AND_ASSIGN(realtime_context, RealtimeContext::Create());
+    ASSERT_OK_AND_ASSIGN(writer, CreateRealtimeWriter(realtime_context));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> replay_batch,
+                         MakeBatch(second_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(replay_batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> replay_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_EQ(1, replay_commits.size());
+    ASSERT_EQ(OffsetRange(3, 5), replay_commits[0].offset_range);
+    ASSERT_OK(Commit(replay_commits, /*commit_identifier=*/0));
+
+    std::vector<Row> expected_rows = first_rows;
+    expected_rows.insert(expected_rows.end(), second_rows.begin(), second_rows.end());
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> actual_rows, ReadRows());
+    ASSERT_EQ(expected_rows, actual_rows);
     ASSERT_OK(writer->Close());
 }
 
@@ -1392,6 +1958,14 @@ TEST_F(RealtimeWriteInteTest, TestMultiplePartitions) {
     }
     ASSERT_EQ(committed_offsets.end(),
               committed_offsets.find(RealtimePartitionBucket({{"pt", "p2"}}, /*bucket=*/0)));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> final_commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/1));
+    ASSERT_EQ(2, final_commits.size());
+    ASSERT_OK_AND_ASSIGN(int64_t final_snapshot_id, Commit(final_commits, /*commit_identifier=*/1));
+    ASSERT_OK(writer->RefreshCommittedSnapshot(final_snapshot_id));
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> committed_rows, ReadRows(realtime_context));
+    ASSERT_EQ(expected_rows, committed_rows);
     ASSERT_OK(writer->Close());
 }
 

--- a/test/inte/realtime_write_inte_test.cpp
+++ b/test/inte/realtime_write_inte_test.cpp
@@ -189,9 +189,10 @@ class RealtimeWriteInteTest : public ::testing::Test {
                    arrow::field("pt", arrow::utf8())};
         schema_ = arrow::schema(fields_);
         options_ = {
-            {Options::MANIFEST_FORMAT, "orc"}, {Options::FILE_FORMAT, "orc"},
-            {Options::FILE_SYSTEM, "local"},   {Options::BUCKET, "1"},
-            {Options::BUCKET_KEY, "id"},       {Options::TARGET_FILE_SIZE, "1048576"},
+            {Options::MANIFEST_FORMAT, "orc"},   {Options::FILE_FORMAT, "orc"},
+            {Options::FILE_SYSTEM, "local"},     {Options::BUCKET, "1"},
+            {Options::BUCKET_KEY, "id"},         {Options::TARGET_FILE_SIZE, "1048576"},
+            {Options::REALTIME_ENABLED, "true"},
         };
     }
 
@@ -568,6 +569,44 @@ class RealtimeWriteInteTest : public ::testing::Test {
     std::shared_ptr<MemoryPool> pool_;
 };
 
+TEST_F(RealtimeWriteInteTest, TestRealtimeOperationsRequireEnabledOption) {
+    CreateTable(/*partition_keys=*/{});
+    std::map<std::string, std::string> disabled_options = options_;
+    disabled_options[Options::REALTIME_ENABLED] = "false";
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RealtimeContext> realtime_context,
+                         RealtimeContext::Create());
+
+    WriteContextBuilder write_builder(table_path_, commit_user_);
+    write_builder.SetOptions(disabled_options)
+        .WithStreamingMode(true)
+        .WithRealtimeContext(realtime_context);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<WriteContext> write_context, write_builder.Finish());
+    ASSERT_NOK_WITH_MSG(FileStoreWrite::Create(std::move(write_context)),
+                        "real-time write requires realtime.enabled=true");
+
+    ScanContextBuilder scan_builder(table_path_);
+    scan_builder.SetOptions(disabled_options).WithRealtimeContext(realtime_context);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<ScanContext> scan_context, scan_builder.Finish());
+    ASSERT_NOK_WITH_MSG(TableScan::Create(std::move(scan_context)),
+                        "real-time scan requires realtime.enabled=true");
+
+    ReadContextBuilder read_builder(table_path_);
+    read_builder.SetOptions(disabled_options).WithRealtimeContext(realtime_context);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<ReadContext> read_context, read_builder.Finish());
+    ASSERT_NOK_WITH_MSG(TableRead::Create(std::move(read_context)),
+                        "real-time read requires realtime.enabled=true");
+
+    CommitContextBuilder commit_builder(table_path_, commit_user_);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<CommitContext> commit_context,
+                         commit_builder.SetOptions(disabled_options).Finish());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreCommit> commit,
+                         FileStoreCommit::Create(std::move(commit_context)));
+    ASSERT_NOK_WITH_MSG(commit->CommitWithProgress(/*realtime_commits=*/{},
+                                                   /*commit_identifier=*/0,
+                                                   /*watermark=*/std::nullopt),
+                        "CommitWithProgress requires realtime.enabled=true");
+}
+
 TEST_F(RealtimeWriteInteTest, TestAppendCommitAndRead) {
     CreateTable(/*partition_keys=*/{});
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer, CreateRealtimeWriter());
@@ -712,6 +751,31 @@ TEST_F(RealtimeWriteInteTest, TestCommitWithProgressRetryIsIdempotent) {
     ASSERT_OK(writer->Close());
 }
 
+TEST_F(RealtimeWriteInteTest, TestCommitWithProgressRejectsCoveredRangesFromAnotherUser) {
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer, CreateRealtimeWriter());
+    std::vector<Row> expected_rows = MakeRows(/*first_id=*/0, /*count=*/3, /*partition=*/"p0");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                         MakeBatch(expected_rows, /*partitioned=*/false));
+    ASSERT_OK(writer->Write(std::move(batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK(Commit(commits, /*commit_identifier=*/0));
+
+    CommitContextBuilder builder(table_path_, "another_realtime_commit_user");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<CommitContext> context,
+                         builder.SetOptions(options_).Finish());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreCommit> commit,
+                         FileStoreCommit::Create(std::move(context)));
+    ASSERT_NOK_WITH_MSG(commit->CommitWithProgress(commits, /*commit_identifier=*/0,
+                                                   /*watermark=*/std::nullopt),
+                        "another commit user or identifier");
+
+    ASSERT_OK_AND_ASSIGN(std::vector<Row> actual_rows, ReadRows());
+    ASSERT_EQ(expected_rows, actual_rows);
+    ASSERT_OK(writer->Close());
+}
+
 TEST_F(RealtimeWriteInteTest, TestRealtimeWriteAcrossAppendCompaction) {
     options_[Options::TARGET_FILE_ROW_NUM] = "2";
     options_[Options::COMPACTION_MIN_FILE_NUM] = "2";
@@ -841,6 +905,53 @@ TEST_F(RealtimeWriteInteTest, TestRealtimeOffsetFileLifecycle) {
     ASSERT_TRUE(second_offsets_exist);
     ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap committed_offsets,
                          RealtimeCommitProperties::ReadOffsets(second_snapshot, file_system));
+    ASSERT_EQ(5, committed_offsets.at(RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0)));
+    ASSERT_OK(writer->Close());
+}
+
+TEST_F(RealtimeWriteInteTest, TestCompactionSnapshotRetainsSharedOffsetFile) {
+    options_[Options::TARGET_FILE_ROW_NUM] = "2";
+    options_[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    options_[Options::SNAPSHOT_NUM_RETAINED_MIN] = "1";
+    options_[Options::SNAPSHOT_NUM_RETAINED_MAX] = "1";
+    options_[Options::SNAPSHOT_TIME_RETAINED] = "1ms";
+    CreateTable(/*partition_keys=*/{});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> writer, CreateRealtimeWriter());
+
+    for (int64_t first_id = 0; first_id < 5; first_id += 2) {
+        std::vector<Row> rows =
+            MakeRows(first_id, std::min<int64_t>(2, 5 - first_id), /*partition=*/"p0");
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                             MakeBatch(rows, /*partitioned=*/false));
+        ASSERT_OK(writer->Write(std::move(batch)));
+    }
+    ASSERT_OK_AND_ASSIGN(std::vector<RealtimeCommitProgress> commits,
+                         writer->PrepareCommitWithProgress(/*commit_identifier=*/0));
+    ASSERT_OK_AND_ASSIGN(int64_t realtime_snapshot_id, Commit(commits, /*commit_identifier=*/0));
+
+    ASSERT_OK_AND_ASSIGN(Snapshot compact_snapshot, CompactAndCommit(/*partition=*/{}, /*bucket=*/0,
+                                                                     /*commit_identifier=*/1));
+    ASSERT_EQ(Snapshot::CommitKind::Compact(), compact_snapshot.GetCommitKind());
+
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options, CoreOptions::FromMap(options_));
+    std::shared_ptr<FileSystem> file_system = core_options.GetFileSystem();
+    SnapshotManager snapshot_manager(file_system, table_path_);
+    ASSERT_OK_AND_ASSIGN(Snapshot realtime_snapshot,
+                         snapshot_manager.LoadSnapshot(realtime_snapshot_id));
+    std::optional<std::string> realtime_offsets_path =
+        RealtimeCommitProperties::GetOffsetsPath(realtime_snapshot);
+    std::optional<std::string> compact_offsets_path =
+        RealtimeCommitProperties::GetOffsetsPath(compact_snapshot);
+    ASSERT_TRUE(realtime_offsets_path);
+    ASSERT_TRUE(compact_offsets_path);
+    ASSERT_EQ(realtime_offsets_path, compact_offsets_path);
+
+    ASSERT_OK_AND_ASSIGN(int32_t expired_snapshots, ExpireSnapshots());
+    ASSERT_EQ(1, expired_snapshots);
+    ASSERT_OK_AND_ASSIGN(bool offsets_exist, file_system->Exists(compact_offsets_path.value()));
+    ASSERT_TRUE(offsets_exist);
+    ASSERT_OK_AND_ASSIGN(RealtimeOffsetMap committed_offsets,
+                         RealtimeCommitProperties::ReadOffsets(compact_snapshot, file_system));
     ASSERT_EQ(5, committed_offsets.at(RealtimePartitionBucket(/*partition=*/{}, /*bucket=*/0)));
     ASSERT_OK(writer->Close());
 }


### PR DESCRIPTION
<!-- PR titles must follow Conventional Commits: <type>(<optional-scope>): <description> -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #158

This PR completes several follow-up capabilities for append-table real-time reads and writes:

- support batch-level statistics and predicate pushdown in the default Arrow `RealtimeStore`;
- support count readers and independently schedulable disk splits;
- make `CommitWithProgress` retries idempotent;
- preserve real-time progress across compaction and require context recreation after rollback;
- clean up expired and orphan real-time offset files;
- extend integration coverage for commit retry, compaction, rollback, schema rename, predicate pushdown, offset cleanup, and memory reclamation.


<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

- Adds the `realtime.store.stats-mode` option with `none` and `full` modes.
- Adds `StatisticsMode` to `RealtimeStoreFactory::Create`.
- Clarifies retry and rollback behavior in the public APIs.

<!-- Does this change affect API in include dir or storage format or protocol -->

### Documentation

<!-- Does this change introduce a new feature -->

### Generative AI tooling
Generated-by: OpenAI Codex (GPT-5)
<!--
If generative AI tooling has been used in the process of authoring this patch, please include the
phrase: 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
