### PR TITLE
fix(parquet): pass ReadHints into VECTOR ParquetFileBatchReader tests

### DIFF
--- a/src/paimon/format/parquet/parquet_vector_io_test.cpp
+++ b/src/paimon/format/parquet/parquet_vector_io_test.cpp
@@ -155,7 +155,8 @@ class ParquetVectorIoTest : public ::testing::Test {
             std::unique_ptr<ParquetFileBatchReader> reader,
             ParquetFileBatchReader::Create(std::move(in_stream), /*options=*/{},
                                            /*batch_size=*/10, /*file_metadata=*/nullptr,
-                                           /*storage_read_bytes=*/nullptr, arrow_pool_));
+                                           /*storage_read_bytes=*/nullptr, arrow_pool_,
+                                           /*hints=*/std::nullopt));
         ASSERT_OK_AND_ASSIGN(std::unique_ptr<ArrowSchema> c_file_schema, reader->GetFileSchema());
         arrow::Result<std::shared_ptr<arrow::DataType>> file_type_result =
             arrow::ImportType(c_file_schema.get());
@@ -176,7 +177,8 @@ class ParquetVectorIoTest : public ::testing::Test {
             std::unique_ptr<ParquetFileBatchReader> reader,
             ParquetFileBatchReader::Create(std::move(in_stream), options, batch_size,
                                            /*file_metadata=*/nullptr,
-                                           /*storage_read_bytes=*/nullptr, arrow_pool_));
+                                           /*storage_read_bytes=*/nullptr, arrow_pool_,
+                                           /*hints=*/std::nullopt));
         std::unique_ptr<FileBatchReader> vector_reader =
             std::make_unique<VectorFileBatchReader>(std::move(reader), pool_);
         auto c_schema = std::make_unique<ArrowSchema>();


### PR DESCRIPTION
### Purpose

Linked issue: #197

Restore `main` CI after #198 merged on top of #209.

`ParquetFileBatchReader::Create` now requires a `ReadHints` argument. #198 added `parquet_vector_io_test.cpp` with the previous 6-argument call, so the merge failed to compile:

```text
parquet_vector_io_test.cpp:158: error: too few arguments to function call, expected 7, have 6
parquet_vector_io_test.cpp:179: error: too few arguments to function call, expected 7, have 6
```

Pass `/*hints=*/std::nullopt` at both VECTOR test call sites, matching the other Parquet reader tests.

### Tests

- `ParquetVectorIoTest` in `src/paimon/format/parquet/parquet_vector_io_test.cpp`

Local validation (Debug, g++ 13):

```bash
cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DPAIMON_BUILD_TESTS=ON
cmake --build build --target paimon-parquet-format-test paimon-common-test paimon-core-test paimon-write-and-read-inte-test -j 4
./build/debug/paimon-parquet-format-test --gtest_filter='ParquetVectorIoTest.*:ParquetVectorConverterTest.*'   # 13 passed
./build/debug/paimon-common-test --gtest_filter='VectorUtilsTest.*:ArrowUtilsTest.TestCheckNullableMatchRejects*'   # 5 passed
./build/debug/paimon-core-test --gtest_filter='VectorFileBatchReaderTest.*:SchemaValidationTest.TestVectorType:ArrowSchemaValidatorTest.TestVectorElementType'   # 8 passed
./build/debug/paimon-write-and-read-inte-test --gtest_filter='*Vector*'   # 9 passed
./build/debug/paimon-parquet-format-test   # 201 passed
```

### API and Format

**API**: No.

**Schema protocol**: No.

**Storage format**: No.

### Documentation

No.

### Generative AI tooling

Generated-by: Cursor Cloud Agent (Cursor Grok 4.6)