### PR TITLE
feat(core): support primary-key managed BLOBs and field-group compaction

### DIFF
--- a/docs/source/user_guide/compaction.rst
+++ b/docs/source/user_guide/compaction.rst
@@ -43,24 +43,13 @@ to improve read efficiency. The compaction is performed asynchronously and does
 not block writes.
 
 .. note::
-   Append-only table compaction is only available for fixed-bucket mode
-   (``bucket > 0``). Dynamic bucketing (``bucket = -1``) does not support
-   compaction. Tables with blob columns also skip compaction.
-
-.. _data-evolution-deletion-vectors-compaction:
-
-.. note::
-   A data-evolution table (``data-evolution.enabled = true``) may enable
-   ``deletion-vectors.enabled``. Paimon C++ never compacts such a table: auto
-   compaction never runs on it, since data evolution requires ``bucket = -1``,
-   and ``AppendCompactCoordinator::Run``, the dedicated compaction entry point,
-   rejects it outright rather than dropping the deletes. This matches the
-   Paimon Java revision this support was ported from, which ends the compaction
-   scan as soon as deletion vectors are enabled; later Java releases do compact
-   such a table, and Paimon C++ has not caught up.
-
-   Reading such a table is supported; see
-   :ref:`data-evolution-deletion-vectors`.
+   Automatic append-only compaction is only available for fixed-bucket mode
+   (``bucket > 0``); it never runs under dynamic bucketing (``bucket = -1``)
+   or for tables with blob columns. Unaware-bucket append tables
+   (``bucket = -1``) are compacted through the dedicated entry point
+   ``AppendCompactCoordinator::Run`` instead; for a data-evolution table that
+   entry point plans across evolved field groups, described in
+   :ref:`data-evolution-compaction`.
 
 Auto Compaction
 ~~~~~~~~~~~~~~~
@@ -107,6 +96,213 @@ Append-Only Table Compaction Options
      - The minimum number of files to trigger an auto compaction for
        append-only tables.
 
+
+.. _data-evolution-compaction:
+
+Data-Evolution Table Compaction
+-------------------------------
+For a data-evolution table (``data-evolution.enabled = true``),
+``AppendCompactCoordinator::Run`` plans compaction across evolved field groups
+instead of running the plain append rewrite. Files are grouped by row id range:
+files covering the exact same rows form one evolved field group, holding
+different versions or different subsets of the table columns produced by
+partial-column updates. Each compact task merges the field groups of one
+contiguous row id run — the newest version of every column wins — and rewrites
+them into a single normal file holding every non-dedicated column.
+
+Row ids are never changed by this compaction: ``_ROW_ID`` values stay stable.
+The rewritten file carries the merged ``[min, max]`` sequence number range of
+its inputs, so per-row ``_SEQUENCE_NUMBER`` values, which derive from the
+file-level maximum, may rise to the group's maximum after the compaction.
+Blob files are dedicated storage and are not rewritten; their row ranges
+remain covered by the compacted data file. Tables holding vector-store files
+are rejected until Paimon C++ gains a ``VECTOR`` schema type that lets the
+rewrite exclude their columns; Paimon Java instead compacts the normal files
+of such tables and leaves the vector files in place.
+
+The normal-file bin-packing rules follow Paimon Java's
+``DataEvolutionCompactCoordinator``:
+
+- A file group's weight is ``sum(max(file_size, source.split.open-file-cost))``;
+  a bin of groups becomes a task once its weight exceeds ``target-file-size``.
+- A single file group heavier than the target is compacted on its own —
+  provided it holds at least ``compaction.min.file-num`` files (merging its
+  files is still worthwhile) — and is never packed with neighbors.
+- A row id gap always cuts the current bin, so tasks stay contiguous.
+- A bin becomes a task only when it holds at least ``compaction.min.file-num``
+  files.
+
+Deletion Vectors
+~~~~~~~~~~~~~~~~
+A data-evolution table may enable ``deletion-vectors.enabled`` and still be
+compacted. The rewrite never applies the deletions: every input row is written
+to the output file and the row ids are preserved, so the deletions stay
+logical. Because a deletion vector is keyed by the *anchor file* of its row
+range group, the compaction re-keys the vectors of the groups it replaced onto
+the file that now holds those rows, and commits the rewritten deletion-vector
+index in the same snapshot as the data files. Deleted rows therefore stay
+deleted across a compaction, and ``_ROW_ID`` references remain valid.
+
+Only the index files a move actually touches are rewritten, as in Paimon Java.
+Which index file owns which vector is taken from the index metadata, so
+nothing is deserialized to find out, and an index file no move touches is
+never opened however many vectors the partition holds. A touched index file is
+replaced whole: the vectors that stay have to move into the file taking over,
+so they are read through a single opened stream and rewritten, while one left
+with no vector at all is deleted outright. New index files roll at
+``deletion-vector.index-file.target-size`` rather than being written as a
+single file. Both vector kinds are supported — a table with
+``deletion-vectors.bitmap64 = true`` has its moved vectors rebuilt as 64 bit
+vectors, since the two kinds serialize differently and cannot be merged into
+one another.
+
+One rule differs from Paimon Java: a replaced file's vector is taken away even
+when it deletes nothing, where Java leaves such an entry in place. Keeping it
+would key a vector by a data file the commit removes, and the commit check
+below — which can only see the recorded cardinality, absent altogether in index
+metadata written by older Paimon versions — would then have to guess whether
+that entry was harmless.
+
+The commit is checked for exactly this migration, against the deletion vectors
+the *latest* snapshot holds rather than the one the round was planned against.
+Each dropped file is attributed to the rewritten file that took over its rows,
+in the same partition and bucket, so the accounting is per compact group rather
+than per partition. Four shapes are refused:
+
+- A data file the commit drops whose vector it does not remove. This is what a
+  concurrent commit re-keying that vector looks like: the vector belongs to an
+  index file the round never saw, and would outlive its data file.
+- A data file the commit drops whose rows none of the files it writes covers,
+  so its deletions have nowhere to move to.
+- A rewritten file given no vector, or one deleting a different number of rows
+  than the groups it absorbed. The row ranges of distinct groups are disjoint,
+  so the merged vector deletes exactly as many rows as they did together.
+- A data file the commit keeps whose vector it removes without writing back one
+  deleting as many rows, which happens when an index file also held vectors for
+  files outside the compacted groups.
+
+Each would make deleted rows visible again, so the commit fails and the round
+is planned afresh instead. Only the index entries that can decide these four
+questions are kept from the snapshot's index manifest, so a round holds what
+its own work touches rather than the table's whole deletion-vector index.
+
+All four are decided from index metadata alone — which index file holds a
+vector and how many rows it deletes — so no vector is read during the commit.
+The check therefore catches a vector that went missing or changed size, not one
+that deletes the right *number* of wrong rows; positions are moved one by one
+by the rewrite itself, and reading every vector back to re-prove that is the
+cost this check is built to avoid.
+
+Deletion vectors on a *plain* append table are still not compacted: that
+rewrite reorders rows and has no equivalent migration.
+
+Materializing Deletions
+~~~~~~~~~~~~~~~~~~~~~~~
+Everything above keeps the deletions *logical*. The heavy alternative is to
+apply them physically, which
+``AppendCompactCoordinator::MaterializeDeletionVectors`` does — the counterpart
+of Paimon Java's ``materialize_deletion_vectors`` procedure. It rewrites every
+row range that carries deletions with the deleted rows dropped, so the surviving
+rows get **new** row ids assigned by the commit, and it drops the vectors rather
+than moving them.
+
+That is a much more disruptive operation than the default rewrite, which is why
+neither Paimon Java nor Paimon C++ does it automatically:
+
+- Every column of a rewritten range has to be rewritten together, because a
+  column left in place would still be addressed by the old row ids.
+- ``_ROW_ID`` values change, so anything holding a reference to one — another
+  engine's bookkeeping, a materialized view, an external index — has to look it
+  up again.
+- Global indexes of the touched partitions are invalidated and deleted in the
+  same commit by ``DataEvolutionCompactGlobalIndexDropper``, scanned at the
+  newest snapshot. The deletions are re-derived from the latest index manifest
+  on every commit attempt, so an index another writer commits while this runs is
+  either deleted by the attempt that sees it or forces a retry that does. They
+  have to be rebuilt afterwards.
+
+Only ranges that actually carry deletions are rewritten; a table with no
+deletion vectors is a no-op. Unlike the default rewrite, the output is split by
+the table's ordinary rolling rules rather than pinned to one file, since the
+input range is not preserved anyway.
+
+The work is split into rounds over the row id space exactly as ``RunAndCommit``
+splits compaction, with the same soft target and the same manifest-gap cuts, and
+each round commits on its own — so a large table neither holds every live file's
+metadata at once nor lands in a single commit. The call returns how many rounds
+committed. Rows a round renumbers land above every planned window, so a later
+round never re-plans what an earlier one rewrote.
+
+Because the commit assigns new row ids to whole ranges, it also has to fail when
+another writer touched those rows while it ran: the commit checks the snapshots
+since the one the round planned against and rejects any file added over a range
+it rewrites, whatever columns that file wrote. An update landing on a range this
+run does not touch commits normally.
+
+Compared with Paimon Java, two things differ. A row range covered by a
+dedicated blob or vector-store file is **rejected**: Paimon C++ does not rewrite
+those, so their row ids cannot be reassigned in step with the rows they belong
+to, and refusing is the only safe answer — Java rewrites blob files instead, and
+rejects vector-store files as this does. And the planning is simpler: Java packs
+runs into bins weighted by their estimated size after the deletions are applied,
+while Paimon C++ emits one task per contiguous row id run, which streams through
+the reader at bounded memory either way.
+
+Bounded Rounds and Committing
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``AppendCompactCoordinator::Run`` plans the whole snapshot in one pass and
+returns the commit messages for the caller to commit. For a large
+data-evolution table that means holding every live file's metadata at once and
+landing everything in a single commit.
+
+``AppendCompactCoordinator::RunAndCommit`` avoids both. It splits the table's
+row id space into rounds targeting ``candidate_files_per_round`` files
+(default 100,000, matching Paimon Java's candidate batch size) and commits each
+round on its own, so only one round's metadata is live at a time. The count is
+a soft target rather than a bound: because a cut needs a gap between two
+manifests' coverage, a single large manifest — or manifests whose row id
+ranges overlap — keeps all of its files in one round however many they are.
+The split is
+derived from the row id ranges and file counts already recorded on the
+snapshot's data manifests, so it costs no manifest-entry reads; a cut is only
+placed where one manifest's coverage ends before the next one begins, which
+keeps every file inside exactly one round. Each round re-reads the snapshot so
+it observes the rounds committed before it, but not most of the manifest files:
+an ADD-bearing manifest carrying usable row id statistics is pruned by the
+round's row id window and so is read for exactly one round. A manifest holding
+only DELETE entries is left out of the split — it contributes no candidate
+file — and if it also lacks row id statistics the window cannot place it, so
+every round reads it; its stray entries cancel nothing in the rounds they do
+not belong to.
+When a partition filter is given, manifests it rules out are left out of the
+split as well, so compacting one partition does not produce rounds covering
+only other partitions' rows. A manifest without usable row id statistics
+disables the split — the run logs that and falls back to a single round.
+Rounds are independent — if one fails, the rounds already committed stay
+committed and a later call re-plans whatever is left. A plain append table has
+no row id space to split on, so it runs as a single round and only gains the
+commit.
+
+.. note::
+   Auto compaction never runs on data-evolution tables, since data evolution
+   requires ``bucket = -1``.
+
+   Compared with Paimon Java, the following are not ported yet: the
+   concurrent-MERGE rebase retry of the Spark integration, and the
+   ``blob-compaction.enabled`` blob pack rewriting — that option has no effect
+   here, blob packs are never rewritten whatever it is set to. Java also plans
+   its batches by reading manifests with a projection, while Paimon C++ derives
+   them from manifest-level row id statistics.
+
+   Two further differences are intentional. The planning scan drops manifest
+   statistics only when ``manifest.delete-file-drop-stats`` asks for it, while
+   Paimon Java always drops them for this scan, so the DELETE entries this
+   compaction commits may carry statistics Java would have left out; the plans
+   themselves are identical. A table holding vector-store files is rejected
+   outright rather than compacted for its normal files, as described above.
+
+   Reading a data-evolution table with deletion vectors is described in
+   :ref:`data-evolution-deletion-vectors`.
 
 Primary Key Table Compaction
 ----------------------------

--- a/docs/source/user_guide/primary_key_table.rst
+++ b/docs/source/user_guide/primary_key_table.rst
@@ -80,3 +80,97 @@ merged according to the user-specified merge engine and the timestamp of each re
 New records written into the LSM tree will be first buffered in memory. When the
 memory buffer is full, all records in memory will be sorted and flushed to disk.
 A new sorted run is now created.
+
+.. _primary-key-managed-blob:
+
+Managed BLOB Storage
+--------------------
+A primary-key table may define top-level ``BLOB`` columns. Their payload bytes
+are table-managed: they never enter the merge-tree write buffer or the data
+files. Unlike ``BLOB`` columns in append tables, primary-key managed BLOB
+storage does not require ``row-tracking.enabled`` or
+``data-evolution.enabled`` — a row-tracking table cannot define primary keys
+in the first place. When a row is written, each non-null blob value is copied into a pack
+file named ``data-<uuid>-<n>.managed.blob`` in the bucket directory, and the
+row stores only a small descriptor (pack path, offset, length) in its place.
+A pack is sealed once it reaches ``blob.target-file-size``; the copy uses a
+``blob.copy-buffer-size`` buffer (default ``4 kb``, must be between 1 byte and
+2147483647 bytes). Paimon C++ checks those bounds while parsing the table
+options, so a table configured with an out-of-range value fails to open; Paimon
+Java checks the same bounds only when a blob write first needs the buffer.
+Retract rows (``DELETE`` / ``UPDATE_BEFORE``) never keep a payload; their blob
+value becomes NULL.
+
+Reads resolve the descriptors back to payload bytes with one ranged read per
+value, after merging, so only surviving rows ever fetch their payloads. Set
+``blob-as-descriptor`` to ``true`` to receive the serialized descriptors
+instead.
+
+Every data file carries a ``.blobref`` sidecar in its extra files, listing the
+pack files its rows reference. Compaction rewrites descriptors verbatim —
+payloads are never copied again — and rebuilds the sidecar so it lists exactly
+the packs the surviving rows still reference. The sidecar is removed wherever
+its data file is removed with its companion files; a pack file may be shared
+by several data files and is never deleted by table maintenance (orphan file
+clean skips ``.managed.blob`` files).
+
+A pack is owned by the writer that **created** it until ``prepareCommit``, and
+by that commit from then on. ``prepareCommit`` seals the open packs and hands
+their paths to the commit message it produces, so a rollback knows exactly
+which packs to remove:
+
+- A writer that aborts or closes without committing deletes the packs it has
+  not handed over, along with the data files and sidecars it wrote.
+- A ``prepareCommit`` that fails partway — one bucket's writer already produced
+  a message when a later one fails — deletes what the messages it had already
+  produced own, since the caller never receives them.
+- A commit that fails hands its messages to ``FileStoreCommit::Abort``, which
+  deletes the rolled back data files, their sidecars, and the packs those
+  messages own.
+
+Owning a pack and referencing one are different things, and only ownership
+decides a rollback. Compaction rewrites blob descriptors verbatim, so a
+compacted file's sidecar lists the packs of the files it merged — packs that
+the snapshots a failed compaction never touched still read. A rollback that
+deleted every pack its files reference would break those snapshots, so it
+deletes only what the same writer created.
+
+.. note::
+   The owned-pack list travels in memory only; it is not part of the commit
+   message's serialized form, which is shared with Paimon Java. A message that
+   crosses a process boundary before being aborted therefore leaves its packs
+   behind instead of removing the wrong ones.
+
+.. note::
+   Snapshot expiration removes a ``.blobref`` sidecar together with its
+   expired data file. What no cleanup covers is a process that neither commits
+   nor aborts, for instance one that crashes after ``prepareCommit``: its data
+   files, sidecars and packs stay behind, and unlike an append table's stray
+   files they cannot be collected later, because the orphan files cleaner does
+   not support primary-key tables and never treats a ``.managed.blob`` pack as
+   an orphan.
+
+Restrictions:
+
+- Only top-level scalar ``BLOB`` columns are managed. ``ARRAY<BLOB>`` and
+  ``MAP<K, BLOB>`` fields, which Paimon Java also externalizes, are not
+  supported yet.
+- ``blob-descriptor.source-table`` (re-materializing descriptors through the
+  source table's credentials) is not supported: configuring it fails schema
+  validation, and descriptors are always read and copied through the table's
+  own file system.
+- ``pk-clustering-override`` set to ``true`` is not supported; an explicit
+  ``false`` is accepted.
+- Only the ``deduplicate``, ``partial-update`` and ``first-row`` merge engines
+  are supported, and ``changelog-producer`` must stay ``none``.
+- A managed ``BLOB`` column cannot be a primary key, bucket key, sequence
+  field or partition key, and the table needs at least one other normal
+  column.
+- A ``BLOB`` column cannot order a partial-update sequence group, and a
+  sequence-group-protected managed ``BLOB`` field only supports no aggregate
+  function, ``last_value``, or ``fields.<field>.ignore-retract`` set to
+  ``true`` (retract rows do not retain the payload).
+- ``data-file.external-paths`` is not supported.
+- ``blob-descriptor-field`` / ``blob-view-field`` columns are inline blob
+  fields: they keep caller-provided bytes in the data files and are not
+  table-managed.

--- a/docs/source/user_guide/read.rst
+++ b/docs/source/user_guide/read.rst
@@ -340,13 +340,14 @@ come back.
 Limitations
 ~~~~~~~~~~~
 
-- Only the default 32-bit deletion vectors can be read. ``deletion-vectors.bitmap64`` is not
-  supported yet, and a read fails when it actually encounters a 64-bit deletion vector.
-- Paimon C++ does not write deletion vectors for data-evolution tables, so the deletes
-  themselves have to be issued by another engine.
+- Paimon C++ does not originate new logical deletions on a data-evolution table, so the
+  deletes themselves have to be issued by another engine. It does write deletion-vector index
+  files when compacting, but only to carry existing deletions onto the rewritten files.
 - A commit that drops data files from such a table, an overwrite for instance, is refused.
   Whether it conflicts with a concurrent commit rewriting those files' deletion vectors cannot
   be decided yet, so it fails rather than committing against a stale state. Appending is
   unaffected, and so is another engine replacing a deletion vector.
-- Such a table is never compacted; see
-  :ref:`the compaction note <data-evolution-deletion-vectors-compaction>`.
+- Compacting such a table re-keys its deletion vectors onto the rewritten files in the same
+  snapshot, so deleted rows stay deleted; see :ref:`data-evolution-compaction`. Applying the
+  deletions physically instead, which reassigns ``_ROW_ID`` values and drops the affected
+  global indexes, is a separate explicit operation described there.

--- a/include/paimon/append/append_compact_coordinator.h
+++ b/include/paimon/append/append_compact_coordinator.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
@@ -37,29 +38,126 @@ class MemoryPool;
 /// and generates compaction tasks using a bin-packing algorithm. It then synchronously
 /// executes all tasks and returns the resulting commit messages.
 ///
-/// @note This implementation does not support deletion vectors or streaming mode.
-///       It only scans the current latest snapshot (batch mode).
+/// For a data-evolution table (`data-evolution.enabled` = true) the coordinator instead plans
+/// with `DataEvolutionCompactPlanner`: files are grouped by row id range into evolved
+/// field groups, each task merges the field groups of one contiguous row id run into a single
+/// normal file holding every non-dedicated column, and row ids and file-level sequence number
+/// ranges are preserved.
+///
+/// A data-evolution table may also enable `deletion-vectors.enabled`, with either vector
+/// kind. The rewrite keeps every input row and preserves row ids, so the deletions of the
+/// replaced files are re-keyed onto the rewritten ones and committed in the same snapshot.
+/// Deletion vectors on a plain append table are still unsupported.
+///
+/// @note This implementation does not support streaming mode. It only scans the current
+///       latest snapshot (batch mode).
 class PAIMON_EXPORT AppendCompactCoordinator {
  public:
     AppendCompactCoordinator() = delete;
     ~AppendCompactCoordinator() = delete;
     /// Run the compaction coordinator.
     ///
-    /// Scans the latest snapshot for small files across the specified partitions,
-    /// generates compact tasks via bin-packing, executes them synchronously,
-    /// and returns the resulting commit messages.
+    /// Scans the latest snapshot across the specified partitions — small files only for a
+    /// plain append table, every live file for a data-evolution table — generates compact
+    /// tasks, executes them synchronously, and returns the resulting commit messages.
     ///
     /// @param table_path The root path of the table.
-    /// @param options User-defined options (will be merged with schema options).
+    /// @param options User-defined options, merged over the schema options. Options that
+    ///                decide the compaction path or the physical layout (row tracking, data
+    ///                evolution, deletion vectors, bucket and the blob layout fields) must
+    ///                not change the persisted values; such an override is rejected.
     /// @param partitions Partition filters; each element is a partition spec as key-value pairs.
     ///                   Empty vector means all partitions.
     /// @param file_system The file system to use. If nullptr, will be created from options.
     /// @param pool The memory pool to use. If nullptr, will use default pool.
-    /// @return Result containing a vector of commit messages from compaction tasks.
+    /// @return Result containing a vector of commit messages from compaction tasks. On a
+    ///         data-evolution table with deletion vectors the vector also holds index-only
+    ///         messages that re-key the deletions of the replaced files. The caller must
+    ///         commit the whole vector in one commit: committing only the data messages
+    ///         publishes the rewritten files without their deletions and brings deleted rows
+    ///         back. Use `RunAndCommit` to have the commit handled here instead.
     static Result<std::vector<std::shared_ptr<CommitMessage>>> Run(
         const std::string& table_path, const std::map<std::string, std::string>& options,
         const std::vector<std::map<std::string, std::string>>& partitions,
         const std::shared_ptr<FileSystem>& file_system, const std::shared_ptr<MemoryPool>& pool);
+
+    /// Default target for the number of files one `RunAndCommit` round plans over.
+    ///
+    /// A soft target, not a bound: a round can only be cut where one data manifest's row id
+    /// coverage ends before the next one's begins, so a single large manifest — or manifests
+    /// whose row id ranges overlap — keeps its files in one round however many they are.
+    static constexpr int64_t kDefaultCandidateFilesPerRound = 100000;
+
+    /// Run the compaction coordinator and commit its results.
+    ///
+    /// Unlike `Run`, which plans the whole snapshot at once and hands the messages back, this
+    /// splits a data-evolution table's row id space into rounds targeting
+    /// `candidate_files_per_round` files and commits each round on its own, so one round's file
+    /// metadata is held at a time rather than the whole table's. The target is soft, as
+    /// `kDefaultCandidateFilesPerRound` documents, and a snapshot whose manifests carry no
+    /// usable row id statistics falls back to a single round. Rounds are independent: if one
+    /// fails, the rounds already committed stay committed and a later call re-plans whatever
+    /// is left.
+    ///
+    /// A plain append table has no row id space to split on, so it runs as a single round and
+    /// only gains the commit.
+    ///
+    /// @param table_path The root path of the table.
+    /// @param options User-defined options, merged over the schema options, with the same
+    ///                immutable-option rules as `Run`.
+    /// @param partitions Partition filters; each element is a partition spec as key-value pairs.
+    ///                   Empty vector means all partitions.
+    /// @param commit_user The user recorded on every snapshot this call commits.
+    /// @param file_system The file system to use. If nullptr, will be created from options.
+    /// @param pool The memory pool to use. If nullptr, will use default pool.
+    /// @param candidate_files_per_round Target number of files one round plans over, honored
+    ///                                  only where the manifests allow a cut. Must be positive.
+    /// @return The number of rounds that produced a commit.
+    static Result<int32_t> RunAndCommit(
+        const std::string& table_path, const std::map<std::string, std::string>& options,
+        const std::vector<std::map<std::string, std::string>>& partitions,
+        const std::string& commit_user, const std::shared_ptr<FileSystem>& file_system = nullptr,
+        const std::shared_ptr<MemoryPool>& pool = nullptr,
+        int64_t candidate_files_per_round = kDefaultCandidateFilesPerRound);
+
+    /// Physically applies the deletion vectors of a data-evolution table and commits.
+    ///
+    /// This is the heavy alternative to what `Run` and `RunAndCommit` do. They keep every row
+    /// and leave the deletions logical, so row ids survive; this drops the deleted rows for
+    /// real, which means the surviving rows get **new** row ids assigned by the commit. Three
+    /// consequences follow, and they are why it is never done automatically:
+    ///
+    /// - Every column of a rewritten range is rewritten together.
+    /// - `_ROW_ID` values change, so anything holding a reference to one has to look it up
+    ///   again.
+    /// - Global indexes of the touched partitions are invalidated and dropped in the same
+    ///   commit; they have to be rebuilt afterwards.
+    ///
+    /// Only the row ranges that actually carry deletions are rewritten. A table with no
+    /// deletion vectors is a no-op.
+    ///
+    /// The work is split into rounds over the row id space the same way `RunAndCommit` splits
+    /// compaction, and with the same soft target, so one round's file metadata is held at a
+    /// time and each round commits on its own. Rounds are independent: if one fails, the
+    /// rounds already committed stay committed and a later call re-plans whatever is left.
+    ///
+    /// @param table_path The root path of the table.
+    /// @param options User-defined options, merged over the schema options, with the same
+    ///                immutable-option rules as `Run`.
+    /// @param partitions Partition filters; each element is a partition spec as key-value pairs.
+    ///                   Empty vector means all partitions.
+    /// @param commit_user The user recorded on every snapshot this call commits.
+    /// @param file_system The file system to use. If nullptr, will be created from options.
+    /// @param pool The memory pool to use. If nullptr, will use default pool.
+    /// @return The number of rounds that produced a commit, 0 when there was nothing to do.
+    /// @note Not supported for a row range covered by a dedicated blob or vector-store file:
+    ///       Paimon C++ does not rewrite those, so their row ids cannot be reassigned in step
+    ///       with the rows they belong to, and such a range is rejected rather than corrupted.
+    static Result<int32_t> MaterializeDeletionVectors(
+        const std::string& table_path, const std::map<std::string, std::string>& options,
+        const std::vector<std::map<std::string, std::string>>& partitions,
+        const std::string& commit_user, const std::shared_ptr<FileSystem>& file_system = nullptr,
+        const std::shared_ptr<MemoryPool>& pool = nullptr);
 };
 
 }  // namespace paimon

--- a/include/paimon/defs.h
+++ b/include/paimon/defs.h
@@ -143,6 +143,10 @@ struct PAIMON_EXPORT Options {
     /// scan splitting. When unset, defaults to the negation of BLOB_AS_DESCRIPTOR.
     static const char BLOB_SPLIT_BY_FILE_SIZE[];
 
+    /// "blob.copy-buffer-size" - Buffer size used when copying blob payloads into blob files.
+    /// Must be between 1 byte and 2147483647 bytes. Default value is "4 kb".
+    static const char BLOB_COPY_BUFFER_SIZE[];
+
     /// "partition.default-name" - The default partition name in case the dynamic partition column
     /// value is null/empty string. Default is "__DEFAULT_PARTITION__".
     static const char PARTITION_DEFAULT_NAME[];
@@ -360,9 +364,12 @@ struct PAIMON_EXPORT Options {
     /// files containing deletion vectors are generated when data is written, which marks the data
     /// for deletion. During read operations, by applying these index files, merging can be avoided.
     /// Default value is false.
-    /// @note On a data-evolution table (`DATA_EVOLUTION_ENABLED`), Paimon C++ reads deletion
-    /// vectors but does not write them: the deletes have to be issued by another engine, and such
-    /// a table is never compacted.
+    /// @note On a data-evolution table (`DATA_EVOLUTION_ENABLED`), Paimon C++ does not originate
+    /// new logical deletions: a delete has to be issued by another engine. It does read the
+    /// resulting vectors, and compacting such a table writes deletion-vector index files of its
+    /// own — the deletions of the replaced files re-keyed onto the rewritten ones, committed in
+    /// the same snapshot. On a plain append table without buckets, deletion vectors still block
+    /// compaction.
     static const char DELETION_VECTORS_ENABLED[];
 
     /// "deletion-vector.index-file.target-size" - The target size of deletion vector index file.
@@ -371,7 +378,6 @@ struct PAIMON_EXPORT Options {
 
     /// "deletion-vectors.bitmap64" - Enable 64 bit bitmap implementation. Note that only 64 bit
     /// bitmap implementation is compatible with Iceberg. Default value is "false".
-    /// @note: bitmap64 dv is not supported.
     static const char DELETION_VECTOR_BITMAP64[];
 
     ///  @note `CHANGELOG_PRODUCER` currently only support `none`
@@ -431,6 +437,14 @@ struct PAIMON_EXPORT Options {
     /// "data-evolution.enabled" - Whether enable data evolution for row tracking table. Default
     /// value is "false".
     static const char DATA_EVOLUTION_ENABLED[];
+    /// "data-evolution.compaction.rewrite-row-ids" - The legacy data-evolution row-id rewriting
+    /// mode. No longer supported; setting it to "true" fails the compaction. Default value is
+    /// "false".
+    static const char DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS[];
+    /// "pk-clustering-override" - Whether to override clustering for primary-key tables. Not
+    /// supported by Paimon C++: "true" is rejected by the commit path (and by schema validation
+    /// for primary-key managed BLOB tables). Default value is "false".
+    static const char PK_CLUSTERING_OVERRIDE[];
     /// "partition.legacy-name" - The legacy partition name is using `ToString` for all types. If
     /// false, using casting to string for all types. Default value is "true".
     static const char PARTITION_GENERATE_LEGACY_NAME[];
@@ -496,6 +510,11 @@ struct PAIMON_EXPORT Options {
     /// "blob-descriptor-field" - Comma-separated field names to treat as BLOB fields and store as
     /// serialized BlobDescriptor bytes inline in data files. No default value.
     static const char BLOB_DESCRIPTOR_FIELD[];
+    /// "blob-descriptor.source-table" - The source table whose credentials would re-materialize
+    /// blob descriptors. Not supported by Paimon C++, which always reads descriptors through
+    /// the table's own file system; configuring it on a primary-key managed BLOB table fails
+    /// schema validation instead of silently changing semantics. No default value.
+    static const char BLOB_DESCRIPTOR_SOURCE_TABLE[];
     /// "blob.stored-descriptor-fields" deprecated as a fallback for `BLOB_DESCRIPTOR_FIELD`.
     static const char FALLBACK_BLOB_DESCRIPTOR_FIELD[];
     /// "blob-view-field" - Comma-separated field names to treat as BLOB fields and store as

--- a/include/paimon/file_store_commit.h
+++ b/include/paimon/file_store_commit.h
@@ -195,6 +195,20 @@ class PAIMON_EXPORT FileStoreCommit {
     virtual FileStoreCommit& RowIdCheckConflict(
         std::optional<int64_t> row_id_check_from_snapshot) = 0;
 
+    /// Configure row-id conflict checking for a commit that materializes deletion vectors.
+    ///
+    /// Such a commit drops the rows its deletion vectors marked and lets the commit assign new
+    /// row ids to the survivors, so it conflicts with anything another writer added over the
+    /// row ranges it rewrites - whatever columns that writer wrote. `RowIdCheckConflict`
+    /// checks the narrower column-overlap rule instead, which a rewrite of whole ranges cannot
+    /// rely on. Only compaction commits are checked. Passing std::nullopt disables it.
+    ///
+    /// @param row_id_check_from_snapshot Snapshot id the materialization was planned against,
+    ///     or std::nullopt to disable.
+    /// @return Current commit object for chaining.
+    virtual FileStoreCommit& RowIdCheckConflictForMaterializeDeletionVectors(
+        std::optional<int64_t> row_id_check_from_snapshot) = 0;
+
     /// Retrieve metrics related to commit operations.
     ///
     /// @return A shared pointer to a `Metrics` object containing commit metrics.

--- a/include/paimon/format/format_writer.h
+++ b/include/paimon/format/format_writer.h
@@ -18,9 +18,12 @@
 
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
+#include <utility>
 
 #include "paimon/status.h"
 #include "paimon/type_fwd.h"
@@ -75,6 +78,18 @@ class PAIMON_EXPORT FormatWriter {
     /// Adds metadata to the file footer. Values are encoded by each format writer
     /// before being persisted. Must be called before Finish().
     virtual Status AddMetadata(const std::map<std::string, std::string>& metadata) = 0;
+
+    /// The `(offset, length)` of the payload bytes the last `AddBatch()` stored, for a format
+    /// that stores one addressable payload per record.
+    ///
+    /// A caller that has to point a descriptor at the bytes it just wrote needs this, and the
+    /// byte range is the only thing it needs — declaring it here keeps that caller from
+    /// downcasting a `FormatWriter` the format factory handed it to the one implementation it
+    /// happens to expect. The default is empty, which is also what a record that kept no
+    /// payload reports, so a caller that requires one has to reject both alike.
+    virtual std::optional<std::pair<int64_t, int64_t>> LastPayloadRange() const {
+        return std::nullopt;
+    }
 };
 
 }  // namespace paimon

--- a/src/paimon/CMakeLists.txt
+++ b/src/paimon/CMakeLists.txt
@@ -139,6 +139,7 @@ set(PAIMON_COMMON_SRCS
     common/reader/reader_utils.cpp
     common/reader/blob_fallback_batch_reader.cpp
     common/reader/blob_view_resolving_batch_reader.cpp
+    common/reader/managed_blob_resolving_batch_reader.cpp
     common/reader/complete_row_kind_batch_reader.cpp
     common/reader/data_evolution_file_reader.cpp
     common/sst/block_handle.cpp
@@ -209,6 +210,11 @@ set(PAIMON_CORE_SRCS
     core/bucket/bucket_select_converter.cpp
     core/append/append_compact_task.cpp
     core/append/append_compact_coordinator.cpp
+    core/append/data_evolution_compact_deletion_vector_rewriter.cpp
+    core/append/data_evolution_compact_global_index_dropper.cpp
+    core/append/data_evolution_compact_planner.cpp
+    core/append/data_evolution_materialize_deletion_compact_task.cpp
+    core/append/data_evolution_normal_compact_task.cpp
     core/bucket/hive_bucket_function.cpp
     core/bucket/mod_bucket_function.cpp
     core/bucket/bucket_id_calculator.cpp
@@ -246,6 +252,7 @@ set(PAIMON_CORE_SRCS
     core/core_options.cpp
     core/deletionvectors/deletion_vector.cpp
     core/deletionvectors/deletion_file_writer.cpp
+    core/deletionvectors/bitmap64_deletion_vector.cpp
     core/deletionvectors/bitmap_deletion_vector.cpp
     core/deletionvectors/deletion_vectors_index_file.cpp
     core/deletionvectors/deletion_vector_index_file_writer.cpp
@@ -284,6 +291,9 @@ set(PAIMON_CORE_SRCS
     core/io/key_value_data_file_record_reader.cpp
     core/io/key_value_data_file_writer_factory.cpp
     core/io/key_value_data_file_writer.cpp
+    core/io/managed_blob_reference_collector.cpp
+    core/io/managed_blob_reference_file.cpp
+    core/io/primary_key_blob_externalizer.cpp
     core/io/key_value_in_memory_record_reader.cpp
     core/io/merged_key_value_record_reader.cpp
     core/io/key_value_meta_projection_consumer.cpp
@@ -352,7 +362,10 @@ set(PAIMON_CORE_SRCS
     core/operation/commit/overwrite_changes_provider.cpp
     core/operation/commit/realtime_commit_properties.cpp
     core/operation/commit/row_id_column_conflict_checker.cpp
+    core/operation/commit/row_id_range_conflict_checker.cpp
+    core/operation/commit/uncommitted_file_cleaner.cpp
     core/operation/commit/manifest_entry_changes.cpp
+    core/operation/commit/materialized_index_changes_provider.cpp
     core/operation/commit/row_tracking_commit_utils.cpp
     core/operation/commit/sequence_snapshot_properties.cpp
     core/operation/commit/retry_waiter.cpp
@@ -605,6 +618,7 @@ if(PAIMON_BUILD_TESTS)
                     common/reader/complete_row_kind_batch_reader_test.cpp
                     common/reader/blob_fallback_batch_reader_test.cpp
                     common/reader/blob_view_resolving_batch_reader_test.cpp
+                    common/reader/managed_blob_resolving_batch_reader_test.cpp
                     common/reader/data_evolution_file_reader_test.cpp
                     common/reader/data_evolution_array_test.cpp
                     common/reader/data_evolution_row_test.cpp
@@ -708,6 +722,11 @@ if(PAIMON_BUILD_TESTS)
                     core/append/append_only_writer_test.cpp
                     core/append/append_compact_coordinator_test.cpp
                     core/append/bucketed_append_compact_manager_test.cpp
+                    core/append/data_evolution_compact_deletion_vector_rewriter_test.cpp
+                    core/append/data_evolution_compact_global_index_dropper_test.cpp
+                    core/append/data_evolution_compact_planner_test.cpp
+                    core/append/data_evolution_materialize_deletion_compact_task_test.cpp
+                    core/append/data_evolution_normal_compact_task_test.cpp
                     core/bucket/bucket_select_converter_test.cpp
                     core/bucket/default_bucket_function_test.cpp
                     core/bucket/hive_bucket_function_test.cpp
@@ -728,6 +747,7 @@ if(PAIMON_BUILD_TESTS)
                     core/core_options_test.cpp
                     core/options/lookup_strategy_test.cpp
                     core/deletionvectors/apply_deletion_vector_batch_reader_test.cpp
+                    core/deletionvectors/bitmap64_deletion_vector_test.cpp
                     core/deletionvectors/bitmap_deletion_vector_test.cpp
                     core/deletionvectors/bucketed_dv_maintainer_test.cpp
                     core/deletionvectors/deletion_file_writer_test.cpp
@@ -759,6 +779,9 @@ if(PAIMON_BUILD_TESTS)
                     core/io/data_file_index_writer_test.cpp
                     core/io/file_index_options_test.cpp
                     core/io/file_index_evaluator_test.cpp
+                    core/io/managed_blob_reference_collector_test.cpp
+                    core/io/managed_blob_reference_file_test.cpp
+                    core/io/primary_key_blob_externalizer_test.cpp
                     core/io/single_file_writer_test.cpp
                     core/io/rolling_blob_file_writer_test.cpp
                     core/global_index/global_index_evaluator_impl_test.cpp
@@ -839,6 +862,9 @@ if(PAIMON_BUILD_TESTS)
                     core/operation/commit/manifest_entry_changes_test.cpp
                     core/operation/commit/overwrite_changes_provider_test.cpp
                     core/operation/commit/row_id_column_conflict_checker_test.cpp
+                    core/operation/commit/row_id_range_conflict_checker_test.cpp
+                    core/operation/commit/uncommitted_file_cleaner_test.cpp
+                    core/operation/commit/materialized_index_changes_provider_test.cpp
                     core/operation/commit/row_tracking_commit_utils_test.cpp
                     core/operation/commit/realtime_commit_properties_test.cpp
                     core/operation/commit/sequence_snapshot_properties_test.cpp

--- a/src/paimon/common/data/blob.cpp
+++ b/src/paimon/common/data/blob.cpp
@@ -94,23 +94,32 @@ Result<std::unique_ptr<InputStream>> Blob::NewInputStream(
     if (fs == nullptr) {
         return Status::Invalid("file system is nullptr");
     }
-    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> file,
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> opened,
                            fs->Open(impl_->GetDescriptor()->Uri()));
 
-    int64_t blob_length = impl_->GetDescriptor()->Length();
-    int64_t blob_offset = impl_->GetDescriptor()->Offset();
+    // Keep a shared handle so the stream is explicitly closed when a check below or
+    // OffsetInputStream::Create itself fails; on success the offset stream shares ownership.
+    std::shared_ptr<InputStream> file = std::move(opened);
+    Result<std::unique_ptr<InputStream>> result = [&]() -> Result<std::unique_ptr<InputStream>> {
+        int64_t blob_length = impl_->GetDescriptor()->Length();
+        int64_t blob_offset = impl_->GetDescriptor()->Offset();
 
-    PAIMON_ASSIGN_OR_RAISE(int64_t total_length, file->Length());
-    if (PAIMON_UNLIKELY(blob_offset > total_length)) {
-        return Status::Invalid(
-            fmt::format("offset {} exceed total length {}", blob_offset, total_length));
-    }
-    if (blob_length == -1) {
-        // blob_length == -1 means it's dynamic length, should read to the end
-        blob_length = total_length - blob_offset;
-    }
+        PAIMON_ASSIGN_OR_RAISE(int64_t total_length, file->Length());
+        if (PAIMON_UNLIKELY(blob_offset > total_length)) {
+            return Status::Invalid(
+                fmt::format("offset {} exceed total length {}", blob_offset, total_length));
+        }
+        if (blob_length == -1) {
+            // blob_length == -1 means it's dynamic length, should read to the end
+            blob_length = total_length - blob_offset;
+        }
 
-    return OffsetInputStream::Create(std::move(file), blob_length, blob_offset, total_length);
+        return OffsetInputStream::Create(file, blob_length, blob_offset, total_length);
+    }();
+    if (!result.ok()) {
+        [[maybe_unused]] Status close_status = file->Close();
+    }
+    return result;
 }
 
 Result<PAIMON_UNIQUE_PTR<Bytes>> Blob::ToData(const std::shared_ptr<FileSystem>& fs,

--- a/src/paimon/common/data/blob_defs.h
+++ b/src/paimon/common/data/blob_defs.h
@@ -50,6 +50,10 @@ class BlobDefs {
     /// Metadata value identifying a Paimon Blob extension type field.
     static constexpr char kExtensionTypeValue[] = "paimon.type.blob";
 
+    /// Default buffer size for copying blob payloads into blob files, the "4 kb" default of
+    /// `blob.copy-buffer-size` (Options::BLOB_COPY_BUFFER_SIZE).
+    static constexpr int64_t kDefaultCopyBufferSize = 4 * 1024;
+
     /// A bin_length value of -1 in the index indicates a null blob entry.
     static constexpr int64_t kNullBinLength = -1;
     /// A bin_length value of -2 in the index indicates a placeholder blob entry, written by

--- a/src/paimon/common/data/blob_test.cpp
+++ b/src/paimon/common/data/blob_test.cpp
@@ -19,6 +19,11 @@
 
 #include "paimon/data/blob.h"
 
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
 #include "arrow/api.h"
 #include "arrow/c/bridge.h"
 #include "gtest/gtest.h"
@@ -27,6 +32,71 @@
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
+
+namespace {
+
+/// An input stream that delegates to a real one and counts how often it was closed, so a test
+/// can tell whether a handle was handed over or released.
+class CloseCountingInputStream : public InputStream {
+ public:
+    CloseCountingInputStream(std::unique_ptr<InputStream>&& wrapped, int32_t* close_count)
+        : wrapped_(std::move(wrapped)), close_count_(close_count) {}
+
+    Status Seek(int64_t offset, SeekOrigin origin) override {
+        return wrapped_->Seek(offset, origin);
+    }
+
+    Result<int64_t> GetPos() const override {
+        return wrapped_->GetPos();
+    }
+
+    Result<int64_t> Read(char* buffer, int64_t size) override {
+        return wrapped_->Read(buffer, size);
+    }
+
+    Result<int64_t> Read(char* buffer, int64_t size, int64_t offset) override {
+        return wrapped_->Read(buffer, size, offset);
+    }
+
+    void ReadAsync(char* buffer, int64_t size, int64_t offset,
+                   std::function<void(Status)>&& callback) override {
+        wrapped_->ReadAsync(buffer, size, offset, std::move(callback));
+    }
+
+    Status Close() override {
+        (*close_count_)++;
+        return wrapped_->Close();
+    }
+
+    Result<std::string> GetUri() const override {
+        return wrapped_->GetUri();
+    }
+
+    Result<int64_t> Length() const override {
+        return wrapped_->Length();
+    }
+
+ private:
+    std::unique_ptr<InputStream> wrapped_;
+    int32_t* close_count_;
+};
+
+/// A local file system handing out those streams.
+class CloseCountingFileSystem : public LocalFileSystem {
+ public:
+    explicit CloseCountingFileSystem(int32_t* close_count) : close_count_(close_count) {}
+
+    Result<std::unique_ptr<InputStream>> Open(const std::string& path) const override {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> wrapped, LocalFileSystem::Open(path));
+        return std::unique_ptr<InputStream>(
+            std::make_unique<CloseCountingInputStream>(std::move(wrapped), close_count_));
+    }
+
+ private:
+    int32_t* close_count_;
+};
+
+}  // namespace
 
 class BlobTest : public ::testing::Test {
  public:
@@ -144,6 +214,28 @@ TEST_F(BlobTest, TestNewInputStreamWithDynamicLength) {
     ASSERT_OK_AND_ASSIGN(auto bytes_read, input_stream->Read(buffer.data(), buffer.size()));
     ASSERT_EQ(12, bytes_read);
     ASSERT_EQ("cdefghijklmn", buffer);
+}
+
+TEST_F(BlobTest, TestNewInputStreamClosesTheFileOnFailure) {
+    // Whether the descriptor fits its file can only be told once the file is open, so a
+    // descriptor pointing past the end fails after the open. The handle taken to find that out
+    // has to be released there and then: nothing else can reach it any more.
+    int32_t close_count = 0;
+    auto counting_fs = std::make_shared<CloseCountingFileSystem>(&close_count);
+
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<Blob> out_of_range_blob,
+                         Blob::FromPath(uri_, /*offset=*/100, /*length=*/1));
+    ASSERT_NOK_WITH_MSG(out_of_range_blob->NewInputStream(counting_fs), "exceed total length");
+    ASSERT_EQ(close_count, 1);
+
+    // A descriptor that fits hands the open file to the caller instead, who closes it.
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<Blob> blob,
+                         Blob::FromPath(uri_, /*offset=*/2, /*length=*/6));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<InputStream> input_stream,
+                         blob->NewInputStream(counting_fs));
+    ASSERT_EQ(close_count, 1);
+    ASSERT_OK(input_stream->Close());
+    ASSERT_EQ(close_count, 2);
 }
 
 TEST_F(BlobTest, TestArrowField) {

--- a/src/paimon/common/data/blob_utils.cpp
+++ b/src/paimon/common/data/blob_utils.cpp
@@ -97,6 +97,17 @@ Result<BlobUtils::SeparatedStructArrays> BlobUtils::SeparateBlobArray(
     return result;
 }
 
+std::vector<std::string> BlobUtils::ManagedBlobFieldNames(
+    const std::shared_ptr<arrow::Schema>& schema, const std::set<std::string>& inline_fields) {
+    std::vector<std::string> managed_fields;
+    for (const auto& field : schema->fields()) {
+        if (IsBlobField(field) && inline_fields.count(field->name()) == 0) {
+            managed_fields.push_back(field->name());
+        }
+    }
+    return managed_fields;
+}
+
 bool BlobUtils::IsBlobField(const std::shared_ptr<arrow::Field>& field) {
     const auto& type = field->type();
     if (type->id() != arrow::Type::LARGE_BINARY) {

--- a/src/paimon/common/data/blob_utils.h
+++ b/src/paimon/common/data/blob_utils.h
@@ -76,6 +76,14 @@ class PAIMON_EXPORT BlobUtils {
     static bool IsBlobMetadata(const std::shared_ptr<const arrow::KeyValueMetadata>& metadata);
     static bool IsBlobFile(const std::string& file_name);
 
+    /// Names of the blob fields in `schema` whose payloads live outside the data file, which
+    /// holds a descriptor in their place. Inline blob fields (descriptor / view) are excluded,
+    /// they hold caller-provided bytes. Where the payload goes depends on the table: a
+    /// primary-key table externalizes it into a `.managed.blob` pack, an append
+    /// data-evolution table writes a dedicated `.blob` file per field group.
+    static std::vector<std::string> ManagedBlobFieldNames(
+        const std::shared_ptr<arrow::Schema>& schema, const std::set<std::string>& inline_fields);
+
     static std::shared_ptr<arrow::Field> ToArrowField(
         const std::string& field_name, bool nullable = false,
         std::unordered_map<std::string, std::string> metadata = {});

--- a/src/paimon/common/data/blob_utils_test.cpp
+++ b/src/paimon/common/data/blob_utils_test.cpp
@@ -19,6 +19,10 @@
 
 #include "paimon/common/data/blob_utils.h"
 
+#include <set>
+#include <string>
+#include <vector>
+
 #include "arrow/api.h"
 #include "arrow/c/bridge.h"
 #include "gtest/gtest.h"
@@ -138,6 +142,27 @@ TEST_F(BlobUtilsTest, SeparateBlobSchema) {
         ASSERT_TRUE(schemas.main_schema->Equals(*schema));
         ASSERT_EQ(schemas.blob_schema->num_fields(), 0);
     }
+}
+
+TEST_F(BlobUtilsTest, ManagedBlobFieldNames) {
+    auto int_field = arrow::field("f1_int", arrow::int32());
+    std::shared_ptr<arrow::Field> blob_field_1 = BlobUtils::ToArrowField("f2_blob", true);
+    std::shared_ptr<arrow::Field> blob_field_2 = BlobUtils::ToArrowField("f3_blob", true);
+    std::shared_ptr<arrow::Schema> schema = arrow::schema({int_field, blob_field_1, blob_field_2});
+
+    // Managed fields are the blob fields the table does not keep inline, in schema order: they
+    // are the ones whose payload is externalized into a pack and replaced by a descriptor.
+    ASSERT_EQ(BlobUtils::ManagedBlobFieldNames(schema, /*inline_fields=*/{}),
+              (std::vector<std::string>{"f2_blob", "f3_blob"}));
+    ASSERT_EQ(BlobUtils::ManagedBlobFieldNames(schema, /*inline_fields=*/{"f2_blob"}),
+              (std::vector<std::string>{"f3_blob"}));
+    ASSERT_TRUE(
+        BlobUtils::ManagedBlobFieldNames(schema, /*inline_fields=*/{"f2_blob", "f3_blob"}).empty());
+
+    // A non-blob field is never managed, and naming one inline changes nothing.
+    std::shared_ptr<arrow::Schema> no_blob_schema = arrow::schema({int_field});
+    ASSERT_TRUE(
+        BlobUtils::ManagedBlobFieldNames(no_blob_schema, /*inline_fields=*/{"f1_int"}).empty());
 }
 
 TEST_F(BlobUtilsTest, SeparateBlobArray) {

--- a/src/paimon/common/data/columnar/columnar_utils.h
+++ b/src/paimon/common/data/columnar/columnar_utils.h
@@ -51,6 +51,13 @@ class ColumnarUtils {
         auto type_id = array->type_id();
         bool is_dict = (type_id == arrow::Type::type::DICTIONARY);
         if (!is_dict) {
+            // Large binary/string arrays carry 64-bit offsets and must not be read through
+            // the 32-bit-offset BinaryArray accessors (e.g. managed blob descriptor columns).
+            if (type_id == arrow::Type::type::LARGE_BINARY ||
+                type_id == arrow::Type::type::LARGE_STRING) {
+                const auto* typed_array = checked_cast<const arrow::LargeBinaryArray*>(array);
+                return typed_array->GetView(pos);
+            }
             const auto* typed_array = checked_cast<const arrow::BinaryArray*>(array);
             return typed_array->GetView(pos);
         } else {

--- a/src/paimon/common/data/columnar/columnar_utils_test.cpp
+++ b/src/paimon/common/data/columnar/columnar_utils_test.cpp
@@ -36,6 +36,21 @@ TEST(ColumnarUtilsTest, TestGetViewAndBytes) {
     ASSERT_EQ(*std::make_shared<Bytes>("def", pool.get()), *bytes);
 }
 
+TEST(ColumnarUtilsTest, TestGetViewAndBytesOfLargeBinary) {
+    auto pool = GetDefaultPool();
+    // Large binary and large string carry 64-bit offsets, so they have to be read through the
+    // large accessors: a managed blob descriptor column is stored as large binary, and reading
+    // it as a 32-bit-offset binary array would take the offsets apart at the wrong stride.
+    for (const auto& type : {arrow::large_binary(), arrow::large_utf8()}) {
+        auto array =
+            arrow::ipc::internal::json::ArrayFromJSON(type, R"(["abc", "def", "hi"])").ValueOrDie();
+        ASSERT_EQ(std::string(ColumnarUtils::GetView(array.get(), 0)), "abc");
+        ASSERT_EQ(std::string(ColumnarUtils::GetView(array.get(), 2)), "hi");
+        auto bytes = ColumnarUtils::GetBytes<arrow::LargeBinaryType>(array.get(), 1, pool.get());
+        ASSERT_EQ(*std::make_shared<Bytes>("def", pool.get()), *bytes);
+    }
+}
+
 TEST(ColumnarUtilsTest, TestGetViewAndBytesOfDict) {
     auto pool = GetDefaultPool();
     auto dict = arrow::ipc::internal::json::ArrayFromJSON(arrow::utf8(), R"(["foo", "bar", "baz"])")

--- a/src/paimon/common/data/internal_row.cpp
+++ b/src/paimon/common/data/internal_row.cpp
@@ -103,6 +103,18 @@ Result<InternalRow::FieldGetterFunc> InternalRow::CreateFieldGetter(
             };
             break;
         }
+        case arrow::Type::type::LARGE_BINARY: {
+            // Managed blob columns of a primary-key table hold their serialized descriptors
+            // as large binary.
+            field_getter = [field_idx, use_view](const InternalRow& row) -> VariantType {
+                if (use_view) {
+                    return row.GetStringView(field_idx);
+                } else {
+                    return row.GetBinary(field_idx);
+                }
+            };
+            break;
+        }
         case arrow::Type::type::TIMESTAMP: {
             auto timestamp_type = checked_pointer_cast<arrow::TimestampType>(field_type);
             int32_t precision = DateTimeUtils::GetPrecisionFromType(timestamp_type);

--- a/src/paimon/common/data/internal_row_test.cpp
+++ b/src/paimon/common/data/internal_row_test.cpp
@@ -37,6 +37,7 @@
 #include "paimon/common/utils/decimal_utils.h"
 #include "paimon/data/decimal.h"
 #include "paimon/data/timestamp.h"
+#include "paimon/memory/bytes.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/status.h"
 #include "paimon/testing/utils/testharness.h"
@@ -70,6 +71,7 @@ TEST(InternalRowTest, TestCreateFieldGetter) {
         arrow::field("f21",
                      arrow::struct_({field("sub1", arrow::int64()), field("sub2", arrow::float64()),
                                      field("sub3", arrow::boolean())})),
+        arrow::field("f22", arrow::large_binary()),
     };
 
     auto src_array = std::dynamic_pointer_cast<arrow::StructArray>(
@@ -77,7 +79,7 @@ TEST(InternalRowTest, TestCreateFieldGetter) {
         [true, 1, 2, 3, 4, 5.1, 6.12, "abc", "def", "1970-01-02 00:00:01", "1970-01-02 00:00:00.001",
         "1970-01-02 00:00:00.000001", "1970-01-02 00:00:00.000000001", "1970-01-02 00:00:02", "1970-01-02 00:00:00.002",
         "1970-01-02 00:00:00.000002", "1970-01-02 00:00:00.000000002", "-123456789987654321.45678", 12345,
-        [1, 2, 3], [[true, 3], [false, 4]], [10, 10.1, false]]
+        [1, 2, 3], [[true, 3], [false, 4]], [10, 10.1, false], "ghi"]
     ])")
             .ValueOrDie());
     auto pool = GetDefaultPool();
@@ -134,6 +136,18 @@ TEST(InternalRowTest, TestCreateFieldGetter) {
     ASSERT_EQ(inner_row->GetLong(0), 10l);
     ASSERT_EQ(inner_row->GetDouble(1), 10.1);
     ASSERT_EQ(inner_row->GetBoolean(2), false);
+    auto string_view22 = DataDefine::GetVariantValue<std::string_view>(getters[22](row));
+    ASSERT_EQ(std::string(string_view22), "ghi");
+
+    // The same large binary field read without views, which is what a casted row and the
+    // metadata system tables ask for: the bytes are copied out instead of pointing into the
+    // batch that produced them.
+    ASSERT_OK_AND_ASSIGN(
+        InternalRow::FieldGetterFunc binary_getter,
+        InternalRow::CreateFieldGetter(22, fields[22]->type(), /*use_view=*/false));
+    auto bytes22 = DataDefine::GetVariantValue<std::shared_ptr<Bytes>>(binary_getter(row));
+    ASSERT_TRUE(bytes22 != nullptr);
+    ASSERT_EQ(std::string(bytes22->data(), bytes22->size()), "ghi");
 }
 
 TEST(InternalRowTest, TestCreateFieldGetterWithNull) {

--- a/src/paimon/common/defs.cpp
+++ b/src/paimon/common/defs.cpp
@@ -42,6 +42,7 @@ const char Options::TARGET_FILE_SIZE[] = "target-file-size";
 const char Options::TARGET_FILE_ROW_NUM[] = "target-file-row-num";
 const char Options::BLOB_TARGET_FILE_SIZE[] = "blob.target-file-size";
 const char Options::BLOB_SPLIT_BY_FILE_SIZE[] = "blob.split-by-file-size";
+const char Options::BLOB_COPY_BUFFER_SIZE[] = "blob.copy-buffer-size";
 const char Options::PAGE_SIZE[] = "page-size";
 const char Options::PARTITION_DEFAULT_NAME[] = "partition.default-name";
 const char Options::FILE_COMPRESSION[] = "file.compression";
@@ -109,6 +110,9 @@ const char Options::ROW_TRACKING_ENABLED[] = "row-tracking.enabled";
 const char Options::ROW_TRACKING_PARTITION_GROUP_ON_COMMIT[] =
     "row-tracking.partition-group-on-commit";
 const char Options::DATA_EVOLUTION_ENABLED[] = "data-evolution.enabled";
+const char Options::DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS[] =
+    "data-evolution.compaction.rewrite-row-ids";
+const char Options::PK_CLUSTERING_OVERRIDE[] = "pk-clustering-override";
 const char Options::PARTITION_GENERATE_LEGACY_NAME[] = "partition.legacy-name";
 const char Options::MAP_STORAGE_LAYOUT[] = "map.storage-layout";
 const char Options::MAP_SHARED_SHREDDING_MAX_COLUMNS[] = "map.shared-shredding.max-columns";
@@ -131,6 +135,7 @@ const char Options::VARIANT_SHREDDING_ADAPTIVE_RETENTION_RATIO[] =
 const char Options::BLOB_AS_DESCRIPTOR[] = "blob-as-descriptor";
 const char Options::BLOB_FIELD[] = "blob-field";
 const char Options::BLOB_DESCRIPTOR_FIELD[] = "blob-descriptor-field";
+const char Options::BLOB_DESCRIPTOR_SOURCE_TABLE[] = "blob-descriptor.source-table";
 const char Options::FALLBACK_BLOB_DESCRIPTOR_FIELD[] = "blob.stored-descriptor-fields";
 const char Options::BLOB_VIEW_FIELD[] = "blob-view-field";
 const char Options::BLOB_VIEW_RESOLVE_ENABLED[] = "blob-view.resolve.enabled";

--- a/src/paimon/common/reader/managed_blob_resolving_batch_reader.cpp
+++ b/src/paimon/common/reader/managed_blob_resolving_batch_reader.cpp
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/common/reader/managed_blob_resolving_batch_reader.h"
+
+#include <iterator>
+#include <string_view>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/data/blob.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/status.h"
+
+namespace paimon {
+
+ManagedBlobResolvingBatchReader::ManagedBlobResolvingBatchReader(
+    std::unique_ptr<BatchReader>&& reader, std::vector<std::string> managed_blob_fields,
+    const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool)
+    : pool_(pool),
+      arrow_pool_(GetArrowPool(pool)),
+      reader_(std::move(reader)),
+      managed_blob_fields_(std::make_move_iterator(managed_blob_fields.begin()),
+                           std::make_move_iterator(managed_blob_fields.end())),
+      fs_(fs) {}
+
+Result<BatchReader::ReadBatch> ManagedBlobResolvingBatchReader::NextBatch() {
+    PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch batch, reader_->NextBatch());
+    if (BatchReader::IsEofBatch(batch)) {
+        return batch;
+    }
+    if (managed_blob_fields_.empty()) {
+        return batch;
+    }
+
+    auto& [c_array, c_schema] = batch;
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                      arrow::ImportArray(c_array.get(), c_schema.get()));
+    auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+    if (struct_array == nullptr) {
+        return Status::Invalid(
+            "invalid batch, ManagedBlobResolvingBatchReader expects a StructArray batch.");
+    }
+    const auto struct_type = struct_array->struct_type();
+
+    arrow::ArrayVector new_fields = struct_array->fields();
+    for (int32_t field_idx = 0; field_idx < struct_type->num_fields(); ++field_idx) {
+        const auto& field = struct_type->field(field_idx);
+        if (managed_blob_fields_.find(field->name()) == managed_blob_fields_.end()) {
+            continue;
+        }
+        const auto& column = struct_array->field(field_idx);
+        auto descriptor_array = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(column);
+        if (descriptor_array == nullptr) {
+            return Status::Invalid(fmt::format(
+                "ManagedBlobResolvingBatchReader expects managed blob column {} to be a "
+                "LargeBinaryArray.",
+                field->name()));
+        }
+        PAIMON_ASSIGN_OR_RAISE(new_fields[field_idx], ResolveBlobColumn(descriptor_array));
+    }
+    // Rebuild with the original fields so the blob extension metadata and nullability survive
+    // the resolution.
+    std::shared_ptr<arrow::StructArray> resolved_struct_array;
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(resolved_struct_array,
+                                      arrow::StructArray::Make(new_fields, struct_type->fields()));
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(
+        arrow::ExportArray(*resolved_struct_array, c_array.get(), c_schema.get()));
+    return batch;
+}
+
+Result<std::shared_ptr<arrow::Array>> ManagedBlobResolvingBatchReader::ResolveBlobColumn(
+    const std::shared_ptr<arrow::LargeBinaryArray>& descriptor_array) {
+    arrow::LargeBinaryBuilder builder(arrow_pool_.get());
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Reserve(descriptor_array->length()));
+    for (int64_t row = 0; row < descriptor_array->length(); ++row) {
+        if (descriptor_array->IsNull(row)) {
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.AppendNull());
+            continue;
+        }
+        std::string_view value = descriptor_array->GetView(row);
+        // Every non-null managed value is a descriptor written by the externalizer; anything
+        // else means the file was not produced by a managed blob write.
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<Blob> blob,
+                               Blob::FromDescriptor(value.data(), value.size()));
+        PAIMON_ASSIGN_OR_RAISE(PAIMON_UNIQUE_PTR<Bytes> payload, blob->ToData(fs_, pool_));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(
+            builder.Append(reinterpret_cast<const uint8_t*>(payload->data()), payload->size()));
+    }
+    std::shared_ptr<arrow::Array> payload_array;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Finish(&payload_array));
+    return payload_array;
+}
+
+}  // namespace paimon

--- a/src/paimon/common/reader/managed_blob_resolving_batch_reader.h
+++ b/src/paimon/common/reader/managed_blob_resolving_batch_reader.h
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "arrow/memory_pool.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class Array;
+class LargeBinaryArray;
+}  // namespace arrow
+
+namespace paimon {
+
+/// Materializes the managed blob columns of a primary-key read: every non-null value is a
+/// serialized `BlobDescriptor` pointing into a `.managed.blob` pack, and this reader replaces
+/// it with the payload bytes through one ranged read per value. Wraps the fully merged batch
+/// stream, so only values of surviving rows are ever fetched. Not used when the read keeps
+/// descriptors (`blob-as-descriptor`).
+class ManagedBlobResolvingBatchReader : public BatchReader {
+ public:
+    ManagedBlobResolvingBatchReader(std::unique_ptr<BatchReader>&& reader,
+                                    std::vector<std::string> managed_blob_fields,
+                                    const std::shared_ptr<FileSystem>& fs,
+                                    const std::shared_ptr<MemoryPool>& pool);
+
+    Result<ReadBatch> NextBatch() override;
+
+    void Close() override {
+        reader_->Close();
+    }
+
+    std::shared_ptr<Metrics> GetReaderMetrics() const override {
+        return reader_->GetReaderMetrics();
+    }
+
+ private:
+    Result<std::shared_ptr<arrow::Array>> ResolveBlobColumn(
+        const std::shared_ptr<arrow::LargeBinaryArray>& descriptor_array);
+
+ private:
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+    std::unique_ptr<BatchReader> reader_;
+    std::set<std::string> managed_blob_fields_;
+    std::shared_ptr<FileSystem> fs_;
+};
+
+}  // namespace paimon

--- a/src/paimon/common/reader/managed_blob_resolving_batch_reader_test.cpp
+++ b/src/paimon/common/reader/managed_blob_resolving_batch_reader_test.cpp
@@ -1,0 +1,281 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/common/reader/managed_blob_resolving_batch_reader.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/abi.h"
+#include "arrow/c/bridge.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/metrics/metrics_impl.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/reader/batch_reader.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class ManagedBlobResolvingBatchReaderTest : public ::testing::Test {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+        dir_ = UniqueTestDirectory::Create("local");
+        fields_ = {arrow::field("id", arrow::int32()),
+                   BlobUtils::ToArrowField("b", /*nullable=*/true)};
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    class InMemoryBatchReader : public BatchReader {
+     public:
+        explicit InMemoryBatchReader(const std::shared_ptr<arrow::Array>& array) : array_(array) {}
+
+        Result<ReadBatch> NextBatch() override {
+            if (exhausted_) {
+                return MakeEofBatch();
+            }
+            exhausted_ = true;
+            auto c_array = std::make_unique<ArrowArray>();
+            auto c_schema = std::make_unique<ArrowSchema>();
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                arrow::ExportArray(*array_, c_array.get(), c_schema.get()));
+            return std::make_pair(std::move(c_array), std::move(c_schema));
+        }
+
+        std::shared_ptr<Metrics> GetReaderMetrics() const override {
+            return std::make_shared<MetricsImpl>();
+        }
+
+        void Close() override {}
+
+     private:
+        std::shared_ptr<arrow::Array> array_;
+        bool exhausted_ = false;
+    };
+
+    /// Writes `payload` to a file and returns serialized descriptor bytes pointing at it.
+    std::string WritePayloadAndMakeDescriptor(const std::string& file_name,
+                                              const std::string& payload) {
+        std::string path = PathUtil::JoinPath(dir_->Str(), file_name);
+        auto out = dir_->GetFileSystem()->Create(path, /*overwrite=*/false).value();
+        EXPECT_EQ(out->Write(payload.data(), payload.size()).value(),
+                  static_cast<int64_t>(payload.size()));
+        EXPECT_OK(out->Close());
+        auto descriptor =
+            BlobDescriptor::Create(path, /*offset=*/0, /*length=*/payload.size()).value();
+        PAIMON_UNIQUE_PTR<Bytes> bytes = descriptor->Serialize(pool_);
+        return std::string(bytes->data(), bytes->size());
+    }
+
+    std::shared_ptr<arrow::StructArray> BuildBatch(
+        const std::vector<int32_t>& ids,
+        const std::vector<std::optional<std::string>>& blob_values) {
+        arrow::Int32Builder id_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        for (size_t i = 0; i < ids.size(); i++) {
+            EXPECT_TRUE(id_builder.Append(ids[i]).ok());
+            if (blob_values[i]) {
+                EXPECT_TRUE(blob_builder.Append(blob_values[i].value()).ok());
+            } else {
+                EXPECT_TRUE(blob_builder.AppendNull().ok());
+            }
+        }
+        std::shared_ptr<arrow::Array> id_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(id_builder.Finish(&id_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        return arrow::StructArray::Make({id_array, blob_array}, fields_).ValueOrDie();
+    }
+
+    /// Reads the resolver's single batch back as a struct array.
+    Result<std::shared_ptr<arrow::StructArray>> ResolveOneBatch(
+        ManagedBlobResolvingBatchReader* reader) {
+        PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch batch, reader->NextBatch());
+        if (BatchReader::IsEofBatch(batch)) {
+            return Status::Invalid("unexpected eof");
+        }
+        auto& [c_array, c_schema] = batch;
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                          arrow::ImportArray(c_array.get(), c_schema.get()));
+        auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+        if (struct_array == nullptr) {
+            return Status::Invalid("not a struct array");
+        }
+        return struct_array;
+    }
+
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<UniqueTestDirectory> dir_;
+    arrow::FieldVector fields_;
+};
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestResolvesDescriptorsAndPreservesNulls) {
+    std::string descriptor_bytes = WritePayloadAndMakeDescriptor("pack-1", "resolved-payload");
+    auto batch = BuildBatch({1, 2}, {descriptor_bytes, std::nullopt});
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(batch), {"b"},
+                                           dir_->GetFileSystem(), pool_);
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> resolved, ResolveOneBatch(&reader));
+    auto blob_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved->GetFieldByName("b"));
+    ASSERT_TRUE(blob_column != nullptr);
+    ASSERT_EQ(blob_column->length(), 2);
+    EXPECT_EQ(std::string(blob_column->GetView(0)), "resolved-payload");
+    EXPECT_TRUE(blob_column->IsNull(1));
+
+    // The resolution must not strip the blob extension metadata or the nullability off the
+    // resolved field.
+    auto resolved_field = resolved->struct_type()->GetFieldByName("b");
+    ASSERT_TRUE(resolved_field != nullptr);
+    EXPECT_TRUE(BlobUtils::IsBlobField(resolved_field));
+    EXPECT_TRUE(resolved_field->nullable());
+
+    // Untouched columns pass through.
+    auto id_column = std::dynamic_pointer_cast<arrow::Int32Array>(resolved->GetFieldByName("id"));
+    ASSERT_TRUE(id_column != nullptr);
+    EXPECT_EQ(id_column->Value(0), 1);
+    EXPECT_EQ(id_column->Value(1), 2);
+
+    // End of input is handed through untouched rather than resolved.
+    ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatch eof, reader.NextBatch());
+    ASSERT_TRUE(BatchReader::IsEofBatch(eof));
+}
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestRejectsANonStructBatch) {
+    // Every batch this reader wraps is a struct of columns; anything else has no managed blob
+    // column to resolve and must not be handed on as if it had been resolved.
+    arrow::Int32Builder id_builder;
+    ASSERT_TRUE(id_builder.Append(1).ok());
+    std::shared_ptr<arrow::Array> id_array;
+    ASSERT_TRUE(id_builder.Finish(&id_array).ok());
+
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(id_array), {"b"},
+                                           dir_->GetFileSystem(), pool_);
+    ASSERT_NOK_WITH_MSG(ResolveOneBatch(&reader).status(), "expects a StructArray batch");
+}
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestRejectsAColumnThatIsNotLargeBinary) {
+    // Descriptors are stored as large binary; a 32 bit binary column would be read through the
+    // wrong accessors, so it is refused instead of silently misread.
+    arrow::Int32Builder id_builder;
+    arrow::BinaryBuilder blob_builder;
+    ASSERT_TRUE(id_builder.Append(1).ok());
+    ASSERT_TRUE(blob_builder.Append("not-large-binary").ok());
+    std::shared_ptr<arrow::Array> id_array;
+    std::shared_ptr<arrow::Array> blob_array;
+    ASSERT_TRUE(id_builder.Finish(&id_array).ok());
+    ASSERT_TRUE(blob_builder.Finish(&blob_array).ok());
+    arrow::FieldVector fields = {arrow::field("id", arrow::int32()),
+                                 arrow::field("b", arrow::binary())};
+    std::shared_ptr<arrow::StructArray> batch =
+        arrow::StructArray::Make({id_array, blob_array}, fields).ValueOrDie();
+
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(batch), {"b"},
+                                           dir_->GetFileSystem(), pool_);
+    ASSERT_NOK_WITH_MSG(ResolveOneBatch(&reader).status(), "to be a LargeBinaryArray");
+}
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestFailsWhenTheReferencedPackIsMissing) {
+    // A descriptor pointing at a pack that is not there must surface as an error; resolving
+    // silently to nothing would hand the caller a row whose blob had been lost.
+    std::unique_ptr<BlobDescriptor> descriptor =
+        BlobDescriptor::Create(PathUtil::JoinPath(dir_->Str(), "absent.managed.blob"),
+                               /*offset=*/0, /*length=*/4)
+            .value();
+    PAIMON_UNIQUE_PTR<Bytes> descriptor_bytes = descriptor->Serialize(pool_);
+    auto batch = BuildBatch({1}, {std::string(descriptor_bytes->data(), descriptor_bytes->size())});
+
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(batch), {"b"},
+                                           dir_->GetFileSystem(), pool_);
+    ASSERT_NOK(ResolveOneBatch(&reader).status());
+}
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestRejectsNonDescriptorValue) {
+    auto batch = BuildBatch({1}, {std::string("raw-bytes-not-a-descriptor")});
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(batch), {"b"},
+                                           dir_->GetFileSystem(), pool_);
+    // The failure must come from descriptor deserialization, not from a later resolution step.
+    ASSERT_NOK_WITH_MSG(ResolveOneBatch(&reader).status(), "BlobDescriptor");
+}
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestPassThroughWithoutManagedFields) {
+    auto batch = BuildBatch({1}, {std::string("raw-bytes-left-alone")});
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(batch), {},
+                                           dir_->GetFileSystem(), pool_);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> resolved, ResolveOneBatch(&reader));
+    auto blob_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved->GetFieldByName("b"));
+    ASSERT_TRUE(blob_column != nullptr);
+    EXPECT_EQ(std::string(blob_column->GetView(0)), "raw-bytes-left-alone");
+}
+
+TEST_F(ManagedBlobResolvingBatchReaderTest, TestResolvesOnlyTheDeclaredColumns) {
+    // A table may keep one blob column inline - a blob-descriptor or blob-view field - next to a
+    // managed one, and only the managed columns are declared to this reader. The inline column
+    // has to reach the caller exactly as it was stored: its descriptor bytes are what the caller
+    // asked for, and resolving them here would hand back payload bytes instead.
+    std::string managed_bytes = WritePayloadAndMakeDescriptor("pack-1", "managed-payload");
+    std::string inline_bytes = WritePayloadAndMakeDescriptor("pack-2", "inline-payload");
+
+    arrow::Int32Builder id_builder;
+    arrow::LargeBinaryBuilder managed_builder;
+    arrow::LargeBinaryBuilder inline_builder;
+    ASSERT_TRUE(id_builder.Append(1).ok());
+    ASSERT_TRUE(managed_builder.Append(managed_bytes).ok());
+    ASSERT_TRUE(inline_builder.Append(inline_bytes).ok());
+    std::shared_ptr<arrow::Array> id_array;
+    std::shared_ptr<arrow::Array> managed_array;
+    std::shared_ptr<arrow::Array> inline_array;
+    ASSERT_TRUE(id_builder.Finish(&id_array).ok());
+    ASSERT_TRUE(managed_builder.Finish(&managed_array).ok());
+    ASSERT_TRUE(inline_builder.Finish(&inline_array).ok());
+    arrow::FieldVector fields = {arrow::field("id", arrow::int32()),
+                                 BlobUtils::ToArrowField("b", /*nullable=*/true),
+                                 BlobUtils::ToArrowField("d", /*nullable=*/true)};
+    std::shared_ptr<arrow::StructArray> batch =
+        arrow::StructArray::Make({id_array, managed_array, inline_array}, fields).ValueOrDie();
+
+    ManagedBlobResolvingBatchReader reader(std::make_unique<InMemoryBatchReader>(batch), {"b"},
+                                           dir_->GetFileSystem(), pool_);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> resolved, ResolveOneBatch(&reader));
+
+    auto managed_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved->GetFieldByName("b"));
+    ASSERT_TRUE(managed_column != nullptr);
+    EXPECT_EQ(std::string(managed_column->GetView(0)), "managed-payload");
+
+    auto inline_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved->GetFieldByName("d"));
+    ASSERT_TRUE(inline_column != nullptr);
+    EXPECT_EQ(std::string(inline_column->GetView(0)), inline_bytes);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/append/append_compact_coordinator.cpp
+++ b/src/paimon/core/append/append_compact_coordinator.cpp
@@ -19,18 +19,37 @@
 #include "paimon/append/append_compact_coordinator.h"
 
 #include <algorithm>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/commit_context.h"
 #include "paimon/common/data/binary_row.h"
+#include "paimon/common/predicate/predicate_filter.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/linked_hash_map.h"
+#include "paimon/common/utils/range_helper.h"
 #include "paimon/core/append/append_compact_task.h"
+#include "paimon/core/append/data_evolution_compact_deletion_vector_rewriter.h"
+#include "paimon/core/append/data_evolution_compact_global_index_dropper.h"
+#include "paimon/core/append/data_evolution_compact_planner.h"
+#include "paimon/core/append/data_evolution_materialize_deletion_compact_task.h"
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
 #include "paimon/core/core_options.h"
+#include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
+#include "paimon/core/index/deletion_vector_meta.h"
+#include "paimon/core/index/index_file_handler.h"
+#include "paimon/core/index/index_file_meta.h"
 #include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/index_manifest_file.h"
 #include "paimon/core/manifest/manifest_entry.h"
 #include "paimon/core/manifest/manifest_file.h"
 #include "paimon/core/manifest/manifest_list.h"
@@ -40,11 +59,20 @@
 #include "paimon/core/schema/schema_manager.h"
 #include "paimon/core/schema/table_schema.h"
 #include "paimon/core/snapshot.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/table/source/deletion_file.h"
 #include "paimon/core/utils/field_mapping.h"
 #include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/core/utils/index_file_path_factories.h"
 #include "paimon/core/utils/snapshot_manager.h"
+#include "paimon/defs.h"
 #include "paimon/executor.h"
+#include "paimon/file_store_commit.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/logging.h"
 #include "paimon/memory/memory_pool.h"
+#include "paimon/utils/range.h"
+#include "paimon/utils/row_range_index.h"
 namespace paimon {
 
 namespace {
@@ -174,6 +202,51 @@ std::unique_ptr<AppendOnlyFileStoreWrite> CreateFileStoreWrite(
         /*realtime_context=*/nullptr, executor, pool);
 }
 
+/// Rejects caller options that change an immutable table option: they decide which
+/// compaction path runs and the physical layout the rewrite must preserve, so overriding
+/// them could route a data-evolution table into the plain append rewrite (reordering row
+/// ids) or slip a deletion-vector table past its rejection. Compared on the parsed effective
+/// values, so passing an explicit default is still allowed.
+Status ValidateImmutableOptions(const CoreOptions& schema_options,
+                                const CoreOptions& merged_options) {
+    std::vector<std::string> changed_options;
+    if (schema_options.RowTrackingEnabled() != merged_options.RowTrackingEnabled()) {
+        changed_options.emplace_back(Options::ROW_TRACKING_ENABLED);
+    }
+    if (schema_options.DataEvolutionEnabled() != merged_options.DataEvolutionEnabled()) {
+        changed_options.emplace_back(Options::DATA_EVOLUTION_ENABLED);
+    }
+    if (schema_options.DeletionVectorsEnabled() != merged_options.DeletionVectorsEnabled()) {
+        changed_options.emplace_back(Options::DELETION_VECTORS_ENABLED);
+    }
+    // The two deletion vector kinds serialize differently and refuse to merge into one
+    // another, so flipping this at the compaction entry point would either fail the rewrite
+    // or quietly replace a table's vectors with the other kind.
+    if (schema_options.DeletionVectorsBitmap64() != merged_options.DeletionVectorsBitmap64()) {
+        changed_options.emplace_back(Options::DELETION_VECTOR_BITMAP64);
+    }
+    if (schema_options.GetBucket() != merged_options.GetBucket()) {
+        changed_options.emplace_back(Options::BUCKET);
+    }
+    if (schema_options.GetBlobFields() != merged_options.GetBlobFields()) {
+        changed_options.emplace_back(Options::BLOB_FIELD);
+    }
+    if (schema_options.GetBlobDescriptorFields() != merged_options.GetBlobDescriptorFields()) {
+        changed_options.emplace_back(Options::BLOB_DESCRIPTOR_FIELD);
+    }
+    if (schema_options.GetBlobViewFields() != merged_options.GetBlobViewFields()) {
+        changed_options.emplace_back(Options::BLOB_VIEW_FIELD);
+    }
+    if (!changed_options.empty()) {
+        return Status::Invalid(
+            fmt::format("Compaction options must not change immutable table options [{}]: they "
+                        "decide the compaction path and the physical layout the rewrite must "
+                        "preserve.",
+                        fmt::join(changed_options, ", ")));
+    }
+    return Status::OK();
+}
+
 /// Load schema from table path and merge user options with schema options.
 Result<std::pair<std::shared_ptr<TableSchema>, CoreOptions>> LoadSchemaAndOptions(
     const std::string& table_path, const std::map<std::string, std::string>& options,
@@ -193,10 +266,13 @@ Result<std::pair<std::shared_ptr<TableSchema>, CoreOptions>> LoadSchemaAndOption
     }
     PAIMON_ASSIGN_OR_RAISE(CoreOptions core_options,
                            CoreOptions::FromMap(final_options, file_system));
+    PAIMON_ASSIGN_OR_RAISE(CoreOptions schema_core_options,
+                           CoreOptions::FromMap(table_schema->Options(), file_system));
+    PAIMON_RETURN_NOT_OK(ValidateImmutableOptions(schema_core_options, core_options));
     return std::make_pair(table_schema, std::move(core_options));
 }
 
-/// Validate that the table is an append-only unaware-bucket table without DV.
+/// Validate that the table is an append-only unaware-bucket table this coordinator can compact.
 Status ValidateTable(const std::shared_ptr<TableSchema>& table_schema,
                      const CoreOptions& core_options) {
     if (!table_schema->PrimaryKeys().empty() || core_options.GetBucket() != -1) {
@@ -205,10 +281,31 @@ Status ValidateTable(const std::shared_ptr<TableSchema>& table_schema,
             "with UNAWARE_BUCKET mode");
     }
     if (core_options.DeletionVectorsEnabled()) {
-        return Status::NotImplemented(
-            "AppendCompactCoordinator not support for dv in UNAWARE_BUCKET mode");
+        // A data-evolution rewrite preserves row ids, so its deletions can be re-keyed onto
+        // the rewritten files by DataEvolutionCompactDeletionVectorRewriter. The plain append
+        // rewrite reorders rows and has no such migration, so it still refuses.
+        if (!core_options.DataEvolutionEnabled()) {
+            return Status::NotImplemented(
+                "AppendCompactCoordinator does not support deletion vectors in UNAWARE_BUCKET "
+                "mode");
+        }
     }
     return Status::OK();
+}
+
+/// Build the index file handler used to read and rewrite a table's deletion-vector index.
+Result<std::shared_ptr<IndexFileHandler>> BuildIndexFileHandler(
+    const std::shared_ptr<FileStorePathFactory>& path_factory, const CoreOptions& core_options,
+    const std::shared_ptr<MemoryPool>& pool) {
+    PAIMON_ASSIGN_OR_RAISE(
+        std::unique_ptr<IndexManifestFile> index_manifest_file,
+        IndexManifestFile::Create(core_options.GetFileSystem(), core_options.GetManifestFormat(),
+                                  core_options.GetManifestCompression(), path_factory,
+                                  core_options.GetBucket(), pool, core_options));
+    return std::make_shared<IndexFileHandler>(
+        core_options.GetFileSystem(), std::move(index_manifest_file),
+        std::make_shared<IndexFilePathFactories>(path_factory),
+        core_options.DeletionVectorsBitmap64(), pool);
 }
 
 /// Build FileStorePathFactory from core options and table schema.
@@ -227,16 +324,25 @@ Result<std::shared_ptr<FileStorePathFactory>> BuildPathFactory(
         global_index_external_path, core_options.IndexFileInDataFileDir(), pool);
 }
 
-/// Scan the latest snapshot and collect small files grouped by partition.
-Result<LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>> ScanSmallFiles(
+/// Scan the latest snapshot and collect files grouped by partition. When `small_files_only` is
+/// set, files at or above the compaction trigger size are dropped; a data-evolution plan needs
+/// every live file instead, since whether a file takes part depends on its field group, not
+/// only on its size.
+///
+/// `row_id_window`, when set, restricts the scan to the files whose rows fall in that row id
+/// window, which is how a batched data-evolution run keeps one round's file metadata bounded.
+/// `snapshot_out` receives the snapshot that was scanned, so a later deletion-vector rewrite
+/// reads the very same table state.
+Result<LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>> ScanFiles(
     const std::shared_ptr<SnapshotManager>& snapshot_manager,
     const std::shared_ptr<SchemaManager>& schema_manager,
     const std::shared_ptr<TableSchema>& table_schema,
     const std::shared_ptr<arrow::Schema>& arrow_schema,
     const std::shared_ptr<arrow::Schema>& partition_schema, const CoreOptions& core_options,
     const std::shared_ptr<FileStorePathFactory>& path_factory,
-    const std::vector<std::map<std::string, std::string>>& partitions,
-    const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool) {
+    const std::vector<std::map<std::string, std::string>>& partitions, bool small_files_only,
+    const std::optional<Range>& row_id_window, const std::shared_ptr<Executor>& executor,
+    const std::shared_ptr<MemoryPool>& pool, std::optional<Snapshot>* snapshot_out) {
     auto scan_filter = std::make_shared<ScanFilter>(
         /*predicate=*/nullptr, partitions, /*bucket_filter=*/std::nullopt);
 
@@ -247,8 +353,16 @@ Result<LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>> Sca
     if (core_options.ManifestDeleteFileDropStats()) {
         scan->EnableDropStats();
     }
+    if (row_id_window.has_value()) {
+        PAIMON_ASSIGN_OR_RAISE(RowRangeIndex row_range_index,
+                               RowRangeIndex::Create({row_id_window.value()}));
+        scan->WithRowRangeIndex(row_range_index);
+    }
 
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileStoreScan::RawPlan> plan, scan->CreatePlan());
+    if (snapshot_out != nullptr) {
+        *snapshot_out = plan->GetSnapshot();
+    }
     std::vector<ManifestEntry> add_entries = plan->Files(FileKind::Add());
 
     int64_t compaction_file_size = core_options.GetCompactionFileSize(/*has_primary_key=*/false);
@@ -256,7 +370,7 @@ Result<LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>> Sca
 
     for (const auto& entry : add_entries) {
         const auto& file = entry.File();
-        if (file->file_size < compaction_file_size) {
+        if (!small_files_only || file->file_size < compaction_file_size) {
             partition_files[entry.Partition()].push_back(file);
         }
     }
@@ -279,6 +393,75 @@ std::vector<AppendCompactTask> GenerateCompactTasks(
         }
     }
     return tasks;
+}
+
+/// Cleans up the rewritten output files of already finished tasks, best effort. Used when a
+/// later task fails: the collected commit messages are discarded, so their outputs would
+/// otherwise linger until an orphan clean. Failures are logged and never mask the original
+/// compaction error the caller returns.
+void CleanupCompactOutputs(const std::vector<std::shared_ptr<CommitMessage>>& commit_messages,
+                           const std::shared_ptr<FileStorePathFactory>& path_factory,
+                           const CoreOptions& core_options) {
+    auto logger = Logger::GetLogger("AppendCompactCoordinator");
+    for (const auto& message : commit_messages) {
+        auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(message);
+        if (!message_impl) {
+            // The log macros require at least one format argument.
+            PAIMON_LOG_WARN(logger, "%s",
+                            "Skipping cleanup of a compact output: unexpected commit message "
+                            "type");
+            continue;
+        }
+        Result<std::shared_ptr<DataFilePathFactory>> data_file_path_factory =
+            path_factory->CreateDataFilePathFactory(message_impl->Partition(),
+                                                    message_impl->Bucket());
+        if (!data_file_path_factory.ok()) {
+            PAIMON_LOG_WARN(logger,
+                            "Skipping cleanup of compact outputs in partition %s bucket %d: %s",
+                            message_impl->Partition().ToString().c_str(), message_impl->Bucket(),
+                            data_file_path_factory.status().ToString().c_str());
+            continue;
+        }
+        for (const auto& file : message_impl->GetCompactIncrement().CompactAfter()) {
+            for (const auto& path : data_file_path_factory.value()->CollectFiles(file)) {
+                auto status = core_options.GetFileSystem()->Delete(path);
+                if (!status.ok()) {
+                    PAIMON_LOG_WARN(logger, "Failed to delete compact output %s: %s", path.c_str(),
+                                    status.ToString().c_str());
+                }
+            }
+        }
+    }
+}
+
+/// Execute data-evolution compact tasks synchronously and collect commit messages.
+Result<std::vector<std::shared_ptr<CommitMessage>>> ExecuteDataEvolutionNormalCompactTasks(
+    std::vector<DataEvolutionNormalCompactTask>&& tasks, const std::string& table_path,
+    const std::shared_ptr<TableSchema>& table_schema,
+    const std::shared_ptr<arrow::Schema>& arrow_schema, const CoreOptions& core_options,
+    const std::shared_ptr<FileStorePathFactory>& path_factory,
+    const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool) {
+    DataEvolutionCompactContext context{table_path,   table_schema, arrow_schema, core_options,
+                                        path_factory, executor,     pool};
+    auto logger = Logger::GetLogger("AppendCompactCoordinator");
+    PAIMON_LOG_DEBUG(logger, "Executing %zu data-evolution compact tasks for table %s",
+                     tasks.size(), table_path.c_str());
+
+    std::vector<std::shared_ptr<CommitMessage>> commit_messages;
+    commit_messages.reserve(tasks.size());
+    for (auto& task : tasks) {
+        Result<std::shared_ptr<CommitMessage>> message = task.DoCompact(context);
+        if (!message.ok()) {
+            PAIMON_LOG_WARN(logger, "Data-evolution compact task failed: %s, status: %s",
+                            task.ToString().c_str(), message.status().ToString().c_str());
+            // The failed task aborted its own output; the finished tasks' outputs will never
+            // be committed anymore, so remove them too.
+            CleanupCompactOutputs(commit_messages, path_factory, core_options);
+            return message.status();
+        }
+        commit_messages.push_back(std::move(message).value());
+    }
+    return commit_messages;
 }
 
 /// Execute compact tasks synchronously and collect commit messages.
@@ -304,6 +487,302 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> ExecuteCompactTasks(
         commit_messages.push_back(std::move(message));
     }
     return commit_messages;
+}
+
+/// Commits one round's messages under `commit_user`.
+///
+/// The compaction options are passed through so the commit reaches the table through the same
+/// file system and manifest settings the rest of the run used.
+///
+/// `materialize_row_id_check_from_snapshot` carries the snapshot a materialization was planned
+/// against. Such a commit drops the rows of the ranges it rewrites and has the commit assign
+/// new row ids to the survivors, so anything another writer added over those ranges since then
+/// has to fail the commit rather than be left addressing rows that moved.
+Status CommitRound(
+    const std::string& table_path, const std::string& commit_user, const CoreOptions& core_options,
+    const std::vector<std::shared_ptr<CommitMessage>>& messages,
+    const std::shared_ptr<Executor>& executor, const std::shared_ptr<MemoryPool>& pool,
+    const std::optional<int64_t>& materialize_row_id_check_from_snapshot = std::nullopt) {
+    CommitContextBuilder builder(table_path, commit_user);
+    builder.SetOptions(core_options.ToMap())
+        .WithFileSystem(core_options.GetFileSystem())
+        .WithExecutor(executor)
+        .WithMemoryPool(pool);
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> commit_context, builder.Finish());
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> file_store_commit,
+                           FileStoreCommit::Create(std::move(commit_context)));
+    if (materialize_row_id_check_from_snapshot) {
+        file_store_commit->RowIdCheckConflictForMaterializeDeletionVectors(
+            materialize_row_id_check_from_snapshot);
+    }
+    return file_store_commit->Commit(messages);
+}
+
+/// Builds the deletion file of each data file of one partition from the index metas the
+/// snapshot records for it, which already say where every vector sits.
+Result<std::map<std::string, DeletionFile>> CollectDeletionFiles(
+    const std::shared_ptr<IndexFileHandler>& index_file_handler, const BinaryRow& partition,
+    const std::vector<std::shared_ptr<IndexFileMeta>>& index_metas) {
+    std::map<std::string, DeletionFile> result;
+    for (const auto& index_meta : index_metas) {
+        const std::optional<LinkedHashMap<std::string, DeletionVectorMeta>>& dv_metas =
+            index_meta->DvRanges();
+        if (dv_metas == std::nullopt) {
+            return Status::Invalid(
+                fmt::format("Deletion vector index file {} has no deletion vector metas.",
+                            index_meta->FileName()));
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::string path,
+                               index_file_handler->FilePath(partition, /*bucket=*/0, index_meta));
+        for (const auto& [data_file_name, dv_meta] : dv_metas.value()) {
+            auto inserted = result.emplace(
+                data_file_name, DeletionFile(path, dv_meta.GetOffset(), dv_meta.GetLength(),
+                                             dv_meta.GetCardinality()));
+            if (!inserted.second) {
+                return Status::Invalid(fmt::format(
+                    "Data file {} has a deletion vector in more than one index file of the same "
+                    "partition.",
+                    data_file_name));
+            }
+        }
+    }
+    return result;
+}
+
+/// Plans one materialize task per contiguous row id run that carries deletions.
+///
+/// Runs are not packed into bins by their estimated size after the deletions are applied: the
+/// run is streamed through the reader and the output is split by the table's ordinary rolling
+/// rules, so a long run costs bounded memory either way, and a run without a single deletion
+/// is skipped rather than rewritten.
+Result<std::vector<DataEvolutionMaterializeDeletionCompactTask>> PlanMaterializeTasks(
+    const LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>& partition_files,
+    const std::shared_ptr<IndexFileHandler>& index_file_handler, const Snapshot& snapshot) {
+    // One scan for every partition of the round rather than one per partition: the index
+    // manifest is a single file, and scanning it per partition would read it once per
+    // partition the round touched.
+    std::unordered_set<BinaryRow> partitions;
+    for (const auto& [partition, files] : partition_files) {
+        partitions.insert(partition);
+    }
+    IndexFileHandler::IndexFileMetaGroups index_metas_by_group;
+    PAIMON_ASSIGN_OR_RAISE(
+        index_metas_by_group,
+        index_file_handler->Scan(snapshot, DeletionVectorsIndexFile::DELETION_VECTORS_INDEX,
+                                 partitions));
+
+    std::vector<DataEvolutionMaterializeDeletionCompactTask> tasks;
+    for (const auto& [partition, files] : partition_files) {
+        auto index_metas = index_metas_by_group.find({partition, /*bucket=*/0});
+        if (index_metas == index_metas_by_group.end()) {
+            continue;
+        }
+        std::map<std::string, DeletionFile> deletion_files;
+        PAIMON_ASSIGN_OR_RAISE(deletion_files, CollectDeletionFiles(index_file_handler, partition,
+                                                                    index_metas->second));
+        if (deletion_files.empty()) {
+            continue;
+        }
+        // Contiguous runs, the same adjacency the compaction planner uses: files whose ranges
+        // touch belong to one run and have to be rewritten together, because a run is what a
+        // reassignment of row ids can be kept self-consistent over.
+        std::vector<std::shared_ptr<DataFileMeta>> run_candidates = files;
+        RangeHelper<std::shared_ptr<DataFileMeta>> adjacency_helper(
+            [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+                return file->NonNullFirstRowId();
+            },
+            [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+                PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+                return first_row_id + file->row_count;
+            });
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> runs,
+                               adjacency_helper.MergeOverlappingRanges(std::move(run_candidates)));
+        for (auto& run : runs) {
+            std::vector<std::optional<DeletionFile>> aligned;
+            aligned.reserve(run.size());
+            bool has_deletions = false;
+            for (const auto& file : run) {
+                auto deletion_file = deletion_files.find(file->file_name);
+                if (deletion_file == deletion_files.end()) {
+                    aligned.push_back(std::nullopt);
+                } else {
+                    aligned.push_back(deletion_file->second);
+                    has_deletions = true;
+                }
+            }
+            if (!has_deletions) {
+                continue;
+            }
+            PAIMON_ASSIGN_OR_RAISE(
+                DataEvolutionMaterializeDeletionCompactTask task,
+                DataEvolutionMaterializeDeletionCompactTask::Create(partition, run, aligned));
+            tasks.push_back(std::move(task));
+        }
+    }
+    return tasks;
+}
+
+/// Runs one data-evolution compaction round over `row_id_window`: scan, plan, rewrite the
+/// files, then move the deletion vectors of the rewritten row range groups onto the new
+/// files.
+///
+/// The returned messages belong to one atomic commit: the index-only messages re-key the
+/// deletions of exactly the files the data messages replace, so committing the data without
+/// them would resurrect deleted rows.
+Result<std::vector<std::shared_ptr<CommitMessage>>> RunDataEvolutionRound(
+    const std::string& table_path, const std::shared_ptr<SnapshotManager>& snapshot_manager,
+    const std::shared_ptr<SchemaManager>& schema_manager,
+    const std::shared_ptr<TableSchema>& table_schema,
+    const std::shared_ptr<arrow::Schema>& arrow_schema,
+    const std::shared_ptr<arrow::Schema>& partition_schema, const CoreOptions& core_options,
+    const std::shared_ptr<FileStorePathFactory>& path_factory,
+    const std::vector<std::map<std::string, std::string>>& partitions,
+    const std::optional<Range>& row_id_window, const std::shared_ptr<Executor>& executor,
+    const std::shared_ptr<MemoryPool>& pool) {
+    std::optional<Snapshot> snapshot;
+    LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>> partition_files;
+    PAIMON_ASSIGN_OR_RAISE(
+        partition_files,
+        ScanFiles(snapshot_manager, schema_manager, table_schema, arrow_schema, partition_schema,
+                  core_options, path_factory, partitions, /*small_files_only=*/false, row_id_window,
+                  executor, pool, &snapshot));
+    if (partition_files.empty()) {
+        return std::vector<std::shared_ptr<CommitMessage>>{};
+    }
+
+    // Data-evolution tables compact across evolved field groups while preserving row ids; the
+    // plain append rewrite would reorder rows and drop the column merge, so it must not run
+    // here.
+    PAIMON_ASSIGN_OR_RAISE(
+        std::vector<DataEvolutionNormalCompactTask> tasks,
+        DataEvolutionCompactPlanner::PlanCompactTasks(partition_files, core_options));
+    if (tasks.empty()) {
+        return std::vector<std::shared_ptr<CommitMessage>>{};
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<CommitMessage>> messages,
+                           ExecuteDataEvolutionNormalCompactTasks(
+                               std::move(tasks), table_path, table_schema, arrow_schema,
+                               core_options, path_factory, executor, pool));
+    // Short-circuit before building the index handler. The rewriter re-checks the option
+    // itself, so this is an optimization rather than the safety net.
+    if (!core_options.DeletionVectorsEnabled() || messages.empty()) {
+        return messages;
+    }
+
+    // The rewrite kept every input row, so the deletions of the replaced files still apply —
+    // they only have to be re-keyed onto the file that now holds those rows.
+    if (!snapshot.has_value()) {
+        return Status::Invalid(
+            "Data-evolution compaction planned files without a snapshot to rewrite deletion "
+            "vectors against.");
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<IndexFileHandler> index_file_handler,
+                           BuildIndexFileHandler(path_factory, core_options, pool));
+    Result<std::vector<std::shared_ptr<CommitMessage>>> index_messages =
+        DataEvolutionCompactDeletionVectorRewriter::RewriteDeletionVectors(
+            messages, snapshot.value(), core_options, index_file_handler);
+    if (!index_messages.ok()) {
+        // The rewritten data files can never be committed without their deletions, so drop
+        // them instead of leaving them for an orphan clean.
+        CleanupCompactOutputs(messages, path_factory, core_options);
+        return index_messages.status();
+    }
+    for (auto& index_message : index_messages.value()) {
+        messages.push_back(std::move(index_message));
+    }
+    return messages;
+}
+
+/// Runs one materialization round over `row_id_window`.
+///
+/// Scans the live files the window covers, rewrites every row range in it that carries
+/// deletions, and returns the commit messages of that rewrite together with the index changes
+/// it needs: the vectors that go away with the rows they deleted, and the global indexes the
+/// new row ids invalidate. Empty when the window has nothing to materialize.
+///
+/// `planned_snapshot_id` receives the snapshot the round planned against, which the commit
+/// checks concurrent writers against.
+Result<std::vector<std::shared_ptr<CommitMessage>>> RunMaterializeRound(
+    const std::string& table_path, const std::shared_ptr<SnapshotManager>& snapshot_manager,
+    const std::shared_ptr<SchemaManager>& schema_manager,
+    const std::shared_ptr<TableSchema>& table_schema,
+    const std::shared_ptr<arrow::Schema>& arrow_schema,
+    const std::shared_ptr<arrow::Schema>& partition_schema, const CoreOptions& core_options,
+    const std::shared_ptr<FileStorePathFactory>& path_factory,
+    const std::vector<std::map<std::string, std::string>>& partitions,
+    const std::optional<Range>& row_id_window, const std::shared_ptr<Executor>& executor,
+    const std::shared_ptr<MemoryPool>& pool, Logger* logger,
+    std::optional<int64_t>* planned_snapshot_id) {
+    // Every live file of the window is needed, not only the small ones: a range is materialized
+    // because it carries deletions, whatever its files weigh.
+    std::optional<Snapshot> snapshot;
+    LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>> partition_files;
+    PAIMON_ASSIGN_OR_RAISE(
+        partition_files,
+        ScanFiles(snapshot_manager, schema_manager, table_schema, arrow_schema, partition_schema,
+                  core_options, path_factory, partitions, /*small_files_only=*/false, row_id_window,
+                  executor, pool, &snapshot));
+    if (partition_files.empty() || !snapshot.has_value()) {
+        return std::vector<std::shared_ptr<CommitMessage>>{};
+    }
+    *planned_snapshot_id = snapshot.value().Id();
+
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<IndexFileHandler> index_file_handler,
+                           BuildIndexFileHandler(path_factory, core_options, pool));
+    PAIMON_ASSIGN_OR_RAISE(
+        std::vector<DataEvolutionMaterializeDeletionCompactTask> tasks,
+        PlanMaterializeTasks(partition_files, index_file_handler, snapshot.value()));
+    if (tasks.empty()) {
+        return std::vector<std::shared_ptr<CommitMessage>>{};
+    }
+    PAIMON_LOG_DEBUG(logger, "Materializing deletion vectors of table %s in %zu task(s)",
+                     table_path.c_str(), tasks.size());
+
+    DataEvolutionCompactContext context{table_path,   table_schema, arrow_schema, core_options,
+                                        path_factory, executor,     pool};
+    std::vector<std::shared_ptr<CommitMessage>> messages;
+    messages.reserve(tasks.size());
+    for (auto& task : tasks) {
+        Result<std::shared_ptr<CommitMessage>> message = task.DoCompact(context);
+        if (!message.ok()) {
+            PAIMON_LOG_WARN(logger, "Materialize deletion task failed: %s, status: %s",
+                            task.ToString().c_str(), message.status().ToString().c_str());
+            CleanupCompactOutputs(messages, path_factory, core_options);
+            return message.status();
+        }
+        messages.push_back(std::move(message).value());
+    }
+
+    // The old vectors are removed rather than moved, and the global indexes of the touched
+    // partitions go with them: their row ids no longer exist. Both travel in the same commit as
+    // the rewritten data, so no reader ever sees the rows without their deletions applied.
+    Result<std::vector<std::shared_ptr<CommitMessage>>> index_messages =
+        DataEvolutionCompactDeletionVectorRewriter::RewriteDeletionVectors(
+            messages, snapshot.value(), core_options, index_file_handler);
+    if (!index_messages.ok()) {
+        CleanupCompactOutputs(messages, path_factory, core_options);
+        return index_messages.status();
+    }
+    // Scanned at the newest snapshot rather than the planned one, and the commit re-derives the
+    // deletions on every attempt, so an index another engine commits while this runs is dropped
+    // by this commit or by the retry it forces.
+    PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> latest_snapshot,
+                           snapshot_manager->LatestSnapshot());
+    Result<std::vector<std::shared_ptr<CommitMessage>>> dropped_indexes =
+        DataEvolutionCompactGlobalIndexDropper::DropGlobalIndexes(
+            messages, latest_snapshot.has_value() ? latest_snapshot.value() : snapshot.value(),
+            index_file_handler);
+    if (!dropped_indexes.ok()) {
+        CleanupCompactOutputs(messages, path_factory, core_options);
+        return dropped_indexes.status();
+    }
+    for (auto& index_message : index_messages.value()) {
+        messages.push_back(std::move(index_message));
+    }
+    for (auto& dropped_index : dropped_indexes.value()) {
+        messages.push_back(std::move(dropped_index));
+    }
+    return messages;
 }
 
 }  // namespace
@@ -338,12 +817,31 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> AppendCompactCoordinator::Ru
         std::shared_ptr<FileStorePathFactory> path_factory,
         BuildPathFactory(table_path, table_schema, arrow_schema, core_options, pool));
 
-    // Scan small files from latest snapshot
+    // The legacy row-id rewriting mode is gone; a table whose options still carry it fails
+    // instead of having the option silently ignored. Checked before any scanning, so even an
+    // empty table fails loudly.
+    bool data_evolution = core_options.DataEvolutionEnabled();
+    if (data_evolution && core_options.DataEvolutionCompactionRewriteRowIds()) {
+        return Status::Invalid(fmt::format(
+            "'{}' is no longer supported: normal data-evolution compaction preserves row ids "
+            "and logical deletions.",
+            Options::DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS));
+    }
+
+    if (data_evolution) {
+        // One round over the whole snapshot: Run hands its messages back for the caller to
+        // commit, so it cannot split the work across commits. RunAndCommit does that.
+        return RunDataEvolutionRound(table_path, snapshot_manager, schema_manager, table_schema,
+                                     arrow_schema, partition_schema, core_options, path_factory,
+                                     partitions, /*row_id_window=*/std::nullopt, executor, pool);
+    }
+
     LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>> partition_files;
     PAIMON_ASSIGN_OR_RAISE(
         partition_files,
-        ScanSmallFiles(snapshot_manager, schema_manager, table_schema, arrow_schema,
-                       partition_schema, core_options, path_factory, partitions, executor, pool));
+        ScanFiles(snapshot_manager, schema_manager, table_schema, arrow_schema, partition_schema,
+                  core_options, path_factory, partitions, /*small_files_only=*/true,
+                  /*row_id_window=*/std::nullopt, executor, pool, /*snapshot_out=*/nullptr));
 
     if (partition_files.empty()) {
         return std::vector<std::shared_ptr<CommitMessage>>{};
@@ -359,6 +857,212 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> AppendCompactCoordinator::Ru
     return ExecuteCompactTasks(std::move(tasks), path_factory, snapshot_manager, schema_manager,
                                table_path, table_schema, arrow_schema, partition_schema,
                                core_options, executor, pool);
+}
+
+Result<int32_t> AppendCompactCoordinator::RunAndCommit(
+    const std::string& table_path, const std::map<std::string, std::string>& options,
+    const std::vector<std::map<std::string, std::string>>& partitions,
+    const std::string& commit_user, const std::shared_ptr<FileSystem>& file_system,
+    const std::shared_ptr<MemoryPool>& input_pool, int64_t candidate_files_per_round) {
+    if (commit_user.empty()) {
+        return Status::Invalid("AppendCompactCoordinator::RunAndCommit needs a commit user.");
+    }
+    if (candidate_files_per_round <= 0) {
+        return Status::Invalid(fmt::format(
+            "candidate_files_per_round must be positive, but was {}.", candidate_files_per_round));
+    }
+    auto pool = input_pool ? input_pool : GetDefaultPool();
+    std::shared_ptr<Executor> executor = CreateDefaultExecutor();
+    auto logger = Logger::GetLogger("AppendCompactCoordinator");
+
+    std::pair<std::shared_ptr<TableSchema>, CoreOptions> schema_and_options;
+    PAIMON_ASSIGN_OR_RAISE(schema_and_options,
+                           LoadSchemaAndOptions(table_path, options, file_system));
+    const auto& [table_schema, core_options] = schema_and_options;
+    PAIMON_RETURN_NOT_OK(ValidateTable(table_schema, core_options));
+
+    auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<arrow::Schema> partition_schema,
+        FieldMapping::GetPartitionSchema(arrow_schema, table_schema->PartitionKeys()));
+    auto snapshot_manager =
+        std::make_shared<SnapshotManager>(core_options.GetFileSystem(), table_path);
+    auto schema_manager = std::make_shared<SchemaManager>(core_options.GetFileSystem(), table_path);
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<FileStorePathFactory> path_factory,
+        BuildPathFactory(table_path, table_schema, arrow_schema, core_options, pool));
+
+    if (!core_options.DataEvolutionEnabled()) {
+        // A plain append table has no row id space to split on, so it keeps the single-round
+        // behaviour and only gains the commit.
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<CommitMessage>> messages,
+                               Run(table_path, options, partitions, file_system, pool));
+        if (messages.empty()) {
+            return 0;
+        }
+        PAIMON_RETURN_NOT_OK(
+            CommitRound(table_path, commit_user, core_options, messages, executor, pool));
+        return 1;
+    }
+    if (core_options.DataEvolutionCompactionRewriteRowIds()) {
+        return Status::Invalid(fmt::format(
+            "'{}' is no longer supported: normal data-evolution compaction preserves row ids "
+            "and logical deletions.",
+            Options::DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS));
+    }
+
+    // The windows are planned once, against the snapshot the run starts from; every round
+    // then re-scans and sees the rounds committed before it. That re-scan re-reads the
+    // snapshot and the manifest list, but not most of the manifest files: a manifest is
+    // pruned by its recorded row id range, and because windows are cut only at coverage gaps
+    // it belongs to exactly one round. `DataEvolutionCompactPlanner::PlanRowIdWindows`
+    // documents the one exception, a delete-only manifest without row id statistics.
+    PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> snapshot, snapshot_manager->LatestSnapshot());
+    if (!snapshot.has_value()) {
+        return 0;
+    }
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<ManifestList> manifest_list,
+        ManifestList::Create(core_options.GetFileSystem(), core_options.GetManifestFormat(),
+                             core_options.GetManifestCompression(), path_factory,
+                             core_options.GetCache(), pool));
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<PredicateFilter> partition_filter,
+                           FileStoreScan::CreatePartitionPredicate(
+                               table_schema->PartitionKeys(),
+                               core_options.GetPartitionDefaultName(), arrow_schema, partitions));
+    PAIMON_ASSIGN_OR_RAISE(std::vector<Range> windows,
+                           DataEvolutionCompactPlanner::PlanRowIdWindows(
+                               manifest_list, snapshot.value(), partition_filter, partition_schema,
+                               candidate_files_per_round, logger.get()));
+    if (windows.empty()) {
+        // Nothing to split on; one unbounded round still commits correctly.
+        windows.emplace_back(0, std::numeric_limits<int64_t>::max());
+    }
+    PAIMON_LOG_DEBUG(logger, "Compacting table %s in %zu round(s)", table_path.c_str(),
+                     windows.size());
+
+    int32_t committed_rounds = 0;
+    for (const auto& window : windows) {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<std::shared_ptr<CommitMessage>> messages,
+            RunDataEvolutionRound(table_path, snapshot_manager, schema_manager, table_schema,
+                                  arrow_schema, partition_schema, core_options, path_factory,
+                                  partitions, window, executor, pool));
+        if (messages.empty()) {
+            continue;
+        }
+        Status commit_status =
+            CommitRound(table_path, commit_user, core_options, messages, executor, pool);
+        if (!commit_status.ok()) {
+            // The round's rewritten data files are unreachable once its commit failed, and the
+            // rounds already committed stay committed: compaction is idempotent, a later run
+            // re-plans whatever is left. A deletion-vector index file the round may have
+            // written is left to orphan cleaning, which is what collects unreferenced index
+            // files.
+            CleanupCompactOutputs(messages, path_factory, core_options);
+            return commit_status;
+        }
+        committed_rounds++;
+    }
+    return committed_rounds;
+}
+
+Result<int32_t> AppendCompactCoordinator::MaterializeDeletionVectors(
+    const std::string& table_path, const std::map<std::string, std::string>& options,
+    const std::vector<std::map<std::string, std::string>>& partitions,
+    const std::string& commit_user, const std::shared_ptr<FileSystem>& file_system,
+    const std::shared_ptr<MemoryPool>& input_pool) {
+    if (commit_user.empty()) {
+        return Status::Invalid(
+            "AppendCompactCoordinator::MaterializeDeletionVectors needs a commit user.");
+    }
+    auto pool = input_pool ? input_pool : GetDefaultPool();
+    std::shared_ptr<Executor> executor = CreateDefaultExecutor();
+    auto logger = Logger::GetLogger("AppendCompactCoordinator");
+
+    std::pair<std::shared_ptr<TableSchema>, CoreOptions> schema_and_options;
+    PAIMON_ASSIGN_OR_RAISE(schema_and_options,
+                           LoadSchemaAndOptions(table_path, options, file_system));
+    const auto& [table_schema, core_options] = schema_and_options;
+    PAIMON_RETURN_NOT_OK(ValidateTable(table_schema, core_options));
+    if (!core_options.DataEvolutionEnabled()) {
+        return Status::Invalid(
+            "Materializing deletion vectors is only supported for data-evolution tables.");
+    }
+    if (!core_options.DeletionVectorsEnabled()) {
+        return Status::Invalid(
+            "Materializing deletion vectors needs 'deletion-vectors.enabled' to be set.");
+    }
+
+    auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<arrow::Schema> partition_schema,
+        FieldMapping::GetPartitionSchema(arrow_schema, table_schema->PartitionKeys()));
+    auto snapshot_manager =
+        std::make_shared<SnapshotManager>(core_options.GetFileSystem(), table_path);
+    auto schema_manager = std::make_shared<SchemaManager>(core_options.GetFileSystem(), table_path);
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<FileStorePathFactory> path_factory,
+        BuildPathFactory(table_path, table_schema, arrow_schema, core_options, pool));
+
+    // The windows are planned once, against the snapshot this call starts from, and every
+    // round then re-scans so it observes the rounds committed before it. Materialized rows are
+    // renumbered from the table's next row id, past every row id the commits handed out, so a
+    // later round never re-plans what an earlier one rewrote.
+    PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> start_snapshot,
+                           snapshot_manager->LatestSnapshot());
+    if (!start_snapshot.has_value()) {
+        return 0;
+    }
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<ManifestList> manifest_list,
+        ManifestList::Create(core_options.GetFileSystem(), core_options.GetManifestFormat(),
+                             core_options.GetManifestCompression(), path_factory,
+                             core_options.GetCache(), pool));
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<PredicateFilter> partition_filter,
+                           FileStoreScan::CreatePartitionPredicate(
+                               table_schema->PartitionKeys(),
+                               core_options.GetPartitionDefaultName(), arrow_schema, partitions));
+    PAIMON_ASSIGN_OR_RAISE(std::vector<Range> windows,
+                           DataEvolutionCompactPlanner::PlanRowIdWindows(
+                               manifest_list, start_snapshot.value(), partition_filter,
+                               partition_schema, kDefaultCandidateFilesPerRound, logger.get()));
+    if (windows.empty()) {
+        // Nothing to split on; one unbounded round still materializes correctly.
+        windows.emplace_back(0, std::numeric_limits<int64_t>::max());
+    }
+    PAIMON_LOG_DEBUG(logger, "Materializing deletion vectors of table %s in %zu round(s)",
+                     table_path.c_str(), windows.size());
+
+    int32_t committed_rounds = 0;
+    for (const auto& window : windows) {
+        std::optional<int64_t> planned_snapshot_id;
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<std::shared_ptr<CommitMessage>> messages,
+            RunMaterializeRound(table_path, snapshot_manager, schema_manager, table_schema,
+                                arrow_schema, partition_schema, core_options, path_factory,
+                                partitions, window, executor, pool, logger.get(),
+                                &planned_snapshot_id));
+        if (messages.empty()) {
+            continue;
+        }
+        Status commit_status =
+            CommitRound(table_path, commit_user, core_options, messages, executor, pool,
+                        /*materialize_row_id_check_from_snapshot=*/planned_snapshot_id);
+        if (!commit_status.ok()) {
+            // The round's rewritten files are unreachable once its commit failed, and the
+            // rounds already committed stay committed: a later call re-plans whatever is left.
+            CleanupCompactOutputs(messages, path_factory, core_options);
+            return commit_status;
+        }
+        committed_rounds++;
+    }
+    if (committed_rounds == 0) {
+        PAIMON_LOG_DEBUG(
+            logger, "Nothing to materialize for table %s: no row range carries a deletion vector.",
+            table_path.c_str());
+    }
+    return committed_rounds;
 }
 
 }  // namespace paimon

--- a/src/paimon/core/append/append_compact_coordinator_test.cpp
+++ b/src/paimon/core/append/append_compact_coordinator_test.cpp
@@ -289,6 +289,83 @@ TEST_F(AppendCompactCoordinatorTest, TestRunCompactsAllPartitions) {
     ScanAndVerify(table_path, fields, expected_datas);
 }
 
+/// Test that AppendCompactCoordinator::RunAndCommit commits its own results on a plain append
+/// table, which has no row id space to split into rounds.
+TEST_F(AppendCompactCoordinatorTest, TestRunAndCommitOnPlainAppendTable) {
+    std::map<std::string, std::string> options = {
+        {Options::FILE_FORMAT, "parquet"},
+        {Options::BUCKET, "-1"},
+        {Options::FILE_SYSTEM, "local"},
+        {Options::COMPACTION_MIN_FILE_NUM, "2"},
+    };
+
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::utf8()), arrow::field("f1", arrow::int32()),
+        arrow::field("f2", arrow::int32()), arrow::field("f3", arrow::float64())};
+    CreateTable(fields, /*partition_keys=*/{"f1"}, options);
+
+    auto table_path = TablePath();
+    auto data_type = arrow::struct_(fields);
+
+    {
+        auto array = arrow::ipc::internal::json::ArrayFromJSON(data_type, R"([
+            ["Alice", 10, 1, 11.1],
+            ["Bob", 10, 0, 12.1],
+            ["Emily", 10, 0, 13.1],
+            ["Tony", 10, 0, 14.1]
+        ])")
+                         .ValueOrDie();
+        ASSERT_OK(WriteAndCommit(table_path, {{"f1", "10"}}, /*bucket=*/0, array,
+                                 /*commit_identifier=*/0));
+    }
+    {
+        auto array = arrow::ipc::internal::json::ArrayFromJSON(data_type, R"([
+            ["Emily", 10, 0, 15.1],
+            ["Bob", 10, 0, 12.1],
+            ["Alex", 10, 0, 16.1]
+        ])")
+                         .ValueOrDie();
+        ASSERT_OK(WriteAndCommit(table_path, {{"f1", "10"}}, /*bucket=*/0, array,
+                                 /*commit_identifier=*/1));
+    }
+
+    // One round, committed here rather than by the caller.
+    ASSERT_OK_AND_ASSIGN(int32_t commits,
+                         AppendCompactCoordinator::RunAndCommit(
+                             table_path, options, /*partitions=*/{},
+                             /*commit_user=*/"commit_user_1", /*file_system=*/nullptr, pool_));
+    ASSERT_EQ(commits, 1);
+
+    // The compaction is visible without the caller committing anything.
+    std::map<std::pair<std::string, int32_t>, std::string> expected_datas;
+    // Files are sorted by file_size ascending in PackFiles, so the smaller file (3 rows) comes
+    // before the larger one (4 rows).
+    expected_datas[std::make_pair("f1=10/", 0)] = R"([
+[0, "Emily", 10, 0, 15.1],
+[0, "Bob", 10, 0, 12.1],
+[0, "Alex", 10, 0, 16.1],
+[0, "Alice", 10, 1, 11.1],
+[0, "Bob", 10, 0, 12.1],
+[0, "Emily", 10, 0, 13.1],
+[0, "Tony", 10, 0, 14.1]
+])";
+    ScanAndVerify(table_path, fields, expected_datas);
+
+    // Only the rewritten file is left, which is fewer than 'compaction.min.file-num': there is
+    // nothing to compact and nothing to commit.
+    ASSERT_OK_AND_ASSIGN(
+        commits, AppendCompactCoordinator::RunAndCommit(table_path, options, /*partitions=*/{},
+                                                        /*commit_user=*/"commit_user_1",
+                                                        /*file_system=*/nullptr, pool_));
+    ASSERT_EQ(commits, 0);
+
+    // A commit needs a user to record on the snapshot.
+    ASSERT_NOK_WITH_MSG(
+        AppendCompactCoordinator::RunAndCommit(table_path, options, /*partitions=*/{},
+                                               /*commit_user=*/"", /*file_system=*/nullptr, pool_),
+        "needs a commit user");
+}
+
 /// Test that AppendCompactCoordinator::Run only compacts the specified partition.
 ///
 /// Steps:
@@ -508,7 +585,28 @@ TEST_F(AppendCompactCoordinatorTest, TestValidateFailsOnDvTable) {
 
     ASSERT_NOK_WITH_MSG(AppendCompactCoordinator::Run(TablePath(), options, /*partitions=*/{},
                                                       /*file_system=*/nullptr, pool_),
-                        "not support for dv in UNAWARE_BUCKET mode");
+                        "does not support deletion vectors in UNAWARE_BUCKET mode");
+}
+
+/// Test that materializing deletion vectors is refused on a table that has none to materialize.
+TEST_F(AppendCompactCoordinatorTest, TestMaterializeFailsOnPlainAppendTable) {
+    // Materializing rewrites row ranges and lets the commit assign fresh row ids, which only a
+    // data-evolution table can absorb. On a plain append table the entry point must refuse
+    // rather than rewrite files for nothing.
+    std::map<std::string, std::string> options = {{Options::FILE_FORMAT, "parquet"},
+                                                  {Options::BUCKET, "-1"},
+                                                  {Options::FILE_SYSTEM, "local"}};
+
+    arrow::FieldVector fields = {
+        arrow::field("f0", arrow::utf8()), arrow::field("f1", arrow::int32()),
+        arrow::field("f2", arrow::int32()), arrow::field("f3", arrow::float64())};
+    CreateTable(fields, /*partition_keys=*/{"f1"}, options);
+
+    ASSERT_NOK_WITH_MSG(
+        AppendCompactCoordinator::MaterializeDeletionVectors(
+            TablePath(), options, /*partitions=*/{}, /*commit_user=*/"commit_user_1",
+            /*file_system=*/nullptr, pool_),
+        "Materializing deletion vectors is only supported for data-evolution tables");
 }
 
 /// Test that compact output files are written to external path when configured.

--- a/src/paimon/core/append/data_evolution_compact_deletion_vector_rewriter.cpp
+++ b/src/paimon/core/append/data_evolution_compact_deletion_vector_rewriter.cpp
@@ -1,0 +1,407 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_compact_deletion_vector_rewriter.h"
+
+#include <map>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+#include "fmt/format.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/linked_hash_map.h"
+#include "paimon/common/utils/range_helper.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/deletionvectors/deletion_vector.h"
+#include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
+#include "paimon/core/index/deletion_vector_meta.h"
+#include "paimon/core/index/index_file_handler.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/table/source/deletion_file.h"
+#include "paimon/core/utils/data_evolution_utils.h"
+#include "paimon/logging.h"
+#include "paimon/utils/range.h"
+
+namespace paimon {
+
+namespace {
+
+/// Bucket every data-evolution compact message writes to. Unaware-bucket tables keep the
+/// legacy single bucket, and the rewritten index files have to land in the same one.
+constexpr int32_t kUnawareBucket = 0;
+
+/// One deletion-vector index file of a partition, described by metadata alone: which data
+/// files it stores a vector for and where in the file each vector sits.
+///
+/// Nothing is deserialized to build this. A vector is read only when a move actually takes it
+/// away, and the vectors that stay are read only for the index files a move touched, so an
+/// untouched index file is never opened.
+struct IndexFileState {
+    std::shared_ptr<IndexFileMeta> meta;
+    std::string path;
+    /// The vectors this index file still owns, in write order.
+    LinkedHashMap<std::string, DeletionVectorMeta> dv_metas;
+    bool dirty;
+};
+
+/// The recorded position of one vector inside its index file.
+DeletionFile ToDeletionFile(const std::string& index_file_path, const DeletionVectorMeta& dv_meta) {
+    return DeletionFile(index_file_path, dv_meta.GetOffset(), dv_meta.GetLength(),
+                        dv_meta.GetCardinality());
+}
+
+/// The files a rewritten deletion vector has to be keyed by after one compact task: the
+/// task's inputs, whose per-group anchors hold the deletions today, and the single output
+/// file they were merged into.
+///
+/// A materialized task has no such output. It applied the deletions while rewriting, so its
+/// rows carry fresh row ids the commit assigns and the old vectors are dropped rather than
+/// moved; `after` is null and `after_range` unused for one of those.
+struct CompactedGroup {
+    std::vector<std::shared_ptr<DataFileMeta>> before;
+    std::shared_ptr<DataFileMeta> after;
+    Range after_range;
+    bool materialized = false;
+};
+
+std::vector<std::shared_ptr<DataFileMeta>> NormalFiles(
+    const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+    std::vector<std::shared_ptr<DataFileMeta>> result;
+    result.reserve(files.size());
+    for (const auto& file : files) {
+        if (DataEvolutionUtils::IsNormalFile(file->file_name)) {
+            result.push_back(file);
+        }
+    }
+    return result;
+}
+
+Result<Range> RowRangeOf(const std::shared_ptr<DataFileMeta>& file) {
+    PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+    return Range(first_row_id, first_row_id + file->row_count - 1);
+}
+
+/// Merges the files of one compact task into row range groups: files covering the same rows
+/// belong to the same group and share one deletion vector, keyed by the group's anchor.
+Result<std::vector<std::vector<std::shared_ptr<DataFileMeta>>>> RowRangeGroups(
+    std::vector<std::shared_ptr<DataFileMeta>>&& files) {
+    RangeHelper<std::shared_ptr<DataFileMeta>> helper(
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            return file->NonNullFirstRowId();
+        },
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+            return first_row_id + file->row_count - 1;
+        });
+    return helper.MergeOverlappingRanges(std::move(files));
+}
+
+/// Collects the compacted groups of each partition, validating the shape data-evolution
+/// compaction is expected to produce.
+Result<LinkedHashMap<BinaryRow, std::vector<CompactedGroup>>> CollectCompactedGroups(
+    const std::vector<std::shared_ptr<CommitMessage>>& compact_messages) {
+    LinkedHashMap<BinaryRow, std::vector<CompactedGroup>> result;
+    for (const auto& message : compact_messages) {
+        auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(message);
+        if (message_impl == nullptr) {
+            return Status::Invalid(
+                "Data evolution compaction produced an unexpected commit message type.");
+        }
+        const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+        // The rewriter owns every index change of this round; a task that already produced
+        // one would be silently dropped by the index-only messages built below.
+        if (!compact_increment.NewIndexFiles().empty() ||
+            !compact_increment.DeletedIndexFiles().empty()) {
+            return Status::Invalid(
+                "Data evolution compaction should not produce index changes before the "
+                "deletion vector rewrite.");
+        }
+        if (message_impl->Bucket() != kUnawareBucket ||
+            message_impl->TotalBuckets() != std::nullopt) {
+            return Status::Invalid(fmt::format(
+                "Data evolution compaction should only produce unaware-bucket commit messages, "
+                "but got bucket {}.",
+                message_impl->Bucket()));
+        }
+
+        std::vector<std::shared_ptr<DataFileMeta>> before =
+            NormalFiles(compact_increment.CompactBefore());
+        std::vector<std::shared_ptr<DataFileMeta>> after =
+            NormalFiles(compact_increment.CompactAfter());
+        // A blob-only or index-only message carries no rows whose deletions could move.
+        if (before.empty() && after.empty()) {
+            continue;
+        }
+        // A materialized task wrote its rows without row ids, so the commit assigns fresh ones
+        // and the deletions it applied must not follow them: the old vectors are dropped
+        // rather than moved. The global index dropper and the commit's conflict check decide
+        // the same shape through the same helper.
+        bool materialized = DataEvolutionUtils::IsMaterializedCompaction(
+            compact_increment.CompactBefore(), compact_increment.CompactAfter());
+        if (materialized) {
+            result[message_impl->Partition()].push_back(
+                CompactedGroup{std::move(before), /*after=*/nullptr, Range(0, 0),
+                               /*materialized=*/true});
+            continue;
+        }
+        if (after.size() != 1) {
+            return Status::Invalid(
+                "One data evolution compact task should produce exactly one normal file.");
+        }
+        PAIMON_ASSIGN_OR_RAISE(Range after_range, RowRangeOf(after[0]));
+        // A task that keeps its rows in place must cover exactly the rows it replaced, or the
+        // deletions would move onto the wrong ones.
+        PAIMON_ASSIGN_OR_RAISE(Range before_range,
+                               DataEvolutionUtils::CheckContiguousRowRange(before));
+        if (!(before_range == after_range)) {
+            return Status::Invalid(fmt::format(
+                "Data evolution compaction must keep the same row id range, but compacted {} "
+                "into {}.",
+                before_range.ToString(), after_range.ToString()));
+        }
+        result[message_impl->Partition()].push_back(
+            CompactedGroup{std::move(before), after[0], after_range, /*materialized=*/false});
+    }
+    return result;
+}
+
+/// Moves one row range group's deletion vector from its anchor file onto `merged`, whose
+/// positions are relative to `after_range`.
+Status MoveDeletionVector(const std::shared_ptr<DeletionVector>& old_vector,
+                          const Range& anchor_range, const Range& after_range,
+                          const std::shared_ptr<DeletionVector>& merged) {
+    if (anchor_range == after_range) {
+        // The group already spans the whole compacted file: the vector only changes its key.
+        return merged->Merge(old_vector);
+    }
+    // The compacted file starts at or before the group it absorbed, so a group's positions
+    // shift right by the distance between the two starts.
+    int64_t shift = anchor_range.from - after_range.from;
+    int64_t after_count = after_range.Count();
+    return old_vector->ForEachDeletedPosition([&](int64_t position) -> Status {
+        int64_t moved = position + shift;
+        if (moved < 0 || moved >= after_count) {
+            return Status::Invalid(fmt::format(
+                "Cannot move deletion position {} of row range {} into row range {}.",
+                anchor_range.from + position, anchor_range.ToString(), after_range.ToString()));
+        }
+        return merged->Delete(moved);
+    });
+}
+
+}  // namespace
+
+Result<std::vector<std::shared_ptr<CommitMessage>>>
+DataEvolutionCompactDeletionVectorRewriter::RewriteDeletionVectors(
+    const std::vector<std::shared_ptr<CommitMessage>>& compact_messages, const Snapshot& snapshot,
+    const CoreOptions& core_options, const std::shared_ptr<IndexFileHandler>& index_file_handler) {
+    // Guarded here as well as at the call site: a table without deletion vectors has nothing
+    // to move, and a future caller that forgets to pre-check stays correct.
+    if (!core_options.DeletionVectorsEnabled() || compact_messages.empty()) {
+        return std::vector<std::shared_ptr<CommitMessage>>{};
+    }
+    // Declared first: a template type with a comma cannot be spelled inside the macro, which
+    // would take it for a second macro argument.
+    LinkedHashMap<BinaryRow, std::vector<CompactedGroup>> compacted_groups_by_partition;
+    PAIMON_ASSIGN_OR_RAISE(compacted_groups_by_partition, CollectCompactedGroups(compact_messages));
+    // A round that replaced no normal file - a blob-only message, say - holds no row range
+    // whose deletions could move, so it never reads the index at all.
+    if (compacted_groups_by_partition.empty()) {
+        return std::vector<std::shared_ptr<CommitMessage>>{};
+    }
+
+    // One scan for every partition of the round rather than one per partition: the index
+    // manifest is a single file, and scanning it per partition would read it once per
+    // partition the round touched.
+    std::unordered_set<BinaryRow> partitions;
+    for (const auto& [partition, groups] : compacted_groups_by_partition) {
+        partitions.insert(partition);
+    }
+    IndexFileHandler::IndexFileMetaGroups index_metas_by_group;
+    PAIMON_ASSIGN_OR_RAISE(
+        index_metas_by_group,
+        index_file_handler->Scan(snapshot, DeletionVectorsIndexFile::DELETION_VECTORS_INDEX,
+                                 partitions));
+
+    auto logger = Logger::GetLogger("DataEvolutionCompactDeletionVectorRewriter");
+    std::vector<std::shared_ptr<CommitMessage>> result;
+    for (const auto& [partition, groups] : compacted_groups_by_partition) {
+        auto index_metas_entry = index_metas_by_group.find({partition, kUnawareBucket});
+        // A partition without a deletion-vector index has nothing to move.
+        if (index_metas_entry == index_metas_by_group.end() || index_metas_entry->second.empty()) {
+            continue;
+        }
+        std::vector<std::shared_ptr<IndexFileMeta>> index_metas =
+            std::move(index_metas_entry->second);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<DeletionVectorsIndexFile> dv_index,
+                               index_file_handler->DvIndex(partition, kUnawareBucket));
+
+        // Ownership comes from the index metadata alone: DvRanges already records which data
+        // files an index file stores a vector for, and where. No vector is deserialized here.
+        std::vector<IndexFileState> states;
+        states.reserve(index_metas.size());
+        std::map<std::string, size_t> owner_by_data_file;
+        for (auto& index_meta : index_metas) {
+            std::optional<LinkedHashMap<std::string, DeletionVectorMeta>> dv_metas =
+                index_meta->DvRanges();
+            if (dv_metas == std::nullopt) {
+                return Status::Invalid(
+                    fmt::format("Deletion vector index file {} has no deletion vector metas.",
+                                index_meta->FileName()));
+            }
+            PAIMON_ASSIGN_OR_RAISE(
+                std::string index_file_path,
+                index_file_handler->FilePath(partition, kUnawareBucket, index_meta));
+            for (const auto& entry : dv_metas.value()) {
+                auto inserted = owner_by_data_file.emplace(entry.first, states.size());
+                if (!inserted.second) {
+                    return Status::Invalid(
+                        fmt::format("Data file {} has a deletion vector in more than one index "
+                                    "file of the same partition.",
+                                    entry.first));
+                }
+            }
+            states.push_back(IndexFileState{std::move(index_meta), std::move(index_file_path),
+                                            std::move(dv_metas).value(), /*dirty=*/false});
+        }
+
+        // Vectors of the rewritten files belong to no existing index file yet, so they are
+        // collected apart and written as their own index files.
+        std::map<std::string, std::shared_ptr<DeletionVector>> moved_vectors;
+        int64_t taken_vectors = 0;
+        for (const auto& group : groups) {
+            // A moved vector has to be built as the kind the table already holds, since the
+            // two refuse to merge.
+            std::shared_ptr<DeletionVector> merged =
+                DeletionVector::Create(core_options.DeletionVectorsBitmap64());
+            std::vector<std::shared_ptr<DataFileMeta>> before = group.before;
+            PAIMON_ASSIGN_OR_RAISE(
+                std::vector<std::vector<std::shared_ptr<DataFileMeta>>> subgroups,
+                RowRangeGroups(std::move(before)));
+            for (const auto& subgroup : subgroups) {
+                PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<DataFileMeta> anchor,
+                                       DataEvolutionUtils::RetrieveAnchorFile(subgroup));
+                auto owner = owner_by_data_file.find(anchor->file_name);
+                if (owner == owner_by_data_file.end()) {
+                    continue;
+                }
+                IndexFileState& state = states[owner->second];
+                auto dv_meta = state.dv_metas.find(anchor->file_name);
+                if (dv_meta == state.dv_metas.end()) {
+                    continue;
+                }
+                if (group.materialized) {
+                    // The rewrite already dropped these rows, so the vector goes away with the
+                    // file it belonged to instead of being read and moved.
+                    state.dv_metas.erase(anchor->file_name);
+                    state.dirty = true;
+                    taken_vectors++;
+                    continue;
+                }
+                // Only the anchor's vector is read, by its recorded position.
+                PAIMON_ASSIGN_OR_RAISE(
+                    std::shared_ptr<DeletionVector> old_vector,
+                    dv_index->ReadDeletionVector(ToDeletionFile(state.path, dv_meta->second)));
+                // Taken away before it is looked at, and unconditionally: the anchor is a file
+                // this commit deletes, so an entry left behind would key a vector by a data
+                // file that no longer exists — exactly the shape
+                // `ConflictDetection::CheckDeletionVectorMigrationIsComplete` refuses.
+                state.dv_metas.erase(anchor->file_name);
+                state.dirty = true;
+                taken_vectors++;
+                if (old_vector->IsEmpty()) {
+                    continue;
+                }
+                PAIMON_ASSIGN_OR_RAISE(Range anchor_range, RowRangeOf(anchor));
+                PAIMON_RETURN_NOT_OK(
+                    MoveDeletionVector(old_vector, anchor_range, group.after_range, merged));
+            }
+            if (!group.materialized && !merged->IsEmpty()) {
+                moved_vectors[group.after->file_name] = merged;
+            }
+        }
+
+        // Only an index file a move touched is replaced. Its remaining vectors are read now,
+        // the ones it lost are already gone, and an index file left with nothing is deleted
+        // outright.
+        int64_t target_size = core_options.DeletionVectorTargetFileSize();
+        std::vector<std::shared_ptr<IndexFileMeta>> new_index_files;
+        std::vector<std::shared_ptr<IndexFileMeta>> deleted_index_files;
+        for (auto& state : states) {
+            if (!state.dirty) {
+                continue;
+            }
+            deleted_index_files.push_back(std::move(state.meta));
+            if (state.dv_metas.empty()) {
+                continue;
+            }
+            // Read through one opened stream: an index file may hold many vectors of which a
+            // move took only one, and reading the rest one by one would cost one open each.
+            std::map<std::string, DeletionFile> unchanged_deletion_files;
+            for (const auto& entry : state.dv_metas) {
+                unchanged_deletion_files.emplace(entry.first,
+                                                 ToDeletionFile(state.path, entry.second));
+            }
+            std::map<std::string, std::shared_ptr<DeletionVector>> unchanged_vectors;
+            PAIMON_ASSIGN_OR_RAISE(unchanged_vectors,
+                                   dv_index->ReadDeletionVectors(unchanged_deletion_files));
+            PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<IndexFileMeta>> rewritten,
+                                   dv_index->WriteWithRolling(unchanged_vectors, target_size));
+            for (auto& rewritten_file : rewritten) {
+                new_index_files.push_back(std::move(rewritten_file));
+            }
+        }
+        if (!moved_vectors.empty()) {
+            PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<IndexFileMeta>> moved_index_files,
+                                   dv_index->WriteWithRolling(moved_vectors, target_size));
+            for (auto& moved_index_file : moved_index_files) {
+                new_index_files.push_back(std::move(moved_index_file));
+            }
+        }
+        if (new_index_files.empty() && deleted_index_files.empty()) {
+            continue;
+        }
+        // What the round actually moved in this partition, which is the first thing to look at
+        // when a migration check rejects the commit or a deleted row reappears.
+        PAIMON_LOG_DEBUG(logger,
+                         "Migrated deletion vectors of partition %s: %ld vector(s) taken from "
+                         "their replaced files, %zu re-keyed onto rewritten files, %zu index "
+                         "file(s) replaced by %zu new one(s).",
+                         partition.ToString().c_str(), taken_vectors, moved_vectors.size(),
+                         deleted_index_files.size(), new_index_files.size());
+
+        CompactIncrement compact_increment(/*compact_before=*/{}, /*compact_after=*/{},
+                                           /*changelog_files=*/{}, std::move(new_index_files),
+                                           std::move(deleted_index_files));
+        DataIncrement data_increment(/*new_files=*/{}, /*deleted_files=*/{},
+                                     /*changelog_files=*/{});
+        result.push_back(std::make_shared<CommitMessageImpl>(partition, kUnawareBucket,
+                                                             /*total_buckets=*/std::nullopt,
+                                                             data_increment, compact_increment));
+    }
+    return result;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_compact_deletion_vector_rewriter.h
+++ b/src/paimon/core/append/data_evolution_compact_deletion_vector_rewriter.h
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "paimon/result.h"
+
+namespace paimon {
+
+class CommitMessage;
+class CoreOptions;
+class IndexFileHandler;
+class Snapshot;
+
+/// Moves the deletion vectors of a data-evolution compaction onto its rewritten files.
+///
+/// Data-evolution compaction rewrites files without applying their deletion vectors: every
+/// input row survives into the output file, and row ids are preserved. The deletions
+/// themselves are keyed by the *anchor file* of each row range group (see
+/// `DataEvolutionUtils::RetrieveAnchorFile`), so once a task replaces a group's files with a
+/// single new file, the vectors have to be re-keyed onto that file before the compaction is
+/// committed — otherwise the deleted rows come back.
+///
+/// The rewriter consumes the compact commit messages of one round and returns extra
+/// index-only commit messages that add the rewritten deletion-vector index files and delete
+/// the ones they replace. The caller commits both sets together, so the data files and their
+/// deletions move in a single atomic snapshot.
+///
+/// The rewrite is scoped to what it actually changes:
+///
+/// - Ownership of a vector is taken from the index metadata, which already records which data
+///   files each index file stores a vector for and where. Building it deserializes nothing.
+/// - An index file is opened only if a move takes one of its vectors away. An untouched index
+///   file is never opened, however many vectors the partition holds.
+/// - Such a touched index file is replaced whole, because its remaining vectors have to move
+///   into the file that takes over: they are read through a single opened stream, by their
+///   recorded positions, and rewritten. One left with no vector at all is simply deleted.
+/// - A replaced file's vector is taken away whether or not it deletes anything, so no entry is
+///   ever left keying a vector by a data file this commit removes. That keeps this rule and
+///   the commit-side migration check, which can only see the recorded cardinality, deciding on
+///   the same thing.
+/// - New index files are rolled at `deletion-vector.index-file.target-size` rather than
+///   written as one file, which also keeps a large rewrite inside the int32 offsets an index
+///   file addresses its vectors with.
+///
+/// Both vector kinds are supported. A moved vector is rebuilt as the kind the table stores,
+/// because the two serialize differently and refuse to merge into one another.
+class DataEvolutionCompactDeletionVectorRewriter {
+ public:
+    DataEvolutionCompactDeletionVectorRewriter() = delete;
+    ~DataEvolutionCompactDeletionVectorRewriter() = delete;
+
+    /// Rewrites the deletion vectors touched by `compact_messages`.
+    ///
+    /// @param compact_messages The compact commit messages of one coordinator round. Messages
+    ///                         carrying no normal data file are ignored.
+    /// @param snapshot The snapshot the compaction planned against; its deletion-vector index
+    ///                 is the one being moved.
+    /// @param core_options The table's options. A table without deletion vectors returns no
+    ///                     messages, so a caller that does not pre-check stays correct.
+    /// @param index_file_handler Reads the snapshot's index files and writes the new ones.
+    /// @return Index-only commit messages, one per touched partition, or an empty vector when
+    ///         nothing had to move.
+    static Result<std::vector<std::shared_ptr<CommitMessage>>> RewriteDeletionVectors(
+        const std::vector<std::shared_ptr<CommitMessage>>& compact_messages,
+        const Snapshot& snapshot, const CoreOptions& core_options,
+        const std::shared_ptr<IndexFileHandler>& index_file_handler);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_compact_deletion_vector_rewriter_test.cpp
+++ b/src/paimon/core/append/data_evolution_compact_deletion_vector_rewriter_test.cpp
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_compact_deletion_vector_rewriter.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/defs.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+namespace {
+
+std::shared_ptr<DataFileMeta> CreateFile(const std::string& file_name,
+                                         const std::optional<int64_t>& first_row_id,
+                                         int64_t row_count) {
+    return std::make_shared<DataFileMeta>(
+        file_name, /*file_size=*/1024, row_count, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_seq_no=*/1, /*max_seq_no=*/2, /*schema_id=*/0, /*level=*/0,
+        /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(0, 0), /*delete_row_count=*/std::nullopt,
+        /*embedded_index=*/nullptr, /*file_source=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*value_stats_cols=*/std::nullopt, first_row_id, /*write_cols=*/std::nullopt);
+}
+
+BinaryRow EmptyPartition() {
+    BinaryRow row(0);
+    BinaryRowWriter writer(&row, 8, GetDefaultPool().get());
+    writer.Complete();
+    return row;
+}
+
+std::shared_ptr<CommitMessage> CompactMessage(
+    std::vector<std::shared_ptr<DataFileMeta>> before,
+    std::vector<std::shared_ptr<DataFileMeta>> after, int32_t bucket = 0,
+    std::vector<std::shared_ptr<IndexFileMeta>> new_index_files = {}) {
+    CompactIncrement compact_increment(std::move(before), std::move(after), /*changelog_files=*/{},
+                                       std::move(new_index_files), /*deleted_index_files=*/{});
+    DataIncrement data_increment(/*new_files=*/{}, /*deleted_files=*/{}, /*changelog_files=*/{});
+    return std::make_shared<CommitMessageImpl>(EmptyPartition(), bucket,
+                                               /*total_buckets=*/std::nullopt, data_increment,
+                                               compact_increment);
+}
+
+Snapshot MakeSnapshot() {
+    return Snapshot(
+        /*id=*/1, /*schema_id=*/0, /*base_manifest_list=*/"base",
+        /*base_manifest_list_size=*/std::nullopt, /*delta_manifest_list=*/"delta",
+        /*delta_manifest_list_size=*/std::nullopt, /*changelog_manifest_list=*/std::nullopt,
+        /*changelog_manifest_list_size=*/std::nullopt, /*index_manifest=*/std::nullopt,
+        /*commit_user=*/"test-user", /*commit_identifier=*/1, Snapshot::CommitKind::Compact(),
+        /*time_millis=*/0, /*total_record_count=*/0, /*delta_record_count=*/0,
+        /*changelog_record_count=*/std::nullopt, /*watermark=*/std::nullopt,
+        /*statistics=*/std::nullopt, /*properties=*/std::nullopt, /*next_row_id=*/std::nullopt);
+}
+
+/// Every case below stops before the rewriter reads anything, which is why a null index handler
+/// is enough: the validation and the two short circuits all run on the messages alone. The
+/// paths that do read are covered end to end in `test/inte/data_evolution_table_test.cpp`.
+Result<std::vector<std::shared_ptr<CommitMessage>>> Rewrite(
+    const std::vector<std::shared_ptr<CommitMessage>>& messages, const CoreOptions& core_options) {
+    return DataEvolutionCompactDeletionVectorRewriter::RewriteDeletionVectors(
+        messages, MakeSnapshot(), core_options, /*index_file_handler=*/nullptr);
+}
+
+Result<CoreOptions> DeletionVectorOptions(bool enabled) {
+    std::map<std::string, std::string> options;
+    if (enabled) {
+        options.emplace(Options::DELETION_VECTORS_ENABLED, "true");
+    }
+    return CoreOptions::FromMap(options);
+}
+
+}  // namespace
+
+TEST(DataEvolutionCompactDeletionVectorRewriterTest, ShortCircuitsWithoutDeletionVectors) {
+    // A table without deletion vectors has nothing to move, and the guard runs before anything
+    // is read so a caller that forgets to pre-check stays correct rather than failing.
+    ASSERT_OK_AND_ASSIGN(CoreOptions disabled, DeletionVectorOptions(/*enabled=*/false));
+    std::vector<std::shared_ptr<CommitMessage>> messages = {
+        CompactMessage({CreateFile("before.parquet", /*first_row_id=*/0, /*row_count=*/2)},
+                       {CreateFile("after.parquet", /*first_row_id=*/0, /*row_count=*/2)})};
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> result,
+                         Rewrite(messages, disabled));
+    ASSERT_TRUE(result.empty());
+
+    ASSERT_OK_AND_ASSIGN(CoreOptions enabled, DeletionVectorOptions(/*enabled=*/true));
+    ASSERT_OK_AND_ASSIGN(result, Rewrite(/*messages=*/{}, enabled));
+    ASSERT_TRUE(result.empty());
+}
+
+TEST(DataEvolutionCompactDeletionVectorRewriterTest, RejectsMessagesThatAlreadyChangedTheIndex) {
+    // The rewriter owns every index change of the round; one produced earlier would be dropped
+    // by the index-only messages it builds, so it refuses instead of losing it.
+    ASSERT_OK_AND_ASSIGN(CoreOptions enabled, DeletionVectorOptions(/*enabled=*/true));
+    auto index_file = std::make_shared<IndexFileMeta>(
+        "DELETION_VECTORS", "index-0", /*file_size=*/10, /*row_count=*/1,
+        /*dv_ranges=*/std::nullopt, /*external_path=*/std::nullopt);
+    std::vector<std::shared_ptr<CommitMessage>> messages = {
+        CompactMessage({CreateFile("before.parquet", /*first_row_id=*/0, /*row_count=*/2)},
+                       {CreateFile("after.parquet", /*first_row_id=*/0, /*row_count=*/2)},
+                       /*bucket=*/0, {index_file})};
+    ASSERT_NOK_WITH_MSG(Rewrite(messages, enabled),
+                        "should not produce index changes before the deletion vector rewrite");
+}
+
+TEST(DataEvolutionCompactDeletionVectorRewriterTest, RejectsABucketedMessage) {
+    // Data-evolution compaction only ever writes the unaware bucket, and the rewritten index
+    // files have to land in the same one.
+    ASSERT_OK_AND_ASSIGN(CoreOptions enabled, DeletionVectorOptions(/*enabled=*/true));
+    std::vector<std::shared_ptr<CommitMessage>> messages = {
+        CompactMessage({CreateFile("before.parquet", /*first_row_id=*/0, /*row_count=*/2)},
+                       {CreateFile("after.parquet", /*first_row_id=*/0, /*row_count=*/2)},
+                       /*bucket=*/3)};
+    ASSERT_NOK_WITH_MSG(Rewrite(messages, enabled), "unaware-bucket commit messages");
+}
+
+TEST(DataEvolutionCompactDeletionVectorRewriterTest, RejectsARewriteThatMovedItsRows) {
+    // A task that keeps its row ids must cover exactly the rows it replaced. A different range
+    // would move the deletions onto rows that are not the ones they were written for.
+    ASSERT_OK_AND_ASSIGN(CoreOptions enabled, DeletionVectorOptions(/*enabled=*/true));
+    std::vector<std::shared_ptr<CommitMessage>> messages = {
+        CompactMessage({CreateFile("before.parquet", /*first_row_id=*/0, /*row_count=*/4)},
+                       {CreateFile("after.parquet", /*first_row_id=*/8, /*row_count=*/4)})};
+    ASSERT_NOK_WITH_MSG(Rewrite(messages, enabled), "must keep the same row id range");
+}
+
+TEST(DataEvolutionCompactDeletionVectorRewriterTest, RejectsATaskWithSeveralNormalOutputs) {
+    // A normal task merges its row range into a single file, and the moved vector is keyed by
+    // that file. Two outputs would leave the rewriter without one file to key the deletions of
+    // the range by, so the shape is refused rather than guessed at.
+    ASSERT_OK_AND_ASSIGN(CoreOptions enabled, DeletionVectorOptions(/*enabled=*/true));
+    std::vector<std::shared_ptr<CommitMessage>> messages = {
+        CompactMessage({CreateFile("before.parquet", /*first_row_id=*/0, /*row_count=*/4)},
+                       {CreateFile("after-0.parquet", /*first_row_id=*/0, /*row_count=*/2),
+                        CreateFile("after-1.parquet", /*first_row_id=*/2, /*row_count=*/2)})};
+    ASSERT_NOK_WITH_MSG(Rewrite(messages, enabled), "should produce exactly one normal file");
+}
+
+TEST(DataEvolutionCompactDeletionVectorRewriterTest, IgnoresMessagesCarryingNoNormalFile) {
+    // A blob-only message replaces no rows whose deletions could move, so it never reaches the
+    // index at all — which is what lets this run with no index handler.
+    ASSERT_OK_AND_ASSIGN(CoreOptions enabled, DeletionVectorOptions(/*enabled=*/true));
+    std::vector<std::shared_ptr<CommitMessage>> messages = {
+        CompactMessage({CreateFile("before-f2-0.blob", /*first_row_id=*/0, /*row_count=*/2)},
+                       {CreateFile("after-f2-0.blob", /*first_row_id=*/0, /*row_count=*/2)})};
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> result,
+                         Rewrite(messages, enabled));
+    ASSERT_TRUE(result.empty());
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/append/data_evolution_compact_global_index_dropper.cpp
+++ b/src/paimon/core/append/data_evolution_compact_global_index_dropper.cpp
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_compact_global_index_dropper.h"
+
+#include <unordered_set>
+#include <utility>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/linked_hash_map.h"
+#include "paimon/core/index/index_file_handler.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/manifest/index_manifest_entry.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/utils/data_evolution_utils.h"
+
+namespace paimon {
+
+namespace {
+
+/// The partitions whose row ids this round reassigned. An empty output counts too: a range
+/// whose rows were all deleted leaves those row ids gone for good, so an index over them is
+/// just as invalid as one over renumbered rows.
+Result<std::unordered_set<BinaryRow>> MaterializedPartitions(
+    const std::vector<std::shared_ptr<CommitMessage>>& compact_messages) {
+    std::unordered_set<BinaryRow> result;
+    for (const auto& message : compact_messages) {
+        auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(message);
+        if (message_impl == nullptr) {
+            return Status::Invalid(
+                "Data evolution compaction produced an unexpected commit message type.");
+        }
+        const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+        if (DataEvolutionUtils::IsMaterializedCompaction(compact_increment.CompactBefore(),
+                                                         compact_increment.CompactAfter())) {
+            result.insert(message_impl->Partition());
+        }
+    }
+    return result;
+}
+
+}  // namespace
+
+Result<std::vector<std::shared_ptr<CommitMessage>>>
+DataEvolutionCompactGlobalIndexDropper::DropGlobalIndexes(
+    const std::vector<std::shared_ptr<CommitMessage>>& compact_messages,
+    const Snapshot& latest_snapshot, const std::shared_ptr<IndexFileHandler>& index_file_handler) {
+    PAIMON_ASSIGN_OR_RAISE(std::unordered_set<BinaryRow> partitions,
+                           MaterializedPartitions(compact_messages));
+    if (partitions.empty()) {
+        return std::vector<std::shared_ptr<CommitMessage>>{};
+    }
+
+    // Scanned at the latest snapshot rather than the compaction's base, so an index another
+    // engine committed in between — still built on the pre-materialization row ids — is dropped
+    // too instead of surviving as a silently wrong index.
+    PAIMON_ASSIGN_OR_RAISE(
+        std::vector<IndexManifestEntry> entries,
+        index_file_handler->Scan(latest_snapshot,
+                                 [&partitions](const IndexManifestEntry& entry) -> Result<bool> {
+                                     return partitions.count(entry.partition) != 0 &&
+                                            entry.index_file->GetGlobalIndexMeta() != std::nullopt;
+                                 }));
+    if (entries.empty()) {
+        return std::vector<std::shared_ptr<CommitMessage>>{};
+    }
+
+    // One message per partition and bucket, since an index file is addressed through both.
+    LinkedHashMap<BinaryRow, LinkedHashMap<int32_t, std::vector<std::shared_ptr<IndexFileMeta>>>>
+        deleted_by_group;
+    for (const IndexManifestEntry& entry : entries) {
+        deleted_by_group[entry.partition][entry.bucket].push_back(entry.index_file);
+    }
+
+    std::vector<std::shared_ptr<CommitMessage>> result;
+    for (const auto& [partition, by_bucket] : deleted_by_group) {
+        for (const auto& [bucket, deleted_index_files] : by_bucket) {
+            std::vector<std::shared_ptr<IndexFileMeta>> deleted = deleted_index_files;
+            CompactIncrement compact_increment(/*compact_before=*/{}, /*compact_after=*/{},
+                                               /*changelog_files=*/{}, /*new_index_files=*/{},
+                                               std::move(deleted));
+            DataIncrement data_increment(/*new_files=*/{}, /*deleted_files=*/{},
+                                         /*changelog_files=*/{});
+            result.push_back(std::make_shared<CommitMessageImpl>(
+                partition, bucket, /*total_buckets=*/std::nullopt, data_increment,
+                compact_increment));
+        }
+    }
+    return result;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_compact_global_index_dropper.h
+++ b/src/paimon/core/append/data_evolution_compact_global_index_dropper.h
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "paimon/result.h"
+
+namespace paimon {
+
+class CommitMessage;
+class IndexFileHandler;
+class Snapshot;
+
+/// Drops the global indexes a materialized data-evolution compaction invalidates.
+///
+/// A global index maps a value to the row id holding it. Materializing deletion vectors gives
+/// the surviving rows new row ids, so every global index of a touched partition now points at
+/// rows that moved or no longer exist. There is no way to fix such an index up from the
+/// compaction's own metadata, so it is dropped and has to be rebuilt.
+///
+/// Only a *materialized* task invalidates anything: a normal data-evolution compaction keeps
+/// row ids, which is exactly what lets its indexes stand. The two are told apart the same way
+/// the deletion vector rewriter tells them apart — by whether the rewritten files carry row ids.
+class DataEvolutionCompactGlobalIndexDropper {
+ public:
+    DataEvolutionCompactGlobalIndexDropper() = delete;
+    ~DataEvolutionCompactGlobalIndexDropper() = delete;
+
+    /// Returns index-only commit messages deleting the global indexes of every partition
+    /// `compact_messages` materialized, or an empty vector when none did.
+    ///
+    /// @param latest_snapshot The snapshot to scan, which should be the newest one rather than
+    ///                        the one the compaction planned against: an index built
+    ///                        concurrently still refers to pre-materialization row ids and has
+    ///                        to be dropped as well.
+    static Result<std::vector<std::shared_ptr<CommitMessage>>> DropGlobalIndexes(
+        const std::vector<std::shared_ptr<CommitMessage>>& compact_messages,
+        const Snapshot& latest_snapshot,
+        const std::shared_ptr<IndexFileHandler>& index_file_handler);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_compact_global_index_dropper_test.cpp
+++ b/src/paimon/core/append/data_evolution_compact_global_index_dropper_test.cpp
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_compact_global_index_dropper.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+namespace {
+
+std::shared_ptr<DataFileMeta> CreateFile(const std::string& file_name,
+                                         const std::optional<int64_t>& first_row_id) {
+    return std::make_shared<DataFileMeta>(
+        file_name, /*file_size=*/1024, /*row_count=*/4, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_seq_no=*/1, /*max_seq_no=*/2, /*schema_id=*/0, /*level=*/0,
+        /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(0, 0), /*delete_row_count=*/std::nullopt,
+        /*embedded_index=*/nullptr, /*file_source=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*value_stats_cols=*/std::nullopt, first_row_id, /*write_cols=*/std::nullopt);
+}
+
+BinaryRow EmptyPartition() {
+    BinaryRow row(0);
+    BinaryRowWriter writer(&row, 8, GetDefaultPool().get());
+    writer.Complete();
+    return row;
+}
+
+std::shared_ptr<CommitMessage> CompactMessage(
+    const std::vector<std::shared_ptr<DataFileMeta>>& before,
+    const std::vector<std::shared_ptr<DataFileMeta>>& after) {
+    std::vector<std::shared_ptr<DataFileMeta>> before_copy = before;
+    std::vector<std::shared_ptr<DataFileMeta>> after_copy = after;
+    CompactIncrement compact_increment(std::move(before_copy), std::move(after_copy),
+                                       /*changelog_files=*/{}, /*new_index_files=*/{},
+                                       /*deleted_index_files=*/{});
+    DataIncrement data_increment(/*new_files=*/{}, /*deleted_files=*/{}, /*changelog_files=*/{});
+    return std::make_shared<CommitMessageImpl>(EmptyPartition(), /*bucket=*/0,
+                                               /*total_buckets=*/std::nullopt, data_increment,
+                                               compact_increment);
+}
+
+Snapshot MakeSnapshot() {
+    return Snapshot(
+        /*id=*/1, /*schema_id=*/0, /*base_manifest_list=*/"base",
+        /*base_manifest_list_size=*/std::nullopt, /*delta_manifest_list=*/"delta",
+        /*delta_manifest_list_size=*/std::nullopt, /*changelog_manifest_list=*/std::nullopt,
+        /*changelog_manifest_list_size=*/std::nullopt, /*index_manifest=*/std::nullopt,
+        /*commit_user=*/"test-user", /*commit_identifier=*/1, Snapshot::CommitKind::Compact(),
+        /*time_millis=*/0, /*total_record_count=*/0, /*delta_record_count=*/0,
+        /*changelog_record_count=*/std::nullopt, /*watermark=*/std::nullopt,
+        /*statistics=*/std::nullopt, /*properties=*/std::nullopt, /*next_row_id=*/std::nullopt);
+}
+
+}  // namespace
+
+TEST(DataEvolutionCompactGlobalIndexDropperTest, DropsNothingForANormalCompaction) {
+    // A normal data-evolution compaction preserves row ids, which is exactly what keeps the
+    // global indexes valid. Dropping them would throw away work for nothing, so the detection
+    // has to say no here — and say it before touching the index handler, which is why passing a
+    // null one is safe.
+    std::vector<std::shared_ptr<CommitMessage>> messages = {
+        CompactMessage({CreateFile("before.parquet", /*first_row_id=*/0)},
+                       {CreateFile("after.parquet", /*first_row_id=*/0)})};
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> dropped,
+                         DataEvolutionCompactGlobalIndexDropper::DropGlobalIndexes(
+                             messages, MakeSnapshot(), /*index_file_handler=*/nullptr));
+    ASSERT_TRUE(dropped.empty());
+}
+
+TEST(DataEvolutionCompactGlobalIndexDropperTest, DropsNothingWithoutReplacedNormalFiles) {
+    // An index-only or blob-only message replaces no rows, so it invalidates no index however
+    // its outputs look.
+    std::vector<std::shared_ptr<CommitMessage>> messages = {
+        CompactMessage(/*before=*/{}, /*after=*/{}),
+        CompactMessage({CreateFile("before-f2-0.blob", /*first_row_id=*/0)},
+                       {CreateFile("after-f2-0.blob", /*first_row_id=*/std::nullopt)})};
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> dropped,
+                         DataEvolutionCompactGlobalIndexDropper::DropGlobalIndexes(
+                             messages, MakeSnapshot(), /*index_file_handler=*/nullptr));
+    ASSERT_TRUE(dropped.empty());
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/append/data_evolution_compact_planner.cpp
+++ b/src/paimon/core/append/data_evolution_compact_planner.cpp
@@ -1,0 +1,319 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_compact_planner.h"
+
+#include <algorithm>
+#include <iterator>
+#include <limits>
+#include <string>
+#include <utility>
+
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/predicate/predicate_filter.h"
+#include "paimon/common/utils/range_helper.h"
+#include "paimon/common/utils/vector_store_utils.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/manifest/manifest_file_meta.h"
+#include "paimon/core/manifest/manifest_list.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/logging.h"
+
+namespace paimon {
+
+namespace {
+
+/// A bin that packs evolved field groups of one contiguous row id run into one compact task.
+class CompactBin {
+ public:
+    Status Add(std::vector<std::shared_ptr<DataFileMeta>>&& file_group, int64_t weight) {
+        if (weight_ > std::numeric_limits<int64_t>::max() - weight) {
+            return Status::Invalid("Data evolution compaction bin weight overflows.");
+        }
+        files_.insert(files_.end(), std::make_move_iterator(file_group.begin()),
+                      std::make_move_iterator(file_group.end()));
+        weight_ += weight;
+        return Status::OK();
+    }
+
+    int64_t Weight() const {
+        return weight_;
+    }
+
+    std::vector<std::shared_ptr<DataFileMeta>> Drain() {
+        std::vector<std::shared_ptr<DataFileMeta>> result = std::move(files_);
+        files_.clear();
+        weight_ = 0;
+        return result;
+    }
+
+ private:
+    std::vector<std::shared_ptr<DataFileMeta>> files_;
+    int64_t weight_ = 0;
+};
+
+/// Emits a task for the bin's files when there are enough of them; too few files are simply
+/// left as they are (they will be reconsidered by a later coordinator run once neighbors
+/// appear).
+Status TriggerTask(std::vector<std::shared_ptr<DataFileMeta>>&& files, const BinaryRow& partition,
+                   int32_t compact_min_file_num,
+                   std::vector<DataEvolutionNormalCompactTask>* tasks) {
+    if (static_cast<int32_t>(files.size()) < compact_min_file_num) {
+        return Status::OK();
+    }
+    PAIMON_ASSIGN_OR_RAISE(DataEvolutionNormalCompactTask task,
+                           DataEvolutionNormalCompactTask::Create(partition, files));
+    tasks->push_back(std::move(task));
+    return Status::OK();
+}
+
+int64_t FileWeight(const std::shared_ptr<DataFileMeta>& file, int64_t open_file_cost) {
+    return std::max(file->file_size, open_file_cost);
+}
+
+Status PlanPartition(const BinaryRow& partition,
+                     const std::vector<std::shared_ptr<DataFileMeta>>& files,
+                     int64_t target_file_size, int64_t open_file_cost, int32_t compact_min_file_num,
+                     std::vector<DataEvolutionNormalCompactTask>* tasks) {
+    // Blob files are dedicated storage: they are not rewritten and never enter a task, and
+    // their row ranges stay covered by the rewritten data files. Vector-store files were
+    // already rejected by PlanCompactTasks, so everything else is a normal file.
+    std::vector<std::shared_ptr<DataFileMeta>> data_files;
+    data_files.reserve(files.size());
+    for (const auto& file : files) {
+        if (BlobUtils::IsBlobFile(file->file_name)) {
+            continue;
+        }
+        data_files.push_back(file);
+    }
+    if (data_files.empty()) {
+        return Status::OK();
+    }
+
+    // Contiguous runs extend each file's range to [first, first + row_count], one past its
+    // last row: adjacent files share an endpoint and overlap, so a run only breaks on a real
+    // row id gap.
+    RangeHelper<std::shared_ptr<DataFileMeta>> adjacency_helper(
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            return file->NonNullFirstRowId();
+        },
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+            return first_row_id + file->row_count;
+        });
+    // Field groups use the closed range [first, first + row_count - 1]: only files holding the
+    // same rows overlap here, and a group must cover the exact same range in every file.
+    RangeHelper<std::shared_ptr<DataFileMeta>> field_group_helper(
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            return file->NonNullFirstRowId();
+        },
+        [](const std::shared_ptr<DataFileMeta>& file) -> Result<int64_t> {
+            PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+            return first_row_id + file->row_count - 1;
+        });
+
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> components,
+                           adjacency_helper.MergeOverlappingRanges(std::move(data_files)));
+    for (auto& component : components) {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::vector<std::shared_ptr<DataFileMeta>>> field_groups,
+                               field_group_helper.MergeOverlappingRanges(std::move(component)));
+        CompactBin bin;
+        for (auto& field_group : field_groups) {
+            PAIMON_ASSIGN_OR_RAISE(bool same_range,
+                                   field_group_helper.AreAllRangesSame(field_group));
+            if (!same_range) {
+                std::vector<std::string> file_names;
+                file_names.reserve(field_group.size());
+                for (const auto& file : field_group) {
+                    file_names.push_back(file->file_name);
+                }
+                return Status::Invalid(fmt::format(
+                    "Files of one data evolution field group should share the same row range, "
+                    "but got [{}].",
+                    fmt::join(file_names, ", ")));
+            }
+            int64_t weight = 0;
+            for (const auto& file : field_group) {
+                int64_t file_weight = FileWeight(file, open_file_cost);
+                if (weight > std::numeric_limits<int64_t>::max() - file_weight) {
+                    return Status::Invalid(
+                        "Data evolution compaction field group weight overflows.");
+                }
+                weight += file_weight;
+            }
+            if (weight > target_file_size) {
+                // A heavy group cuts the current bin and is considered on its own (still
+                // subject to the min-file-num gate): merging its files is worthwhile, but
+                // nothing else is packed on top of it.
+                PAIMON_RETURN_NOT_OK(
+                    TriggerTask(bin.Drain(), partition, compact_min_file_num, tasks));
+                CompactBin single_group_bin;
+                PAIMON_RETURN_NOT_OK(single_group_bin.Add(std::move(field_group), weight));
+                PAIMON_RETURN_NOT_OK(
+                    TriggerTask(single_group_bin.Drain(), partition, compact_min_file_num, tasks));
+                continue;
+            }
+            PAIMON_RETURN_NOT_OK(bin.Add(std::move(field_group), weight));
+            if (bin.Weight() > target_file_size) {
+                PAIMON_RETURN_NOT_OK(
+                    TriggerTask(bin.Drain(), partition, compact_min_file_num, tasks));
+            }
+        }
+        // A row id gap follows: whatever is left in the bin cannot be packed any further.
+        PAIMON_RETURN_NOT_OK(TriggerTask(bin.Drain(), partition, compact_min_file_num, tasks));
+    }
+    return Status::OK();
+}
+
+}  // namespace
+
+Result<std::vector<DataEvolutionNormalCompactTask>> DataEvolutionCompactPlanner::PlanCompactTasks(
+    const LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>& partition_files,
+    const CoreOptions& options) {
+    int64_t target_file_size = options.GetTargetFileSize(/*has_primary_key=*/false);
+    int64_t open_file_cost = options.GetSourceSplitOpenFileCost();
+    int32_t compact_min_file_num = options.GetCompactionMinFileNum();
+    if (target_file_size <= 0 || open_file_cost < 0 || compact_min_file_num <= 0) {
+        return Status::Invalid(fmt::format(
+            "Invalid data-evolution compaction options: target-file-size {} must be positive, "
+            "open-file-cost {} must be non-negative, min-file-num {} must be positive.",
+            target_file_size, open_file_cost, compact_min_file_num));
+    }
+
+    std::vector<DataEvolutionNormalCompactTask> tasks;
+    for (const auto& [partition, files] : partition_files) {
+        for (const auto& file : files) {
+            // PlanCompactTasks is a public entry, so the input is validated here before any
+            // planning arithmetic runs on it.
+            if (file == nullptr) {
+                return Status::Invalid("Data evolution compaction files must not be null.");
+            }
+            // Vector-store tables are rejected outright: without a VECTOR schema type the
+            // rewrite cannot exclude the vector columns, and a normal file claiming them as
+            // NULL would shadow the dedicated files. Checked before the row id validation
+            // below so an unsupported table says so, rather than reporting whichever metadata
+            // of a vector file happens to look invalid.
+            if (VectorStoreUtils::IsVectorStoreFile(file->file_name)) {
+                return Status::NotImplemented(
+                    "Data-evolution compaction does not support tables with vector-store files "
+                    "yet.");
+            }
+            PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+            if (file->row_count <= 0 || file->file_size < 0 || first_row_id < 0 ||
+                first_row_id > std::numeric_limits<int64_t>::max() - file->row_count) {
+                return Status::Invalid(fmt::format(
+                    "Invalid data-evolution compaction input {}: file size {}, first row id "
+                    "{} and row count {} must form a valid file and row id range.",
+                    file->file_name, file->file_size, first_row_id, file->row_count));
+            }
+        }
+        PAIMON_RETURN_NOT_OK(PlanPartition(partition, files, target_file_size, open_file_cost,
+                                           compact_min_file_num, &tasks));
+    }
+    return tasks;
+}
+
+Result<std::vector<Range>> DataEvolutionCompactPlanner::PlanRowIdWindows(
+    const std::shared_ptr<ManifestList>& manifest_list, const Snapshot& snapshot,
+    const std::shared_ptr<PredicateFilter>& partition_filter,
+    const std::shared_ptr<arrow::Schema>& partition_schema, int64_t candidate_files_per_round,
+    Logger* logger) {
+    std::vector<ManifestFileMeta> manifests;
+    PAIMON_RETURN_NOT_OK(manifest_list->ReadDataManifests(snapshot, &manifests));
+
+    struct ManifestBound {
+        int64_t min_row_id;
+        int64_t max_row_id;
+        int64_t num_files;
+    };
+    std::vector<ManifestBound> bounds;
+    bounds.reserve(manifests.size());
+    for (const auto& manifest : manifests) {
+        // Skipping a manifest the scan would drop anyway keeps its row ids from padding the
+        // windows. It cannot hide a straddling file either: the gap test below only ever
+        // looks at manifests that are kept.
+        if (partition_filter != nullptr) {
+            SimpleStats partition_stats = manifest.PartitionStats();
+            PAIMON_ASSIGN_OR_RAISE(
+                bool matches,
+                partition_filter->Test(partition_schema,
+                                       manifest.NumAddedFiles() + manifest.NumDeletedFiles(),
+                                       partition_stats.MinValues(), partition_stats.MaxValues(),
+                                       partition_stats.NullCounts()));
+            if (!matches) {
+                continue;
+            }
+        }
+        // A manifest holding no ADD entry contributes no candidate file, so it can neither
+        // pad a window nor hide a file that straddles a cut. Skipped before the statistics
+        // check so a delete-only manifest cannot disable the split; the trade-off is that
+        // such a manifest, if it also lacks row id statistics, is read by every round.
+        if (manifest.NumAddedFiles() <= 0) {
+            continue;
+        }
+        // A single manifest without usable row id statistics would leave a hole in the
+        // windows, so the whole batching is abandoned rather than silently skipping its files.
+        if (!manifest.MinRowId().has_value() || !manifest.MaxRowId().has_value() ||
+            manifest.MinRowId().value() > manifest.MaxRowId().value()) {
+            PAIMON_LOG_INFO(
+                logger,
+                "Compacting in a single round: manifest %s carries no usable row id statistics, "
+                "so the row id space cannot be split.",
+                manifest.FileName().c_str());
+            return std::vector<Range>{};
+        }
+        bounds.push_back(ManifestBound{manifest.MinRowId().value(), manifest.MaxRowId().value(),
+                                       manifest.NumAddedFiles()});
+    }
+    if (bounds.empty()) {
+        return std::vector<Range>{};
+    }
+    std::sort(bounds.begin(), bounds.end(),
+              [](const ManifestBound& left, const ManifestBound& right) {
+                  return left.min_row_id != right.min_row_id ? left.min_row_id < right.min_row_id
+                                                             : left.max_row_id < right.max_row_id;
+              });
+
+    std::vector<Range> windows;
+    int64_t window_from = 0;
+    int64_t covered_to = bounds.front().max_row_id;
+    int64_t window_files = 0;
+    for (size_t i = 0; i < bounds.size(); i++) {
+        covered_to = std::max(covered_to, bounds[i].max_row_id);
+        window_files += bounds[i].num_files;
+        bool has_next = i + 1 < bounds.size();
+        if (has_next && window_files >= candidate_files_per_round &&
+            covered_to < bounds[i + 1].min_row_id) {
+            windows.emplace_back(window_from, covered_to);
+            window_from = covered_to + 1;
+            window_files = 0;
+            // Start the next window at the manifest that opened the gap instead of carrying
+            // this window's reach forward.
+            covered_to = bounds[i + 1].max_row_id;
+        }
+    }
+    // The tail stays open ended so rows appended after the manifests were read still belong
+    // to a window rather than falling outside every one of them.
+    windows.emplace_back(window_from, std::numeric_limits<int64_t>::max());
+    return windows;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_compact_planner.h
+++ b/src/paimon/core/append/data_evolution_compact_planner.h
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/linked_hash_map.h"
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/result.h"
+#include "paimon/utils/range.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+class CoreOptions;
+class Logger;
+class ManifestList;
+class PredicateFilter;
+class Snapshot;
+
+/// Plans compaction for data-evolution tables.
+///
+/// Files of a data-evolution table are grouped by row id range: files sharing the exact same
+/// range form one evolved field group (different versions or subsets of the table columns for
+/// the same rows, produced by partial-column updates). The planner packs field groups of one
+/// contiguous row id run into bins and emits a `DataEvolutionNormalCompactTask` per bin, so
+/// one task merges its field groups back into a single normal file holding every
+/// non-dedicated column, without changing any row id.
+///
+/// Planning rules:
+/// - Blob files are dedicated storage and never enter a task. Tables holding vector-store
+///   files are rejected until a VECTOR schema type allows excluding their columns from the
+///   rewrite.
+/// - A file group's weight is `sum(max(file_size, open_file_cost))`. A bin is emitted once its
+///   weight exceeds `target-file-size` (strictly greater).
+/// - A single group heavier than the target cuts the current bin and is emitted on its own —
+///   provided it holds at least `compaction.min.file-num` files — so bins never span a large
+///   file.
+/// - A row id gap always cuts the current bin: tasks stay contiguous.
+/// - A bin becomes a task only when it holds at least `compaction.min.file-num` files.
+///
+/// The row id windows a batched run compacts one at a time are planned here too, from the
+/// manifest metadata rather than from the files themselves.
+class DataEvolutionCompactPlanner {
+ public:
+    DataEvolutionCompactPlanner() = delete;
+    ~DataEvolutionCompactPlanner() = delete;
+
+    /// Plans compact tasks from the ADD file entries of one snapshot, grouped by partition.
+    /// `partition_files` must contain every live file of the scanned partitions, small or
+    /// large: whether a file takes part in compaction is decided here, not by a size
+    /// pre-filter.
+    static Result<std::vector<DataEvolutionNormalCompactTask>> PlanCompactTasks(
+        const LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>>& partition_files,
+        const CoreOptions& options);
+
+    /// Plans the row id windows a batched data-evolution run compacts one at a time.
+    ///
+    /// The windows come from the snapshot's data manifests, which carry the row id range and the
+    /// file count of their entries, so the split is decided without reading a single manifest
+    /// entry. Manifests the partition filter rules out are skipped, so compacting one partition
+    /// does not produce rounds that only cover other partitions' rows.
+    ///
+    /// Manifests are walked in row id order and the current window is closed once the files it
+    /// claims reach `candidate_files_per_round` — but only where the next manifest starts beyond
+    /// everything the window covers. Cutting only at such a gap keeps every file inside exactly
+    /// one window, so no file is planned, rewritten and committed twice, and the row-range
+    /// pruning of the per-round scan then reads each *candidate-bearing* manifest file for exactly
+    /// one round. The exception is a delete-only manifest, which carries no candidate at all:
+    /// it is left out of the split, and if it also lacks row id statistics every round reads it.
+    ///
+    /// That gap rule is the only thing keeping the rounds disjoint: `AppendOnlyFileStoreScan`
+    /// applies a row id window at manifest granularity only, so a cut placed anywhere but a
+    /// coverage gap would hand the same file to two rounds and have it committed twice.
+    ///
+    /// The windows are disjoint and the last one is open ended, so together they cover every row
+    /// id the table can hold. Returns an empty vector when the snapshot carries no usable row id
+    /// statistics, which asks the caller to fall back to a single unbounded round.
+    static Result<std::vector<Range>> PlanRowIdWindows(
+        const std::shared_ptr<ManifestList>& manifest_list, const Snapshot& snapshot,
+        const std::shared_ptr<PredicateFilter>& partition_filter,
+        const std::shared_ptr<arrow::Schema>& partition_schema, int64_t candidate_files_per_round,
+        Logger* logger);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_compact_planner_test.cpp
+++ b/src/paimon/core/append/data_evolution_compact_planner_test.cpp
@@ -1,0 +1,467 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_compact_planner.h"
+
+#include <limits>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/manifest/manifest_file_meta.h"
+#include "paimon/core/manifest/manifest_list.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/defs.h"
+#include "paimon/format/file_format.h"
+#include "paimon/logging.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/testing/utils/testharness.h"
+#include "paimon/utils/range.h"
+
+namespace paimon::test {
+
+/// The `(path, size)` pair `ManifestList::Write` returns. Named so it can be spelled without a
+/// comma inside a `PAIMON_ASSIGN_OR_RAISE` argument.
+using ManifestListFile = std::pair<std::string, int64_t>;
+
+class DataEvolutionCompactPlannerTest : public testing::Test {
+ protected:
+    static std::shared_ptr<DataFileMeta> NewFile(const std::string& file_name, int64_t file_size,
+                                                 int64_t first_row_id, int64_t row_count,
+                                                 int64_t min_sequence_number,
+                                                 int64_t max_sequence_number) {
+        return DataFileMeta::ForAppend(file_name, file_size, row_count, SimpleStats::EmptyStats(),
+                                       min_sequence_number, max_sequence_number, /*schema_id=*/0,
+                                       FileSource::Append(),
+                                       /*value_stats_cols=*/std::nullopt,
+                                       /*external_path=*/std::nullopt, first_row_id,
+                                       /*write_cols=*/std::nullopt)
+            .value();
+    }
+
+    static ManifestFileMeta NewManifest(const std::string& file_name, int64_t num_added_files,
+                                        int64_t num_deleted_files,
+                                        const std::optional<int64_t>& min_row_id,
+                                        const std::optional<int64_t>& max_row_id) {
+        return ManifestFileMeta(file_name, /*file_size=*/1024, num_added_files, num_deleted_files,
+                                SimpleStats::EmptyStats(), /*schema_id=*/0,
+                                /*min_bucket=*/std::nullopt, /*max_bucket=*/std::nullopt,
+                                /*min_level=*/std::nullopt, /*max_level=*/std::nullopt, min_row_id,
+                                max_row_id);
+    }
+
+    /// Writes `metas` as the manifest lists of one snapshot and plans the row id windows over
+    /// it. The metas are split across the base and the delta list, because a snapshot always
+    /// has both and the planner reads them together: which list a manifest sits in must not
+    /// change the windows. Requires at least two metas so neither list is written empty.
+    static Result<std::vector<Range>> PlanWindows(const std::vector<ManifestFileMeta>& metas,
+                                                  int64_t candidate_files_per_round) {
+        EXPECT_GE(metas.size(), 2u);
+        std::unique_ptr<UniqueTestDirectory> dir = UniqueTestDirectory::Create();
+        EXPECT_TRUE(dir);
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options, CoreOptions::FromMap({}));
+        std::shared_ptr<arrow::Schema> schema = arrow::schema({arrow::field("f0", arrow::int32())});
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileStorePathFactory> path_factory,
+                               FileStorePathFactory::Create(
+                                   dir->Str(), schema, /*partition_keys=*/{},
+                                   /*default_part_value=*/"", options.GetFileFormat()->Identifier(),
+                                   /*data_file_prefix=*/"data-",
+                                   /*legacy_partition_name_enabled=*/true,
+                                   /*external_paths=*/{},
+                                   /*global_index_external_path=*/std::nullopt,
+                                   /*index_file_in_data_file_dir=*/false, GetDefaultPool()));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<ManifestList> manifest_list,
+            ManifestList::Create(dir->GetFileSystem(), options.GetManifestFormat(),
+                                 options.GetManifestCompression(), path_factory, options.GetCache(),
+                                 GetDefaultPool()));
+        std::vector<ManifestFileMeta> delta_metas = {metas.front()};
+        std::vector<ManifestFileMeta> base_metas(metas.begin() + 1, metas.end());
+        PAIMON_ASSIGN_OR_RAISE(ManifestListFile base, manifest_list->Write(base_metas));
+        PAIMON_ASSIGN_OR_RAISE(ManifestListFile delta, manifest_list->Write(delta_metas));
+
+        Snapshot snapshot(/*id=*/1, /*schema_id=*/0, base.first,
+                          /*base_manifest_list_size=*/base.second, delta.first,
+                          /*delta_manifest_list_size=*/delta.second,
+                          /*changelog_manifest_list=*/std::nullopt,
+                          /*changelog_manifest_list_size=*/std::nullopt,
+                          /*index_manifest=*/std::nullopt, /*commit_user=*/"test-user",
+                          /*commit_identifier=*/1, Snapshot::CommitKind::Append(),
+                          /*time_millis=*/0, /*total_record_count=*/0, /*delta_record_count=*/0,
+                          /*changelog_record_count=*/std::nullopt, /*watermark=*/std::nullopt,
+                          /*statistics=*/std::nullopt, /*properties=*/std::nullopt,
+                          /*next_row_id=*/std::nullopt);
+        auto logger = Logger::GetLogger("DataEvolutionCompactPlannerTest");
+        return DataEvolutionCompactPlanner::PlanRowIdWindows(
+            manifest_list, snapshot, /*partition_filter=*/nullptr, /*partition_schema=*/nullptr,
+            candidate_files_per_round, logger.get());
+    }
+
+    static BinaryRow CreateIntRow(int32_t value) {
+        BinaryRow row(1);
+        BinaryRowWriter writer(&row, 20, GetDefaultPool().get());
+        writer.WriteInt(0, value);
+        writer.Complete();
+        return row;
+    }
+
+    static CoreOptions CreateOptions(const std::string& target_file_size,
+                                     const std::string& open_file_cost,
+                                     const std::string& min_file_num) {
+        return CoreOptions::FromMap({{Options::TARGET_FILE_SIZE, target_file_size},
+                                     {Options::SOURCE_SPLIT_OPEN_FILE_COST, open_file_cost},
+                                     {Options::COMPACTION_MIN_FILE_NUM, min_file_num},
+                                     {Options::ROW_TRACKING_ENABLED, "true"},
+                                     {Options::DATA_EVOLUTION_ENABLED, "true"}})
+            .value();
+    }
+
+    static Result<std::vector<DataEvolutionNormalCompactTask>> Plan(
+        const std::vector<std::shared_ptr<DataFileMeta>>& files, const CoreOptions& options,
+        const BinaryRow& partition = BinaryRow::EmptyRow()) {
+        LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>> partition_files;
+        partition_files[partition] = files;
+        return DataEvolutionCompactPlanner::PlanCompactTasks(partition_files, options);
+    }
+
+    static std::vector<std::string> FileNames(const DataEvolutionNormalCompactTask& task) {
+        std::vector<std::string> names;
+        names.reserve(task.CompactBefore().size());
+        for (const auto& file : task.CompactBefore()) {
+            names.push_back(file->file_name);
+        }
+        return names;
+    }
+};
+
+TEST_F(DataEvolutionCompactPlannerTest, TestSingleFileProducesNoTask) {
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks,
+                         Plan({NewFile("f1", 100, 0, 100, 1, 1)}, options));
+    ASSERT_TRUE(tasks.empty());
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestContiguousFilesPackedByTargetSize) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 100, 100, 100, 2, 2),
+                                                        NewFile("f3", 100, 200, 100, 3, 3)};
+
+    // The bin is emitted once its weight strictly exceeds the target: with target 199 the first
+    // two files trigger a task and the third stays alone (too few files for its own task).
+    CoreOptions options = CreateOptions("199", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 199));
+
+    // With target 200 two files weigh exactly the target, so all three files pack together.
+    options = CreateOptions("200", "1", "2");
+    ASSERT_OK_AND_ASSIGN(tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2", "f3"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 299));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestOpenFileCostWeighsSmallFiles) {
+    // A bin weighs each file by max(file_size, open-file-cost), so many tiny files still cost
+    // an open each and fill a bin far sooner than their bytes suggest.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 1, 0, 1, 1, 1), NewFile("f2", 1, 1, 1, 2, 2), NewFile("f3", 1, 2, 1, 3, 3)};
+
+    // With an open-file cost of 100 each file weighs 100: the first two exceed the target and
+    // form a task, leaving the third below the minimum file count.
+    CoreOptions options = CreateOptions("199", "100", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 1));
+
+    // Weighed by their bytes alone the same files never fill the bin and pack together.
+    options = CreateOptions("199", "1", "2");
+    ASSERT_OK_AND_ASSIGN(tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2", "f3"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 2));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestRowIdGapCutsBin) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 100, 0, 100, 1, 1), NewFile("f2", 100, 100, 100, 2, 2),
+        NewFile("f3", 100, 1000, 100, 3, 3), NewFile("f4", 100, 1100, 100, 4, 4)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 2);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 199));
+    EXPECT_EQ(FileNames(tasks[1]), (std::vector<std::string>{"f3", "f4"}));
+    EXPECT_EQ(tasks[1].RowRange(), Range(1000, 1199));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestLargeFileSkippedAndCutsBin) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 100, 0, 100, 1, 1), NewFile("f2", 100, 100, 100, 2, 2),
+        NewFile("big", 5000, 200, 100, 3, 3), NewFile("f4", 100, 300, 100, 4, 4),
+        NewFile("f5", 100, 400, 100, 5, 5)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    // The large file exceeds the target on its own: it cuts the bin, is not packed with its
+    // neighbors, and alone it stays below the configured minimum file count.
+    ASSERT_EQ(tasks.size(), 2);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    // The rewritten ranges stop short of the large file's rows and resume after them.
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 199));
+    EXPECT_EQ(FileNames(tasks[1]), (std::vector<std::string>{"f4", "f5"}));
+    EXPECT_EQ(tasks[1].RowRange(), Range(300, 499));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestEvolvedFieldGroupsPackTogether) {
+    // f1 holds all columns of rows [0, 99], f2 is a newer partial-column file over the exact
+    // same rows (one evolved field group), f3 continues the row id run.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 50, 0, 100, 2, 2),
+                                                        NewFile("f3", 100, 100, 100, 3, 3)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2", "f3"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 199));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestHeavyFieldGroupCompactedAlone) {
+    // The field group of rows [100, 199] outweighs the target by itself: it still becomes a
+    // task (merging versions is worthwhile), but nothing else is packed on top of it.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 100, 0, 100, 1, 1), NewFile("g1", 600, 100, 100, 2, 2),
+        NewFile("g2", 600, 100, 100, 3, 3), NewFile("f4", 100, 200, 100, 4, 4)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"g1", "g2"}));
+    EXPECT_EQ(tasks[0].RowRange(), Range(100, 199));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestMismatchedFieldGroupRangesRejected) {
+    // Overlapping files that do not cover the exact same rows cannot form a field group.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 100, 0, 50, 2, 2)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    Result<std::vector<DataEvolutionNormalCompactTask>> result = Plan(files, options);
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().ToString().find("same row range") != std::string::npos)
+        << result.status().ToString();
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestBlobFilesExcluded) {
+    // Blob files share the row range of their data files but are dedicated storage: they must
+    // not join a field group or a task.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 50, 0, 100, 2, 2),
+                                                        NewFile("f3.blob", 100, 0, 100, 2, 2)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1", "f2"}));
+    // The excluded blob file shares these rows, so the range must stay the data files' own.
+    EXPECT_EQ(tasks[0].RowRange(), Range(0, 99));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestVectorStoreFilesRejected) {
+    // Without a VECTOR schema type the rewrite cannot exclude vector columns, so a table
+    // holding vector-store files is rejected instead of silently mis-planned.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        NewFile("f1", 100, 0, 100, 1, 1), NewFile("f2", 50, 0, 100, 2, 2),
+        NewFile("f3.vector.lance", 100, 0, 100, 2, 2)};
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    Result<std::vector<DataEvolutionNormalCompactTask>> result = Plan(files, options);
+    ASSERT_FALSE(result.ok());
+    EXPECT_TRUE(result.status().ToString().find("vector-store") != std::string::npos)
+        << result.status().ToString();
+
+    // The rejection is reported even when the vector-store file's own metadata is unusable:
+    // an unsupported table should say so rather than blame whichever field looks invalid.
+    std::vector<std::shared_ptr<DataFileMeta>> files_with_bad_vector_meta = {
+        NewFile("f1", 100, 0, 100, 1, 1), NewFile("f2", 50, 0, 100, 2, 2),
+        NewFile("f3.vector.lance", 100, /*first_row_id=*/0, /*row_count=*/0, 2, 2)};
+    Result<std::vector<DataEvolutionNormalCompactTask>> bad_meta_result =
+        Plan(files_with_bad_vector_meta, options);
+    ASSERT_FALSE(bad_meta_result.ok());
+    EXPECT_TRUE(bad_meta_result.status().ToString().find("vector-store") != std::string::npos)
+        << bad_meta_result.status().ToString();
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestPartitionsPlanIndependently) {
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    LinkedHashMap<BinaryRow, std::vector<std::shared_ptr<DataFileMeta>>> partition_files;
+    partition_files[CreateIntRow(0)] = {NewFile("p0-f1", 100, 0, 100, 1, 1),
+                                        NewFile("p0-f2", 100, 100, 100, 2, 2)};
+    partition_files[CreateIntRow(1)] = {NewFile("p1-f1", 100, 0, 100, 1, 1),
+                                        NewFile("p1-f2", 100, 100, 100, 2, 2)};
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks,
+                         DataEvolutionCompactPlanner::PlanCompactTasks(partition_files, options));
+    ASSERT_EQ(tasks.size(), 2);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"p0-f1", "p0-f2"}));
+    EXPECT_EQ(FileNames(tasks[1]), (std::vector<std::string>{"p1-f1", "p1-f2"}));
+    EXPECT_EQ(tasks[0].Partition(), CreateIntRow(0));
+    EXPECT_EQ(tasks[1].Partition(), CreateIntRow(1));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestMinFileNumOneAllowsSingleFileTask) {
+    // There is no lower bound on a normal task's input size: with compaction.min.file-num=1
+    // even a lone file may be rewritten.
+    CoreOptions options = CreateOptions("1024", "1", "1");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks,
+                         Plan({NewFile("f1", 100, 0, 100, 1, 1)}, options));
+    ASSERT_EQ(tasks.size(), 1);
+    EXPECT_EQ(FileNames(tasks[0]), (std::vector<std::string>{"f1"}));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestMinFileNumSuppressesSmallBins) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {NewFile("f1", 100, 0, 100, 1, 1),
+                                                        NewFile("f2", 100, 100, 100, 2, 2)};
+    CoreOptions options = CreateOptions("1024", "1", "5");
+    ASSERT_OK_AND_ASSIGN(std::vector<DataEvolutionNormalCompactTask> tasks, Plan(files, options));
+    ASSERT_TRUE(tasks.empty());
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestPlanRejectsInvalidFileMeta) {
+    CoreOptions options = CreateOptions("1024", "1", "2");
+    auto expect_plan_error = [](const Result<std::vector<DataEvolutionNormalCompactTask>>& result,
+                                const std::string& expected) {
+        EXPECT_FALSE(result.ok());
+        EXPECT_NE(result.status().ToString().find(expected), std::string::npos)
+            << result.status().ToString();
+    };
+    // A null file must fail the plan instead of crashing it.
+    expect_plan_error(Plan({nullptr}, options), "compaction files must not be null");
+    // A zero row count cannot form a valid row id range.
+    expect_plan_error(
+        Plan({NewFile("f1", 100, /*first_row_id=*/0, /*row_count=*/0, 1, 1)}, options),
+        "must form a valid file and row id range");
+    // A negative file size cannot weigh a bin.
+    expect_plan_error(
+        Plan({NewFile("f1", -1, /*first_row_id=*/0, /*row_count=*/100, 1, 1)}, options),
+        "must form a valid file and row id range");
+    // A row range overflowing int64 is rejected before any packing arithmetic runs on it.
+    expect_plan_error(
+        Plan({NewFile("f1", 100, /*first_row_id=*/std::numeric_limits<int64_t>::max() - 1,
+                      /*row_count=*/100, 1, 1)},
+             options),
+        "must form a valid file and row id range");
+    // A file without a first row id cannot take part in data evolution planning.
+    auto file_without_row_id =
+        DataFileMeta::ForAppend("f1", 100, 100, SimpleStats::EmptyStats(), 1, 1, /*schema_id=*/0,
+                                FileSource::Append(), /*value_stats_cols=*/std::nullopt,
+                                /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt,
+                                /*write_cols=*/std::nullopt)
+            .value();
+    expect_plan_error(Plan({file_without_row_id, NewFile("f2", 100, 100, 100, 2, 2)}, options),
+                      "First row id of f1 should not be null");
+}
+
+/// The open ended tail of the last window: every row id the table can still grow into.
+constexpr int64_t kOpenEnd = std::numeric_limits<int64_t>::max();
+
+TEST_F(DataEvolutionCompactPlannerTest, TestPlanRowIdWindowsCutsAtCoverageGaps) {
+    // Three manifests, none reaching into the next: with a one-file budget every manifest is a
+    // round of its own, and the last window stays open ended so rows appended later belong to
+    // it rather than to no window at all.
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<Range> windows,
+        PlanWindows({NewManifest("m0", /*num_added_files=*/1,
+                                 /*num_deleted_files=*/0, 0, 9),
+                     NewManifest("m1", 1, 0, 10, 19), NewManifest("m2", 1, 0, 20, 29)},
+                    /*candidate_files_per_round=*/1));
+    ASSERT_EQ(windows, (std::vector<Range>{Range(0, 9), Range(10, 19), Range(20, kOpenEnd)}));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestPlanRowIdWindowsNeverCutsInsideCoveredRows) {
+    // A cut anywhere but a coverage gap would hand a file straddling it to two rounds, so an
+    // overlapping manifest holds the window open even though the budget is already reached.
+    ASSERT_OK_AND_ASSIGN(std::vector<Range> windows,
+                         PlanWindows({NewManifest("m0", 1, 0, 0, 9), NewManifest("m1", 1, 0, 5, 14),
+                                      NewManifest("m2", 1, 0, 20, 29)},
+                                     /*candidate_files_per_round=*/1));
+    ASSERT_EQ(windows, (std::vector<Range>{Range(0, 14), Range(15, kOpenEnd)}));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestPlanRowIdWindowsHonorsTheFileBudget) {
+    // The same three manifests with a two-file budget: the first gap is passed over because the
+    // window has not collected enough candidates yet.
+    ASSERT_OK_AND_ASSIGN(std::vector<Range> windows, PlanWindows({NewManifest("m0", 1, 0, 0, 9),
+                                                                  NewManifest("m1", 1, 0, 10, 19),
+                                                                  NewManifest("m2", 1, 0, 20, 29)},
+                                                                 /*candidate_files_per_round=*/2));
+    ASSERT_EQ(windows, (std::vector<Range>{Range(0, 19), Range(20, kOpenEnd)}));
+
+    // A budget no window reaches leaves the whole row id space in one round.
+    ASSERT_OK_AND_ASSIGN(
+        windows, PlanWindows({NewManifest("m0", 1, 0, 0, 9), NewManifest("m1", 1, 0, 10, 19),
+                              NewManifest("m2", 1, 0, 20, 29)},
+                             /*candidate_files_per_round=*/100));
+    ASSERT_EQ(windows, (std::vector<Range>{Range(0, kOpenEnd)}));
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestPlanRowIdWindowsFallsBackWithoutRowIdStatistics) {
+    // A manifest whose files cannot be placed would leave a hole in the windows, so the split
+    // is abandoned rather than silently skipping those files. An empty result asks the caller
+    // for a single unbounded round.
+    ASSERT_OK_AND_ASSIGN(std::vector<Range> windows,
+                         PlanWindows({NewManifest("m0", 1, 0, 0, 9),
+                                      NewManifest("m1", 1, 0, /*min_row_id=*/std::nullopt,
+                                                  /*max_row_id=*/std::nullopt)},
+                                     /*candidate_files_per_round=*/1));
+    ASSERT_TRUE(windows.empty());
+
+    // Statistics that cannot describe a range are just as unusable.
+    ASSERT_OK_AND_ASSIGN(windows,
+                         PlanWindows({NewManifest("m0", 1, 0, 0, 9),
+                                      NewManifest("m1", 1, 0, /*min_row_id=*/5, /*max_row_id=*/4)},
+                                     /*candidate_files_per_round=*/1));
+    ASSERT_TRUE(windows.empty());
+}
+
+TEST_F(DataEvolutionCompactPlannerTest, TestPlanRowIdWindowsIgnoresDeleteOnlyManifests) {
+    // A manifest holding no ADD entry carries no candidate, so it can neither pad a window nor
+    // disable the split by lacking row id statistics - which is exactly what the manifest left
+    // behind by materializing a fully deleted range looks like.
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<Range> windows,
+        PlanWindows({NewManifest("m0", /*num_added_files=*/1, /*num_deleted_files=*/0, 0, 9),
+                     NewManifest("deletes", /*num_added_files=*/0, /*num_deleted_files=*/3,
+                                 /*min_row_id=*/std::nullopt, /*max_row_id=*/std::nullopt),
+                     NewManifest("m1", 1, 0, 20, 29)},
+                    /*candidate_files_per_round=*/1));
+    ASSERT_EQ(windows, (std::vector<Range>{Range(0, 9), Range(10, kOpenEnd)}));
+
+    // With nothing but delete-only manifests there is no candidate at all, so there is nothing
+    // to split and the caller falls back to one round.
+    ASSERT_OK_AND_ASSIGN(
+        windows, PlanWindows({NewManifest("d0", 0, 3, 0, 9), NewManifest("d1", 0, 3, 20, 29)},
+                             /*candidate_files_per_round=*/1));
+    ASSERT_TRUE(windows.empty());
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/append/data_evolution_materialize_deletion_compact_task.cpp
+++ b/src/paimon/core/append/data_evolution_materialize_deletion_compact_task.cpp
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_materialize_deletion_compact_task.h"
+
+#include <algorithm>
+#include <map>
+#include <string>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "arrow/c/helpers.h"
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/data/shredding/shredding_write_plan_factories.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/utils/arrow/arrow_utils.h"
+#include "paimon/common/utils/long_counter.h"
+#include "paimon/common/utils/scope_guard.h"
+#include "paimon/common/utils/vector_store_utils.h"
+#include "paimon/core/io/append_data_file_writer_factory.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/io/rolling_file_writer.h"
+#include "paimon/core/io/shredding_append_data_file_writer_factory.h"
+#include "paimon/core/operation/data_evolution_split_read.h"
+#include "paimon/core/operation/internal_read_context.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/core/utils/data_evolution_utils.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/defs.h"
+#include "paimon/read_context.h"
+#include "paimon/reader/batch_reader.h"
+
+namespace paimon {
+
+DataEvolutionMaterializeDeletionCompactTask::DataEvolutionMaterializeDeletionCompactTask(
+    const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files,
+    const std::vector<std::optional<DeletionFile>>& deletion_files, const Range& row_range)
+    : partition_(partition),
+      compact_before_(files),
+      deletion_files_(deletion_files),
+      row_range_(row_range) {}
+
+Result<DataEvolutionMaterializeDeletionCompactTask>
+DataEvolutionMaterializeDeletionCompactTask::Create(
+    const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files,
+    const std::vector<std::optional<DeletionFile>>& deletion_files) {
+    if (files.size() != deletion_files.size()) {
+        return Status::Invalid(fmt::format(
+            "A materialize deletion task needs one deletion file slot per data file, but got {} "
+            "files and {} slots.",
+            files.size(), deletion_files.size()));
+    }
+    // Rewriting only the normal files of a range would leave the dedicated ones indexed by row
+    // ids that no longer exist, so a range covering one is refused rather than half rewritten.
+    for (const auto& file : files) {
+        if (BlobUtils::IsBlobFile(file->file_name)) {
+            return Status::NotImplemented(fmt::format(
+                "Materializing deletion vectors is not supported for a row range covered by the "
+                "blob file {}: Paimon C++ does not rewrite blob files, so their row ids cannot "
+                "be reassigned with the rows they belong to.",
+                file->file_name));
+        }
+        if (VectorStoreUtils::IsVectorStoreFile(file->file_name)) {
+            return Status::NotImplemented(fmt::format(
+                "Materializing deletion vectors is not supported for a row range covered by the "
+                "vector-store file {}.",
+                file->file_name));
+        }
+    }
+    bool has_deletions = std::any_of(deletion_files.begin(), deletion_files.end(),
+                                     [](const std::optional<DeletionFile>& deletion_file) {
+                                         return deletion_file != std::nullopt;
+                                     });
+    if (!has_deletions) {
+        return Status::Invalid(
+            "A materialize deletion task needs at least one file carrying a deletion vector.");
+    }
+    PAIMON_ASSIGN_OR_RAISE(Range row_range, DataEvolutionUtils::CheckContiguousRowRange(files));
+    return DataEvolutionMaterializeDeletionCompactTask(partition, files, deletion_files, row_range);
+}
+
+Result<std::shared_ptr<CommitMessage>> DataEvolutionMaterializeDeletionCompactTask::DoCompact(
+    const DataEvolutionCompactContext& context) {
+    if (compact_before_.empty()) {
+        return Status::Invalid(
+            "DataEvolutionMaterializeDeletionCompactTask needs at least one file input.");
+    }
+    // A task rewrites its input once. Running it again would append a second set of outputs and
+    // commit the same surviving rows twice.
+    if (!compact_after_.empty()) {
+        return Status::Invalid(
+            "DataEvolutionMaterializeDeletionCompactTask has already been compacted and cannot "
+            "run twice.");
+    }
+
+    // Every column is rewritten: materializing changes the row ids, so a column left in place
+    // would still be addressed by the old ones. Create() already refused the ranges whose
+    // columns live in dedicated files this cannot rewrite.
+    std::vector<std::string> read_write_field_names;
+    read_write_field_names.reserve(context.arrow_schema->fields().size());
+    for (const auto& field : context.arrow_schema->fields()) {
+        read_write_field_names.push_back(field->name());
+    }
+    if (read_write_field_names.empty()) {
+        return Status::Invalid("Materializing deletion vectors requires at least one column.");
+    }
+    auto write_schema = context.arrow_schema;
+
+    // Unlike the normal task, the deletion files *are* attached: the read drops the deleted rows
+    // so they never reach the writer. DataEvolutionSplitRead resolves them per row range group,
+    // which is how a vector keyed by a group's anchor reaches the group's other files.
+    ReadContextBuilder context_builder(context.table_path);
+    context_builder.SetOptions(context.core_options.ToMap())
+        .WithFileSystem(context.core_options.GetFileSystem())
+        .SetReadFieldNames(read_write_field_names)
+        .EnablePrefetch(true)
+        .SetPrefetchMaxParallelNum(1)
+        .SetPrefetchBatchCount(3)
+        .WithMemoryPool(context.pool);
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ReadContext> read_context, context_builder.Finish());
+    std::map<std::string, std::string> read_options = context.core_options.ToMap();
+    if (read_options.find("parquet.read.enable-pre-buffer") == read_options.end()) {
+        read_options["parquet.read.enable-pre-buffer"] = "false";
+    }
+    // Blob-view columns must be rewritten as their serialized BlobViewStruct bytes, exactly as
+    // the normal task does; resolving them here would bake descriptors into the column.
+    read_options[Options::BLOB_VIEW_RESOLVE_ENABLED] = "false";
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<InternalReadContext> internal_read_context,
+        InternalReadContext::Create(read_context, context.table_schema, read_options));
+    auto split_read = std::make_unique<DataEvolutionSplitRead>(
+        context.path_factory, internal_read_context, context.pool, context.executor);
+
+    PAIMON_ASSIGN_OR_RAISE(std::string bucket_path,
+                           context.path_factory->BucketPath(partition_, /*bucket=*/0));
+    auto data_files = compact_before_;
+    auto deletion_files = deletion_files_;
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<DataSplitImpl> split,
+        DataSplitImpl::Builder(partition_, /*bucket=*/0, bucket_path, std::move(data_files))
+            .WithDataDeletionFiles(std::move(deletion_files))
+            .RawConvertible(false)
+            .Build());
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> reader, split_read->CreateReader(split));
+    ScopeGuard reader_guard([&]() {
+        if (reader) {
+            reader->Close();
+        }
+    });
+
+    // The surviving rows are written through the table's ordinary rolling rules rather than into
+    // one file pinned to the input range: the range is not preserved anyway, so there is no
+    // reason to produce a single oversized file.
+    //
+    // FileSource::Append(), not Compact(): that is what makes the commit assign fresh row ids to
+    // these files. The rewriter recognises the missing row ids and drops the old vectors.
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<DataFilePathFactory> data_file_path_factory,
+        context.path_factory->CreateDataFilePathFactory(partition_, /*bucket=*/0));
+    auto seq_num_counter = std::make_shared<LongCounter>(0);
+    std::shared_ptr<SingleFileWriterFactory<::ArrowArray*, std::shared_ptr<DataFileMeta>>>
+        writer_factory;
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ShreddingWritePlanFactory> plan_factory,
+                           ShreddingWritePlanFactories::SelectActive(context.core_options,
+                                                                     write_schema, context.pool));
+    if (plan_factory != nullptr) {
+        writer_factory = std::make_shared<ShreddingAppendDataFileWriterFactory>(
+            context.core_options, context.table_schema->Id(), write_schema,
+            /*write_cols=*/std::nullopt, seq_num_counter, FileSource::Append(),
+            data_file_path_factory, plan_factory, context.pool);
+    } else {
+        writer_factory = std::make_shared<AppendDataFileWriterFactory>(
+            context.core_options, context.table_schema->Id(), write_schema,
+            /*write_cols=*/std::nullopt, seq_num_counter, FileSource::Append(),
+            data_file_path_factory, context.pool);
+    }
+    auto rewriter =
+        std::make_unique<RollingFileWriter<::ArrowArray*, std::shared_ptr<DataFileMeta>>>(
+            context.core_options.GetTargetFileSize(/*has_primary_key=*/false),
+            context.core_options.GetTargetFileRowNum(), writer_factory);
+    ScopeGuard rewriter_guard([&]() {
+        if (rewriter) {
+            rewriter->Abort();
+        }
+    });
+
+    while (true) {
+        PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch batch, reader->NextBatch());
+        if (BatchReader::IsEofBatch(batch)) {
+            break;
+        }
+        auto& [c_array, c_schema] = batch;
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                          arrow::ImportArray(c_array.get(), c_schema.get()));
+        auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+        if (!struct_array) {
+            return Status::Invalid(
+                "cannot cast array to StructArray in DataEvolutionMaterializeDeletionCompactTask");
+        }
+        PAIMON_ASSIGN_OR_RAISE(struct_array, ArrowUtils::RemoveFieldFromStructArray(
+                                                 struct_array, SpecialFields::ValueKind().Name()));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(
+            arrow::ExportArray(*struct_array, c_array.get(), c_schema.get()));
+        ArrowSchemaRelease(c_schema.get());
+        ScopeGuard guard([array = c_array.get()]() { ArrowArrayRelease(array); });
+        PAIMON_RETURN_NOT_OK(rewriter->Write(c_array.get()));
+        guard.Release();
+    }
+    PAIMON_RETURN_NOT_OK(rewriter->Close());
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<DataFileMeta>> write_result,
+                           rewriter->GetResult());
+    rewriter_guard.Release();
+
+    // No row ids and no sequence numbers are assigned here: the commit gives the surviving rows
+    // fresh row ids, which is the whole point of materializing, and the writer's own sequence
+    // numbers stand because the output no longer competes with a field group.
+    compact_after_ = std::move(write_result);
+
+    auto compact_before_copy = compact_before_;
+    auto compact_after_copy = compact_after_;
+    CompactIncrement compact_increment(std::move(compact_before_copy),
+                                       std::move(compact_after_copy),
+                                       /*changelog_files=*/{},
+                                       /*new_index_files=*/{},
+                                       /*deleted_index_files=*/{});
+    DataIncrement data_increment(/*new_files=*/{}, /*deleted_files=*/{}, /*changelog_files=*/{});
+
+    // Bucket 0 is the bucket for unaware-bucket tables, and total buckets stay unset, matching
+    // the contract the deletion vector rewriter asserts on.
+    return std::make_shared<CommitMessageImpl>(partition_,
+                                               /*bucket=*/0, /*total_buckets=*/std::nullopt,
+                                               data_increment, compact_increment);
+}
+
+std::string DataEvolutionMaterializeDeletionCompactTask::ToString() const {
+    std::vector<std::string> before_names;
+    before_names.reserve(compact_before_.size());
+    for (const auto& file : compact_before_) {
+        before_names.emplace_back(file->file_name);
+    }
+
+    std::vector<std::string> after_names;
+    after_names.reserve(compact_after_.size());
+    for (const auto& file : compact_after_) {
+        after_names.emplace_back(file->file_name);
+    }
+
+    return fmt::format(
+        "DataEvolutionMaterializeDeletionCompactTask {{partition = {}, rowRange = {}, "
+        "compactBefore = [{}], compactAfter = [{}]}}",
+        partition_.ToString(), row_range_.ToString(), fmt::join(before_names, ", "),
+        fmt::join(after_names, ", "));
+}
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_materialize_deletion_compact_task.h
+++ b/src/paimon/core/append/data_evolution_materialize_deletion_compact_task.h
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/table/source/deletion_file.h"
+#include "paimon/result.h"
+
+namespace paimon {
+
+class CommitMessage;
+
+/// Physically applies the deletion vectors of one contiguous row id range while rewriting it.
+///
+/// This is the heavy counterpart of `DataEvolutionNormalCompactTask`. That one keeps every
+/// input row and leaves the deletions logical, so row ids survive and the vectors are merely
+/// re-keyed. Materializing instead drops the deleted rows for real, which means the output
+/// holds fewer rows than its inputs and cannot keep their row ids: the files are written
+/// without any, and the commit assigns fresh ones the way it does for an append. So every
+/// column of the range has to be rewritten together, and the global indexes over it are
+/// invalidated and dropped by `DataEvolutionCompactGlobalIndexDropper` in the same commit -
+/// the consequences `AppendCompactCoordinator::MaterializeDeletionVectors` documents for the
+/// caller.
+///
+/// The vectors themselves are not moved anywhere:
+/// `DataEvolutionCompactDeletionVectorRewriter` recognises a materialized task by its output
+/// carrying no row id and removes the old vectors instead of re-keying them.
+///
+/// Scope: a range covered by a dedicated blob or vector-store file is rejected. Those files are
+/// never rewritten by Paimon C++, so reassigning the row ids of the normal file alone would
+/// break the alignment they are read through.
+class DataEvolutionMaterializeDeletionCompactTask {
+ public:
+    /// Creates a task over `files`, which must cover one contiguous row id range, together with
+    /// the deletion file of each — `std::nullopt` for a file that has none. At least one file
+    /// has to carry deletions, or there is nothing to materialize.
+    static Result<DataEvolutionMaterializeDeletionCompactTask> Create(
+        const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files,
+        const std::vector<std::optional<DeletionFile>>& deletion_files);
+
+    ~DataEvolutionMaterializeDeletionCompactTask() = default;
+
+    const BinaryRow& Partition() const {
+        return partition_;
+    }
+
+    const std::vector<std::shared_ptr<DataFileMeta>>& CompactBefore() const {
+        return compact_before_;
+    }
+
+    const std::vector<std::shared_ptr<DataFileMeta>>& CompactAfter() const {
+        return compact_after_;
+    }
+
+    const std::vector<std::optional<DeletionFile>>& DeletionFiles() const {
+        return deletion_files_;
+    }
+
+    /// Rewrites the range with its deletions applied. Unlike the normal task this may produce
+    /// several files, because the surviving rows are written through the table's ordinary
+    /// rolling rules rather than into one file pinned to the input range.
+    Result<std::shared_ptr<CommitMessage>> DoCompact(const DataEvolutionCompactContext& context);
+
+    std::string ToString() const;
+
+ private:
+    DataEvolutionMaterializeDeletionCompactTask(
+        const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files,
+        const std::vector<std::optional<DeletionFile>>& deletion_files, const Range& row_range);
+
+    BinaryRow partition_;
+    std::vector<std::shared_ptr<DataFileMeta>> compact_before_;
+    std::vector<std::optional<DeletionFile>> deletion_files_;
+    std::vector<std::shared_ptr<DataFileMeta>> compact_after_;
+    Range row_range_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_materialize_deletion_compact_task_test.cpp
+++ b/src/paimon/core/append/data_evolution_materialize_deletion_compact_task_test.cpp
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_materialize_deletion_compact_task.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+namespace {
+
+std::shared_ptr<DataFileMeta> CreateFile(const std::string& file_name, int64_t first_row_id,
+                                         int64_t row_count) {
+    return std::make_shared<DataFileMeta>(
+        file_name, /*file_size=*/1024, row_count, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_seq_no=*/1, /*max_seq_no=*/2, /*schema_id=*/0, /*level=*/0,
+        /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(0, 0), /*delete_row_count=*/std::nullopt,
+        /*embedded_index=*/nullptr, /*file_source=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*value_stats_cols=*/std::nullopt, first_row_id, /*write_cols=*/std::nullopt);
+}
+
+BinaryRow EmptyPartition() {
+    BinaryRow row(0);
+    BinaryRowWriter writer(&row, 8, GetDefaultPool().get());
+    writer.Complete();
+    return row;
+}
+
+DeletionFile SomeDeletionFile() {
+    return DeletionFile("/tmp/index-0", /*offset=*/1, /*length=*/8, /*cardinality=*/2);
+}
+
+}  // namespace
+
+TEST(DataEvolutionMaterializeDeletionCompactTaskTest, CreateAcceptsAContiguousRangeWithDeletions) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateFile("a.parquet", /*first_row_id=*/0, /*row_count=*/4),
+        CreateFile("b.parquet", /*first_row_id=*/4, /*row_count=*/4)};
+    std::vector<std::optional<DeletionFile>> deletion_files = {SomeDeletionFile(), std::nullopt};
+
+    ASSERT_OK_AND_ASSIGN(DataEvolutionMaterializeDeletionCompactTask task,
+                         DataEvolutionMaterializeDeletionCompactTask::Create(
+                             EmptyPartition(), files, deletion_files));
+    ASSERT_EQ(task.CompactBefore().size(), 2);
+    ASSERT_EQ(task.DeletionFiles().size(), 2);
+    // Nothing is written until DoCompact runs.
+    ASSERT_TRUE(task.CompactAfter().empty());
+    ASSERT_NE(task.ToString().find("a.parquet"), std::string::npos);
+}
+
+TEST(DataEvolutionMaterializeDeletionCompactTaskTest, CreateRejectsMisalignedDeletionFiles) {
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateFile("a.parquet", /*first_row_id=*/0, /*row_count=*/4)};
+    ASSERT_NOK_WITH_MSG(DataEvolutionMaterializeDeletionCompactTask::Create(EmptyPartition(), files,
+                                                                            /*deletion_files=*/{}),
+                        "one deletion file slot per data file");
+}
+
+TEST(DataEvolutionMaterializeDeletionCompactTaskTest, CreateRejectsARangeWithoutDeletions) {
+    // Materializing a range that deletes nothing would renumber its row ids for no gain, so the
+    // planner must not produce such a task and Create refuses one.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateFile("a.parquet", /*first_row_id=*/0, /*row_count=*/4)};
+    std::vector<std::optional<DeletionFile>> deletion_files = {std::nullopt};
+    ASSERT_NOK_WITH_MSG(DataEvolutionMaterializeDeletionCompactTask::Create(EmptyPartition(), files,
+                                                                            deletion_files),
+                        "at least one file carrying a deletion vector");
+}
+
+TEST(DataEvolutionMaterializeDeletionCompactTaskTest, CreateRejectsADiscontiguousRange) {
+    // Row ids are reassigned over the whole task, so a hole in the middle would renumber rows
+    // that were never read together.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateFile("a.parquet", /*first_row_id=*/0, /*row_count=*/4),
+        CreateFile("b.parquet", /*first_row_id=*/100, /*row_count=*/4)};
+    std::vector<std::optional<DeletionFile>> deletion_files = {SomeDeletionFile(), std::nullopt};
+    ASSERT_NOK_WITH_MSG(DataEvolutionMaterializeDeletionCompactTask::Create(EmptyPartition(), files,
+                                                                            deletion_files),
+                        "contiguous row range");
+}
+
+TEST(DataEvolutionMaterializeDeletionCompactTaskTest, CreateRejectsDedicatedStorageFiles) {
+    // Paimon C++ does not rewrite blob or vector-store files, so their row ids cannot be
+    // reassigned in step with the rows they belong to. Refusing is the only safe answer;
+    // rewriting the normal file alone would silently break the alignment they are read through.
+    std::vector<std::optional<DeletionFile>> deletion_files = {SomeDeletionFile(), std::nullopt};
+
+    std::vector<std::shared_ptr<DataFileMeta>> with_blob = {
+        CreateFile("a.parquet", /*first_row_id=*/0, /*row_count=*/4),
+        CreateFile("b-f2-0.blob", /*first_row_id=*/0, /*row_count=*/4)};
+    ASSERT_NOK_WITH_MSG(DataEvolutionMaterializeDeletionCompactTask::Create(
+                            EmptyPartition(), with_blob, deletion_files),
+                        "blob file");
+
+    std::vector<std::shared_ptr<DataFileMeta>> with_vector_store = {
+        CreateFile("a.parquet", /*first_row_id=*/0, /*row_count=*/4),
+        CreateFile("b-f2-0.vector.parquet", /*first_row_id=*/0, /*row_count=*/4)};
+    ASSERT_NOK_WITH_MSG(DataEvolutionMaterializeDeletionCompactTask::Create(
+                            EmptyPartition(), with_vector_store, deletion_files),
+                        "vector-store file");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/append/data_evolution_normal_compact_task.cpp
+++ b/src/paimon/core/append/data_evolution_normal_compact_task.cpp
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <set>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "arrow/c/helpers.h"
+#include "fmt/format.h"
+#include "fmt/ranges.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/data/shredding/shredding_write_plan_factories.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/utils/arrow/arrow_utils.h"
+#include "paimon/common/utils/long_counter.h"
+#include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/io/append_data_file_writer_factory.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/io/rolling_file_writer.h"
+#include "paimon/core/io/shredding_append_data_file_writer_factory.h"
+#include "paimon/core/operation/data_evolution_split_read.h"
+#include "paimon/core/operation/internal_read_context.h"
+#include "paimon/core/schema/table_schema.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/core/utils/data_evolution_utils.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/defs.h"
+#include "paimon/read_context.h"
+#include "paimon/reader/batch_reader.h"
+
+namespace paimon {
+
+DataEvolutionNormalCompactTask::DataEvolutionNormalCompactTask(
+    const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files,
+    const Range& row_range)
+    : partition_(partition), compact_before_(files), row_range_(row_range) {}
+
+Result<DataEvolutionNormalCompactTask> DataEvolutionNormalCompactTask::Create(
+    const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+    PAIMON_ASSIGN_OR_RAISE(Range row_range, DataEvolutionUtils::CheckContiguousRowRange(files));
+    return DataEvolutionNormalCompactTask(partition, files, row_range);
+}
+
+Result<std::shared_ptr<CommitMessage>> DataEvolutionNormalCompactTask::DoCompact(
+    const DataEvolutionCompactContext& context) {
+    if (compact_before_.empty()) {
+        return Status::Invalid("DataEvolutionNormalCompactTask needs at least one file input.");
+    }
+    // A task rewrites its input once. Running it again would append a second output to
+    // `compact_after_` and commit two files for the same rows, so a repeat is refused rather
+    // than silently duplicating the group.
+    if (!compact_after_.empty()) {
+        return Status::Invalid(
+            "DataEvolutionNormalCompactTask has already been compacted and cannot run twice.");
+    }
+
+    // The read/write schema drops blob fields stored in dedicated .blob files: they are not
+    // rewritten by data-evolution compaction. Inline blob fields (descriptor / view) live in
+    // the normal data files and stay in the schema.
+    std::vector<std::string> inline_field_names = context.core_options.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> dedicated_field_names =
+        BlobUtils::ManagedBlobFieldNames(context.arrow_schema, inline_fields);
+    std::set<std::string> dedicated_fields(dedicated_field_names.begin(),
+                                           dedicated_field_names.end());
+    std::vector<std::string> read_write_field_names;
+    arrow::FieldVector write_fields;
+    for (const auto& field : context.arrow_schema->fields()) {
+        if (dedicated_fields.count(field->name()) != 0) {
+            continue;
+        }
+        read_write_field_names.push_back(field->name());
+        write_fields.push_back(field);
+    }
+    if (write_fields.empty()) {
+        return Status::Invalid(
+            "Data evolution compaction requires at least one non-blob column to rewrite.");
+    }
+    auto write_schema = arrow::schema(write_fields);
+
+    // A file holding every table column stores no write cols; a partial-column file names the
+    // columns it holds.
+    std::optional<std::vector<std::string>> write_cols = read_write_field_names;
+    if (context.arrow_schema->Equals(*write_schema)) {
+        write_cols = std::nullopt;
+    }
+
+    // Deletion files are intentionally not attached to the read, so the output file keeps
+    // every input row and the deletions stay logical. They are moved onto the output file by
+    // DataEvolutionCompactDeletionVectorRewriter, which runs over the whole round's commit
+    // messages before anything is committed.
+    ReadContextBuilder context_builder(context.table_path);
+    context_builder.SetOptions(context.core_options.ToMap())
+        .WithFileSystem(context.core_options.GetFileSystem())
+        .SetReadFieldNames(read_write_field_names)
+        .EnablePrefetch(true)
+        .SetPrefetchMaxParallelNum(1)
+        .SetPrefetchBatchCount(3)
+        .WithMemoryPool(context.pool);
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ReadContext> read_context, context_builder.Finish());
+    // TODO(xinyu.lxy): temporarily disabled pre-buffer for parquet, which may cause high
+    // memory usage during compaction. Will fix via parquet format refactor.
+    std::map<std::string, std::string> read_options = context.core_options.ToMap();
+    if (read_options.find("parquet.read.enable-pre-buffer") == read_options.end()) {
+        read_options["parquet.read.enable-pre-buffer"] = "false";
+    }
+    // Blob-view columns must be rewritten as their serialized BlobViewStruct bytes: resolving
+    // them here would bake descriptors into the blob-view column and break later reads.
+    read_options[Options::BLOB_VIEW_RESOLVE_ENABLED] = "false";
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<InternalReadContext> internal_read_context,
+        InternalReadContext::Create(read_context, context.table_schema, read_options));
+    auto split_read = std::make_unique<DataEvolutionSplitRead>(
+        context.path_factory, internal_read_context, context.pool, context.executor);
+
+    PAIMON_ASSIGN_OR_RAISE(std::string bucket_path,
+                           context.path_factory->BucketPath(partition_, /*bucket=*/0));
+    auto data_files = compact_before_;
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<DataSplitImpl> split,
+        DataSplitImpl::Builder(partition_, /*bucket=*/0, bucket_path, std::move(data_files))
+            .RawConvertible(false)
+            .Build());
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> reader, split_read->CreateReader(split));
+    ScopeGuard reader_guard([&]() {
+        if (reader) {
+            reader->Close();
+        }
+    });
+
+    // A single output file: rolling is disabled so the rewritten rows keep exactly the input
+    // group's row range. The sequence counter is irrelevant, the real sequence numbers are
+    // assigned on the result below.
+    PAIMON_ASSIGN_OR_RAISE(
+        std::shared_ptr<DataFilePathFactory> data_file_path_factory,
+        context.path_factory->CreateDataFilePathFactory(partition_, /*bucket=*/0));
+    auto seq_num_counter = std::make_shared<LongCounter>(0);
+    std::shared_ptr<SingleFileWriterFactory<::ArrowArray*, std::shared_ptr<DataFileMeta>>>
+        writer_factory;
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<ShreddingWritePlanFactory> plan_factory,
+                           ShreddingWritePlanFactories::SelectActive(context.core_options,
+                                                                     write_schema, context.pool));
+    if (plan_factory != nullptr) {
+        writer_factory = std::make_shared<ShreddingAppendDataFileWriterFactory>(
+            context.core_options, context.table_schema->Id(), write_schema, write_cols,
+            seq_num_counter, FileSource::Compact(), data_file_path_factory, plan_factory,
+            context.pool);
+    } else {
+        writer_factory = std::make_shared<AppendDataFileWriterFactory>(
+            context.core_options, context.table_schema->Id(), write_schema, write_cols,
+            seq_num_counter, FileSource::Compact(), data_file_path_factory, context.pool);
+    }
+    auto rewriter =
+        std::make_unique<RollingFileWriter<::ArrowArray*, std::shared_ptr<DataFileMeta>>>(
+            /*target_file_size=*/std::numeric_limits<int64_t>::max(),
+            /*target_file_row_num=*/std::numeric_limits<int64_t>::max(), writer_factory);
+    // Abort on any failure up to and including result validation: a half-written or
+    // unvalidated output must be deleted, never committed. RollingFileWriter::Abort also
+    // removes files already sealed by Close().
+    ScopeGuard rewriter_guard([&]() {
+        if (rewriter) {
+            rewriter->Abort();
+        }
+    });
+
+    while (true) {
+        PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch batch, reader->NextBatch());
+        if (BatchReader::IsEofBatch(batch)) {
+            break;
+        }
+        auto& [c_array, c_schema] = batch;
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                          arrow::ImportArray(c_array.get(), c_schema.get()));
+        auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+        if (!struct_array) {
+            return Status::Invalid(
+                "cannot cast array to StructArray in DataEvolutionNormalCompactTask");
+        }
+        PAIMON_ASSIGN_OR_RAISE(struct_array, ArrowUtils::RemoveFieldFromStructArray(
+                                                 struct_array, SpecialFields::ValueKind().Name()));
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(
+            arrow::ExportArray(*struct_array, c_array.get(), c_schema.get()));
+        ArrowSchemaRelease(c_schema.get());
+        ScopeGuard guard([array = c_array.get()]() { ArrowArrayRelease(array); });
+        PAIMON_RETURN_NOT_OK(rewriter->Write(c_array.get()));
+        guard.Release();
+    }
+    PAIMON_RETURN_NOT_OK(rewriter->Close());
+    PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<DataFileMeta>> write_result,
+                           rewriter->GetResult());
+    if (write_result.size() != 1) {
+        return Status::Invalid(
+            fmt::format("Data evolution compaction should produce exactly one file, but got {}.",
+                        write_result.size()));
+    }
+    rewriter_guard.Release();
+
+    // Keep the row ids and the merged [min, max] sequence number range of the input group:
+    // _ROW_ID values stay unchanged and the rewritten file keeps its position in the "newest
+    // field group wins" ordering, while per-row _SEQUENCE_NUMBER values, derived from the
+    // file-level maximum, may rise to the group's maximum.
+    int64_t min_sequence_number = std::numeric_limits<int64_t>::max();
+    int64_t max_sequence_number = std::numeric_limits<int64_t>::min();
+    for (const auto& file : compact_before_) {
+        min_sequence_number = std::min(min_sequence_number, file->min_sequence_number);
+        max_sequence_number = std::max(max_sequence_number, file->max_sequence_number);
+    }
+    const std::shared_ptr<DataFileMeta>& compacted_file = write_result[0];
+    compacted_file->AssignFirstRowId(row_range_.from);
+    compacted_file->AssignSequenceNumber(min_sequence_number, max_sequence_number);
+    compact_after_.push_back(compacted_file);
+
+    auto compact_before_copy = compact_before_;
+    auto compact_after_copy = compact_after_;
+    CompactIncrement compact_increment(std::move(compact_before_copy),
+                                       std::move(compact_after_copy),
+                                       /*changelog_files=*/{},
+                                       /*new_index_files=*/{},
+                                       /*deleted_index_files=*/{});
+    DataIncrement data_increment(/*new_files=*/{}, /*deleted_files=*/{}, /*changelog_files=*/{});
+
+    // Bucket 0 is the bucket for unaware-bucket table, for compatibility with the old design.
+    // Total buckets stay unset for a data-evolution compact message; the deletion vector
+    // rewriter rejects one that carries them.
+    auto commit_message = std::make_shared<CommitMessageImpl>(
+        partition_,
+        /*bucket=*/0, /*total_buckets=*/std::nullopt, data_increment, compact_increment);
+    return commit_message;
+}
+
+std::string DataEvolutionNormalCompactTask::ToString() const {
+    std::vector<std::string> before_names;
+    before_names.reserve(compact_before_.size());
+    for (const auto& file : compact_before_) {
+        before_names.emplace_back(file->file_name);
+    }
+
+    std::vector<std::string> after_names;
+    after_names.reserve(compact_after_.size());
+    for (const auto& file : compact_after_) {
+        after_names.emplace_back(file->file_name);
+    }
+
+    return fmt::format(
+        "DataEvolutionNormalCompactTask {{partition = {}, rowRange = {}, compactBefore = [{}], "
+        "compactAfter = [{}]}}",
+        partition_.ToString(), row_range_.ToString(), fmt::join(before_names, ", "),
+        fmt::join(after_names, ", "));
+}
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_normal_compact_task.h
+++ b/src/paimon/core/append/data_evolution_normal_compact_task.h
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/core/core_options.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/result.h"
+#include "paimon/utils/range.h"
+
+namespace arrow {
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+class CommitMessage;
+class Executor;
+class FileStorePathFactory;
+class MemoryPool;
+class TableSchema;
+
+/// Everything a data-evolution compact task needs to rewrite its files, shared by all tasks of
+/// one coordinator run.
+struct DataEvolutionCompactContext {
+    std::string table_path;
+    std::shared_ptr<TableSchema> table_schema;
+    std::shared_ptr<arrow::Schema> arrow_schema;
+    CoreOptions core_options;
+    std::shared_ptr<FileStorePathFactory> path_factory;
+    std::shared_ptr<Executor> executor;
+    std::shared_ptr<MemoryPool> pool;
+};
+
+/// Compaction task for data-evolution tables.
+///
+/// The files to compact cover one contiguous row id range and may span several evolved field
+/// groups: files sharing the exact same row range whose columns are different versions or
+/// different subsets of the table fields, produced by partial-column updates. The task reads the
+/// files through `DataEvolutionSplitRead`, which merges the field groups so the newest version
+/// of every column wins, and rewrites the merged rows into a single new file.
+///
+/// Row ids are never changed: the output file keeps the input group's first row id and its
+/// merged `[min, max]` sequence number range, so `_ROW_ID` values derived from manifest
+/// metadata and the "newest field group wins" ordering stay intact. That is also what lets
+/// deletion vectors survive the rewrite: the task keeps every input row, and
+/// `DataEvolutionCompactDeletionVectorRewriter` re-keys the deletions of the replaced row
+/// range groups onto the output file before the compaction is committed. Blob files are
+/// dedicated storage and are not part of a task; their row ranges remain covered by the
+/// rewritten data file.
+class DataEvolutionNormalCompactTask {
+ public:
+    /// Creates a task after validating that `files` cover one contiguous row id range.
+    static Result<DataEvolutionNormalCompactTask> Create(
+        const BinaryRow& partition, const std::vector<std::shared_ptr<DataFileMeta>>& files);
+
+    ~DataEvolutionNormalCompactTask() = default;
+
+    const BinaryRow& Partition() const {
+        return partition_;
+    }
+
+    const std::vector<std::shared_ptr<DataFileMeta>>& CompactBefore() const {
+        return compact_before_;
+    }
+
+    const std::vector<std::shared_ptr<DataFileMeta>>& CompactAfter() const {
+        return compact_after_;
+    }
+
+    /// The contiguous row id range covered by the task's input files.
+    const Range& RowRange() const {
+        return row_range_;
+    }
+
+    Result<std::shared_ptr<CommitMessage>> DoCompact(const DataEvolutionCompactContext& context);
+
+    std::string ToString() const;
+
+ private:
+    DataEvolutionNormalCompactTask(const BinaryRow& partition,
+                                   const std::vector<std::shared_ptr<DataFileMeta>>& files,
+                                   const Range& row_range);
+
+    BinaryRow partition_;
+    std::vector<std::shared_ptr<DataFileMeta>> compact_before_;
+    std::vector<std::shared_ptr<DataFileMeta>> compact_after_;
+    Range row_range_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/append/data_evolution_normal_compact_task_test.cpp
+++ b/src/paimon/core/append/data_evolution_normal_compact_task_test.cpp
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/append/data_evolution_normal_compact_task.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+namespace {
+
+std::shared_ptr<DataFileMeta> CreateFile(const std::string& file_name,
+                                         const std::optional<int64_t>& first_row_id,
+                                         int64_t row_count) {
+    return std::make_shared<DataFileMeta>(
+        file_name, /*file_size=*/1024, row_count, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_seq_no=*/1, /*max_seq_no=*/2, /*schema_id=*/0, /*level=*/0,
+        /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(0, 0), /*delete_row_count=*/std::nullopt,
+        /*embedded_index=*/nullptr, /*file_source=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*value_stats_cols=*/std::nullopt, first_row_id, /*write_cols=*/std::nullopt);
+}
+
+BinaryRow EmptyPartition() {
+    BinaryRow row(0);
+    BinaryRowWriter writer(&row, 8, GetDefaultPool().get());
+    writer.Complete();
+    return row;
+}
+
+}  // namespace
+
+TEST(DataEvolutionNormalCompactTaskTest, CreateCoversTheUnionOfItsInputs) {
+    // Two evolved field groups over the same rows plus the group after them: one contiguous run,
+    // and the task's range is what the rewritten file has to end up covering exactly.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateFile("group-a-full.parquet", /*first_row_id=*/0, /*row_count=*/4),
+        CreateFile("group-a-f2.parquet", /*first_row_id=*/0, /*row_count=*/4),
+        CreateFile("group-b.parquet", /*first_row_id=*/4, /*row_count=*/2)};
+
+    ASSERT_OK_AND_ASSIGN(DataEvolutionNormalCompactTask task,
+                         DataEvolutionNormalCompactTask::Create(EmptyPartition(), files));
+    ASSERT_EQ(task.RowRange().from, 0);
+    ASSERT_EQ(task.RowRange().to, 5);
+    ASSERT_EQ(task.CompactBefore().size(), 3);
+    ASSERT_TRUE(task.CompactAfter().empty());
+    ASSERT_NE(task.ToString().find("group-a-full.parquet"), std::string::npos);
+}
+
+TEST(DataEvolutionNormalCompactTaskTest, CreateRejectsADiscontiguousRun) {
+    // The rewritten file covers one range, so a hole between the inputs would leave the rows in
+    // the hole claimed by a file that does not hold them.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateFile("a.parquet", /*first_row_id=*/0, /*row_count=*/2),
+        CreateFile("b.parquet", /*first_row_id=*/100, /*row_count=*/2)};
+    ASSERT_NOK_WITH_MSG(DataEvolutionNormalCompactTask::Create(EmptyPartition(), files),
+                        "contiguous row range");
+}
+
+TEST(DataEvolutionNormalCompactTaskTest, CreateRejectsUnusableInputs) {
+    // Create() validates before it touches its input, so the two shapes that would otherwise
+    // fault it - no file at all and a null file - come back as errors. The rest of the row id
+    // range matrix belongs to `data_evolution_utils_test.cpp`, which owns the shared rule this
+    // delegates to; `CreateRejectsADiscontiguousRun` above is what proves the delegation.
+    ASSERT_NOK_WITH_MSG(DataEvolutionNormalCompactTask::Create(EmptyPartition(), /*files=*/{}),
+                        "compact files should not be empty");
+    ASSERT_NOK_WITH_MSG(DataEvolutionNormalCompactTask::Create(EmptyPartition(), {nullptr}),
+                        "compact files must not be null");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/core_options.cpp
+++ b/src/paimon/core/core_options.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "fmt/format.h"
+#include "paimon/common/data/blob_defs.h"
 #include "paimon/common/fs/resolving_file_system.h"
 #include "paimon/common/options/memory_size.h"
 #include "paimon/common/options/time_duration.h"
@@ -481,6 +482,8 @@ struct CoreOptions::Impl {
     double variant_shredding_adaptive_retention_ratio = 0.05;
     bool blob_view_resolve_enabled = true;
     bool blob_as_descriptor = false;
+    bool data_evolution_compaction_rewrite_row_ids = false;
+    bool pk_clustering_override = false;
     std::optional<bool> blob_split_by_file_size;
     bool legacy_partition_name_enabled = true;
     bool global_index_enabled = true;
@@ -537,6 +540,21 @@ struct CoreOptions::Impl {
         // Parse blob.target-file-size - target size of a blob file
         PAIMON_RETURN_NOT_OK(
             parser.ParseMemorySize(Options::BLOB_TARGET_FILE_SIZE, &blob_target_file_size));
+        // Validate blob.copy-buffer-size. The value itself is not kept here: the blob format
+        // lives in a plugin library, so the writer is always built through the format factory
+        // and BlobWriterBuilder reads the option from the raw option map. Only the bounds are
+        // checked, and at parse time rather than at first use, so a table carrying an
+        // out-of-range value fails to open instead of failing on its first blob write.
+        int64_t blob_copy_buffer_size = BlobDefs::kDefaultCopyBufferSize;
+        PAIMON_RETURN_NOT_OK(
+            parser.ParseMemorySize(Options::BLOB_COPY_BUFFER_SIZE, &blob_copy_buffer_size));
+        if (blob_copy_buffer_size <= 0 ||
+            blob_copy_buffer_size > std::numeric_limits<int32_t>::max()) {
+            return Status::Invalid(
+                fmt::format("'{}' must be between 1 byte and {} bytes, but was {} bytes.",
+                            Options::BLOB_COPY_BUFFER_SIZE, std::numeric_limits<int32_t>::max(),
+                            blob_copy_buffer_size));
+        }
         // Parse source.split.target-size - target size of a source split when scanning a bucket
         PAIMON_RETURN_NOT_OK(
             parser.ParseMemorySize(Options::SOURCE_SPLIT_TARGET_SIZE, &source_split_target_size));
@@ -621,6 +639,14 @@ struct CoreOptions::Impl {
             parser.Parse<bool>(Options::BLOB_VIEW_RESOLVE_ENABLED, &blob_view_resolve_enabled));
         // Parse blob-as-descriptor - read blob field as descriptor rather than blob bytes
         PAIMON_RETURN_NOT_OK(parser.Parse<bool>(Options::BLOB_AS_DESCRIPTOR, &blob_as_descriptor));
+        // Parse data-evolution.compaction.rewrite-row-ids - legacy row-id rewriting mode,
+        // kept only so a table carrying it fails loudly instead of being mis-compacted
+        PAIMON_RETURN_NOT_OK(parser.Parse<bool>(Options::DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS,
+                                                &data_evolution_compaction_rewrite_row_ids));
+        // Parse pk-clustering-override - unsupported clustering override; parsed so an
+        // explicit false can be told apart from true (only true is rejected)
+        PAIMON_RETURN_NOT_OK(
+            parser.Parse<bool>(Options::PK_CLUSTERING_OVERRIDE, &pk_clustering_override));
         // Parse blob.split-by-file-size - whether blob file size counts in scan splitting
         PAIMON_RETURN_NOT_OK(
             parser.Parse(Options::BLOB_SPLIT_BY_FILE_SIZE, &blob_split_by_file_size));
@@ -1132,6 +1158,18 @@ int64_t CoreOptions::GetBlobTargetFileSize() const {
 
 bool CoreOptions::BlobSplitByFileSize() const {
     return impl_->blob_split_by_file_size.value_or(!impl_->blob_as_descriptor);
+}
+
+bool CoreOptions::BlobAsDescriptor() const {
+    return impl_->blob_as_descriptor;
+}
+
+bool CoreOptions::DataEvolutionCompactionRewriteRowIds() const {
+    return impl_->data_evolution_compaction_rewrite_row_ids;
+}
+
+bool CoreOptions::PkClusteringOverride() const {
+    return impl_->pk_clustering_override;
 }
 
 int64_t CoreOptions::GetCompactionFileSize(bool has_primary_key) const {

--- a/src/paimon/core/core_options.h
+++ b/src/paimon/core/core_options.h
@@ -89,6 +89,15 @@ class PAIMON_EXPORT CoreOptions {
     int64_t GetTargetFileRowNum() const;
     int64_t GetBlobTargetFileSize() const;
     bool BlobSplitByFileSize() const;
+    /// Whether reads return blob values as serialized descriptors instead of payload bytes.
+    bool BlobAsDescriptor() const;
+    /// The legacy data-evolution row-id rewriting mode; no longer supported and rejected by
+    /// the compaction entry point when set.
+    bool DataEvolutionCompactionRewriteRowIds() const;
+    /// The unsupported clustering override for primary-key tables; only "true" is rejected
+    /// (by the commit path and by managed-blob schema validation), an explicit "false"
+    /// equals the C++ behavior and is allowed.
+    bool PkClusteringOverride() const;
     int64_t GetCompactionFileSize(bool has_primary_key) const;
     std::string GetPartitionDefaultName() const;
 

--- a/src/paimon/core/core_options_test.cpp
+++ b/src/paimon/core/core_options_test.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
 #include "paimon/bucket/bucket_function_type.h"
 #include "paimon/common/fs/resolving_file_system.h"
@@ -193,6 +194,7 @@ TEST(CoreOptionsTest, TestFromMap) {
         {Options::TARGET_FILE_SIZE, "512MB"},
         {Options::TARGET_FILE_ROW_NUM, "123"},
         {Options::BLOB_TARGET_FILE_SIZE, "1G"},
+        {Options::BLOB_COPY_BUFFER_SIZE, "8 kb"},
         {Options::PARTITION_DEFAULT_NAME, "foo"},
         {Options::MANIFEST_TARGET_FILE_SIZE, "16MB"},
         {Options::MANIFEST_FULL_COMPACTION_FILE_SIZE, "32MB"},
@@ -479,6 +481,14 @@ TEST(CoreOptionsTest, TestFromMap) {
 TEST(CoreOptionsTest, TestInvalidCase) {
     ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::TARGET_FILE_ROW_NUM, "0"}}),
                         "target-file-row-num should be at least 1");
+    ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::BLOB_COPY_BUFFER_SIZE, "0"}}),
+                        "must be between 1 byte and");
+    ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::BLOB_COPY_BUFFER_SIZE, "3 gb"}}),
+                        "must be between 1 byte and");
+    // The inclusive upper bound is still accepted.
+    ASSERT_OK(
+        CoreOptions::FromMap({{Options::BLOB_COPY_BUFFER_SIZE,
+                               fmt::format("{} bytes", std::numeric_limits<int32_t>::max())}}));
     ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::BUCKET, "3.5"}}),
                         "Invalid Config [bucket: 3.5]");
     ASSERT_NOK_WITH_MSG(CoreOptions::FromMap({{Options::SCAN_SNAPSHOT_ID, "3.5"}}),

--- a/src/paimon/core/deletionvectors/bitmap64_deletion_vector.cpp
+++ b/src/paimon/core/deletionvectors/bitmap64_deletion_vector.cpp
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/deletionvectors/bitmap64_deletion_vector.h"
+
+#include <limits>
+
+#include "arrow/util/crc32.h"
+#include "fmt/format.h"
+#include "paimon/common/io/data_output_stream.h"
+#include "paimon/common/io/memory_segment_output_stream.h"
+#include "paimon/common/utils/math.h"
+
+namespace paimon {
+
+Result<PAIMON_UNIQUE_PTR<Bytes>> Bitmap64DeletionVector::SerializeToBytes(
+    const std::shared_ptr<MemoryPool>& pool) {
+    // Serialize() run-length encodes the bitmap first, as the on-disk format requires.
+    std::shared_ptr<Bytes> bitmap_bytes = roaring_bitmap_.Serialize(pool.get());
+    if (bitmap_bytes == nullptr) {
+        return Status::Invalid("roaring bitmap 64 serialize failed");
+    }
+    MemorySegmentOutputStream output(MemorySegmentOutputStream::DEFAULT_SEGMENT_SIZE, pool);
+    // The stream writes big-endian, so the swapped value lands on disk little-endian, which is
+    // the byte order this magic is stored in and the reader tells the two vector kinds by.
+    output.WriteValue<int32_t>(EndianSwapValue(MAGIC_NUMBER));
+    output.WriteBytes(bitmap_bytes);
+    return MemorySegmentUtils::CopyToBytes(output.Segments(), /*offset=*/0, output.CurrentSize(),
+                                           pool.get());
+}
+
+Result<int32_t> Bitmap64DeletionVector::SerializeTo(const std::shared_ptr<MemoryPool>& pool,
+                                                    DataOutputStream* out) {
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<Bytes> data, SerializeToBytes(pool));
+    size_t bitmap_data_length = data->size();
+    // The record has to stay addressable by the int32 offset and length a deletion file meta
+    // records, so the whole framed record is bounded, not just the bitmap.
+    if (bitmap_data_length > static_cast<size_t>(std::numeric_limits<int32_t>::max() -
+                                                 LENGTH_SIZE_BYTES - CRC_SIZE_BYTES)) {
+        return Status::Invalid(
+            fmt::format("Bitmap64 deletion vector of {} bytes does not fit a deletion file "
+                        "record.",
+                        bitmap_data_length));
+    }
+    PAIMON_RETURN_NOT_OK(out->WriteValue<int32_t>(static_cast<int32_t>(bitmap_data_length)));
+    PAIMON_RETURN_NOT_OK(out->WriteBytes(data));
+    uint32_t crc32 = 0;
+    crc32 = arrow::internal::crc32(crc32, data->data(), bitmap_data_length);
+    PAIMON_RETURN_NOT_OK(out->WriteValue<int32_t>(static_cast<int32_t>(crc32)));
+    // Unlike a bitmap32 vector, whose recorded length covers only the checksummed region, a
+    // bitmap64 record is recorded whole. `DeletionVector::Read` relies on the difference.
+    return static_cast<int32_t>(LENGTH_SIZE_BYTES + bitmap_data_length + CRC_SIZE_BYTES);
+}
+
+Status Bitmap64DeletionVector::CheckPosition(int64_t position) const {
+    if (position < 0 || position > MAX_VALUE) {
+        return Status::Invalid(
+            fmt::format("Bitmap64 deletion vector supports positions in [0, {}], but got {}.",
+                        MAX_VALUE, position));
+    }
+    return Status::OK();
+}
+
+Result<PAIMON_UNIQUE_PTR<DeletionVector>> Bitmap64DeletionVector::DeserializeWithoutMagicNumber(
+    const char* buffer, int32_t length, MemoryPool* pool) {
+    RoaringBitmap64 roaring_bitmap;
+    PAIMON_RETURN_NOT_OK(roaring_bitmap.Deserialize(buffer, length));
+    return pool->AllocateUnique<Bitmap64DeletionVector>(roaring_bitmap);
+}
+
+Status Bitmap64DeletionVector::Merge(const std::shared_ptr<DeletionVector>& deletion_vector) {
+    if (!deletion_vector || deletion_vector->IsEmpty()) {
+        return Status::OK();
+    }
+    auto* other = dynamic_cast<Bitmap64DeletionVector*>(deletion_vector.get());
+    if (other == nullptr) {
+        return Status::Invalid(
+            "Cannot merge a non-Bitmap64DeletionVector into a Bitmap64DeletionVector");
+    }
+    roaring_bitmap_ |= other->roaring_bitmap_;
+    return Status::OK();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/deletionvectors/bitmap64_deletion_vector.h
+++ b/src/paimon/core/deletionvectors/bitmap64_deletion_vector.h
@@ -18,13 +18,100 @@
  */
 #pragma once
 
+#include <functional>
+#include <limits>
+#include <memory>
+
 #include "paimon/core/deletionvectors/deletion_vector.h"
+#include "paimon/utils/roaring_bitmap64.h"
 
 namespace paimon {
 
+/// A `DeletionVector` based on `RoaringBitmap64`, for files whose row count exceeds what
+/// `BitmapDeletionVector` can index.
+///
+/// On-disk layout, byte-compatible with the shared Paimon format. Note that it is *not* the
+/// layout `BitmapDeletionVector` uses, in two ways every reader has to special case:
+///
+///   length   int32 big-endian    = magic + bitmap byte count
+///   magic    int32 LITTLE-endian = 1681511377   -- checksum covers from here ...
+///   bitmap   RoaringBitmap64, little-endian                       -- ... to here
+///   checksum int32 big-endian    = CRC32 over the magic and the bitmap
+///
+/// The magic is stored little-endian while `BitmapDeletionVector` stores its own big-endian,
+/// which is what lets a reader tell the two apart from the same four bytes (see
+/// `DeletionVector::Read`). The length recorded for a vector also differs: `DeletionVector`
+/// metadata stores only the checksum-covered region for a bitmap32 vector, but the whole
+/// record — length prefix and checksum included — for a bitmap64 one.
 class Bitmap64DeletionVector : public DeletionVector {
  public:
     static constexpr int32_t MAGIC_NUMBER = 1681511377;
+    static constexpr int32_t MAGIC_NUMBER_SIZE_BYTES = 4;
+    static constexpr int32_t LENGTH_SIZE_BYTES = 4;
+    static constexpr int32_t CRC_SIZE_BYTES = 4;
+
+    /// Largest position this vector can hold. The underlying `RoaringBitmap64` would take
+    /// more, but a larger position could not be read back by other Paimon engines.
+    static constexpr int64_t MAX_VALUE =
+        (static_cast<int64_t>(std::numeric_limits<int32_t>::max() - 1) << 32) |
+        static_cast<int64_t>(static_cast<uint32_t>(std::numeric_limits<int32_t>::min()));
+
+    Bitmap64DeletionVector() = default;
+
+    explicit Bitmap64DeletionVector(const RoaringBitmap64& roaring_bitmap)
+        : roaring_bitmap_(roaring_bitmap) {}
+
+    Status Delete(int64_t position) override {
+        PAIMON_RETURN_NOT_OK(CheckPosition(position));
+        roaring_bitmap_.Add(position);
+        return Status::OK();
+    }
+
+    Result<bool> CheckedDelete(int64_t position) override {
+        PAIMON_RETURN_NOT_OK(CheckPosition(position));
+        return roaring_bitmap_.CheckedAdd(position);
+    }
+
+    Result<bool> IsDeleted(int64_t position) const override {
+        PAIMON_RETURN_NOT_OK(CheckPosition(position));
+        return roaring_bitmap_.Contains(position);
+    }
+
+    bool IsEmpty() const override {
+        return roaring_bitmap_.IsEmpty();
+    }
+
+    Result<int64_t> GetCardinality() const override {
+        return roaring_bitmap_.Cardinality();
+    }
+
+    Status ForEachDeletedPosition(const std::function<Status(int64_t)>& consumer) const override {
+        for (auto it = roaring_bitmap_.Begin(); it != roaring_bitmap_.End(); ++it) {
+            PAIMON_RETURN_NOT_OK(consumer(*it));
+        }
+        return Status::OK();
+    }
+
+    Result<int32_t> SerializeTo(const std::shared_ptr<MemoryPool>& pool,
+                                DataOutputStream* out) override;
+
+    Result<PAIMON_UNIQUE_PTR<Bytes>> SerializeToBytes(
+        const std::shared_ptr<MemoryPool>& pool) override;
+
+    Status Merge(const std::shared_ptr<DeletionVector>& deletion_vector) override;
+
+    const RoaringBitmap64* GetBitmap() const {
+        return &roaring_bitmap_;
+    }
+
+    /// Deserializes the bitmap of a record whose magic number the caller already consumed.
+    static Result<PAIMON_UNIQUE_PTR<DeletionVector>> DeserializeWithoutMagicNumber(
+        const char* buffer, int32_t length, MemoryPool* pool);
+
+ private:
+    Status CheckPosition(int64_t position) const;
+
+    RoaringBitmap64 roaring_bitmap_;
 };
 
 }  // namespace paimon

--- a/src/paimon/core/deletionvectors/bitmap64_deletion_vector_test.cpp
+++ b/src/paimon/core/deletionvectors/bitmap64_deletion_vector_test.cpp
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "paimon/core/deletionvectors/bitmap64_deletion_vector.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/utils/math.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
+#include "paimon/fs/file_system_factory.h"
+#include "paimon/io/data_input_stream.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+TEST(Bitmap64DeletionVectorTest, BasicOperations) {
+    Bitmap64DeletionVector dv;
+    ASSERT_TRUE(dv.IsEmpty());
+    ASSERT_OK(dv.Delete(5));
+    // A position beyond what RoaringBitmap32 can index, which is the reason this kind exists.
+    ASSERT_OK(dv.Delete(1L << 33));
+    ASSERT_FALSE(dv.IsEmpty());
+    ASSERT_TRUE(dv.IsDeleted(5).value());
+    ASSERT_TRUE(dv.IsDeleted(1L << 33).value());
+    ASSERT_FALSE(dv.IsDeleted(6).value());
+    ASSERT_EQ(dv.GetCardinality().value(), 2);
+
+    ASSERT_TRUE(dv.CheckedDelete(7).value());
+    ASSERT_FALSE(dv.CheckedDelete(7).value());
+
+    ASSERT_NOK_WITH_MSG(dv.Delete(-1), "supports positions in");
+    ASSERT_NOK_WITH_MSG(dv.Delete(Bitmap64DeletionVector::MAX_VALUE + 1), "supports positions in");
+}
+
+TEST(Bitmap64DeletionVectorTest, ForEachDeletedPositionVisitsPositionsInOrder) {
+    Bitmap64DeletionVector dv;
+    ASSERT_OK(dv.Delete(1L << 33));
+    ASSERT_OK(dv.Delete(3));
+    ASSERT_OK(dv.Delete(1L << 32));
+
+    std::vector<int64_t> visited;
+    ASSERT_OK(dv.ForEachDeletedPosition([&visited](int64_t position) -> Status {
+        visited.push_back(position);
+        return Status::OK();
+    }));
+    ASSERT_EQ(visited, (std::vector<int64_t>{3, 1L << 32, 1L << 33}));
+
+    Bitmap64DeletionVector empty_dv;
+    visited.clear();
+    ASSERT_OK(empty_dv.ForEachDeletedPosition([&visited](int64_t position) -> Status {
+        visited.push_back(position);
+        return Status::OK();
+    }));
+    ASSERT_TRUE(visited.empty());
+}
+
+TEST(Bitmap64DeletionVectorTest, ForEachDeletedPositionStopsOnConsumerFailure) {
+    // The rewriter re-keys a vector position by position, so a failure halfway through has to
+    // surface instead of leaving the remaining positions silently applied.
+    Bitmap64DeletionVector dv;
+    ASSERT_OK(dv.Delete(1));
+    ASSERT_OK(dv.Delete(2));
+    ASSERT_OK(dv.Delete(1L << 33));
+
+    int32_t calls = 0;
+    Status status = dv.ForEachDeletedPosition([&calls](int64_t) -> Status {
+        calls++;
+        return Status::Invalid("stop here");
+    });
+    ASSERT_NOK_WITH_MSG(status, "stop here");
+    ASSERT_EQ(calls, 1);
+}
+
+TEST(Bitmap64DeletionVectorTest, MergeRejectsTheOtherVectorKind) {
+    auto dv64 = std::make_shared<Bitmap64DeletionVector>();
+    ASSERT_OK(dv64->Delete(1L << 33));
+    auto other64 = std::make_shared<Bitmap64DeletionVector>();
+    ASSERT_OK(other64->Delete(4));
+    ASSERT_OK(dv64->Merge(other64));
+    ASSERT_EQ(dv64->GetCardinality().value(), 2);
+
+    // The two kinds serialize differently, so mixing them has to fail rather than silently
+    // dropping deletions.
+    RoaringBitmap32 roaring;
+    roaring.Add(9);
+    auto dv32 = std::make_shared<BitmapDeletionVector>(roaring);
+    ASSERT_NOK_WITH_MSG(dv64->Merge(dv32), "Cannot merge a non-Bitmap64DeletionVector");
+    ASSERT_NOK_WITH_MSG(dv32->Merge(dv64), "Cannot merge a non-BitmapDeletionVector");
+
+    // An empty vector of the other kind is a no-op rather than an error, matching bitmap32.
+    auto empty32 = std::make_shared<BitmapDeletionVector>(RoaringBitmap32());
+    ASSERT_OK(dv64->Merge(empty32));
+}
+
+TEST(Bitmap64DeletionVectorTest, SerializeToStoresTheMagicLittleEndian) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    std::string path = PathUtil::JoinPath(dir->Str(), "dv64");
+
+    Bitmap64DeletionVector dv;
+    ASSERT_OK(dv.Delete(1));
+    ASSERT_OK(dv.Delete(1L << 33));
+
+    int32_t serialized_length = 0;
+    {
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> out, fs->Create(path, true));
+        DataOutputStream data_out(out);
+        ASSERT_OK_AND_ASSIGN(serialized_length, dv.SerializeTo(GetDefaultPool(), &data_out));
+        ASSERT_OK(out->Close());
+    }
+
+    // A bitmap64 record records its whole framed length, unlike a bitmap32 one.
+    ASSERT_OK_AND_ASSIGN(FileStatus status, fs->GetFileStatus(path));
+    ASSERT_EQ(serialized_length, status.GetLen());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs->Open(path));
+    auto data_in = std::make_shared<DataInputStream>(in);
+    ASSERT_OK_AND_ASSIGN(int32_t bitmap_length, data_in->ReadValue<int32_t>());
+    ASSERT_EQ(bitmap_length, serialized_length - Bitmap64DeletionVector::LENGTH_SIZE_BYTES -
+                                 Bitmap64DeletionVector::CRC_SIZE_BYTES);
+    // Read big-endian, the magic only matches after a swap: that asymmetry against
+    // BitmapDeletionVector is what tells the two kinds apart on disk.
+    ASSERT_OK_AND_ASSIGN(int32_t magic, data_in->ReadValue<int32_t>());
+    ASSERT_NE(magic, Bitmap64DeletionVector::MAGIC_NUMBER);
+    ASSERT_EQ(EndianSwapValue(magic), Bitmap64DeletionVector::MAGIC_NUMBER);
+}
+
+TEST(Bitmap64DeletionVectorTest, ReadsDenseBucketArrayCompatibleWithPaimonJava) {
+    // A vector may be serialized as a *dense* bucket array: the bucket count is the length of
+    // the bitmap array and every key from 0 up is written, empty buckets included. CRoaring
+    // writes only the buckets in use, so the two forms differ in bytes for a vector spanning
+    // several 32 bit key ranges even though both follow the portable format. Reading has to
+    // accept the dense form, which is what this assembles by hand: keys 0 and 2 in use with an
+    // empty key 1 between them. Note the bytes are built here rather than captured from a
+    // writer that produces them, so this pins the documented layout rather than a golden
+    // fixture; the reverse direction, another engine reading the sparse form CRoaring writes,
+    // is not covered by any test here either.
+    auto pool = GetDefaultPool();
+    auto portable_bitmap = [&pool](const std::vector<int32_t>& positions) {
+        RoaringBitmap32 roaring;
+        for (int32_t position : positions) {
+            roaring.Add(position);
+        }
+        return roaring.Serialize(pool.get());
+    };
+    PAIMON_UNIQUE_PTR<Bytes> bucket_0 = portable_bitmap({5});
+    PAIMON_UNIQUE_PTR<Bytes> bucket_1 = portable_bitmap({});
+    PAIMON_UNIQUE_PTR<Bytes> bucket_2 = portable_bitmap({7});
+
+    // The bitmap payload is little-endian throughout, as the portable format demands.
+    std::string payload;
+    auto append_little_endian = [&payload](uint64_t value, size_t width) {
+        for (size_t i = 0; i < width; i++) {
+            payload.push_back(static_cast<char>((value >> (8 * i)) & 0xFF));
+        }
+    };
+    append_little_endian(3, 8);  // bucket count, including the empty one
+    append_little_endian(0, 4);
+    payload.append(bucket_0->data(), bucket_0->size());
+    append_little_endian(1, 4);
+    payload.append(bucket_1->data(), bucket_1->size());
+    append_little_endian(2, 4);
+    payload.append(bucket_2->data(), bucket_2->size());
+
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    std::string path = PathUtil::JoinPath(dir->Str(), "dv64-java-dense");
+    int32_t bitmap_data_length =
+        Bitmap64DeletionVector::MAGIC_NUMBER_SIZE_BYTES + static_cast<int32_t>(payload.size());
+    {
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> out, fs->Create(path,
+                                                                           /*overwrite=*/true));
+        DataOutputStream data_out(out);
+        // Length big-endian, magic little-endian: the framing asymmetry a reader tells the two
+        // vector kinds apart by.
+        ASSERT_OK(data_out.WriteValue<int32_t>(bitmap_data_length));
+        ASSERT_OK(
+            data_out.WriteValue<int32_t>(EndianSwapValue(Bitmap64DeletionVector::MAGIC_NUMBER)));
+        ASSERT_OK_AND_ASSIGN(int64_t written,
+                             out->Write(payload.data(), static_cast<int64_t>(payload.size())));
+        ASSERT_EQ(written, static_cast<int64_t>(payload.size()));
+        // The checksum is not validated on read, so any value round-trips the framing.
+        ASSERT_OK(data_out.WriteValue<int32_t>(0));
+        ASSERT_OK(out->Close());
+    }
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs->Open(path));
+    auto data_in = std::make_shared<DataInputStream>(in);
+    int64_t record_length = Bitmap64DeletionVector::LENGTH_SIZE_BYTES + bitmap_data_length +
+                            Bitmap64DeletionVector::CRC_SIZE_BYTES;
+    ASSERT_OK_AND_ASSIGN(PAIMON_UNIQUE_PTR<DeletionVector> read_back,
+                         DeletionVector::Read(data_in.get(), record_length, pool.get()));
+    ASSERT_TRUE(dynamic_cast<Bitmap64DeletionVector*>(read_back.get()) != nullptr);
+    ASSERT_EQ(read_back->GetCardinality().value(), 2);
+    ASSERT_TRUE(read_back->IsDeleted(5).value());
+    // Key 2 with low bits 7, i.e. the empty middle bucket did not shift the keys.
+    ASSERT_TRUE(read_back->IsDeleted((2LL << 32) | 7).value());
+    ASSERT_FALSE(read_back->IsDeleted((1LL << 32) | 7).value());
+}
+
+TEST(Bitmap64DeletionVectorTest, ReadRoundTripThroughDeletionVectorRead) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    std::string path = PathUtil::JoinPath(dir->Str(), "dv64-roundtrip");
+
+    Bitmap64DeletionVector dv;
+    ASSERT_OK(dv.Delete(0));
+    ASSERT_OK(dv.Delete(7));
+    ASSERT_OK(dv.Delete(1L << 34));
+
+    int32_t serialized_length = 0;
+    {
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> out, fs->Create(path, true));
+        DataOutputStream data_out(out);
+        ASSERT_OK_AND_ASSIGN(serialized_length, dv.SerializeTo(GetDefaultPool(), &data_out));
+        ASSERT_OK(out->Close());
+    }
+
+    // DeletionVector::Read dispatches on the magic and has to pick the bitmap64 branch.
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs->Open(path));
+    auto data_in = std::make_shared<DataInputStream>(in);
+    ASSERT_OK_AND_ASSIGN(
+        PAIMON_UNIQUE_PTR<DeletionVector> read_back,
+        DeletionVector::Read(data_in.get(), serialized_length, GetDefaultPool().get()));
+    ASSERT_TRUE(dynamic_cast<Bitmap64DeletionVector*>(read_back.get()) != nullptr);
+    ASSERT_EQ(read_back->GetCardinality().value(), 3);
+    ASSERT_TRUE(read_back->IsDeleted(0).value());
+    ASSERT_TRUE(read_back->IsDeleted(7).value());
+    ASSERT_TRUE(read_back->IsDeleted(1L << 34).value());
+    ASSERT_FALSE(read_back->IsDeleted(1).value());
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/deletionvectors/bitmap_deletion_vector.h
+++ b/src/paimon/core/deletionvectors/bitmap_deletion_vector.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 
+#include <functional>
 #include <memory>
 
 #include "paimon/common/io/data_output_stream.h"
@@ -58,6 +59,13 @@ class BitmapDeletionVector : public DeletionVector {
 
     Result<int64_t> GetCardinality() const override {
         return roaring_bitmap_.Cardinality();
+    }
+
+    Status ForEachDeletedPosition(const std::function<Status(int64_t)>& consumer) const override {
+        for (auto it = roaring_bitmap_.Begin(); it != roaring_bitmap_.End(); ++it) {
+            PAIMON_RETURN_NOT_OK(consumer(static_cast<int64_t>(*it)));
+        }
+        return Status::OK();
     }
 
     Result<int32_t> SerializeTo(const std::shared_ptr<MemoryPool>& pool,

--- a/src/paimon/core/deletionvectors/bitmap_deletion_vector_test.cpp
+++ b/src/paimon/core/deletionvectors/bitmap_deletion_vector_test.cpp
@@ -18,13 +18,16 @@
  */
 #include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 
+#include <memory>
 #include <set>
+#include <vector>
 
 #include "fmt/format.h"
 #include "gtest/gtest.h"
 #include "paimon/common/io/memory_segment_output_stream.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/fs/file_system_factory.h"
+#include "paimon/io/data_input_stream.h"
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
@@ -191,6 +194,48 @@ TEST(BitmapDeletionVectorTest, MergeTwoBitmapDeletionVectors) {
     ASSERT_FALSE(dv1->IsDeleted(0).value());
     ASSERT_FALSE(dv1->IsDeleted(6).value());
     ASSERT_EQ(dv1->GetCardinality().value(), 5);
+}
+
+TEST(BitmapDeletionVectorTest, ForEachDeletedPositionVisitsPositionsInOrder) {
+    RoaringBitmap32 roaring;
+    roaring.Add(20);
+    roaring.Add(3);
+    roaring.Add(11);
+    auto dv = std::make_shared<BitmapDeletionVector>(roaring);
+
+    std::vector<int64_t> visited;
+    ASSERT_OK(dv->ForEachDeletedPosition([&visited](int64_t position) -> Status {
+        visited.push_back(position);
+        return Status::OK();
+    }));
+    // Ascending order, whatever order the positions were added in: callers that relocate a
+    // vector onto another row range rely on visiting every deleted position exactly once.
+    ASSERT_EQ(visited, (std::vector<int64_t>{3, 11, 20}));
+
+    RoaringBitmap32 empty_roaring;
+    auto empty_dv = std::make_shared<BitmapDeletionVector>(empty_roaring);
+    visited.clear();
+    ASSERT_OK(empty_dv->ForEachDeletedPosition([&visited](int64_t position) -> Status {
+        visited.push_back(position);
+        return Status::OK();
+    }));
+    ASSERT_TRUE(visited.empty());
+}
+
+TEST(BitmapDeletionVectorTest, ForEachDeletedPositionStopsOnConsumerFailure) {
+    RoaringBitmap32 roaring;
+    roaring.Add(1);
+    roaring.Add(2);
+    roaring.Add(3);
+    auto dv = std::make_shared<BitmapDeletionVector>(roaring);
+
+    int32_t calls = 0;
+    Status status = dv->ForEachDeletedPosition([&calls](int64_t) -> Status {
+        calls++;
+        return Status::Invalid("stop here");
+    });
+    ASSERT_NOK_WITH_MSG(status, "stop here");
+    ASSERT_EQ(calls, 1);
 }
 
 TEST(BitmapDeletionVectorTest, MergeEmptyDeletionVector) {

--- a/src/paimon/core/deletionvectors/bucketed_dv_maintainer.h
+++ b/src/paimon/core/deletionvectors/bucketed_dv_maintainer.h
@@ -23,7 +23,6 @@
 #include <optional>
 #include <string>
 
-#include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 #include "paimon/core/deletionvectors/deletion_vector.h"
 #include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
 #include "paimon/core/index/index_file_handler.h"
@@ -44,11 +43,7 @@ class BucketedDvMaintainer {
     Status NotifyNewDeletion(const std::string& file_name, int64_t position) {
         std::shared_ptr<DeletionVector> dv;
         if (auto it = deletion_vectors_.find(file_name); it == deletion_vectors_.end()) {
-            if (bitmap64_) {
-                return Status::NotImplemented("not support bitmap 64 deletion vectors");
-            }
-            RoaringBitmap32 roaring_bitmap;
-            auto inserted = std::make_shared<BitmapDeletionVector>(roaring_bitmap);
+            std::shared_ptr<DeletionVector> inserted = NewDeletionVector();
             deletion_vectors_[file_name] = inserted;
             dv = std::move(inserted);
         } else {
@@ -88,6 +83,11 @@ class BucketedDvMaintainer {
 
     std::shared_ptr<DeletionVectorsIndexFile> DvIndexFile() const {
         return dv_index_file_;
+    }
+
+    /// A new empty vector of the kind this table stores.
+    std::shared_ptr<DeletionVector> NewDeletionVector() const {
+        return DeletionVector::Create(bitmap64_);
     }
 
     /// Factory to restore `BucketedDvMaintainer`.

--- a/src/paimon/core/deletionvectors/bucketed_dv_maintainer_test.cpp
+++ b/src/paimon/core/deletionvectors/bucketed_dv_maintainer_test.cpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "gtest/gtest.h"
+#include "paimon/core/deletionvectors/bitmap64_deletion_vector.h"
 #include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 #include "paimon/fs/file_system_factory.h"
 #include "paimon/testing/mock/mock_index_path_factory.h"
@@ -137,20 +138,44 @@ TEST(BucketedDvMaintainerTest, TestNotifyNewDeletionOnExistingVectorOnlyMarksWhe
     ASSERT_TRUE(modified_write.has_value());
 }
 
-TEST(BucketedDvMaintainerTest, TestNotifyNewDeletionReturnsNotImplementedForBitmap64) {
+TEST(BucketedDvMaintainerTest, TestNotifyNewDeletionCreatesTheVectorKindOfTheTable) {
+    // A bitmap64 table stores 64 bit vectors, so that is the kind the maintainer has to create.
+    // A position beyond the 32 bit range is what tells the two apart: the 32 bit vector cannot
+    // hold it at all.
     auto dir = UniqueTestDirectory::Create();
     ASSERT_TRUE(dir);
+    constexpr int64_t kBeyondBitmap32 = int64_t{1} << 33;
+
     auto index_file = CreateDvIndexFile(dir->Str(), /*bitmap64=*/true);
     BucketedDvMaintainer maintainer(index_file, /*deletion_vectors=*/{});
 
-    Status status = maintainer.NotifyNewDeletion("file-new", /*position=*/1);
-    ASSERT_TRUE(status.IsNotImplemented());
+    ASSERT_OK(maintainer.NotifyNewDeletion("file-new", kBeyondBitmap32));
+    auto created = maintainer.DeletionVectorOf("file-new");
+    ASSERT_TRUE(created.has_value());
+    ASSERT_TRUE(std::dynamic_pointer_cast<Bitmap64DeletionVector>(created.value()) != nullptr);
+    ASSERT_OK_AND_ASSIGN(bool deleted, created.value()->IsDeleted(kBeyondBitmap32));
+    ASSERT_TRUE(deleted);
 
-    auto lookup = maintainer.DeletionVectorOf("file-new");
-    ASSERT_FALSE(lookup.has_value());
-
+    // The deletion also has to survive the index file, which frames a 64 bit vector differently
+    // from a 32 bit one.
     ASSERT_OK_AND_ASSIGN(auto write_result, maintainer.WriteDeletionVectorsIndex());
-    ASSERT_FALSE(write_result.has_value());
+    ASSERT_TRUE(write_result.has_value());
+    ASSERT_OK_AND_ASSIGN(auto restored, index_file->ReadAllDeletionVectors(write_result.value()));
+    ASSERT_EQ(restored.size(), 1);
+    auto restored_vector = restored.at("file-new");
+    ASSERT_TRUE(std::dynamic_pointer_cast<Bitmap64DeletionVector>(restored_vector) != nullptr);
+    ASSERT_OK_AND_ASSIGN(bool restored_deleted, restored_vector->IsDeleted(kBeyondBitmap32));
+    ASSERT_TRUE(restored_deleted);
+
+    // A bitmap32 table keeps the 32 bit kind, which refuses the position it cannot hold.
+    auto bitmap32_index_file = CreateDvIndexFile(dir->Str());
+    BucketedDvMaintainer bitmap32_maintainer(bitmap32_index_file, /*deletion_vectors=*/{});
+    ASSERT_NOK(bitmap32_maintainer.NotifyNewDeletion("file-new", kBeyondBitmap32));
+    ASSERT_OK(bitmap32_maintainer.NotifyNewDeletion("file-new", /*position=*/7));
+    auto bitmap32_vector = bitmap32_maintainer.DeletionVectorOf("file-new");
+    ASSERT_TRUE(bitmap32_vector.has_value());
+    ASSERT_TRUE(std::dynamic_pointer_cast<BitmapDeletionVector>(bitmap32_vector.value()) !=
+                nullptr);
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/deletionvectors/deletion_vector.cpp
+++ b/src/paimon/core/deletionvectors/deletion_vector.cpp
@@ -28,6 +28,7 @@
 #include "paimon/core/deletionvectors/bucketed_dv_maintainer.h"
 #include "paimon/core/table/source/deletion_file.h"
 #include "paimon/fs/file_system.h"
+#include "paimon/io/byte_array_input_stream.h"
 #include "paimon/io/data_input_stream.h"
 #include "paimon/memory/memory_pool.h"
 
@@ -78,9 +79,37 @@ std::unordered_map<std::string, DeletionFile> DeletionVector::CreateDeletionFile
     return deletion_file_map;
 }
 
+std::shared_ptr<DeletionVector> DeletionVector::Create(bool bitmap64) {
+    if (bitmap64) {
+        return std::make_shared<Bitmap64DeletionVector>(RoaringBitmap64());
+    }
+    return std::make_shared<BitmapDeletionVector>(RoaringBitmap32());
+}
+
 Result<PAIMON_UNIQUE_PTR<DeletionVector>> DeletionVector::DeserializeFromBytes(const Bytes* bytes,
                                                                                MemoryPool* pool) {
-    return BitmapDeletionVector::Deserialize(bytes->data(), bytes->size(), pool);
+    // `bytes` holds the checksum-covered region: the magic number and the bitmap. The two
+    // vector kinds store that magic in opposite byte orders, which is what identifies them.
+    if (bytes->size() < BitmapDeletionVector::MAGIC_NUMBER_SIZE_BYTES) {
+        return Status::Invalid(fmt::format(
+            "Deletion vector of {} bytes is too short to hold a magic number.", bytes->size()));
+    }
+    auto in = std::make_shared<ByteArrayInputStream>(bytes->data(), bytes->size());
+    DataInputStream input(in);
+    PAIMON_ASSIGN_OR_RAISE(int32_t magic_number, input.ReadValue<int32_t>());
+    if (magic_number == BitmapDeletionVector::MAGIC_NUMBER) {
+        return BitmapDeletionVector::DeserializeWithoutMagicNumber(
+            bytes->data() + BitmapDeletionVector::MAGIC_NUMBER_SIZE_BYTES,
+            bytes->size() - BitmapDeletionVector::MAGIC_NUMBER_SIZE_BYTES, pool);
+    }
+    if (EndianSwapValue(magic_number) == Bitmap64DeletionVector::MAGIC_NUMBER) {
+        return Bitmap64DeletionVector::DeserializeWithoutMagicNumber(
+            bytes->data() + Bitmap64DeletionVector::MAGIC_NUMBER_SIZE_BYTES,
+            bytes->size() - Bitmap64DeletionVector::MAGIC_NUMBER_SIZE_BYTES, pool);
+    }
+    return Status::Invalid(fmt::format(
+        "Invalid magic number: {}, v1 dv magic number: {}, v2 magic number: {}", magic_number,
+        BitmapDeletionVector::MAGIC_NUMBER, Bitmap64DeletionVector::MAGIC_NUMBER));
 }
 
 Result<PAIMON_UNIQUE_PTR<DeletionVector>> DeletionVector::Read(const FileSystem* file_system,
@@ -88,17 +117,21 @@ Result<PAIMON_UNIQUE_PTR<DeletionVector>> DeletionVector::Read(const FileSystem*
                                                                MemoryPool* pool) {
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InputStream> input,
                            file_system->Open(deletion_file.path));
-    DataInputStream file_input_stream(input);
-    PAIMON_RETURN_NOT_OK(file_input_stream.Seek(deletion_file.offset));
-    PAIMON_ASSIGN_OR_RAISE(int32_t actual_length, file_input_stream.ReadValue<int32_t>());
-    if (actual_length != deletion_file.length) {
-        return Status::Invalid(
-            fmt::format("Size not match, actual size: {}, expect size: {}, file path: {}",
-                        actual_length, deletion_file.length, deletion_file.path));
+    auto file_input_stream = std::make_shared<DataInputStream>(input);
+    PAIMON_RETURN_NOT_OK(file_input_stream->Seek(deletion_file.offset));
+    // Delegated rather than re-framed here: the two vector kinds disagree on both the byte
+    // order of the magic and on what the recorded length counts, and the stream overload is
+    // the one place that knows the difference.
+    Result<PAIMON_UNIQUE_PTR<DeletionVector>> result =
+        Read(file_input_stream.get(), deletion_file.length, pool);
+    if (!result.ok()) {
+        // The stream overload cannot name the file it was handed, and that name is what a
+        // corrupt or mismatched deletion file has to be tracked down by.
+        return Status(
+            result.status().code(),
+            fmt::format("{}, file path: {}", result.status().message(), deletion_file.path));
     }
-    auto bytes = Bytes::AllocateBytes(deletion_file.length, pool);
-    PAIMON_RETURN_NOT_OK(file_input_stream.ReadBytes(bytes.get()));
-    return DeserializeFromBytes(bytes.get(), pool);
+    return result;
 }
 
 Result<PAIMON_UNIQUE_PTR<DeletionVector>> DeletionVector::Read(DataInputStream* input_stream,
@@ -127,10 +160,32 @@ Result<PAIMON_UNIQUE_PTR<DeletionVector>> DeletionVector::Read(DataInputStream* 
         return BitmapDeletionVector::DeserializeWithoutMagicNumber(bytes->data(), bytes->size(),
                                                                    pool);
     } else if (EndianSwapValue(magic_number) == Bitmap64DeletionVector::MAGIC_NUMBER) {
-        return Status::NotImplemented(
-            "bitmap64 deletion vectors are not supported in this version, "
-            "please use bitmap deletion vectors instead or upgrade to a version "
-            "that supports bitmap64.");
+        // A bitmap64 record is recorded whole, so the expected bitmap length is the recorded
+        // length minus the framing a bitmap32 record does not count.
+        if (length.has_value()) {
+            int64_t expected_bitmap_length = length.value() -
+                                             Bitmap64DeletionVector::LENGTH_SIZE_BYTES -
+                                             Bitmap64DeletionVector::CRC_SIZE_BYTES;
+            if (bitmap_length != expected_bitmap_length) {
+                return Status::Invalid(
+                    fmt::format("Size not match, actual size: {}, expected size: {}", bitmap_length,
+                                expected_bitmap_length));
+            }
+        }
+
+        int32_t payload_length = bitmap_length - Bitmap64DeletionVector::MAGIC_NUMBER_SIZE_BYTES;
+        if (payload_length < 0) {
+            return Status::Invalid(fmt::format("Invalid bitmap length: {}", bitmap_length));
+        }
+
+        auto bytes = Bytes::AllocateBytes(payload_length, pool);
+        PAIMON_RETURN_NOT_OK(input_stream->ReadBytes(bytes.get()));
+        // skip crc (4 bytes)
+        PAIMON_ASSIGN_OR_RAISE([[maybe_unused]] int32_t unused_crc,
+                               input_stream->ReadValue<int32_t>());
+
+        return Bitmap64DeletionVector::DeserializeWithoutMagicNumber(bytes->data(), bytes->size(),
+                                                                     pool);
     }
 
     return Status::Invalid(fmt::format(

--- a/src/paimon/core/deletionvectors/deletion_vector.h
+++ b/src/paimon/core/deletionvectors/deletion_vector.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <utility>
@@ -106,6 +107,14 @@ class DeletionVector {
     /// @return the number of distinct integers added to the DeletionVector.
     virtual Result<int64_t> GetCardinality() const = 0;
 
+    /// Invokes `consumer` once per deleted position, in ascending order, and stops at the
+    /// first non-OK status it returns.
+    ///
+    /// Callers that have to relocate deletions — moving a vector onto a file whose row range
+    /// starts elsewhere — need the positions themselves; probing `IsDeleted` across the whole
+    /// range instead would cost one virtual call per row rather than one per deletion.
+    virtual Status ForEachDeletedPosition(const std::function<Status(int64_t)>& consumer) const = 0;
+
     /// Serializes the deletion vector.
     virtual Result<int32_t> SerializeTo(const std::shared_ptr<MemoryPool>& pool,
                                         DataOutputStream* out) = 0;
@@ -116,7 +125,20 @@ class DeletionVector {
     virtual Result<PAIMON_UNIQUE_PTR<Bytes>> SerializeToBytes(
         const std::shared_ptr<MemoryPool>& pool) = 0;
 
+    /// Creates an empty deletion vector of the kind a table configured with `bitmap64`
+    /// stores.
+    ///
+    /// The two kinds serialize differently and refuse to merge into one another, so every
+    /// writer has to build the kind the table already holds. Going through one factory keeps
+    /// that decision in a single place rather than in each call site that happens to need a
+    /// new vector.
+    static std::shared_ptr<DeletionVector> Create(bool bitmap64);
+
     /// Deserializes a deletion vector from a byte array.
+    ///
+    /// The inverse of `SerializeToBytes`, so `bytes` holds only the checksum-covered region —
+    /// the magic number and the bitmap — without the length prefix and checksum a stored record
+    /// is framed with. `Read` is the overload taking the whole framed record instead.
     ///
     /// @param bytes The byte array containing the serialized deletion vector.
     /// @return A DeletionVector instance that represents the deserialized data.

--- a/src/paimon/core/deletionvectors/deletion_vector_index_file_writer.cpp
+++ b/src/paimon/core/deletionvectors/deletion_vector_index_file_writer.cpp
@@ -18,6 +18,10 @@
  */
 #include "paimon/core/deletionvectors/deletion_vector_index_file_writer.h"
 
+#include <utility>
+#include <vector>
+
+#include "fmt/format.h"
 #include "paimon/common/utils/scope_guard.h"
 #include "paimon/core/deletionvectors/deletion_file_writer.h"
 
@@ -39,6 +43,54 @@ Result<std::shared_ptr<IndexFileMeta>> DeletionVectorIndexFileWriter::WriteSingl
     PAIMON_RETURN_NOT_OK(writer->Close());
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<IndexFileMeta> result, writer->GetResult());
     return result;
+}
+
+Result<std::vector<std::shared_ptr<IndexFileMeta>>> DeletionVectorIndexFileWriter::WriteWithRolling(
+    const std::map<std::string, std::shared_ptr<DeletionVector>>& input, int64_t target_size) {
+    if (target_size <= 0) {
+        return Status::Invalid(fmt::format(
+            "Deletion vector index file target size must be positive, but was {}.", target_size));
+    }
+    std::vector<std::shared_ptr<IndexFileMeta>> results;
+    if (input.empty()) {
+        return results;
+    }
+
+    std::unique_ptr<DeletionFileWriter> writer;
+    // Closes a writer that a failure left open, so a partial index file never stays behind
+    // holding its output stream.
+    ScopeGuard guard([&]() {
+        if (writer) {
+            (void)writer->Close();
+        }
+    });
+    for (const auto& [key, value] : input) {
+        if (writer == nullptr) {
+            PAIMON_ASSIGN_OR_RAISE(writer,
+                                   DeletionFileWriter::Create(index_path_factory_, fs_, pool_));
+        }
+        PAIMON_RETURN_NOT_OK(writer->Write(key, value));
+        PAIMON_ASSIGN_OR_RAISE(int64_t written, writer->GetPos());
+        // Strictly greater, so a set of vectors adding up to exactly the target still lands in
+        // one file.
+        if (written <= target_size) {
+            continue;
+        }
+        // Rolled after the write rather than before it, so a vector larger than the target
+        // still lands in a file of its own instead of failing.
+        PAIMON_RETURN_NOT_OK(writer->Close());
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<IndexFileMeta> result, writer->GetResult());
+        results.push_back(std::move(result));
+        writer.reset();
+    }
+    if (writer != nullptr) {
+        PAIMON_RETURN_NOT_OK(writer->Close());
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<IndexFileMeta> result, writer->GetResult());
+        results.push_back(std::move(result));
+        writer.reset();
+    }
+    guard.Release();
+    return results;
 }
 
 }  // namespace paimon

--- a/src/paimon/core/deletionvectors/deletion_vector_index_file_writer.h
+++ b/src/paimon/core/deletionvectors/deletion_vector_index_file_writer.h
@@ -20,6 +20,7 @@
 
 #include <map>
 #include <memory>
+#include <vector>
 
 #include "paimon/core/deletionvectors/deletion_vector.h"
 #include "paimon/core/index/index_path_factory.h"
@@ -43,6 +44,15 @@ class DeletionVectorIndexFileWriter {
     /// future.
     Result<std::shared_ptr<IndexFileMeta>> WriteSingleFile(
         const std::map<std::string, std::shared_ptr<DeletionVector>>& input);
+
+    /// Writes `input` into as many index files as `target_size` allows, rolling to a new file
+    /// once the current one reaches it, and returns them in write order.
+    ///
+    /// A single index file addresses its vectors with int32 offsets and lengths, so a large
+    /// enough set of vectors cannot be written into one file at all. Rolling also keeps a
+    /// rewrite from replacing many small index files with one oversized file.
+    Result<std::vector<std::shared_ptr<IndexFileMeta>>> WriteWithRolling(
+        const std::map<std::string, std::shared_ptr<DeletionVector>>& input, int64_t target_size);
 
  private:
     std::shared_ptr<IndexPathFactory> index_path_factory_;

--- a/src/paimon/core/deletionvectors/deletion_vector_index_file_writer_test.cpp
+++ b/src/paimon/core/deletionvectors/deletion_vector_index_file_writer_test.cpp
@@ -18,11 +18,16 @@
  */
 #include "paimon/core/deletionvectors/deletion_vector_index_file_writer.h"
 
+#include <functional>
 #include <map>
 #include <memory>
+#include <set>
 #include <string>
+#include <vector>
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
+#include "paimon/core/deletionvectors/bitmap64_deletion_vector.h"
 #include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 #include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
 #include "paimon/fs/file_system_factory.h"
@@ -66,6 +71,10 @@ class FailingDeletionVector : public DeletionVector {
     Status Merge(const std::shared_ptr<DeletionVector>&) override {
         return Status::Invalid("injected merge failure");
     }
+
+    Status ForEachDeletedPosition(const std::function<Status(int64_t)>&) const override {
+        return Status::Invalid("injected for-each-deleted-position failure");
+    }
 };
 
 }  // namespace
@@ -105,6 +114,195 @@ TEST(DeletionVectorIndexFileWriterTest, WriteSingleFileRoundTrip) {
 
     ASSERT_OK_AND_ASSIGN(is_deleted, read_back.at("data-b")->IsDeleted(10));
     ASSERT_TRUE(is_deleted);
+}
+
+TEST(DeletionVectorIndexFileWriterTest, WriteWithRollingSplitsWhenTargetSizeIsExceeded) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    auto path_factory = std::make_shared<MockIndexPathFactory>(dir->Str());
+    auto pool = GetDefaultPool();
+    DeletionVectorIndexFileWriter writer(fs, path_factory, pool);
+    DeletionVectorsIndexFile index_file(fs, path_factory, /*bitmap64=*/false, pool);
+
+    // Four one-position vectors, with a target small enough that every one of them overruns it.
+    std::map<std::string, std::shared_ptr<DeletionVector>> input;
+    for (int32_t i = 0; i < 4; i++) {
+        RoaringBitmap32 roaring;
+        roaring.Add(i);
+        input[fmt::format("data-{}", i)] = std::make_shared<BitmapDeletionVector>(roaring);
+    }
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<IndexFileMeta>> metas,
+                         writer.WriteWithRolling(input, /*target_size=*/1));
+    ASSERT_EQ(metas.size(), 4);
+
+    // Every rolled file has to be a complete, readable index file on its own, holding exactly
+    // the vector it was given.
+    for (const std::shared_ptr<IndexFileMeta>& meta : metas) {
+        ASSERT_EQ(meta->IndexType(), DeletionVectorsIndexFile::DELETION_VECTORS_INDEX);
+        ASSERT_EQ(meta->RowCount(), 1);
+        std::map<std::string, std::shared_ptr<DeletionVector>> read_back;
+        ASSERT_OK_AND_ASSIGN(read_back, index_file.ReadAllDeletionVectors(meta));
+        ASSERT_EQ(read_back.size(), 1);
+        const std::string& data_file = read_back.begin()->first;
+        ASSERT_EQ(input.count(data_file), 1U);
+        ASSERT_OK_AND_ASSIGN(int64_t expected, input.at(data_file)->GetCardinality());
+        ASSERT_OK_AND_ASSIGN(int64_t actual, read_back.begin()->second->GetCardinality());
+        ASSERT_EQ(actual, expected);
+    }
+
+    // The file names differ, so nothing was overwritten.
+    std::set<std::string> file_names;
+    for (const std::shared_ptr<IndexFileMeta>& meta : metas) {
+        file_names.insert(meta->FileName());
+    }
+    ASSERT_EQ(file_names.size(), 4U);
+}
+
+TEST(DeletionVectorIndexFileWriterTest, WriteWithRollingKeepsAFileThatReachesTheTargetExactly) {
+    // The boundary itself: rolling happens on `written > target`, so a written size landing
+    // exactly on the target must not roll. One byte less must.
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    auto path_factory = std::make_shared<MockIndexPathFactory>(dir->Str());
+    auto pool = GetDefaultPool();
+    DeletionVectorIndexFileWriter writer(fs, path_factory, pool);
+
+    auto make_input = []() {
+        std::map<std::string, std::shared_ptr<DeletionVector>> input;
+        RoaringBitmap32 roaring_a;
+        roaring_a.Add(1);
+        input["data-a"] = std::make_shared<BitmapDeletionVector>(roaring_a);
+        RoaringBitmap32 roaring_b;
+        roaring_b.Add(2);
+        input["data-b"] = std::make_shared<BitmapDeletionVector>(roaring_b);
+        return input;
+    };
+
+    // The writer's position right after the first vector equals the size of a file holding only
+    // that vector, so measuring one gives the exact boundary to aim at.
+    std::map<std::string, std::shared_ptr<DeletionVector>> first_only;
+    first_only["data-a"] = make_input().at("data-a");
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<IndexFileMeta>> single,
+                         writer.WriteWithRolling(first_only, /*target_size=*/1024 * 1024));
+    ASSERT_EQ(single.size(), 1);
+    int64_t after_first_write = single[0]->FileSize();
+    ASSERT_GT(after_first_write, 1);
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<IndexFileMeta>> at_boundary,
+                         writer.WriteWithRolling(make_input(), after_first_write));
+    ASSERT_EQ(at_boundary.size(), 1);
+    ASSERT_EQ(at_boundary[0]->RowCount(), 2);
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<IndexFileMeta>> past_boundary,
+                         writer.WriteWithRolling(make_input(), after_first_write - 1));
+    ASSERT_EQ(past_boundary.size(), 2);
+}
+
+TEST(DeletionVectorIndexFileWriterTest, WriteWithRollingKeepsOneFileBelowTheTargetSize) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    auto path_factory = std::make_shared<MockIndexPathFactory>(dir->Str());
+    auto pool = GetDefaultPool();
+    DeletionVectorIndexFileWriter writer(fs, path_factory, pool);
+    DeletionVectorsIndexFile index_file(fs, path_factory, /*bitmap64=*/false, pool);
+
+    std::map<std::string, std::shared_ptr<DeletionVector>> input;
+    RoaringBitmap32 roaring_a;
+    roaring_a.Add(1);
+    input["data-a"] = std::make_shared<BitmapDeletionVector>(roaring_a);
+    // A 64 bit vector alongside a 32 bit one: the two frame their records differently, and both
+    // have to survive the same rolled file.
+    auto dv64 = std::make_shared<Bitmap64DeletionVector>();
+    ASSERT_OK(dv64->Delete(1L << 33));
+    input["data-b"] = dv64;
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<IndexFileMeta>> metas,
+                         writer.WriteWithRolling(input, /*target_size=*/1024 * 1024));
+    ASSERT_EQ(metas.size(), 1);
+    ASSERT_EQ(metas[0]->RowCount(), 2);
+    std::map<std::string, std::shared_ptr<DeletionVector>> read_back;
+    ASSERT_OK_AND_ASSIGN(read_back, index_file.ReadAllDeletionVectors(metas[0]));
+    ASSERT_EQ(read_back.size(), 2);
+    ASSERT_OK_AND_ASSIGN(bool is_deleted, read_back.at("data-a")->IsDeleted(1));
+    ASSERT_TRUE(is_deleted);
+    ASSERT_TRUE(dynamic_cast<Bitmap64DeletionVector*>(read_back.at("data-b").get()) != nullptr);
+    ASSERT_OK_AND_ASSIGN(is_deleted, read_back.at("data-b")->IsDeleted(1L << 33));
+    ASSERT_TRUE(is_deleted);
+}
+
+TEST(DeletionVectorIndexFileWriterTest, WriteWithRollingKeepsAnOversizedVectorInItsOwnFile) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    auto path_factory = std::make_shared<MockIndexPathFactory>(dir->Str());
+    auto pool = GetDefaultPool();
+    DeletionVectorIndexFileWriter writer(fs, path_factory, pool);
+    DeletionVectorsIndexFile index_file(fs, path_factory, /*bitmap64=*/false, pool);
+
+    // One vector on its own already exceeds the target. Rolling happens after the write, so it
+    // still lands in a file rather than failing.
+    RoaringBitmap32 roaring;
+    for (int32_t position = 0; position < 5000; position += 2) {
+        roaring.Add(position);
+    }
+    std::map<std::string, std::shared_ptr<DeletionVector>> input;
+    input["data-big"] = std::make_shared<BitmapDeletionVector>(roaring);
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<IndexFileMeta>> metas,
+                         writer.WriteWithRolling(input, /*target_size=*/8));
+    ASSERT_EQ(metas.size(), 1);
+    std::map<std::string, std::shared_ptr<DeletionVector>> read_back;
+    ASSERT_OK_AND_ASSIGN(read_back, index_file.ReadAllDeletionVectors(metas[0]));
+    ASSERT_EQ(read_back.size(), 1);
+    ASSERT_OK_AND_ASSIGN(int64_t cardinality, read_back.at("data-big")->GetCardinality());
+    ASSERT_EQ(cardinality, 2500);
+}
+
+TEST(DeletionVectorIndexFileWriterTest, WriteWithRollingRejectsANonPositiveTargetSize) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    auto path_factory = std::make_shared<MockIndexPathFactory>(dir->Str());
+    auto pool = GetDefaultPool();
+    DeletionVectorIndexFileWriter writer(fs, path_factory, pool);
+
+    RoaringBitmap32 roaring;
+    roaring.Add(1);
+    std::map<std::string, std::shared_ptr<DeletionVector>> input;
+    input["data-a"] = std::make_shared<BitmapDeletionVector>(roaring);
+
+    ASSERT_NOK_WITH_MSG(writer.WriteWithRolling(input, /*target_size=*/0),
+                        "target size must be positive");
+    ASSERT_NOK_WITH_MSG(writer.WriteWithRolling(input, /*target_size=*/-1),
+                        "target size must be positive");
+
+    // An empty input writes nothing, whatever the target is.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<IndexFileMeta>> metas,
+                         writer.WriteWithRolling({}, /*target_size=*/1024));
+    ASSERT_TRUE(metas.empty());
+}
+
+TEST(DeletionVectorIndexFileWriterTest, WriteWithRollingShouldReturnSerializeError) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    auto path_factory = std::make_shared<MockIndexPathFactory>(dir->Str());
+    auto pool = GetDefaultPool();
+    DeletionVectorIndexFileWriter writer(fs, path_factory, pool);
+
+    // The failing vector comes second, so a file is already open when the write fails: the
+    // writer has to close it instead of leaking its output stream.
+    RoaringBitmap32 roaring;
+    roaring.Add(1);
+    std::map<std::string, std::shared_ptr<DeletionVector>> input;
+    input["data-a"] = std::make_shared<BitmapDeletionVector>(roaring);
+    input["data-b"] = std::make_shared<FailingDeletionVector>();
+
+    ASSERT_NOK_WITH_MSG(writer.WriteWithRolling(input, /*target_size=*/1024 * 1024),
+                        "injected serialize failure");
 }
 
 TEST(DeletionVectorIndexFileWriterTest, WriteSingleFileShouldReturnSerializeError) {

--- a/src/paimon/core/deletionvectors/deletion_vector_test.cpp
+++ b/src/paimon/core/deletionvectors/deletion_vector_test.cpp
@@ -121,6 +121,42 @@ TEST(DeletionVectorTest, TestCompatibleWithJava) {
     ASSERT_EQ(*serialized_dv, *serialize_bytes);
 }
 
+TEST(DeletionVectorTest, DeserializeFromBytesTellsTheVectorKindsApart) {
+    // The bytes hold only the checksum-covered region - the magic number and the bitmap - and
+    // the two vector kinds store that magic in opposite byte orders, which is the only thing
+    // identifying the kind here. A bitmap64 vector read back as a bitmap32 one would take its
+    // bitmap apart at the wrong stride, so the round trip has to return the kind it was given.
+    auto pool = GetDefaultPool();
+    auto deletion_vector = std::make_shared<Bitmap64DeletionVector>();
+    ASSERT_OK(deletion_vector->Delete(1));
+    ASSERT_OK(deletion_vector->Delete(int64_t{1} << 33));
+
+    ASSERT_OK_AND_ASSIGN(auto bytes, deletion_vector->SerializeToBytes(pool));
+    ASSERT_OK_AND_ASSIGN(auto deserialized,
+                         DeletionVector::DeserializeFromBytes(bytes.get(), pool.get()));
+    ASSERT_TRUE(dynamic_cast<Bitmap64DeletionVector*>(deserialized.get()) != nullptr);
+    ASSERT_TRUE(deserialized->IsDeleted(1).value());
+    ASSERT_TRUE(deserialized->IsDeleted(int64_t{1} << 33).value());
+    ASSERT_FALSE(deserialized->IsDeleted(2).value());
+}
+
+TEST(DeletionVectorTest, DeserializeFromBytesRejectsUnreadableBytes) {
+    auto pool = GetDefaultPool();
+    // Too short to hold a magic number at all: reading one would run past the buffer.
+    const size_t too_short_size = BitmapDeletionVector::MAGIC_NUMBER_SIZE_BYTES - 1;
+    auto short_bytes = std::make_shared<Bytes>(too_short_size, pool.get());
+    ASSERT_NOK_WITH_MSG(DeletionVector::DeserializeFromBytes(short_bytes.get(), pool.get()),
+                        "too short to hold a magic number");
+
+    // Long enough, but the magic belongs to neither kind in either byte order.
+    std::vector<uint8_t> data;
+    AppendInt32BigEndian(&data, /*value=*/12345);
+    auto bad_magic_bytes = std::make_shared<Bytes>(data.size(), pool.get());
+    memcpy(bad_magic_bytes->data(), data.data(), data.size());
+    ASSERT_NOK_WITH_MSG(DeletionVector::DeserializeFromBytes(bad_magic_bytes.get(), pool.get()),
+                        "Invalid magic number");
+}
+
 TEST(DeletionVectorTest, ReadFromDataInputStreamLengthMismatch) {
     std::vector<uint8_t> data;
     AppendInt32BigEndian(&data, /*value=*/8);
@@ -147,7 +183,7 @@ TEST(DeletionVectorTest, ReadFromDataInputStreamInvalidBitmapLength) {
                         "Invalid bitmap length");
 }
 
-TEST(DeletionVectorTest, ReadFromDataInputStreamBitmap64NotImplemented) {
+TEST(DeletionVectorTest, ReadFromDataInputStreamBitmap64SizeNotMatch) {
     std::vector<uint8_t> data;
     AppendInt32BigEndian(&data, /*value=*/8);
     // Trigger: EndianSwapValue(magic_number) == Bitmap64DeletionVector::MAGIC_NUMBER.
@@ -158,9 +194,10 @@ TEST(DeletionVectorTest, ReadFromDataInputStreamBitmap64NotImplemented) {
     DataInputStream in(input_stream);
     auto pool = GetDefaultPool();
 
-    ASSERT_NOK_WITH_MSG(
-        DeletionVector::Read(&in, std::nullopt, pool.get()),
-        "NotImplemented: bitmap64 deletion vectors are not supported in this version");
+    // A bitmap64 record is recorded whole, so the caller's length has to exceed the bitmap
+    // length by the framing. 100 does not describe this record and must be rejected rather
+    // than read as if it did.
+    ASSERT_NOK_WITH_MSG(DeletionVector::Read(&in, /*length=*/100, pool.get()), "Size not match");
 }
 
 TEST(DeletionVectorTest, ReadFromDataInputStreamInvalidMagicNumber) {

--- a/src/paimon/core/deletionvectors/deletion_vectors_index_file.cpp
+++ b/src/paimon/core/deletionvectors/deletion_vectors_index_file.cpp
@@ -32,6 +32,61 @@ Result<std::shared_ptr<IndexFileMeta>> DeletionVectorsIndexFile::WriteSingleFile
     return CreateWriter()->WriteSingleFile(input);
 }
 
+Result<std::vector<std::shared_ptr<IndexFileMeta>>> DeletionVectorsIndexFile::WriteWithRolling(
+    const std::map<std::string, std::shared_ptr<DeletionVector>>& input, int64_t target_size) {
+    return CreateWriter()->WriteWithRolling(input, target_size);
+}
+
+Result<std::shared_ptr<DeletionVector>> DeletionVectorsIndexFile::ReadDeletionVector(
+    const DeletionFile& deletion_file) const {
+    // A `DeletionFile` does not name the data file it covers, so the key is irrelevant here;
+    // only the single value read back is.
+    std::map<std::string, DeletionFile> single = {{deletion_file.path, deletion_file}};
+    std::map<std::string, std::shared_ptr<DeletionVector>> deletion_vectors;
+    PAIMON_ASSIGN_OR_RAISE(deletion_vectors, ReadDeletionVectors(single));
+    return deletion_vectors.begin()->second;
+}
+
+Result<std::map<std::string, std::shared_ptr<DeletionVector>>>
+DeletionVectorsIndexFile::ReadDeletionVectors(
+    const std::map<std::string, DeletionFile>& deletion_file_by_data_file) const {
+    std::map<std::string, std::shared_ptr<DeletionVector>> deletion_vectors;
+    if (deletion_file_by_data_file.empty()) {
+        return deletion_vectors;
+    }
+
+    const std::string& index_file_path = deletion_file_by_data_file.begin()->second.path;
+    PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<InputStream> input_stream, fs_->Open(index_file_path));
+    auto data_input_stream = std::make_shared<DataInputStream>(input_stream);
+    // Checked once for the whole file instead of seeking straight to a recorded offset: a file
+    // written by a future version must not be parsed as if it were a V1 one.
+    PAIMON_RETURN_NOT_OK(CheckVersion(data_input_stream));
+    for (const auto& [data_file_name, deletion_file] : deletion_file_by_data_file) {
+        if (deletion_file.path != index_file_path) {
+            return Status::Invalid(
+                fmt::format("Deletion vectors of data files {} and {} were read together, but "
+                            "live in different index files {} and {}.",
+                            deletion_file_by_data_file.begin()->first, data_file_name,
+                            index_file_path, deletion_file.path));
+        }
+        // The vectors are addressed by their recorded offsets rather than read in file order,
+        // so each one seeks; the stream, and with it the open file, is shared.
+        PAIMON_RETURN_NOT_OK(data_input_stream->Seek(deletion_file.offset));
+        Result<PAIMON_UNIQUE_PTR<DeletionVector>> deletion_vector =
+            DeletionVector::Read(data_input_stream.get(), deletion_file.length, pool_.get());
+        if (!deletion_vector.ok()) {
+            // The stream overload cannot name the file it was handed, and that name is what a
+            // corrupt or mismatched deletion file has to be tracked down by.
+            return Status(deletion_vector.status().code(),
+                          fmt::format("{}, file path: {}", deletion_vector.status().message(),
+                                      index_file_path));
+        }
+        deletion_vectors[data_file_name] =
+            std::shared_ptr<DeletionVector>(std::move(deletion_vector).value());
+    }
+    return deletion_vectors;
+}
+
 std::shared_ptr<DeletionVectorIndexFileWriter> DeletionVectorsIndexFile::CreateWriter() const {
     return std::make_shared<DeletionVectorIndexFileWriter>(fs_, path_factory_, pool_);
 }

--- a/src/paimon/core/deletionvectors/deletion_vectors_index_file.h
+++ b/src/paimon/core/deletionvectors/deletion_vectors_index_file.h
@@ -21,10 +21,12 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "paimon/core/deletionvectors/deletion_vector.h"
 #include "paimon/core/index/index_file.h"
 #include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/table/source/deletion_file.h"
 
 namespace paimon {
 
@@ -49,6 +51,25 @@ class DeletionVectorsIndexFile : public IndexFile {
 
     Result<std::shared_ptr<IndexFileMeta>> WriteSingleFile(
         const std::map<std::string, std::shared_ptr<DeletionVector>>& input);
+
+    /// Writes `input` into as many index files as `target_size` allows, rolling to a new one
+    /// once the current file reaches it.
+    Result<std::vector<std::shared_ptr<IndexFileMeta>>> WriteWithRolling(
+        const std::map<std::string, std::shared_ptr<DeletionVector>>& input, int64_t target_size);
+
+    /// Reads one deletion vector by its recorded position, leaving the other vectors of the
+    /// same index file untouched.
+    Result<std::shared_ptr<DeletionVector>> ReadDeletionVector(
+        const DeletionFile& deletion_file) const;
+
+    /// Reads several deletion vectors that all live in one index file, keyed by the data file
+    /// each covers, through a single opened stream.
+    ///
+    /// Reading n vectors of the same index file one by one costs n opens, which on an object
+    /// store dominates the read itself. Every `DeletionFile` has to name the same index file;
+    /// one that does not is a caller bug and is rejected.
+    Result<std::map<std::string, std::shared_ptr<DeletionVector>>> ReadDeletionVectors(
+        const std::map<std::string, DeletionFile>& deletion_file_by_data_file) const;
 
     Result<std::map<std::string, std::shared_ptr<DeletionVector>>> ReadAllDeletionVectors(
         const std::shared_ptr<IndexFileMeta>& file_meta) const;

--- a/src/paimon/core/deletionvectors/deletion_vectors_index_file_test.cpp
+++ b/src/paimon/core/deletionvectors/deletion_vectors_index_file_test.cpp
@@ -20,10 +20,13 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
+#include "fmt/format.h"
 #include "gtest/gtest.h"
+#include "paimon/common/io/data_output_stream.h"
 #include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 #include "paimon/core/index/index_file_meta.h"
 #include "paimon/fs/file_system_factory.h"
@@ -154,6 +157,115 @@ TEST(DeletionVectorsIndexFileTest, RoundTripMultipleIndexFilesMerge) {
     ASSERT_TRUE(is_deleted);
     ASSERT_OK_AND_ASSIGN(is_deleted, read_back.at("dv_b")->IsDeleted(8));
     ASSERT_TRUE(is_deleted);
+}
+
+TEST(DeletionVectorsIndexFileTest, ReadDeletionVectorsSelectsASubsetOfOneIndexFile) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    auto path_factory = std::make_shared<MockIndexPathFactory>(dir->Str());
+    auto pool = GetDefaultPool();
+    DeletionVectorsIndexFile index_file(fs, path_factory, /*bitmap64=*/false, pool);
+
+    std::map<std::string, std::shared_ptr<DeletionVector>> input;
+    for (int32_t i = 0; i < 4; i++) {
+        RoaringBitmap32 roaring;
+        roaring.Add(i);
+        input[fmt::format("data-{}", i)] = std::make_shared<BitmapDeletionVector>(roaring);
+    }
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<IndexFileMeta> meta, index_file.WriteSingleFile(input));
+    const std::optional<LinkedHashMap<std::string, DeletionVectorMeta>>& dv_ranges =
+        meta->DvRanges();
+    ASSERT_TRUE(dv_ranges.has_value());
+    std::string index_file_path = path_factory->ToPath(meta);
+
+    // Two of the four vectors, addressed by their recorded positions. The two that are not asked
+    // for must not be returned, which is what lets a rewrite keep an untouched vector's bytes.
+    std::map<std::string, DeletionFile> selected;
+    for (const std::string& data_file : {std::string("data-1"), std::string("data-3")}) {
+        auto dv_meta = dv_ranges.value().find(data_file);
+        ASSERT_TRUE(dv_meta != dv_ranges.value().end());
+        selected.emplace(
+            data_file, DeletionFile(index_file_path, dv_meta->second.GetOffset(),
+                                    dv_meta->second.GetLength(), dv_meta->second.GetCardinality()));
+    }
+    std::map<std::string, std::shared_ptr<DeletionVector>> read_back;
+    ASSERT_OK_AND_ASSIGN(read_back, index_file.ReadDeletionVectors(selected));
+    ASSERT_EQ(read_back.size(), 2);
+    ASSERT_OK_AND_ASSIGN(bool is_deleted, read_back.at("data-1")->IsDeleted(1));
+    ASSERT_TRUE(is_deleted);
+    ASSERT_OK_AND_ASSIGN(is_deleted, read_back.at("data-3")->IsDeleted(3));
+    ASSERT_TRUE(is_deleted);
+    ASSERT_OK_AND_ASSIGN(is_deleted, read_back.at("data-3")->IsDeleted(1));
+    ASSERT_FALSE(is_deleted);
+
+    // The single-vector overload reads the same bytes.
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<DeletionVector> single,
+                         index_file.ReadDeletionVector(selected.at("data-1")));
+    ASSERT_OK_AND_ASSIGN(is_deleted, single->IsDeleted(1));
+    ASSERT_TRUE(is_deleted);
+
+    ASSERT_OK_AND_ASSIGN(read_back, index_file.ReadDeletionVectors({}));
+    ASSERT_TRUE(read_back.empty());
+}
+
+TEST(DeletionVectorsIndexFileTest, ReadDeletionVectorsRejectsMixedIndexFiles) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    auto path_factory = std::make_shared<MockIndexPathFactory>(dir->Str());
+    auto pool = GetDefaultPool();
+    DeletionVectorsIndexFile index_file(fs, path_factory, /*bitmap64=*/false, pool);
+
+    RoaringBitmap32 roaring;
+    roaring.Add(1);
+    std::map<std::string, std::shared_ptr<DeletionVector>> input;
+    input["data-a"] = std::make_shared<BitmapDeletionVector>(roaring);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<IndexFileMeta> meta, index_file.WriteSingleFile(input));
+    const std::optional<LinkedHashMap<std::string, DeletionVectorMeta>>& dv_ranges =
+        meta->DvRanges();
+    ASSERT_TRUE(dv_ranges.has_value());
+    auto dv_meta_iter = dv_ranges.value().find("data-a");
+    ASSERT_TRUE(dv_meta_iter != dv_ranges.value().end());
+    const DeletionVectorMeta& dv_meta = dv_meta_iter->second;
+
+    // A batch that spans two index files cannot be served by one stream, so it is a caller bug
+    // rather than something to silently read from the wrong file.
+    std::map<std::string, DeletionFile> mixed;
+    mixed.emplace("data-a", DeletionFile(path_factory->ToPath(meta), dv_meta.GetOffset(),
+                                         dv_meta.GetLength(), dv_meta.GetCardinality()));
+    mixed.emplace("data-b", DeletionFile(path_factory->ToPath("other-index"), dv_meta.GetOffset(),
+                                         dv_meta.GetLength(), dv_meta.GetCardinality()));
+    ASSERT_NOK_WITH_MSG(index_file.ReadDeletionVectors(mixed), "live in different index files");
+}
+
+TEST(DeletionVectorsIndexFileTest, ReadDeletionVectorsChecksTheIndexFileVersion) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileSystem> fs,
+                         FileSystemFactory::Get("local", dir->Str(), {}));
+    auto path_factory = std::make_shared<MockIndexPathFactory>(dir->Str());
+    auto pool = GetDefaultPool();
+    DeletionVectorsIndexFile index_file(fs, path_factory, /*bitmap64=*/false, pool);
+
+    // An index file whose leading version byte is not V1. Seeking straight to a recorded offset
+    // would parse its payload as if it were V1; the read has to reject the file instead.
+    std::string path = path_factory->ToPath("index-future-version");
+    {
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> out, fs->Create(path,
+                                                                           /*overwrite=*/true));
+        DataOutputStream output_stream(out);
+        ASSERT_OK(output_stream.WriteValue<int8_t>(DeletionVectorsIndexFile::VERSION_ID_V1 + 1));
+        for (int32_t i = 0; i < 32; i++) {
+            ASSERT_OK(output_stream.WriteValue<int8_t>(0));
+        }
+        ASSERT_OK(out->Close());
+    }
+
+    DeletionFile deletion_file(path, /*offset=*/1, /*length=*/16, /*cardinality=*/1);
+    ASSERT_NOK_WITH_MSG(index_file.ReadDeletionVector(deletion_file), "Version not match");
+    std::map<std::string, DeletionFile> batch;
+    batch.emplace("data-a", deletion_file);
+    ASSERT_NOK_WITH_MSG(index_file.ReadDeletionVectors(batch), "Version not match");
 }
 
 TEST(DeletionVectorsIndexFileTest, RoundTripMultipleIndexFilesLastWriteWinsOnSameKey) {

--- a/src/paimon/core/io/data_file_path_factory.h
+++ b/src/paimon/core/io/data_file_path_factory.h
@@ -27,6 +27,7 @@
 #include "paimon/common/fs/external_path_provider.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
 #include "paimon/core/utils/path_factory.h"
 
 namespace paimon {
@@ -62,6 +63,14 @@ class DataFilePathFactory : public PathFactory {
 
     std::string NewBlobPath() const {
         return NewPathFromName(NewFileName(data_file_prefix_, ".blob"));
+    }
+
+    /// A new managed blob pack path for primary-key managed blob storage. Managed packs stay
+    /// in the default bucket directory: external data paths are rejected for primary-key
+    /// managed blob tables.
+    std::string NewManagedBlobPath() const {
+        return PathUtil::JoinPath(
+            parent_, NewFileName(data_file_prefix_, ManagedBlobReferenceFile::kManagedBlobSuffix));
     }
 
     std::string NewPathFromName(const std::string& file_name) const {

--- a/src/paimon/core/io/data_file_path_factory_test.cpp
+++ b/src/paimon/core/io/data_file_path_factory_test.cpp
@@ -18,14 +18,18 @@
 
 #include "paimon/core/io/data_file_path_factory.h"
 
+#include <memory>
 #include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "gtest/gtest.h"
 #include "paimon/common/data/binary_row.h"
 #include "paimon/common/fs/external_path_provider.h"
 #include "paimon/common/utils/string_utils.h"
 #include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/core/stats/simple_stats.h"
 #include "paimon/data/timestamp.h"
@@ -81,6 +85,26 @@ TEST_F(DataFilePathFactoryTest, TestNewPathWithDataFilePrefixAndExternalPath) {
     ASSERT_EQ(factory_.Parent(), "/tmp/p0=1/p1=0/bucket-0/");
     ASSERT_EQ(factory_.NewPathFromName("index-file"),
               "/tmp/external_path/p0=1/p1=0/bucket-0/index-file");
+}
+
+TEST_F(DataFilePathFactoryTest, TestNewManagedBlobPath) {
+    std::string path1 = factory_.NewManagedBlobPath();
+    std::string path2 = factory_.NewManagedBlobPath();
+
+    // A managed pack is named like a data file but carries the managed blob suffix, which is
+    // what tells maintenance apart from a data file it must never delete on its own.
+    ASSERT_NE(path1, path2);
+    ASSERT_TRUE(StringUtils::StartsWith(path1, "/tmp/data-"));
+    ASSERT_TRUE(StringUtils::EndsWith(path1, ManagedBlobReferenceFile::kManagedBlobSuffix));
+
+    // Unlike a data file, a managed pack stays in the bucket directory: external data paths are
+    // rejected for a primary-key managed blob table, so the pack must not follow one.
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<ExternalPathProvider> external_path_provider,
+                         ExternalPathProvider::Create({"/tmp/external_path/"}, "p0=1/bucket-0"));
+    ASSERT_OK(factory_.Init(/*parent=*/"/tmp/p0=1/bucket-0", /*format_identifier=*/"txt",
+                            /*data_file_prefix=*/"data-", std::move(external_path_provider)));
+    ASSERT_TRUE(StringUtils::StartsWith(factory_.NewPath(), "/tmp/external_path/"));
+    ASSERT_TRUE(StringUtils::StartsWith(factory_.NewManagedBlobPath(), "/tmp/p0=1/bucket-0/"));
 }
 
 TEST_F(DataFilePathFactoryTest, TestToPath) {

--- a/src/paimon/core/io/key_value_data_file_writer.cpp
+++ b/src/paimon/core/io/key_value_data_file_writer.cpp
@@ -63,6 +63,11 @@ KeyValueDataFileWriter::KeyValueDataFileWriter(
       is_external_path_(is_external_path),
       disable_stats_(stats_extractor == nullptr) {}
 
+void KeyValueDataFileWriter::SetBlobReferenceCollector(
+    std::unique_ptr<ManagedBlobReferenceCollector> collector) {
+    blob_reference_collector_ = std::move(collector);
+}
+
 Status KeyValueDataFileWriter::Write(KeyValueBatch batch) {
     // update min and max key
     if (!min_key_) {
@@ -75,7 +80,34 @@ Status KeyValueDataFileWriter::Write(KeyValueBatch batch) {
     // update delete row count
     delete_row_count_ += batch.delete_row_count;
 
+    if (blob_reference_collector_) {
+        PAIMON_RETURN_NOT_OK(blob_reference_collector_->Collect(&batch));
+    }
+
     return WriteRecordWithFileIndex(std::move(batch));
+}
+
+Status KeyValueDataFileWriter::BeforeFinish() {
+    PAIMON_RETURN_NOT_OK(DataFileWriterBase::BeforeFinish());
+    if (blob_reference_collector_) {
+        PAIMON_RETURN_NOT_OK(blob_reference_collector_->Close());
+    }
+    return Status::OK();
+}
+
+void KeyValueDataFileWriter::Abort() {
+    if (blob_reference_collector_) {
+        blob_reference_collector_->Abort();
+    }
+    DataFileWriterBase::Abort();
+}
+
+Result<KeyValueDataFileWriter::AbortExecutor> KeyValueDataFileWriter::GetAbortExecutor() const {
+    PAIMON_ASSIGN_OR_RAISE(AbortExecutor executor, DataFileWriterBase::GetAbortExecutor());
+    if (blob_reference_collector_) {
+        executor.Add(fs_, blob_reference_collector_->SidecarPath());
+    }
+    return executor;
 }
 
 Result<std::shared_ptr<DataFileMeta>> KeyValueDataFileWriter::GetResult() {
@@ -104,10 +136,17 @@ Result<std::shared_ptr<DataFileMeta>> KeyValueDataFileWriter::GetResult() {
     }
     PAIMON_ASSIGN_OR_RAISE(int64_t local_micro, DateTimeUtils::GetCurrentLocalTimeUs());
     const FileIndexWriteResult& file_index = GetFileIndexWriteResult();
+    // The blob reference sidecar travels in the extra files, tying its lifecycle to the data
+    // file wherever extra files are collected for deletion.
+    std::vector<std::optional<std::string>> extra_files = file_index.extra_files;
+    if (blob_reference_collector_) {
+        PAIMON_ASSIGN_OR_RAISE(std::string sidecar_file_name,
+                               blob_reference_collector_->ResultFileName());
+        extra_files.emplace_back(std::move(sidecar_file_name));
+    }
     return std::make_shared<DataFileMeta>(
         PathUtil::GetName(path_), output_bytes_, RecordCount(), min_key, max_key, key_stats,
-        value_stats, min_sequence_number_, max_sequence_number_, schema_id_, level_,
-        file_index.extra_files,
+        value_stats, min_sequence_number_, max_sequence_number_, schema_id_, level_, extra_files,
         Timestamp(/*millisecond=*/local_micro / 1000, /*nano_of_millisecond=*/0), delete_row_count_,
         file_index.embedded_index, file_source_, /*value_stats_cols=*/std::nullopt, final_path,
         /*first_row_id=*/std::nullopt, /*write_cols=*/std::nullopt);

--- a/src/paimon/core/io/key_value_data_file_writer.h
+++ b/src/paimon/core/io/key_value_data_file_writer.h
@@ -27,6 +27,7 @@
 
 #include "paimon/core/io/data_file_meta.h"
 #include "paimon/core/io/data_file_writer_base.h"
+#include "paimon/core/io/managed_blob_reference_collector.h"
 #include "paimon/core/key_value.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/result.h"
@@ -55,9 +56,22 @@ class KeyValueDataFileWriter : public DataFileWriterBase<KeyValueBatch> {
                            const std::shared_ptr<arrow::Schema>& write_schema,
                            bool is_external_path, const std::shared_ptr<MemoryPool>& pool);
 
+    /// Attaches the managed blob reference collector of a primary-key managed blob table. The
+    /// collector records the pack files this data file's rows reference; its `.blobref`
+    /// sidecar is written on close and carried in the result's extra files. Must be set before
+    /// the first Write().
+    void SetBlobReferenceCollector(std::unique_ptr<ManagedBlobReferenceCollector> collector);
+
     Status Write(KeyValueBatch batch) override;
 
     Result<std::shared_ptr<DataFileMeta>> GetResult() override;
+
+    void Abort() override;
+
+    Result<AbortExecutor> GetAbortExecutor() const override;
+
+ protected:
+    Status BeforeFinish() override;
 
  private:
     Result<std::vector<std::shared_ptr<ColumnStats>>> GetFieldStats();
@@ -84,6 +98,7 @@ class KeyValueDataFileWriter : public DataFileWriterBase<KeyValueBatch> {
     int64_t max_sequence_number_ = std::numeric_limits<int64_t>::min();
     std::shared_ptr<InternalRow> min_key_;
     std::shared_ptr<InternalRow> max_key_;
+    std::unique_ptr<ManagedBlobReferenceCollector> blob_reference_collector_;
 };
 
 }  // namespace paimon

--- a/src/paimon/core/io/key_value_data_file_writer_factory.cpp
+++ b/src/paimon/core/io/key_value_data_file_writer_factory.cpp
@@ -20,9 +20,12 @@
 #include "paimon/core/io/key_value_data_file_writer_factory.h"
 
 #include <functional>
+#include <set>
 #include <utility>
 
 #include "arrow/c/helpers.h"
+#include "arrow/type.h"
+#include "paimon/common/data/blob_utils.h"
 #include "paimon/core/core_options.h"
 #include "paimon/core/io/data_file_index_writer.h"
 #include "paimon/core/io/data_file_path_factory.h"
@@ -57,6 +60,7 @@ KeyValueDataFileWriterFactory::CreateWriter() const {
     auto format = options_.GetWriteFileFormat(level_);
     PAIMON_ASSIGN_OR_RAISE(WriterResources resources,
                            CreateWriterResources(*format, write_schema_, create_stats_extractor_));
+    std::string path = path_factory_->NewPath();
     auto writer = std::make_unique<KeyValueDataFileWriter>(
         options_.GetWriteFileCompression(level_), std::move(converter), schema_id_, level_,
         file_source_, primary_keys_, resources.stats_extractor, write_schema_,
@@ -66,10 +70,31 @@ KeyValueDataFileWriterFactory::CreateWriter() const {
     if (file_index_writer) {
         writer->SetFileIndexWriter(std::move(file_index_writer), write_schema_);
     }
-    PAIMON_RETURN_NOT_OK(
-        writer->Init(options_.GetFileSystem(), path_factory_->NewPath(), resources.writer_builder));
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ManagedBlobReferenceCollector> collector,
+                           CreateBlobReferenceCollector(path));
+    if (collector) {
+        writer->SetBlobReferenceCollector(std::move(collector));
+    }
+    PAIMON_RETURN_NOT_OK(writer->Init(options_.GetFileSystem(), path, resources.writer_builder));
     return std::unique_ptr<SingleFileWriter<KeyValueBatch, std::shared_ptr<DataFileMeta>>>(
         std::move(writer));
+}
+
+Result<std::unique_ptr<ManagedBlobReferenceCollector>>
+KeyValueDataFileWriterFactory::CreateBlobReferenceCollector(
+    const std::string& data_file_path) const {
+    std::vector<std::string> inline_field_names = options_.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> managed_fields =
+        BlobUtils::ManagedBlobFieldNames(write_schema_, inline_fields);
+    if (managed_fields.empty()) {
+        return std::unique_ptr<ManagedBlobReferenceCollector>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(
+        std::unique_ptr<ManagedBlobReferenceCollector> collector,
+        ManagedBlobReferenceCollector::Create(options_.GetFileSystem(), data_file_path,
+                                              write_schema_, managed_fields));
+    return collector;
 }
 
 }  // namespace paimon

--- a/src/paimon/core/io/key_value_data_file_writer_factory.h
+++ b/src/paimon/core/io/key_value_data_file_writer_factory.h
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "paimon/core/io/data_file_writer_factory.h"
+#include "paimon/core/io/managed_blob_reference_collector.h"
 #include "paimon/core/io/single_file_writer_factory.h"
 #include "paimon/core/key_value.h"
 #include "paimon/core/manifest/file_source.h"
@@ -56,6 +57,11 @@ class KeyValueDataFileWriterFactory
     CreateWriter() const override;
 
  protected:
+    /// Builds the managed blob reference collector for the data file at `data_file_path`, or
+    /// nullptr when the write schema holds no managed blob field.
+    Result<std::unique_ptr<ManagedBlobReferenceCollector>> CreateBlobReferenceCollector(
+        const std::string& data_file_path) const;
+
     std::shared_ptr<arrow::Schema> write_schema_;
     int32_t level_;
     FileSource file_source_;

--- a/src/paimon/core/io/managed_blob_reference_collector.cpp
+++ b/src/paimon/core/io/managed_blob_reference_collector.cpp
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/managed_blob_reference_collector.h"
+
+#include <optional>
+#include <string_view>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "fmt/format.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/types/row_kind.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
+#include "paimon/fs/file_system.h"
+
+namespace paimon {
+
+Result<std::unique_ptr<ManagedBlobReferenceCollector>> ManagedBlobReferenceCollector::Create(
+    const std::shared_ptr<FileSystem>& fs, const std::string& data_file_path,
+    const std::shared_ptr<arrow::Schema>& write_schema,
+    const std::vector<std::string>& managed_field_names) {
+    if (managed_field_names.empty()) {
+        return Status::Invalid(
+            "ManagedBlobReferenceCollector requires at least one managed blob field.");
+    }
+    std::vector<int32_t> managed_field_indices;
+    managed_field_indices.reserve(managed_field_names.size());
+    for (const auto& field_name : managed_field_names) {
+        int32_t index = write_schema->GetFieldIndex(field_name);
+        if (index < 0) {
+            return Status::Invalid(
+                fmt::format("Managed blob field {} is not part of the write schema.", field_name));
+        }
+        managed_field_indices.push_back(index);
+    }
+    int32_t value_kind_index = write_schema->GetFieldIndex(SpecialFields::ValueKind().Name());
+    if (value_kind_index < 0) {
+        return Status::Invalid(
+            "ManagedBlobReferenceCollector requires the value kind column in the write schema.");
+    }
+    auto batch_type = arrow::struct_(write_schema->fields());
+    return std::unique_ptr<ManagedBlobReferenceCollector>(new ManagedBlobReferenceCollector(
+        fs, data_file_path, batch_type, std::move(managed_field_indices), value_kind_index));
+}
+
+ManagedBlobReferenceCollector::ManagedBlobReferenceCollector(
+    const std::shared_ptr<FileSystem>& fs, const std::string& data_file_path,
+    const std::shared_ptr<arrow::DataType>& batch_type, std::vector<int32_t> managed_field_indices,
+    int32_t value_kind_index)
+    : fs_(fs),
+      sidecar_path_(ManagedBlobReferenceFile::SidecarPath(data_file_path)),
+      batch_type_(batch_type),
+      managed_field_indices_(std::move(managed_field_indices)),
+      value_kind_index_(value_kind_index),
+      logger_(Logger::GetLogger("ManagedBlobReferenceCollector")) {}
+
+Status ManagedBlobReferenceCollector::Collect(KeyValueBatch* batch) {
+    if (closed_) {
+        return Status::Invalid("ManagedBlobReferenceCollector is already closed.");
+    }
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                      arrow::ImportArray(batch->batch.get(), batch_type_));
+    // Re-export immediately so the batch stays writable; the imported view shares the buffers.
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*arrow_array, batch->batch.get()));
+
+    auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+    if (struct_array == nullptr) {
+        return Status::Invalid(
+            "ManagedBlobReferenceCollector expects a StructArray key-value batch.");
+    }
+    auto value_kind_column =
+        std::dynamic_pointer_cast<arrow::Int8Array>(struct_array->field(value_kind_index_));
+    if (value_kind_column == nullptr) {
+        return Status::Invalid("ManagedBlobReferenceCollector expects an int8 value kind column.");
+    }
+    for (int32_t field_index : managed_field_indices_) {
+        auto blob_column =
+            std::dynamic_pointer_cast<arrow::LargeBinaryArray>(struct_array->field(field_index));
+        if (blob_column == nullptr) {
+            return Status::Invalid(
+                fmt::format("ManagedBlobReferenceCollector expects managed blob column {} to be a "
+                            "LargeBinaryArray.",
+                            struct_array->struct_type()->field(field_index)->name()));
+        }
+        for (int64_t row = 0; row < blob_column->length(); row++) {
+            if (blob_column->IsNull(row)) {
+                continue;
+            }
+            PAIMON_ASSIGN_OR_RAISE(const RowKind* row_kind,
+                                   RowKind::FromByteValue(value_kind_column->Value(row)));
+            // A retract row keeps no payload, so it contributes no reference.
+            if (row_kind->IsRetract()) {
+                continue;
+            }
+            std::string_view value = blob_column->GetView(row);
+            PAIMON_ASSIGN_OR_RAISE(bool is_descriptor,
+                                   BlobDescriptor::IsBlobDescriptor(value.data(), value.size()));
+            // Only descriptor values reference external payloads; other bytes (for example
+            // inline blob data) carry their payload with the row.
+            if (!is_descriptor) {
+                continue;
+            }
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BlobDescriptor> descriptor,
+                                   BlobDescriptor::Deserialize(value.data(), value.size()));
+            descriptor_uris_.insert(descriptor->Uri());
+        }
+    }
+    return Status::OK();
+}
+
+Status ManagedBlobReferenceCollector::Close() {
+    if (closed_) {
+        return Status::OK();
+    }
+    std::vector<ManagedBlobReferenceFile::Reference> references;
+    for (const auto& uri : descriptor_uris_) {
+        PAIMON_ASSIGN_OR_RAISE(std::optional<ManagedBlobReferenceFile::Reference> reference,
+                               ManagedBlobReferenceFile::FromDescriptorUri(uri));
+        // URIs of non-managed storage carry their own lifecycle and are not recorded.
+        if (reference) {
+            references.push_back(std::move(reference.value()));
+        }
+    }
+    descriptor_uris_.clear();
+    Status status = ManagedBlobReferenceFile::Write(fs_, sidecar_path_, std::move(references));
+    if (!status.ok()) {
+        Abort();
+        return status;
+    }
+    closed_ = true;
+    return Status::OK();
+}
+
+void ManagedBlobReferenceCollector::Abort() {
+    Status status = fs_->Delete(sidecar_path_);
+    // A missing sidecar is normal here (a failed write already removes its partial file);
+    // only a real cleanup failure is worth a warning.
+    if (!status.ok() && !status.IsNotExist()) {
+        PAIMON_LOG_WARN(logger_, "Failed to delete managed blob reference sidecar %s: %s",
+                        sidecar_path_.c_str(), status.ToString().c_str());
+    }
+    closed_ = true;
+}
+
+Result<std::string> ManagedBlobReferenceCollector::ResultFileName() const {
+    if (!closed_) {
+        return Status::Invalid(
+            "ManagedBlobReferenceCollector result requires the collector to be closed.");
+    }
+    return PathUtil::GetName(sidecar_path_);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/managed_blob_reference_collector.h
+++ b/src/paimon/core/io/managed_blob_reference_collector.h
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "paimon/core/key_value.h"
+#include "paimon/logging.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+class FileSystem;
+
+/// Collects, for one primary-key data file, the managed blob pack files its rows reference,
+/// and writes them to the file's `.blobref` sidecar on close.
+///
+/// The collector scans every written key-value batch: managed blob values of non-retract rows
+/// hold serialized blob descriptors after externalization, and each descriptor URI ending in
+/// `.managed.blob` contributes one reference. Values that are not descriptors (for example
+/// inline blob bytes) are ignored. Because compaction rewrites descriptors verbatim, the
+/// sidecar of a compacted file lists exactly the packs its surviving rows still reference.
+class ManagedBlobReferenceCollector {
+ public:
+    /// Creates a collector for the data file at `data_file_path`. `write_schema` is the
+    /// key-value batch schema (special fields followed by value fields); `managed_field_names`
+    /// selects the managed blob columns in it.
+    static Result<std::unique_ptr<ManagedBlobReferenceCollector>> Create(
+        const std::shared_ptr<FileSystem>& fs, const std::string& data_file_path,
+        const std::shared_ptr<arrow::Schema>& write_schema,
+        const std::vector<std::string>& managed_field_names);
+
+    /// Records the managed blob references of `batch`. The batch's Arrow array is imported and
+    /// re-exported in place, its content is not changed.
+    Status Collect(KeyValueBatch* batch);
+
+    /// Writes the sidecar next to the data file. A failed write aborts the collector.
+    Status Close();
+
+    /// Deletes the sidecar, logging a warning on failure, and marks the collector closed.
+    void Abort();
+
+    /// The sidecar file name to record in the data file's extra files. Only valid after a
+    /// successful Close().
+    Result<std::string> ResultFileName() const;
+
+    /// The sidecar path next to the data file.
+    const std::string& SidecarPath() const {
+        return sidecar_path_;
+    }
+
+ private:
+    ManagedBlobReferenceCollector(const std::shared_ptr<FileSystem>& fs,
+                                  const std::string& data_file_path,
+                                  const std::shared_ptr<arrow::DataType>& batch_type,
+                                  std::vector<int32_t> managed_field_indices,
+                                  int32_t value_kind_index);
+
+ private:
+    std::shared_ptr<FileSystem> fs_;
+    std::string sidecar_path_;
+    std::shared_ptr<arrow::DataType> batch_type_;
+    std::vector<int32_t> managed_field_indices_;
+    int32_t value_kind_index_;
+
+    std::unique_ptr<Logger> logger_;
+
+    std::set<std::string> descriptor_uris_;
+    bool closed_ = false;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/managed_blob_reference_collector_test.cpp
+++ b/src/paimon/core/io/managed_blob_reference_collector_test.cpp
@@ -1,0 +1,250 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/managed_blob_reference_collector.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/table/special_fields.h"
+#include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class ManagedBlobReferenceCollectorTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        dir_ = UniqueTestDirectory::Create("local");
+        // The key-value batch schema: special fields followed by the value fields.
+        std::vector<DataField> write_fields = {SpecialFields::SequenceNumber(),
+                                               SpecialFields::ValueKind()};
+        write_fields.emplace_back(0, arrow::field("k", arrow::int32()));
+        write_fields.emplace_back(1, BlobUtils::ToArrowField("b", /*nullable=*/true));
+        write_schema_ = DataField::ConvertDataFieldsToArrowSchema(write_fields);
+        data_file_path_ = PathUtil::JoinPath(dir_->Str(), "data-1.parquet");
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    std::string SerializedDescriptor(const std::string& uri) {
+        auto descriptor = BlobDescriptor::Create(uri, /*offset=*/4, /*length=*/10).value();
+        PAIMON_UNIQUE_PTR<Bytes> bytes = descriptor->Serialize(GetDefaultPool());
+        return std::string(bytes->data(), bytes->size());
+    }
+
+    /// Builds a KeyValueBatch whose blob column holds the given cells; a nullopt cell is NULL.
+    /// `value_kinds` are RowKind byte values, aligned with the rows.
+    KeyValueBatch MakeBatch(const std::vector<int8_t>& value_kinds,
+                            const std::vector<std::optional<std::string>>& blob_values) {
+        arrow::Int64Builder sequence_builder;
+        arrow::Int8Builder value_kind_builder;
+        arrow::Int32Builder key_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        for (size_t i = 0; i < value_kinds.size(); i++) {
+            EXPECT_TRUE(sequence_builder.Append(static_cast<int64_t>(i)).ok());
+            EXPECT_TRUE(value_kind_builder.Append(value_kinds[i]).ok());
+            EXPECT_TRUE(key_builder.Append(static_cast<int32_t>(i)).ok());
+            if (blob_values[i]) {
+                EXPECT_TRUE(blob_builder.Append(blob_values[i].value()).ok());
+            } else {
+                EXPECT_TRUE(blob_builder.AppendNull().ok());
+            }
+        }
+        std::shared_ptr<arrow::Array> sequence_array;
+        std::shared_ptr<arrow::Array> value_kind_array;
+        std::shared_ptr<arrow::Array> key_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(sequence_builder.Finish(&sequence_array).ok());
+        EXPECT_TRUE(value_kind_builder.Finish(&value_kind_array).ok());
+        EXPECT_TRUE(key_builder.Finish(&key_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        auto struct_array =
+            arrow::StructArray::Make({sequence_array, value_kind_array, key_array, blob_array},
+                                     write_schema_->fields())
+                .ValueOrDie();
+        KeyValueBatch batch;
+        batch.batch = std::make_unique<ArrowArray>();
+        EXPECT_TRUE(arrow::ExportArray(*struct_array, batch.batch.get()).ok());
+        return batch;
+    }
+
+    std::unique_ptr<ManagedBlobReferenceCollector> CreateCollector() {
+        return ManagedBlobReferenceCollector::Create(dir_->GetFileSystem(), data_file_path_,
+                                                     write_schema_, {"b"})
+            .value();
+    }
+
+    std::unique_ptr<UniqueTestDirectory> dir_;
+    std::shared_ptr<arrow::Schema> write_schema_;
+    std::string data_file_path_;
+};
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestCollectsManagedReferences) {
+    auto collector = CreateCollector();
+    // Row kinds: INSERT(0), INSERT, DELETE(3), UPDATE_BEFORE(1), INSERT, INSERT.
+    KeyValueBatch batch =
+        MakeBatch({0, 0, 3, 1, 0, 0},
+                  {SerializedDescriptor("/warehouse/bucket-0/data-a.managed.blob"),
+                   SerializedDescriptor("/other/bucket-1/data-b.managed.blob"),
+                   SerializedDescriptor("/warehouse/bucket-0/data-retracted.managed.blob"),
+                   SerializedDescriptor("/warehouse/bucket-0/data-retracted.managed.blob"),
+                   SerializedDescriptor("/warehouse/bucket-0/data-c.blob"),  // not a managed pack
+                   std::nullopt});
+    ASSERT_OK(collector->Collect(&batch));
+    // The batch stays writable after collecting: its arrow array is still exported.
+    ASSERT_TRUE(batch.batch != nullptr);
+    ASSERT_NE(batch.batch->release, nullptr);
+
+    ASSERT_OK(collector->Close());
+    ASSERT_OK_AND_ASSIGN(std::string result_file_name, collector->ResultFileName());
+    ASSERT_EQ(result_file_name, "data-1.parquet.blobref");
+
+    // Retract rows and non-managed URIs contribute nothing; cross-directory managed packs are
+    // both recorded, sorted.
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<ManagedBlobReferenceFile::Reference> references,
+        ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), collector->SidecarPath()));
+    ASSERT_EQ(references.size(), 2);
+    EXPECT_EQ(references[0].ToString(), "/other/bucket-1/data-b.managed.blob");
+    EXPECT_EQ(references[1].ToString(), "/warehouse/bucket-0/data-a.managed.blob");
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestCollectsOnlyDeclaredColumns) {
+    // The sidecar must be built from the declared managed columns, not from the shape of the
+    // values: an inline blob column is skipped even when its descriptor happens to point at a
+    // path that looks exactly like a managed pack.
+    std::vector<DataField> write_fields = {SpecialFields::SequenceNumber(),
+                                           SpecialFields::ValueKind()};
+    write_fields.emplace_back(0, arrow::field("k", arrow::int32()));
+    write_fields.emplace_back(1, BlobUtils::ToArrowField("b", /*nullable=*/true));
+    write_fields.emplace_back(2, BlobUtils::ToArrowField("d", /*nullable=*/true));
+    write_schema_ = DataField::ConvertDataFieldsToArrowSchema(write_fields);
+
+    arrow::Int64Builder sequence_builder;
+    arrow::Int8Builder value_kind_builder;
+    arrow::Int32Builder key_builder;
+    arrow::LargeBinaryBuilder managed_builder;
+    arrow::LargeBinaryBuilder inline_builder;
+    ASSERT_TRUE(sequence_builder.Append(0).ok());
+    ASSERT_TRUE(value_kind_builder.Append(0).ok());
+    ASSERT_TRUE(key_builder.Append(0).ok());
+    ASSERT_TRUE(
+        managed_builder.Append(SerializedDescriptor("/warehouse/bucket-0/data-a.managed.blob"))
+            .ok());
+    ASSERT_TRUE(
+        inline_builder.Append(SerializedDescriptor("/warehouse/bucket-0/data-inline.managed.blob"))
+            .ok());
+    std::vector<std::shared_ptr<arrow::Array>> columns(5);
+    ASSERT_TRUE(sequence_builder.Finish(&columns[0]).ok());
+    ASSERT_TRUE(value_kind_builder.Finish(&columns[1]).ok());
+    ASSERT_TRUE(key_builder.Finish(&columns[2]).ok());
+    ASSERT_TRUE(managed_builder.Finish(&columns[3]).ok());
+    ASSERT_TRUE(inline_builder.Finish(&columns[4]).ok());
+    auto struct_array = arrow::StructArray::Make(columns, write_schema_->fields()).ValueOrDie();
+    KeyValueBatch batch;
+    batch.batch = std::make_unique<ArrowArray>();
+    ASSERT_TRUE(arrow::ExportArray(*struct_array, batch.batch.get()).ok());
+
+    // Only "b" is declared managed; "d" is an inline blob column.
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<ManagedBlobReferenceCollector> collector,
+                         ManagedBlobReferenceCollector::Create(
+                             dir_->GetFileSystem(), data_file_path_, write_schema_, {"b"}));
+    ASSERT_OK(collector->Collect(&batch));
+    ASSERT_OK(collector->Close());
+
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<ManagedBlobReferenceFile::Reference> references,
+        ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), collector->SidecarPath()));
+    ASSERT_EQ(references.size(), 1);
+    EXPECT_EQ(references[0].ToString(), "/warehouse/bucket-0/data-a.managed.blob");
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestNonDescriptorValuesIgnored) {
+    auto collector = CreateCollector();
+    // Inline payload bytes are not descriptors and carry their payload with the row.
+    KeyValueBatch batch = MakeBatch({0}, {std::string("raw-inline-bytes")});
+    ASSERT_OK(collector->Collect(&batch));
+    ASSERT_OK(collector->Close());
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<ManagedBlobReferenceFile::Reference> references,
+        ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), collector->SidecarPath()));
+    ASSERT_TRUE(references.empty());
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestEmptySidecarWrittenWithoutReferences) {
+    auto collector = CreateCollector();
+    ASSERT_OK(collector->Close());
+    // The sidecar is written even with nothing to reference, so the data file always has the
+    // extra file its meta declares.
+    ASSERT_TRUE(dir_->GetFileSystem()->GetFileStatus(collector->SidecarPath()).ok());
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<ManagedBlobReferenceFile::Reference> references,
+        ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), collector->SidecarPath()));
+    ASSERT_TRUE(references.empty());
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestAbortDeletesSidecar) {
+    auto collector = CreateCollector();
+    KeyValueBatch batch =
+        MakeBatch({0}, {SerializedDescriptor("/warehouse/bucket-0/data-a.managed.blob")});
+    ASSERT_OK(collector->Collect(&batch));
+    ASSERT_OK(collector->Close());
+    ASSERT_TRUE(dir_->GetFileSystem()->GetFileStatus(collector->SidecarPath()).ok());
+
+    collector->Abort();
+    ASSERT_FALSE(dir_->GetFileSystem()->GetFileStatus(collector->SidecarPath()).ok());
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestCollectAfterCloseRejected) {
+    // The sidecar is already written at Close, so a later batch could never reach it.
+    auto collector = CreateCollector();
+    ASSERT_OK(collector->Close());
+    KeyValueBatch batch =
+        MakeBatch({0}, {SerializedDescriptor("/warehouse/bucket-0/data-a.managed.blob")});
+    ASSERT_NOK_WITH_MSG(collector->Collect(&batch), "already closed");
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestResultFileNameRequiresClose) {
+    // The name is only meaningful once the sidecar it points at exists.
+    auto collector = CreateCollector();
+    ASSERT_NOK_WITH_MSG(collector->ResultFileName().status(),
+                        "requires the collector to be closed");
+}
+
+TEST_F(ManagedBlobReferenceCollectorTest, TestCreateRejectsUnknownField) {
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceCollector::Create(
+                            dir_->GetFileSystem(), data_file_path_, write_schema_, {"missing"})
+                            .status(),
+                        "is not part of the write schema");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/managed_blob_reference_file.cpp
+++ b/src/paimon/core/io/managed_blob_reference_file.cpp
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/managed_blob_reference_file.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string_view>
+#include <utility>
+
+#include "arrow/util/crc32.h"
+#include "fmt/format.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/status.h"
+
+namespace paimon {
+
+namespace {
+
+constexpr int32_t kMagic = 0x50424C52;  // "PBLR"
+constexpr int8_t kVersion = 1;
+
+void AppendBigEndianInt32(int32_t value, std::string* out) {
+    auto bits = static_cast<uint32_t>(value);
+    out->push_back(static_cast<char>((bits >> 24) & 0xFF));
+    out->push_back(static_cast<char>((bits >> 16) & 0xFF));
+    out->push_back(static_cast<char>((bits >> 8) & 0xFF));
+    out->push_back(static_cast<char>(bits & 0xFF));
+}
+
+/// A sequential big-endian reader over an in-memory buffer.
+class BigEndianBufferReader {
+ public:
+    BigEndianBufferReader(const char* data, size_t size) : data_(data), size_(size) {}
+
+    Result<int32_t> ReadInt32() {
+        PAIMON_RETURN_NOT_OK(Require(4));
+        uint32_t bits = (static_cast<uint32_t>(static_cast<uint8_t>(data_[pos_])) << 24) |
+                        (static_cast<uint32_t>(static_cast<uint8_t>(data_[pos_ + 1])) << 16) |
+                        (static_cast<uint32_t>(static_cast<uint8_t>(data_[pos_ + 2])) << 8) |
+                        static_cast<uint32_t>(static_cast<uint8_t>(data_[pos_ + 3]));
+        pos_ += 4;
+        return static_cast<int32_t>(bits);
+    }
+
+    Result<int8_t> ReadInt8() {
+        PAIMON_RETURN_NOT_OK(Require(1));
+        return static_cast<int8_t>(data_[pos_++]);
+    }
+
+    Result<uint16_t> ReadUInt16() {
+        PAIMON_RETURN_NOT_OK(Require(2));
+        auto bits = static_cast<uint16_t>((static_cast<uint8_t>(data_[pos_]) << 8) |
+                                          static_cast<uint8_t>(data_[pos_ + 1]));
+        pos_ += 2;
+        return bits;
+    }
+
+    Result<std::string_view> ReadBytes(size_t length) {
+        PAIMON_RETURN_NOT_OK(Require(length));
+        std::string_view view(data_ + pos_, length);
+        pos_ += length;
+        return view;
+    }
+
+    size_t Position() const {
+        return pos_;
+    }
+
+    size_t Remaining() const {
+        return size_ - pos_;
+    }
+
+ private:
+    Status Require(size_t length) const {
+        if (pos_ + length > size_) {
+            return Status::Invalid("Managed blob reference file is truncated.");
+        }
+        return Status::OK();
+    }
+
+    const char* data_;
+    size_t size_;
+    size_t pos_ = 0;
+};
+
+/// Encodes a UTF-8 string the way the sidecar format stores it: a uint16 big-endian byte
+/// length followed by modified UTF-8 bytes. Modified UTF-8 equals standard UTF-8 except that
+/// U+0000 becomes the two-byte form 0xC0 0x80 and supplementary characters are encoded as a
+/// CESU-8 surrogate pair (two three-byte groups).
+Status AppendJavaUtf(const std::string& value, std::string* out) {
+    std::string encoded;
+    encoded.reserve(value.size());
+    size_t i = 0;
+    const auto* bytes = reinterpret_cast<const uint8_t*>(value.data());
+    while (i < value.size()) {
+        uint8_t lead = bytes[i];
+        uint32_t code_point = 0;
+        size_t sequence_length = 0;
+        if (lead < 0x80) {
+            code_point = lead;
+            sequence_length = 1;
+        } else if ((lead >> 5) == 0x6) {
+            code_point = lead & 0x1F;
+            sequence_length = 2;
+        } else if ((lead >> 4) == 0xE) {
+            code_point = lead & 0x0F;
+            sequence_length = 3;
+        } else if ((lead >> 3) == 0x1E) {
+            code_point = lead & 0x07;
+            sequence_length = 4;
+        } else {
+            return Status::Invalid("Managed blob reference contains invalid UTF-8.");
+        }
+        if (i + sequence_length > value.size()) {
+            return Status::Invalid("Managed blob reference contains truncated UTF-8.");
+        }
+        for (size_t j = 1; j < sequence_length; j++) {
+            uint8_t continuation = bytes[i + j];
+            if ((continuation >> 6) != 0x2) {
+                return Status::Invalid("Managed blob reference contains invalid UTF-8.");
+            }
+            code_point = (code_point << 6) | (continuation & 0x3F);
+        }
+        i += sequence_length;
+
+        if (code_point == 0) {
+            encoded.push_back(static_cast<char>(0xC0));
+            encoded.push_back(static_cast<char>(0x80));
+        } else if (code_point < 0x10000) {
+            // The single-, two- and three-byte forms match standard UTF-8.
+            encoded.append(value, i - sequence_length, sequence_length);
+        } else {
+            // Supplementary character: encode the UTF-16 surrogate pair, three bytes each.
+            uint32_t offset = code_point - 0x10000;
+            uint32_t high = 0xD800 + (offset >> 10);
+            uint32_t low = 0xDC00 + (offset & 0x3FF);
+            for (uint32_t surrogate : {high, low}) {
+                encoded.push_back(static_cast<char>(0xE0 | (surrogate >> 12)));
+                encoded.push_back(static_cast<char>(0x80 | ((surrogate >> 6) & 0x3F)));
+                encoded.push_back(static_cast<char>(0x80 | (surrogate & 0x3F)));
+            }
+        }
+    }
+    if (encoded.size() > 0xFFFF) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference string is too long: {} bytes.", encoded.size()));
+    }
+    out->push_back(static_cast<char>((encoded.size() >> 8) & 0xFF));
+    out->push_back(static_cast<char>(encoded.size() & 0xFF));
+    out->append(encoded);
+    return Status::OK();
+}
+
+/// Decodes such a value back to a standard UTF-8 string.
+Result<std::string> ReadJavaUtf(BigEndianBufferReader* reader) {
+    PAIMON_ASSIGN_OR_RAISE(uint16_t length, reader->ReadUInt16());
+    PAIMON_ASSIGN_OR_RAISE(std::string_view encoded, reader->ReadBytes(length));
+    std::string decoded;
+    decoded.reserve(encoded.size());
+    const auto* bytes = reinterpret_cast<const uint8_t*>(encoded.data());
+    size_t i = 0;
+    while (i < encoded.size()) {
+        uint8_t lead = bytes[i];
+        if (lead < 0x80) {
+            decoded.push_back(static_cast<char>(lead));
+            i += 1;
+            continue;
+        }
+        size_t sequence_length = (lead >> 5) == 0x6 ? 2 : (lead >> 4) == 0xE ? 3 : 0;
+        if (sequence_length == 0 || i + sequence_length > encoded.size()) {
+            return Status::Invalid("Managed blob reference file holds invalid modified UTF-8.");
+        }
+        uint32_t code_point = lead & (sequence_length == 2 ? 0x1F : 0x0F);
+        for (size_t j = 1; j < sequence_length; j++) {
+            uint8_t continuation = bytes[i + j];
+            if ((continuation >> 6) != 0x2) {
+                return Status::Invalid("Managed blob reference file holds invalid modified UTF-8.");
+            }
+            code_point = (code_point << 6) | (continuation & 0x3F);
+        }
+        i += sequence_length;
+
+        if (code_point >= 0xD800 && code_point <= 0xDBFF) {
+            // High surrogate: the low surrogate must follow as another three-byte group with
+            // valid continuation bytes. A well-formed group outside the low-surrogate range
+            // and a high surrogate at the end of the input are rejected here as well, instead
+            // of decoding into an unpaired surrogate that no longer round-trips.
+            if (i + 3 > encoded.size() || (bytes[i] >> 4) != 0xE || (bytes[i + 1] >> 6) != 0x2 ||
+                (bytes[i + 2] >> 6) != 0x2) {
+                return Status::Invalid("Managed blob reference file holds an unpaired surrogate.");
+            }
+            uint32_t low =
+                ((bytes[i] & 0x0F) << 12) | ((bytes[i + 1] & 0x3F) << 6) | (bytes[i + 2] & 0x3F);
+            if (low < 0xDC00 || low > 0xDFFF) {
+                return Status::Invalid("Managed blob reference file holds an unpaired surrogate.");
+            }
+            i += 3;
+            uint32_t supplementary = 0x10000 + ((code_point - 0xD800) << 10) + (low - 0xDC00);
+            decoded.push_back(static_cast<char>(0xF0 | (supplementary >> 18)));
+            decoded.push_back(static_cast<char>(0x80 | ((supplementary >> 12) & 0x3F)));
+            decoded.push_back(static_cast<char>(0x80 | ((supplementary >> 6) & 0x3F)));
+            decoded.push_back(static_cast<char>(0x80 | (supplementary & 0x3F)));
+            continue;
+        }
+        if (code_point == 0 && sequence_length == 2) {
+            decoded.push_back('\0');
+            continue;
+        }
+        // BMP character: re-encode as standard UTF-8, identical to the input bytes.
+        decoded.append(encoded.substr(i - sequence_length, sequence_length));
+    }
+    return decoded;
+}
+
+}  // namespace
+
+Result<ManagedBlobReferenceFile::Reference> ManagedBlobReferenceFile::Reference::Create(
+    const std::string& storage_root_id, const std::string& relative_path) {
+    if (storage_root_id.empty() || relative_path.empty()) {
+        return Status::Invalid("Managed blob reference parts must not be empty.");
+    }
+    if (relative_path != PathUtil::GetName(relative_path) || relative_path == "." ||
+        relative_path == "..") {
+        return Status::Invalid(fmt::format(
+            "Managed blob reference relative path must be a bare file name, but got {}.",
+            relative_path));
+    }
+    Reference reference;
+    reference.storage_root_id = storage_root_id;
+    reference.relative_path = relative_path;
+    return reference;
+}
+
+std::string ManagedBlobReferenceFile::Reference::ToString() const {
+    return storage_root_id + "/" + relative_path;
+}
+
+Result<std::optional<ManagedBlobReferenceFile::Reference>>
+ManagedBlobReferenceFile::FromDescriptorUri(const std::string& uri) {
+    std::string name = PathUtil::GetName(uri);
+    if (!StringUtils::EndsWith(name, kManagedBlobSuffix)) {
+        return std::optional<Reference>();
+    }
+    PAIMON_ASSIGN_OR_RAISE(Reference reference,
+                           Reference::Create(PathUtil::GetParentDirPath(uri), name));
+    return std::optional<Reference>(std::move(reference));
+}
+
+std::string ManagedBlobReferenceFile::SidecarPath(const std::string& data_file_path) {
+    return data_file_path + kReferenceFileSuffix;
+}
+
+Status ManagedBlobReferenceFile::Write(const std::shared_ptr<FileSystem>& fs,
+                                       const std::string& path, std::vector<Reference> references) {
+    std::sort(references.begin(), references.end());
+    references.erase(std::unique(references.begin(), references.end()), references.end());
+
+    std::string buffer;
+    AppendBigEndianInt32(kMagic, &buffer);
+    size_t covered_start = buffer.size();
+    buffer.push_back(static_cast<char>(kVersion));
+    AppendBigEndianInt32(static_cast<int32_t>(references.size()), &buffer);
+    for (const auto& reference : references) {
+        PAIMON_RETURN_NOT_OK(AppendJavaUtf(reference.storage_root_id, &buffer));
+        PAIMON_RETURN_NOT_OK(AppendJavaUtf(reference.relative_path, &buffer));
+    }
+    uint32_t checksum =
+        arrow::internal::crc32(0, buffer.data() + covered_start, buffer.size() - covered_start);
+    AppendBigEndianInt32(static_cast<int32_t>(checksum), &buffer);
+
+    Status status = [&]() -> Status {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<OutputStream> out,
+                               fs->Create(path, /*overwrite=*/false));
+        // The stream is closed on every path; a failed write keeps its own error.
+        Status write_status = [&]() -> Status {
+            int64_t total_written = 0;
+            while (total_written < static_cast<int64_t>(buffer.size())) {
+                PAIMON_ASSIGN_OR_RAISE(
+                    int64_t written,
+                    out->Write(buffer.data() + total_written,
+                               static_cast<int64_t>(buffer.size()) - total_written));
+                if (written <= 0 || written > static_cast<int64_t>(buffer.size()) - total_written) {
+                    return Status::IOError(
+                        fmt::format("Short write of managed blob reference file {}.", path));
+                }
+                total_written += written;
+            }
+            return out->Flush();
+        }();
+        Status close_status = out->Close();
+        if (write_status.ok()) {
+            write_status = close_status;
+        }
+        return write_status;
+    }();
+    if (!status.ok()) {
+        [[maybe_unused]] Status delete_status = fs->Delete(path);
+        return status;
+    }
+    return Status::OK();
+}
+
+Result<std::vector<ManagedBlobReferenceFile::Reference>> ManagedBlobReferenceFile::Read(
+    const std::shared_ptr<FileSystem>& fs, const std::string& path) {
+    PAIMON_ASSIGN_OR_RAISE(FileStatus file_status, fs->GetFileStatus(path));
+    int64_t length = file_status.GetLen();
+    if (length < 0) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has unknown length.", path));
+    }
+    std::string buffer(static_cast<size_t>(length), '\0');
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> in, fs->Open(file_status));
+    Status read_status = [&]() -> Status {
+        int64_t total_read = 0;
+        while (total_read < length) {
+            PAIMON_ASSIGN_OR_RAISE(int64_t read,
+                                   in->Read(buffer.data() + total_read, length - total_read));
+            if (read <= 0 || read > length - total_read) {
+                return Status::IOError(
+                    fmt::format("Short read of managed blob reference file {}.", path));
+            }
+            total_read += read;
+        }
+        return Status::OK();
+    }();
+    // The stream is closed on every path; a failed read keeps its own error.
+    Status close_status = in->Close();
+    if (read_status.ok()) {
+        read_status = close_status;
+    }
+    PAIMON_RETURN_NOT_OK(read_status);
+
+    BigEndianBufferReader reader(buffer.data(), buffer.size());
+    PAIMON_ASSIGN_OR_RAISE(int32_t magic, reader.ReadInt32());
+    if (magic != kMagic) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has a bad magic number.", path));
+    }
+    size_t covered_start = reader.Position();
+    PAIMON_ASSIGN_OR_RAISE(int8_t version, reader.ReadInt8());
+    if (version != kVersion) {
+        return Status::Invalid(fmt::format(
+            "Managed blob reference file {} has unsupported version {}.", path, version));
+    }
+    PAIMON_ASSIGN_OR_RAISE(int32_t count, reader.ReadInt32());
+    if (count < 0) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has a negative count.", path));
+    }
+    // Each reference occupies at least two writeUTF values with non-empty content (2-byte
+    // length prefix plus one byte each): bound the untrusted count by the remaining bytes
+    // before allocating for it.
+    if (static_cast<uint64_t>(count) > reader.Remaining() / 6) {
+        return Status::Invalid(fmt::format(
+            "Managed blob reference file {} declares more references than it can hold.", path));
+    }
+    std::vector<Reference> references;
+    references.reserve(count);
+    for (int32_t i = 0; i < count; i++) {
+        PAIMON_ASSIGN_OR_RAISE(std::string storage_root_id, ReadJavaUtf(&reader));
+        PAIMON_ASSIGN_OR_RAISE(std::string relative_path, ReadJavaUtf(&reader));
+        PAIMON_ASSIGN_OR_RAISE(Reference reference,
+                               Reference::Create(storage_root_id, relative_path));
+        references.push_back(std::move(reference));
+    }
+    size_t covered_end = reader.Position();
+    uint32_t expected_checksum =
+        arrow::internal::crc32(0, buffer.data() + covered_start, covered_end - covered_start);
+    PAIMON_ASSIGN_OR_RAISE(int32_t checksum, reader.ReadInt32());
+    if (static_cast<uint32_t>(checksum) != expected_checksum) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has a checksum mismatch.", path));
+    }
+    if (reader.Remaining() != 0) {
+        return Status::Invalid(
+            fmt::format("Managed blob reference file {} has trailing bytes.", path));
+    }
+    return references;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/managed_blob_reference_file.h
+++ b/src/paimon/core/io/managed_blob_reference_file.h
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "paimon/result.h"
+
+namespace paimon {
+
+class FileSystem;
+
+/// The `.blobref` sidecar of a primary-key data file, listing the managed blob pack files
+/// (`.managed.blob`) whose payloads the data file's blob descriptors reference. The sidecar is
+/// carried in the data file's extra files, so it is removed together with the data file
+/// wherever the data file's companion files are collected for deletion, while a
+/// pack file may be shared by several data files and is never deleted by table maintenance.
+///
+/// On-disk layout, byte-compatible with the shared Paimon sidecar format (big-endian):
+///
+///   magic    int32  = 0x50424C52 ("PBLR"), not covered by the checksum
+///   version  byte   = 1                     -- checksum covers from here ...
+///   count    int32
+///   count x { storage_root_id : uint16 length + modified UTF-8 bytes
+///             relative_path   : the same }                           -- ... to here
+///   checksum int32  = CRC32 over the covered region
+///
+/// An empty reference list is a valid file and means "this data file references no pack",
+/// which is different from a missing sidecar.
+class ManagedBlobReferenceFile {
+ public:
+    static constexpr char kManagedBlobSuffix[] = ".managed.blob";
+    static constexpr char kReferenceFileSuffix[] = ".blobref";
+
+    /// One referenced pack file: the directory it lives in and its bare file name.
+    struct Reference {
+        /// Creates a reference after validating that `relative_path` is a bare file name.
+        static Result<Reference> Create(const std::string& storage_root_id,
+                                        const std::string& relative_path);
+
+        bool operator==(const Reference& other) const {
+            return storage_root_id == other.storage_root_id && relative_path == other.relative_path;
+        }
+        bool operator<(const Reference& other) const {
+            if (storage_root_id != other.storage_root_id) {
+                return storage_root_id < other.storage_root_id;
+            }
+            return relative_path < other.relative_path;
+        }
+
+        std::string ToString() const;
+
+        std::string storage_root_id;
+        std::string relative_path;
+    };
+
+    ManagedBlobReferenceFile() = delete;
+    ~ManagedBlobReferenceFile() = delete;
+
+    /// Resolves a blob descriptor URI to a pack reference. Returns nullopt when the URI does
+    /// not point at a managed pack file (its name does not end with `.managed.blob`).
+    static Result<std::optional<Reference>> FromDescriptorUri(const std::string& uri);
+
+    /// The sidecar path of a data file: the data file path plus `.blobref`.
+    static std::string SidecarPath(const std::string& data_file_path);
+
+    /// Writes `references` to `path`, normalized by sorting and deduplication so the content
+    /// is deterministic. A failed write deletes the partial file.
+    static Status Write(const std::shared_ptr<FileSystem>& fs, const std::string& path,
+                        std::vector<Reference> references);
+
+    /// Reads and validates a sidecar: magic, version, reference validity, checksum, and that
+    /// no trailing bytes follow the checksum.
+    static Result<std::vector<Reference>> Read(const std::shared_ptr<FileSystem>& fs,
+                                               const std::string& path);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/managed_blob_reference_file_test.cpp
+++ b/src/paimon/core/io/managed_blob_reference_file_test.cpp
@@ -1,0 +1,309 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/managed_blob_reference_file.h"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "arrow/util/crc32.h"
+#include "gtest/gtest.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+class ManagedBlobReferenceFileTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        dir_ = UniqueTestDirectory::Create("local");
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    static ManagedBlobReferenceFile::Reference NewReference(const std::string& root,
+                                                            const std::string& name) {
+        return ManagedBlobReferenceFile::Reference::Create(root, name).value();
+    }
+
+    static void AppendBe32(std::string* buffer, uint32_t value) {
+        buffer->push_back(static_cast<char>((value >> 24) & 0xFF));
+        buffer->push_back(static_cast<char>((value >> 16) & 0xFF));
+        buffer->push_back(static_cast<char>((value >> 8) & 0xFF));
+        buffer->push_back(static_cast<char>(value & 0xFF));
+    }
+
+    /// Writes `content` verbatim, replacing any file already at `path`.
+    void WriteRawFile(const std::string& path, const std::string& content) {
+        if (dir_->GetFileSystem()->GetFileStatus(path).ok()) {
+            ASSERT_OK(dir_->GetFileSystem()->Delete(path));
+        }
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<OutputStream> out,
+                             dir_->GetFileSystem()->Create(path, /*overwrite=*/false));
+        ASSERT_OK_AND_ASSIGN(int64_t written, out->Write(content.data(), content.size()));
+        ASSERT_EQ(written, static_cast<int64_t>(content.size()));
+        ASSERT_OK(out->Close());
+    }
+
+    void ReadRawFile(const std::string& path, std::string* content) {
+        ASSERT_OK_AND_ASSIGN(FileStatus status, dir_->GetFileSystem()->GetFileStatus(path));
+        content->assign(status.GetLen(), '\0');
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<InputStream> in, dir_->GetFileSystem()->Open(status));
+        ASSERT_OK_AND_ASSIGN(int64_t read, in->Read(content->data(), content->size()));
+        ASSERT_EQ(read, static_cast<int64_t>(content->size()));
+        ASSERT_OK(in->Close());
+    }
+
+    /// A well-formed header carrying `count` in its count slot, followed by a matching CRC32
+    /// over the checksum-covered region. Used to reach the header checks with a valid checksum.
+    static std::string HeaderOnlyFile(uint32_t magic, char version, uint32_t count) {
+        std::string content;
+        AppendBe32(&content, magic);
+        size_t covered_start = content.size();
+        content.push_back(version);
+        AppendBe32(&content, count);
+        AppendBe32(&content, arrow::internal::crc32(0, content.data() + covered_start,
+                                                    content.size() - covered_start));
+        return content;
+    }
+
+    std::unique_ptr<UniqueTestDirectory> dir_;
+};
+
+TEST_F(ManagedBlobReferenceFileTest, TestRoundTripSortsAndDeduplicates) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-1.parquet.blobref");
+    std::vector<ManagedBlobReferenceFile::Reference> references = {
+        NewReference("/warehouse/bucket-0", "data-b.managed.blob"),
+        NewReference("/warehouse/bucket-0", "data-a.managed.blob"),
+        NewReference("/warehouse/bucket-0", "data-a.managed.blob"),
+        NewReference("/other/bucket-0", "data-c.managed.blob"),
+    };
+    ASSERT_OK(ManagedBlobReferenceFile::Write(dir_->GetFileSystem(), path, references));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> read_back,
+                         ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path));
+    ASSERT_EQ(read_back.size(), 3);
+    EXPECT_EQ(read_back[0], NewReference("/other/bucket-0", "data-c.managed.blob"));
+    EXPECT_EQ(read_back[1], NewReference("/warehouse/bucket-0", "data-a.managed.blob"));
+    EXPECT_EQ(read_back[2], NewReference("/warehouse/bucket-0", "data-b.managed.blob"));
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestEmptyReferenceListIsValid) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-2.parquet.blobref");
+    ASSERT_OK(ManagedBlobReferenceFile::Write(dir_->GetFileSystem(), path, {}));
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> read_back,
+                         ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path));
+    ASSERT_TRUE(read_back.empty());
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestNonAsciiReferenceRoundTrip) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-3.parquet.blobref");
+    std::vector<ManagedBlobReferenceFile::Reference> references = {
+        NewReference("/warehouse/p0=中文分区/bucket-0", "data-a.managed.blob")};
+    ASSERT_OK(ManagedBlobReferenceFile::Write(dir_->GetFileSystem(), path, references));
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> read_back,
+                         ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path));
+    ASSERT_EQ(read_back.size(), 1);
+    EXPECT_EQ(read_back[0], references[0]);
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestJavaGoldenBytes) {
+    // The exact bytes the sidecar format prescribes for these two references (magic, version,
+    // count and CRC32 big-endian, strings as a uint16 length plus modified UTF-8 bytes).
+    // The checksum constant was computed independently of this codebase; the test locks the
+    // on-disk format against both accidental layout changes and checksum-coverage changes.
+    const std::string root = "/tmp/warehouse/foo.db/bar/bucket-0";
+    const std::string pack0 = "data-2b1a7f4e-0.managed.blob";
+    const std::string pack1 = "data-2b1a7f4e-1.managed.blob";
+    std::string golden;
+    auto append_utf = [&golden](const std::string& value) {
+        golden.push_back(static_cast<char>((value.size() >> 8) & 0xFF));
+        golden.push_back(static_cast<char>(value.size() & 0xFF));
+        golden.append(value);
+    };
+    AppendBe32(&golden, 0x50424C52);  // magic "PBLR"
+    golden.push_back(0x01);           // version
+    AppendBe32(&golden, 2);           // reference count
+    append_utf(root);
+    append_utf(pack0);
+    append_utf(root);
+    append_utf(pack1);
+    AppendBe32(&golden, 0x919BDB75);  // CRC32 of the covered region, computed with zlib
+    ASSERT_EQ(golden.size(), 145);
+
+    // A file carrying exactly those bytes is readable.
+    std::string java_path = PathUtil::JoinPath(dir_->Str(), "data-java.parquet.blobref");
+    WriteRawFile(java_path, golden);
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> read_back,
+                         ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), java_path));
+    ASSERT_EQ(read_back.size(), 2);
+    EXPECT_EQ(read_back[0], NewReference(root, pack0));
+    EXPECT_EQ(read_back[1], NewReference(root, pack1));
+
+    // A C++-written file is byte-identical, including the sort normalization.
+    std::string cpp_path = PathUtil::JoinPath(dir_->Str(), "data-cpp.parquet.blobref");
+    ASSERT_OK(ManagedBlobReferenceFile::Write(
+        dir_->GetFileSystem(), cpp_path, {NewReference(root, pack1), NewReference(root, pack0)}));
+    std::string cpp_content;
+    ReadRawFile(cpp_path, &cpp_content);
+    ASSERT_FALSE(HasFatalFailure());
+    EXPECT_EQ(cpp_content, golden);
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsCorruptedFile) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-4.parquet.blobref");
+    ASSERT_OK(ManagedBlobReferenceFile::Write(
+        dir_->GetFileSystem(), path, {NewReference("/warehouse/bucket-0", "data-a.managed.blob")}));
+
+    // Flip one byte inside a reference string's content, leaving every length prefix intact:
+    // the file still parses, so only the checksum can catch the change. Corrupting a length
+    // prefix instead would trip the framing checks before the checksum is ever compared.
+    std::string content;
+    ReadRawFile(path, &content);
+    ASSERT_FALSE(HasFatalFailure());
+    size_t corrupt_at = content.find("bucket-0");
+    ASSERT_NE(corrupt_at, std::string::npos);
+    content[corrupt_at] = static_cast<char>(content[corrupt_at] ^ 0x1);
+    WriteRawFile(path, content);
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "checksum mismatch");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsTrailingBytes) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-5.parquet.blobref");
+    ASSERT_OK(ManagedBlobReferenceFile::Write(dir_->GetFileSystem(), path, {}));
+    std::string content;
+    ReadRawFile(path, &content);
+    ASSERT_FALSE(HasFatalFailure());
+    content.push_back('x');
+    WriteRawFile(path, content);
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "trailing bytes");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsBadMagic) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-9.parquet.blobref");
+    WriteRawFile(path, HeaderOnlyFile(/*magic=*/0x50424C53, /*version=*/0x01, /*count=*/0));
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "bad magic number");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsUnsupportedVersion) {
+    // A future writer bumps the version; this reader must refuse the file instead of parsing
+    // it under the version 1 layout.
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-10.parquet.blobref");
+    WriteRawFile(path, HeaderOnlyFile(/*magic=*/0x50424C52, /*version=*/0x02, /*count=*/0));
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "unsupported version");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsNegativeCount) {
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-11.parquet.blobref");
+    WriteRawFile(path,
+                 HeaderOnlyFile(/*magic=*/0x50424C52, /*version=*/0x01, /*count=*/0xFFFFFFFF));
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "negative count");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsOversizedCount) {
+    // A corrupted or malicious file may declare a huge reference count with a valid checksum;
+    // the reader must bound it by the remaining bytes before allocating for it.
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-7.parquet.blobref");
+    // Count far beyond what the payload can hold, under a valid checksum.
+    WriteRawFile(path,
+                 HeaderOnlyFile(/*magic=*/0x50424C52, /*version=*/0x01, /*count=*/0x7FFFFFFF));
+    ASSERT_FALSE(HasFatalFailure());
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "more references than it can hold");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestRejectsMalformedLowSurrogate) {
+    // A "low surrogate" group whose middle byte is not a continuation byte (0x30, ASCII '0')
+    // still masks into [0xDC00, 0xDFFF] under plain bit-masking. Such bytes are not valid
+    // modified UTF-8, so the reader must reject them even under a valid checksum.
+    std::string path = PathUtil::JoinPath(dir_->Str(), "data-8.parquet.blobref");
+    std::string content;
+    AppendBe32(&content, 0x50424C52);  // magic
+    size_t covered_start = content.size();
+    content.push_back(0x01);  // version
+    AppendBe32(&content, 1);  // one reference
+    // storage root id: a high surrogate (ED A0 80 = U+D800) followed by ED 30 80, whose
+    // middle byte is not a continuation byte but masks to the low surrogate 0xDC00
+    const uint8_t malformed_root[] = {0xED, 0xA0, 0x80, 0xED, 0x30, 0x80};
+    content.push_back(0x00);
+    content.push_back(static_cast<char>(sizeof(malformed_root)));
+    for (uint8_t byte : malformed_root) {
+        content.push_back(static_cast<char>(byte));
+    }
+    // relative path: a well-formed bare file name
+    const std::string relative_path = "a.managed.blob";
+    content.push_back(0x00);
+    content.push_back(static_cast<char>(relative_path.size()));
+    content += relative_path;
+    AppendBe32(&content, arrow::internal::crc32(0, content.data() + covered_start,
+                                                content.size() - covered_start));
+    WriteRawFile(path, content);
+    ASSERT_FALSE(HasFatalFailure());
+    // The rejection must come from the surrogate pairing check, not from the framing around it.
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Read(dir_->GetFileSystem(), path).status(),
+                        "unpaired surrogate");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestFromDescriptorUri) {
+    ASSERT_OK_AND_ASSIGN(std::optional<ManagedBlobReferenceFile::Reference> managed,
+                         ManagedBlobReferenceFile::FromDescriptorUri(
+                             "/warehouse/foo.db/bar/bucket-0/data-1.managed.blob"));
+    ASSERT_TRUE(managed.has_value());
+    EXPECT_EQ(managed->storage_root_id, "/warehouse/foo.db/bar/bucket-0");
+    EXPECT_EQ(managed->relative_path, "data-1.managed.blob");
+
+    ASSERT_OK_AND_ASSIGN(
+        std::optional<ManagedBlobReferenceFile::Reference> not_managed,
+        ManagedBlobReferenceFile::FromDescriptorUri("/warehouse/foo.db/bar/bucket-0/data-1.blob"));
+    EXPECT_FALSE(not_managed.has_value());
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestReferenceRejectsNestedRelativePath) {
+    // A nested path and a traversal are rejected as non-bare names; an empty part is a
+    // distinct failure, so each case must surface its own reason.
+    ASSERT_NOK_WITH_MSG(
+        ManagedBlobReferenceFile::Reference::Create("/warehouse", "a/b.managed.blob").status(),
+        "must be a bare file name");
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Reference::Create("/warehouse", "..").status(),
+                        "must be a bare file name");
+    ASSERT_NOK_WITH_MSG(ManagedBlobReferenceFile::Reference::Create("", "a.managed.blob").status(),
+                        "must not be empty");
+}
+
+TEST_F(ManagedBlobReferenceFileTest, TestSidecarPath) {
+    EXPECT_EQ(ManagedBlobReferenceFile::SidecarPath("/w/bucket-0/data-1.parquet"),
+              "/w/bucket-0/data-1.parquet.blobref");
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/primary_key_blob_externalizer.cpp
+++ b/src/paimon/core/io/primary_key_blob_externalizer.cpp
@@ -1,0 +1,353 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/primary_key_blob_externalizer.h"
+
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <utility>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "fmt/format.h"
+#include "paimon/common/data/blob_defs.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/utils/arrow/mem_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/checked_cast.h"
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/defs.h"
+#include "paimon/format/file_format.h"
+#include "paimon/format/file_format_factory.h"
+#include "paimon/format/format_writer.h"
+#include "paimon/format/writer_builder.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/bytes.h"
+
+namespace paimon {
+
+namespace {
+
+/// The format managed blob packs are written in. Named once: the writer is built through the
+/// format factory, and the same name is what an error has to report.
+constexpr const char kPackFormat[] = "blob";
+
+}  // namespace
+
+/// Rolls `.managed.blob` packs for one managed blob field. Each written value appends one blob
+/// format record to the current pack; the pack is sealed once it reaches the blob target file
+/// size. Descriptors point straight at the payload bytes inside the pack, so reading one back
+/// is a single ranged read that needs no pack footer.
+class PrimaryKeyBlobExternalizer::ManagedBlobPackWriter {
+ public:
+    ManagedBlobPackWriter(const CoreOptions& options, const std::shared_ptr<arrow::Field>& field,
+                          const std::shared_ptr<DataFilePathFactory>& path_factory,
+                          std::vector<std::string>* uncommitted_packs,
+                          const std::shared_ptr<MemoryPool>& pool)
+        : options_(options),
+          field_(field),
+          path_factory_(path_factory),
+          uncommitted_packs_(uncommitted_packs),
+          target_file_size_(options.GetBlobTargetFileSize()),
+          pool_(pool) {}
+
+    /// Copies row `row` of `column` into the current pack and returns the serialized
+    /// descriptor of the copied payload. The value may itself be a serialized descriptor; the
+    /// blob format writer then streams the referenced bytes in, re-materializing them.
+    Result<PAIMON_UNIQUE_PTR<Bytes>> Write(const std::shared_ptr<arrow::Array>& column,
+                                           int64_t row) {
+        if (writer_ == nullptr) {
+            PAIMON_RETURN_NOT_OK(OpenCurrent());
+        }
+
+        std::shared_ptr<arrow::Array> element = column->Slice(row, 1);
+        std::shared_ptr<arrow::Array> pack_row;
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(pack_row,
+                                          arrow::StructArray::Make({std::move(element)}, {field_}));
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*pack_row, &c_array));
+        PAIMON_RETURN_NOT_OK(writer_->AddBatch(&c_array));
+
+        // The format writer reports the payload bytes of the record it just stored, so the
+        // record layout stays inside the format. Asked through the base interface rather than
+        // by downcasting to the blob writer: the blob format lives in a plugin library, so a
+        // checked cast would need its type info here, and an unchecked one would be undefined
+        // behaviour the moment the factory returned anything else.
+        std::optional<std::pair<int64_t, int64_t>> payload_range = writer_->LastPayloadRange();
+        if (!payload_range) {
+            return Status::Invalid(
+                fmt::format("Managed blob pack {} did not produce a payload record. The '{}' "
+                            "format must store one addressable payload per record.",
+                            current_path_, kPackFormat));
+        }
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<BlobDescriptor> descriptor,
+            BlobDescriptor::Create(current_path_, payload_range->first, payload_range->second));
+        PAIMON_UNIQUE_PTR<Bytes> serialized = descriptor->Serialize(pool_);
+
+        PAIMON_ASSIGN_OR_RAISE(
+            bool reach_target_size,
+            writer_->ReachTargetSize(/*suggested_check=*/true, target_file_size_));
+        if (reach_target_size) {
+            PAIMON_RETURN_NOT_OK(CloseCurrent());
+        }
+        return serialized;
+    }
+
+    /// Seals the current pack: writes the blob format footer and closes the stream. The
+    /// underlying stream is closed even when writing the footer fails, so a failed seal never
+    /// leaks the stream.
+    Status CloseCurrent() {
+        if (writer_ == nullptr) {
+            return Status::OK();
+        }
+        Status status = writer_->Finish();
+        Status close_status = out_->Close();
+        if (status.ok()) {
+            status = close_status;
+        }
+        writer_.reset();
+        out_.reset();
+        current_path_.clear();
+        return status;
+    }
+
+    /// Quietly drops the current pack writer; the file itself is removed through the
+    /// uncommitted pack list.
+    void AbortCurrent() {
+        if (out_) {
+            [[maybe_unused]] Status status = out_->Close();
+        }
+        writer_.reset();
+        out_.reset();
+        current_path_.clear();
+    }
+
+ private:
+    Status OpenCurrent() {
+        std::string path = path_factory_->NewManagedBlobPath();
+        uncommitted_packs_->push_back(path);
+        // The blob format lives in its own plugin library, so the writer is created through
+        // the format factory like every other core write path; core must not reference the
+        // plugin's out-of-line symbols directly.
+        std::map<std::string, std::string> format_options = options_.ToMap();
+        // Managed pack writes never convert fetch failures to NULL payloads and never
+        // interpret placeholder sentinels: strip the user-facing toggles so the format
+        // defaults (false) apply.
+        format_options.erase(Options::BLOB_WRITE_NULL_ON_MISSING_FILE);
+        format_options.erase(Options::BLOB_WRITE_NULL_ON_FETCH_FAILURE);
+        BlobDefs::EraseInternalPlaceholderOptions(&format_options);
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileFormat> format,
+                               FileFormatFactory::Get(kPackFormat, format_options));
+        ::ArrowSchema c_schema;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(
+            arrow::ExportSchema(*arrow::schema(arrow::FieldVector{field_}), &c_schema));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<WriterBuilder> writer_builder,
+                               format->CreateWriterBuilder(&c_schema, /*batch_size=*/1));
+        writer_builder->WithMemoryPool(pool_);
+        if (auto* specific_fs_builder =
+                dynamic_cast<SpecificFSWriterBuilder*>(writer_builder.get())) {
+            specific_fs_builder->WithFileSystem(options_.GetFileSystem());
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<OutputStream> out,
+                               options_.GetFileSystem()->Create(path, /*overwrite=*/false));
+        out_ = std::move(out);
+        PAIMON_ASSIGN_OR_RAISE(writer_, writer_builder->Build(out_, /*compression=*/"none"));
+        current_path_ = path;
+        return Status::OK();
+    }
+
+    CoreOptions options_;
+    std::shared_ptr<arrow::Field> field_;
+    std::shared_ptr<DataFilePathFactory> path_factory_;
+    std::vector<std::string>* uncommitted_packs_;
+    int64_t target_file_size_;
+    std::shared_ptr<MemoryPool> pool_;
+
+    std::string current_path_;
+    std::shared_ptr<OutputStream> out_;
+    std::unique_ptr<FormatWriter> writer_;
+};
+
+Result<std::unique_ptr<PrimaryKeyBlobExternalizer>> PrimaryKeyBlobExternalizer::Create(
+    const CoreOptions& options, const std::shared_ptr<arrow::Schema>& value_schema,
+    const std::shared_ptr<DataFilePathFactory>& path_factory,
+    const std::shared_ptr<MemoryPool>& pool) {
+    std::vector<std::string> inline_field_names = options.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> managed_field_names =
+        BlobUtils::ManagedBlobFieldNames(value_schema, inline_fields);
+    if (managed_field_names.empty()) {
+        return std::unique_ptr<PrimaryKeyBlobExternalizer>();
+    }
+    // Guarded by SchemaValidation for tables created through the catalog; checked again here
+    // because pack rolling cannot work with a non-positive target size.
+    if (options.GetBlobTargetFileSize() <= 0) {
+        return Status::Invalid(
+            fmt::format("Managed blob target file size must be positive, "
+                        "but got {}.",
+                        options.GetBlobTargetFileSize()));
+    }
+    std::vector<int32_t> managed_field_indices;
+    managed_field_indices.reserve(managed_field_names.size());
+    for (const auto& field_name : managed_field_names) {
+        managed_field_indices.push_back(value_schema->GetFieldIndex(field_name));
+    }
+    auto value_type = arrow::struct_(value_schema->fields());
+    return std::unique_ptr<PrimaryKeyBlobExternalizer>(new PrimaryKeyBlobExternalizer(
+        options, value_type, std::move(managed_field_indices), path_factory, pool));
+}
+
+PrimaryKeyBlobExternalizer::PrimaryKeyBlobExternalizer(
+    const CoreOptions& options, const std::shared_ptr<arrow::DataType>& value_type,
+    std::vector<int32_t> managed_field_indices,
+    const std::shared_ptr<DataFilePathFactory>& path_factory,
+    const std::shared_ptr<MemoryPool>& pool)
+    : options_(options),
+      value_type_(value_type),
+      managed_field_indices_(std::move(managed_field_indices)),
+      path_factory_(path_factory),
+      pool_(pool),
+      arrow_pool_(GetArrowPool(pool)),
+      logger_(Logger::GetLogger("PrimaryKeyBlobExternalizer")) {
+    auto struct_type = checked_pointer_cast<arrow::StructType>(value_type_);
+    pack_writers_.reserve(managed_field_indices_.size());
+    for (int32_t field_index : managed_field_indices_) {
+        pack_writers_.push_back(std::make_unique<ManagedBlobPackWriter>(
+            options_, struct_type->field(field_index), path_factory_, &uncommitted_packs_, pool_));
+    }
+}
+
+PrimaryKeyBlobExternalizer::~PrimaryKeyBlobExternalizer() {
+    Abort();
+}
+
+Result<std::unique_ptr<RecordBatch>> PrimaryKeyBlobExternalizer::Externalize(
+    std::unique_ptr<RecordBatch>&& moved_batch) {
+    std::unique_ptr<RecordBatch> batch = std::move(moved_batch);
+    Result<std::unique_ptr<RecordBatch>> result = [&]() -> Result<std::unique_ptr<RecordBatch>> {
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
+                                          arrow::ImportArray(batch->GetData(), value_type_));
+        auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+        if (struct_array == nullptr) {
+            return Status::Invalid(
+                "PrimaryKeyBlobExternalizer expects a StructArray record batch.");
+        }
+        const std::vector<RecordBatch::RowKind>& row_kinds = batch->GetRowKind();
+        if (!row_kinds.empty() &&
+            static_cast<int64_t>(row_kinds.size()) != struct_array->length()) {
+            return Status::Invalid(
+                "PrimaryKeyBlobExternalizer batch row kinds do not match the row count.");
+        }
+        arrow::ArrayVector new_children = struct_array->fields();
+        for (size_t writer_index = 0; writer_index < managed_field_indices_.size();
+             writer_index++) {
+            int32_t field_index = managed_field_indices_[writer_index];
+            const auto& column = struct_array->field(field_index);
+            auto blob_column = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(column);
+            if (blob_column == nullptr) {
+                return Status::Invalid(
+                    fmt::format("PrimaryKeyBlobExternalizer expects managed blob column {} to be a "
+                                "LargeBinaryArray.",
+                                struct_array->struct_type()->field(field_index)->name()));
+            }
+            // The member pool, not a local one: these buffers enter the write buffer and
+            // must stay allocatable-from until the batch is flushed and released.
+            arrow::LargeBinaryBuilder builder(arrow_pool_.get());
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Reserve(blob_column->length()));
+            for (int64_t row = 0; row < blob_column->length(); row++) {
+                bool retract =
+                    !row_kinds.empty() && (row_kinds[row] == RecordBatch::RowKind::UPDATE_BEFORE ||
+                                           row_kinds[row] == RecordBatch::RowKind::DELETE);
+                // A retract row never keeps a payload: the managed value is dropped without
+                // writing anything to a pack.
+                if (retract || blob_column->IsNull(row)) {
+                    PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.AppendNull());
+                    continue;
+                }
+                PAIMON_ASSIGN_OR_RAISE(PAIMON_UNIQUE_PTR<Bytes> descriptor,
+                                       pack_writers_[writer_index]->Write(blob_column, row));
+                PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Append(
+                    reinterpret_cast<const uint8_t*>(descriptor->data()), descriptor->size()));
+            }
+            std::shared_ptr<arrow::Array> descriptor_column;
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(builder.Finish(&descriptor_column));
+            new_children[field_index] = std::move(descriptor_column);
+        }
+
+        auto struct_type = checked_pointer_cast<arrow::StructType>(value_type_);
+        std::shared_ptr<arrow::StructArray> externalized_array;
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            externalized_array, arrow::StructArray::Make(new_children, struct_type->fields()));
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*externalized_array, &c_array));
+        return std::make_unique<RecordBatch>(batch->GetPartition(), batch->GetBucket(), row_kinds,
+                                             &c_array);
+    }();
+    if (!result.ok()) {
+        Abort();
+    }
+    return result;
+}
+
+Status PrimaryKeyBlobExternalizer::CloseCurrentWriters() {
+    Status status = Status::OK();
+    for (const auto& pack_writer : pack_writers_) {
+        Status close_status = pack_writer->CloseCurrent();
+        if (status.ok() && !close_status.ok()) {
+            status = close_status;
+        }
+    }
+    return status;
+}
+
+Result<std::vector<std::string>> PrimaryKeyBlobExternalizer::PrepareCommit() {
+    Status status = CloseCurrentWriters();
+    if (!status.ok()) {
+        Abort();
+        return status;
+    }
+    // The sealed packs are handed over: this externalizer stops tracking them and their paths
+    // go to the caller, which is what lets a failed commit delete exactly the packs it created
+    // instead of every pack its data files happen to reference.
+    std::vector<std::string> handed_over = std::move(uncommitted_packs_);
+    uncommitted_packs_.clear();
+    return handed_over;
+}
+
+void PrimaryKeyBlobExternalizer::Abort() {
+    for (const auto& pack_writer : pack_writers_) {
+        pack_writer->AbortCurrent();
+    }
+    const auto& fs = options_.GetFileSystem();
+    for (const auto& path : uncommitted_packs_) {
+        Status status = fs->Delete(path);
+        // A pack that never came into existence (its create failed) is normal on this path;
+        // only a real cleanup failure is worth a warning.
+        if (!status.ok() && !status.IsNotExist()) {
+            PAIMON_LOG_WARN(logger_, "Failed to delete uncommitted managed blob pack %s: %s",
+                            path.c_str(), status.ToString().c_str());
+        }
+    }
+    uncommitted_packs_.clear();
+}
+
+}  // namespace paimon

--- a/src/paimon/core/io/primary_key_blob_externalizer.h
+++ b/src/paimon/core/io/primary_key_blob_externalizer.h
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "paimon/core/core_options.h"
+#include "paimon/logging.h"
+#include "paimon/record_batch.h"
+#include "paimon/result.h"
+
+namespace arrow {
+class DataType;
+class Field;
+class MemoryPool;
+class Schema;
+}  // namespace arrow
+
+namespace paimon {
+
+class DataFilePathFactory;
+class MemoryPool;
+class OutputStream;
+
+/// Externalizes managed blob values of a primary-key table before they enter the merge-tree
+/// write buffer.
+///
+/// Only top-level scalar BLOB columns are managed. `ARRAY<BLOB>` and `MAP<K, BLOB>` fields are
+/// expressible in Paimon C++'s type system but not handled by the schema validation and the
+/// write/read paths yet, and descriptors are always read and copied through the table's own
+/// file system (`blob-descriptor.source-table` is rejected instead).
+///
+/// Each managed blob field owns a rolling pack writer producing `.managed.blob` files in the
+/// blob file format. Every non-null value of an insert row is copied into the current pack,
+/// even when the input already is a serialized descriptor (the payload is re-materialized into
+/// a pack this table owns), and the buffered column value becomes the serialized
+/// `BlobDescriptor` pointing at the copied payload. Retract rows never write a payload, their
+/// blob value is nulled out.
+///
+/// Packs created since the last `PrepareCommit` are uncommitted: `Abort` (and `Close` without
+/// a commit) deletes them, while `PrepareCommit` seals them and hands them over, returning
+/// their paths. The committed data files' `.blobref` sidecars record which packs are
+/// referenced.
+///
+/// Those returned paths, and only those, are what a failed commit rolls back: they travel with
+/// the commit message and `UncommittedFileCleaner`, which documents why ownership may not be
+/// derived from a sidecar, deletes them. Nothing else collects a pack — orphan file cleaning
+/// skips `.managed.blob` because several data files may share one — so the hand-over has to
+/// stay paired with the rollback.
+class PrimaryKeyBlobExternalizer {
+ public:
+    /// Creates an externalizer for `value_schema`, or nullptr when the schema holds no managed
+    /// blob field.
+    static Result<std::unique_ptr<PrimaryKeyBlobExternalizer>> Create(
+        const CoreOptions& options, const std::shared_ptr<arrow::Schema>& value_schema,
+        const std::shared_ptr<DataFilePathFactory>& path_factory,
+        const std::shared_ptr<MemoryPool>& pool);
+
+    ~PrimaryKeyBlobExternalizer();
+
+    /// Rewrites the managed blob columns of `batch`: payloads move to pack files and the
+    /// columns hold serialized descriptors afterwards. On failure all uncommitted packs are
+    /// deleted and the error is returned.
+    Result<std::unique_ptr<RecordBatch>> Externalize(std::unique_ptr<RecordBatch>&& batch);
+
+    /// Seals the currently open packs and hands over every pack written since the last call, so
+    /// a later `Abort` or `Close` no longer deletes them. Call after the write buffer has been
+    /// flushed, right before the commit messages are handed out.
+    ///
+    /// @return The paths of the handed-over packs, in creation order. The caller owns them from
+    ///     now on and has to delete them if its commit never lands.
+    Result<std::vector<std::string>> PrepareCommit();
+
+    /// Closes the open pack writers and deletes every uncommitted pack.
+    void Abort();
+
+ private:
+    /// A rolling writer for the packs of one managed blob field.
+    class ManagedBlobPackWriter;
+
+    PrimaryKeyBlobExternalizer(const CoreOptions& options,
+                               const std::shared_ptr<arrow::DataType>& value_type,
+                               std::vector<int32_t> managed_field_indices,
+                               const std::shared_ptr<DataFilePathFactory>& path_factory,
+                               const std::shared_ptr<MemoryPool>& pool);
+
+    Status CloseCurrentWriters();
+
+ private:
+    CoreOptions options_;
+    std::shared_ptr<arrow::DataType> value_type_;
+    std::vector<int32_t> managed_field_indices_;
+    std::shared_ptr<DataFilePathFactory> path_factory_;
+    std::shared_ptr<MemoryPool> pool_;
+    /// Allocates the descriptor columns of externalized batches. Those buffers flow into the
+    /// merge-tree write buffer, so the pool must live as long as the externalizer — the
+    /// owning writer keeps the externalizer alive until its buffered batches are released.
+    std::unique_ptr<arrow::MemoryPool> arrow_pool_;
+
+    std::unique_ptr<Logger> logger_;
+
+    /// One pack writer per managed field, aligned with managed_field_indices_.
+    std::vector<std::unique_ptr<ManagedBlobPackWriter>> pack_writers_;
+    /// Paths of packs not yet handed over by PrepareCommit; deleted on Abort.
+    std::vector<std::string> uncommitted_packs_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/io/primary_key_blob_externalizer_test.cpp
+++ b/src/paimon/core/io/primary_key_blob_externalizer_test.cpp
@@ -1,0 +1,576 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "paimon/core/io/primary_key_blob_externalizer.h"
+
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/factories/io_hook.h"
+#include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/data/blob.h"
+#include "paimon/defs.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/fs/local/local_file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/testing/utils/io_exception_helper.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+/// Wraps a local output stream so a test can observe the explicit Close() call and inject
+/// write failures at seal time. Only an explicit Close() is counted — the destructor would
+/// release the file anyway, which is exactly what must not mask a dropped Close in
+/// production code.
+class CloseTrackingOutputStream : public OutputStream {
+ public:
+    CloseTrackingOutputStream(std::unique_ptr<OutputStream> inner, const bool* fail_writes,
+                              int* close_count)
+        : inner_(std::move(inner)), fail_writes_(fail_writes), close_count_(close_count) {}
+
+    Result<int64_t> Write(const char* buffer, int64_t size) override {
+        if (*fail_writes_) {
+            return Status::IOError("injected write failure");
+        }
+        return inner_->Write(buffer, size);
+    }
+
+    Status Flush() override {
+        return inner_->Flush();
+    }
+
+    Result<int64_t> GetPos() const override {
+        return inner_->GetPos();
+    }
+
+    Result<std::string> GetUri() const override {
+        return inner_->GetUri();
+    }
+
+    Status Close() override {
+        (*close_count_)++;
+        return inner_->Close();
+    }
+
+ private:
+    std::unique_ptr<OutputStream> inner_;
+    const bool* fail_writes_;
+    int* close_count_;
+};
+
+/// A local file system whose output streams count explicit Close() calls and can start
+/// failing writes on demand.
+class CloseTrackingFileSystem : public LocalFileSystem {
+ public:
+    Result<std::unique_ptr<OutputStream>> Create(const std::string& path,
+                                                 bool overwrite) const override {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<OutputStream> inner,
+                               LocalFileSystem::Create(path, overwrite));
+        return std::make_unique<CloseTrackingOutputStream>(std::move(inner), &fail_writes_,
+                                                           &close_count_);
+    }
+
+    mutable bool fail_writes_ = false;
+    mutable int close_count_ = 0;
+};
+
+class PrimaryKeyBlobExternalizerTest : public testing::Test {
+ protected:
+    void SetUp() override {
+        dir_ = UniqueTestDirectory::Create("local");
+        value_schema_ = arrow::schema(
+            {arrow::field("id", arrow::int32()), BlobUtils::ToArrowField("b", /*nullable=*/true)});
+        path_factory_ = std::make_shared<DataFilePathFactory>();
+        ASSERT_OK(path_factory_->Init(/*parent=*/dir_->Str(), /*format_identifier=*/"parquet",
+                                      /*data_file_prefix=*/"data-",
+                                      /*external_path_provider=*/nullptr));
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    CoreOptions CreateOptions(const std::string& blob_target_file_size) {
+        return CoreOptions::FromMap({{Options::FILE_SYSTEM, "local"},
+                                     {Options::BLOB_TARGET_FILE_SIZE, blob_target_file_size}})
+            .value();
+    }
+
+    /// An externalizer over the fixture's (id, blob) schema. The result is null when the
+    /// schema holds no managed blob field.
+    Result<std::unique_ptr<PrimaryKeyBlobExternalizer>> MakeExternalizer(
+        const std::string& blob_target_file_size) {
+        CoreOptions options = CreateOptions(blob_target_file_size);
+        return PrimaryKeyBlobExternalizer::Create(options, value_schema_, path_factory_,
+                                                  GetDefaultPool());
+    }
+
+    /// Builds a two-column (id, blob) record batch; a nullopt blob value is a null cell.
+    std::unique_ptr<RecordBatch> CreateBatch(
+        const std::vector<int32_t>& ids, const std::vector<std::optional<std::string>>& blob_values,
+        const std::vector<RecordBatch::RowKind>& row_kinds) {
+        arrow::Int32Builder id_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        for (size_t i = 0; i < ids.size(); i++) {
+            EXPECT_TRUE(id_builder.Append(ids[i]).ok());
+            if (blob_values[i]) {
+                EXPECT_TRUE(blob_builder.Append(blob_values[i].value()).ok());
+            } else {
+                EXPECT_TRUE(blob_builder.AppendNull().ok());
+            }
+        }
+        std::shared_ptr<arrow::Array> id_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(id_builder.Finish(&id_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        auto struct_array =
+            arrow::StructArray::Make({id_array, blob_array}, value_schema_->fields()).ValueOrDie();
+        ArrowArray c_array;
+        EXPECT_TRUE(arrow::ExportArray(*struct_array, &c_array).ok());
+        return std::make_unique<RecordBatch>(std::map<std::string, std::string>(), /*bucket=*/0,
+                                             row_kinds, &c_array);
+    }
+
+    /// Imports the batch and returns the blob column.
+    std::shared_ptr<arrow::LargeBinaryArray> BlobColumn(const RecordBatch& batch) {
+        auto arrow_array =
+            arrow::ImportArray(batch.GetData(), arrow::struct_(value_schema_->fields()))
+                .ValueOrDie();
+        auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(arrow_array);
+        EXPECT_TRUE(struct_array != nullptr);
+        if (struct_array == nullptr) {
+            return nullptr;
+        }
+        return std::dynamic_pointer_cast<arrow::LargeBinaryArray>(struct_array->field(1));
+    }
+
+    Result<std::string> ReadPayload(std::string_view descriptor_bytes, std::string* uri) {
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<Blob> blob,
+            Blob::FromDescriptor(descriptor_bytes.data(), descriptor_bytes.size()));
+        *uri = blob->Uri();
+        PAIMON_ASSIGN_OR_RAISE(PAIMON_UNIQUE_PTR<Bytes> payload,
+                               blob->ToData(dir_->GetFileSystem(), GetDefaultPool()));
+        return std::string(payload->data(), payload->size());
+    }
+
+    bool FileExists(const std::string& path) {
+        return dir_->GetFileSystem()->GetFileStatus(path).ok();
+    }
+
+    std::unique_ptr<UniqueTestDirectory> dir_;
+    std::shared_ptr<arrow::Schema> value_schema_;
+    std::shared_ptr<DataFilePathFactory> path_factory_;
+};
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestCreateReturnsNullWithoutManagedFields) {
+    auto schema_without_blob = arrow::schema({arrow::field("id", arrow::int32())});
+    CoreOptions options = CreateOptions("1024");
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         PrimaryKeyBlobExternalizer::Create(options, schema_without_blob,
+                                                            path_factory_, GetDefaultPool()));
+    ASSERT_TRUE(externalizer == nullptr);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestCreateRejectsNonPositiveTargetFileSize) {
+    // SchemaValidation guards catalog-created tables; the externalizer checks again because
+    // pack rolling cannot work with a non-positive target size.
+    ASSERT_NOK_WITH_MSG(MakeExternalizer("0").status(), "target file size must be positive");
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestExternalizeRejectsRowKindCountMismatch) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    // Two rows but one row kind: the externalizer cannot tell which rows retract.
+    auto batch =
+        CreateBatch({1, 2}, {std::string("a"), std::string("b")}, {RecordBatch::RowKind::INSERT});
+    ASSERT_NOK_WITH_MSG(externalizer->Externalize(std::move(batch)).status(),
+                        "row kinds do not match the row count");
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestExternalizeReplacesPayloadWithDescriptor) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch(
+        {1, 2, 3}, {std::string("hello"), std::nullopt, std::string("world")},
+        {RecordBatch::RowKind::INSERT, RecordBatch::RowKind::INSERT, RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    ASSERT_EQ(blob_column->length(), 3);
+    ASSERT_TRUE(blob_column->IsNull(1));
+
+    std::string uri0;
+    std::string_view value0 = blob_column->GetView(0);
+    ASSERT_OK_AND_ASSIGN(bool is_descriptor,
+                         BlobDescriptor::IsBlobDescriptor(value0.data(), value0.size()));
+    ASSERT_TRUE(is_descriptor);
+    ASSERT_OK_AND_ASSIGN(std::string payload0, ReadPayload(value0, &uri0));
+    EXPECT_EQ(payload0, "hello");
+
+    std::string uri2;
+    ASSERT_OK_AND_ASSIGN(std::string payload2, ReadPayload(blob_column->GetView(2), &uri2));
+    EXPECT_EQ(payload2, "world");
+    // Both payloads fit into one pack below the target size.
+    EXPECT_EQ(uri0, uri2);
+    EXPECT_TRUE(FileExists(uri0));
+
+    // Packs written before PrepareCommit are uncommitted: Abort removes them.
+    externalizer->Abort();
+    EXPECT_FALSE(FileExists(uri0));
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestEachManagedFieldOwnsItsPack) {
+    // Every managed blob column owns a pack writer, so two columns never share a pack even
+    // when their values are written in the same batch.
+    value_schema_ = arrow::schema({arrow::field("id", arrow::int32()),
+                                   BlobUtils::ToArrowField("b1", /*nullable=*/true),
+                                   BlobUtils::ToArrowField("b2", /*nullable=*/true)});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    arrow::Int32Builder id_builder;
+    arrow::LargeBinaryBuilder b1_builder;
+    arrow::LargeBinaryBuilder b2_builder;
+    ASSERT_TRUE(id_builder.Append(1).ok());
+    ASSERT_TRUE(id_builder.Append(2).ok());
+    ASSERT_TRUE(b1_builder.Append("first-column").ok());
+    ASSERT_TRUE(b1_builder.AppendNull().ok());
+    ASSERT_TRUE(b2_builder.Append("second-column").ok());
+    ASSERT_TRUE(b2_builder.Append("second-column-row-2").ok());
+    std::shared_ptr<arrow::Array> id_array;
+    std::shared_ptr<arrow::Array> b1_array;
+    std::shared_ptr<arrow::Array> b2_array;
+    ASSERT_TRUE(id_builder.Finish(&id_array).ok());
+    ASSERT_TRUE(b1_builder.Finish(&b1_array).ok());
+    ASSERT_TRUE(b2_builder.Finish(&b2_array).ok());
+    auto struct_array =
+        arrow::StructArray::Make({id_array, b1_array, b2_array}, value_schema_->fields())
+            .ValueOrDie();
+    ArrowArray c_array;
+    ASSERT_TRUE(arrow::ExportArray(*struct_array, &c_array).ok());
+    auto batch = std::make_unique<RecordBatch>(std::map<std::string, std::string>(), /*bucket=*/0,
+                                               std::vector<RecordBatch::RowKind>(), &c_array);
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    ASSERT_OK(externalizer->PrepareCommit());
+
+    auto resolved =
+        arrow::ImportArray(batch->GetData(), arrow::struct_(value_schema_->fields())).ValueOrDie();
+    auto resolved_struct = std::dynamic_pointer_cast<arrow::StructArray>(resolved);
+    ASSERT_TRUE(resolved_struct != nullptr);
+    auto b1_column = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved_struct->field(1));
+    auto b2_column = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(resolved_struct->field(2));
+    ASSERT_TRUE(b1_column != nullptr);
+    ASSERT_TRUE(b2_column != nullptr);
+    // The null cell of the first column stays null and consumes no pack space.
+    EXPECT_TRUE(b1_column->IsNull(1));
+
+    std::string b1_uri;
+    std::string b2_uri;
+    ASSERT_OK_AND_ASSIGN(std::string b1_payload, ReadPayload(b1_column->GetView(0), &b1_uri));
+    ASSERT_OK_AND_ASSIGN(std::string b2_payload, ReadPayload(b2_column->GetView(0), &b2_uri));
+    EXPECT_EQ(b1_payload, "first-column");
+    EXPECT_EQ(b2_payload, "second-column");
+    EXPECT_NE(b1_uri, b2_uri);
+    EXPECT_TRUE(FileExists(b1_uri));
+    EXPECT_TRUE(FileExists(b2_uri));
+
+    // The second column's other row resolves out of that column's own pack.
+    std::string b2_row2_uri;
+    ASSERT_OK_AND_ASSIGN(std::string b2_row2_payload,
+                         ReadPayload(b2_column->GetView(1), &b2_row2_uri));
+    EXPECT_EQ(b2_row2_payload, "second-column-row-2");
+    EXPECT_EQ(b2_row2_uri, b2_uri);
+    EXPECT_NE(b2_row2_uri, b1_uri);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestRetractRowsDropPayload) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch(
+        {1, 2, 3}, {std::string("kept"), std::string("deleted"), std::string("update-before")},
+        {RecordBatch::RowKind::INSERT, RecordBatch::RowKind::DELETE,
+         RecordBatch::RowKind::UPDATE_BEFORE});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    EXPECT_FALSE(blob_column->IsNull(0));
+    EXPECT_TRUE(blob_column->IsNull(1));
+    EXPECT_TRUE(blob_column->IsNull(2));
+
+    std::string uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload, ReadPayload(blob_column->GetView(0), &uri));
+    EXPECT_EQ(payload, "kept");
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestRetractOnlyBatchOpensNoPack) {
+    // A batch holding nothing but retracts must not even open a pack: the previous test keeps
+    // an INSERT alongside them, so it cannot tell "no pack written" from "pack written and
+    // its descriptor dropped", which would leak storage and inflate the reference set.
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch({1, 2}, {std::string("deleted"), std::string("update-before")},
+                             {RecordBatch::RowKind::DELETE, RecordBatch::RowKind::UPDATE_BEFORE});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    EXPECT_TRUE(blob_column->IsNull(0));
+    EXPECT_TRUE(blob_column->IsNull(1));
+
+    std::vector<BasicFileStatus> statuses;
+    ASSERT_OK(dir_->GetFileSystem()->ListDir(dir_->Str(), &statuses));
+    EXPECT_TRUE(statuses.empty());
+
+    // Sealing and aborting an externalizer that never opened a pack stay no-ops.
+    ASSERT_OK(externalizer->PrepareCommit());
+    externalizer->Abort();
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestPrepareCommitHandsOverPacks) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch({1}, {std::string("payload")}, {RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    std::string uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload, ReadPayload(blob_column->GetView(0), &uri));
+    EXPECT_EQ(payload, "payload");
+
+    // The hand-over names the packs it gives up, which is what a rollback of the resulting
+    // commit deletes; deriving that from the data file's references instead would also catch
+    // packs the writer never created.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> handed_over, externalizer->PrepareCommit());
+    ASSERT_EQ(handed_over, std::vector<std::string>({uri}));
+    // A handed-over pack survives both a later abort and the writer teardown, and is not
+    // handed over twice.
+    externalizer->Abort();
+    EXPECT_TRUE(FileExists(uri));
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> nothing_left, externalizer->PrepareCommit());
+    EXPECT_TRUE(nothing_left.empty());
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestSealFailureStillClosesPackStream) {
+    // A failing footer write must still close the pack stream exactly once. The wrapper counts
+    // only explicit Close() calls, so destructor cleanup cannot mask a Close dropped from
+    // CloseCurrent.
+    auto fs = std::make_shared<CloseTrackingFileSystem>();
+    ASSERT_OK_AND_ASSIGN(
+        CoreOptions options,
+        CoreOptions::FromMap(
+            {{Options::FILE_SYSTEM, "local"}, {Options::BLOB_TARGET_FILE_SIZE, "1024"}}, fs));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         PrimaryKeyBlobExternalizer::Create(options, value_schema_, path_factory_,
+                                                            GetDefaultPool()));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    std::unique_ptr<RecordBatch> batch =
+        CreateBatch({1}, {std::string("payload")}, /*row_kinds=*/{});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> externalized,
+                         externalizer->Externalize(std::move(batch)));
+    ASSERT_TRUE(externalized != nullptr);
+    // The pack is below the target size and stays open after the externalization.
+    ASSERT_EQ(fs->close_count_, 0);
+
+    // Every write fails from here on, so sealing the pack fails at the footer write.
+    fs->fail_writes_ = true;
+    Result<std::vector<std::string>> seal_result = externalizer->PrepareCommit();
+    ASSERT_FALSE(seal_result.ok());
+    // The failed Finish() must not leak the stream: CloseCurrent closed it exactly once, and
+    // the abort path must not close it a second time.
+    ASSERT_EQ(fs->close_count_, 1);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestIOException) {
+    // IO-failure sweep in the repository's TestIOException convention: whichever IO
+    // operation of the externalize-and-seal cycle fails — including the footer write of
+    // PrepareCommit's seal — the failure must surface as the injected error without a crash
+    // or hang. Once no injection point is hit, the run completes and the sealed pack
+    // resolves. The explicit close guarantee is asserted separately above.
+    auto io_hook = IOHook::GetInstance();
+    bool run_complete = false;
+    for (size_t i = 0; i < 100; i++) {
+        auto dir = UniqueTestDirectory::Create("local");
+        ASSERT_TRUE(dir);
+        auto path_factory = std::make_shared<DataFilePathFactory>();
+        ASSERT_OK(path_factory->Init(dir->Str(), "parquet", "data-", nullptr));
+        CoreOptions options = CreateOptions("1024");
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                             PrimaryKeyBlobExternalizer::Create(options, value_schema_,
+                                                                path_factory, GetDefaultPool()));
+        ScopeGuard guard([&io_hook]() { io_hook->Clear(); });
+        io_hook->Reset(i, IOHook::Mode::RETURN_ERROR);
+
+        std::unique_ptr<RecordBatch> batch =
+            CreateBatch({1}, {std::string("seal-payload")}, /*row_kinds=*/{});
+        Result<std::unique_ptr<RecordBatch>> externalized =
+            externalizer->Externalize(std::move(batch));
+        CHECK_HOOK_STATUS(externalized.status(), i);
+        CHECK_HOOK_STATUS(externalizer->PrepareCommit().status(), i);
+
+        // No injection point was hit: the sealed pack must resolve to the payload.
+        io_hook->Clear();
+        std::shared_ptr<arrow::LargeBinaryArray> blob_column = BlobColumn(*externalized.value());
+        ASSERT_TRUE(blob_column != nullptr);
+        std::string pack_uri;
+        ASSERT_OK_AND_ASSIGN(std::string payload, ReadPayload(blob_column->GetView(0), &pack_uri));
+        ASSERT_EQ(payload, "seal-payload");
+        ASSERT_TRUE(FileExists(pack_uri));
+        run_complete = true;
+        break;
+    }
+    ASSERT_TRUE(run_complete);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestPacksRollByTargetFileSize) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    auto batch = CreateBatch({1, 2}, {std::string("first"), std::string("second")},
+                             {RecordBatch::RowKind::INSERT, RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+
+    std::string uri0;
+    std::string uri1;
+    ASSERT_OK_AND_ASSIGN(std::string payload0, ReadPayload(blob_column->GetView(0), &uri0));
+    ASSERT_OK_AND_ASSIGN(std::string payload1, ReadPayload(blob_column->GetView(1), &uri1));
+    EXPECT_EQ(payload0, "first");
+    EXPECT_EQ(payload1, "second");
+    // A one-byte target size seals the pack after every value.
+    EXPECT_NE(uri0, uri1);
+
+    ASSERT_OK(externalizer->PrepareCommit());
+    EXPECT_TRUE(FileExists(uri0));
+    EXPECT_TRUE(FileExists(uri1));
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestInlineDescriptorFieldNotExternalized) {
+    // An inline blob field (blob-descriptor-field) keeps its caller-provided bytes; only the
+    // managed field is externalized.
+    auto schema_with_inline = arrow::schema({arrow::field("id", arrow::int32()),
+                                             BlobUtils::ToArrowField("b", /*nullable=*/true),
+                                             BlobUtils::ToArrowField("d", /*nullable=*/true)});
+    CoreOptions options = CoreOptions::FromMap({{Options::FILE_SYSTEM, "local"},
+                                                {Options::BLOB_TARGET_FILE_SIZE, "1024"},
+                                                {Options::BLOB_DESCRIPTOR_FIELD, "d"}})
+                              .value();
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         PrimaryKeyBlobExternalizer::Create(options, schema_with_inline,
+                                                            path_factory_, GetDefaultPool()));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    const std::string inline_bytes = "caller-provided-inline-bytes";
+    arrow::Int32Builder id_builder;
+    arrow::LargeBinaryBuilder managed_builder;
+    arrow::LargeBinaryBuilder inline_builder;
+    ASSERT_TRUE(id_builder.Append(1).ok());
+    ASSERT_TRUE(managed_builder.Append("managed-payload").ok());
+    ASSERT_TRUE(inline_builder.Append(inline_bytes).ok());
+    std::shared_ptr<arrow::Array> id_array;
+    std::shared_ptr<arrow::Array> managed_array;
+    std::shared_ptr<arrow::Array> inline_array;
+    ASSERT_TRUE(id_builder.Finish(&id_array).ok());
+    ASSERT_TRUE(managed_builder.Finish(&managed_array).ok());
+    ASSERT_TRUE(inline_builder.Finish(&inline_array).ok());
+    auto struct_array = arrow::StructArray::Make({id_array, managed_array, inline_array},
+                                                 schema_with_inline->fields())
+                            .ValueOrDie();
+    ArrowArray c_array;
+    ASSERT_TRUE(arrow::ExportArray(*struct_array, &c_array).ok());
+    auto batch = std::make_unique<RecordBatch>(std::map<std::string, std::string>(), /*bucket=*/0,
+                                               std::vector<RecordBatch::RowKind>(), &c_array);
+
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    auto result_array =
+        arrow::ImportArray(batch->GetData(), arrow::struct_(schema_with_inline->fields()))
+            .ValueOrDie();
+    auto result_struct = std::dynamic_pointer_cast<arrow::StructArray>(result_array);
+    ASSERT_TRUE(result_struct != nullptr);
+
+    auto managed_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(result_struct->GetFieldByName("b"));
+    ASSERT_TRUE(managed_column != nullptr);
+    std::string uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload, ReadPayload(managed_column->GetView(0), &uri));
+    EXPECT_EQ(payload, "managed-payload");
+
+    auto inline_column =
+        std::dynamic_pointer_cast<arrow::LargeBinaryArray>(result_struct->GetFieldByName("d"));
+    ASSERT_TRUE(inline_column != nullptr);
+    EXPECT_EQ(std::string(inline_column->GetView(0)), inline_bytes);
+}
+
+TEST_F(PrimaryKeyBlobExternalizerTest, TestRematerializesDescriptorInput) {
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PrimaryKeyBlobExternalizer> externalizer,
+                         MakeExternalizer("1024"));
+    ASSERT_TRUE(externalizer != nullptr);
+
+    // First write produces a descriptor pointing at a pack.
+    auto batch = CreateBatch({1}, {std::string("original")}, {RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(batch, externalizer->Externalize(std::move(batch)));
+    auto blob_column = BlobColumn(*batch);
+    ASSERT_TRUE(blob_column != nullptr);
+    std::string source_uri;
+    ASSERT_OK_AND_ASSIGN(std::string source_payload,
+                         ReadPayload(blob_column->GetView(0), &source_uri));
+    ASSERT_EQ(source_payload, "original");
+    ASSERT_OK(externalizer->PrepareCommit());
+
+    // Feeding that descriptor back in copies the payload into a fresh pack: the new
+    // descriptor points elsewhere but resolves to the same bytes.
+    std::string_view descriptor_bytes = blob_column->GetView(0);
+    auto second_batch =
+        CreateBatch({2}, {std::string(descriptor_bytes)}, {RecordBatch::RowKind::INSERT});
+    ASSERT_OK_AND_ASSIGN(second_batch, externalizer->Externalize(std::move(second_batch)));
+    auto second_column = BlobColumn(*second_batch);
+    ASSERT_TRUE(second_column != nullptr);
+    std::string second_uri;
+    ASSERT_OK_AND_ASSIGN(std::string second_payload,
+                         ReadPayload(second_column->GetView(0), &second_uri));
+    EXPECT_EQ(second_payload, "original");
+    EXPECT_NE(second_uri, source_uri);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/io/row_to_arrow_array_converter.h
+++ b/src/paimon/core/io/row_to_arrow_array_converter.h
@@ -150,6 +150,14 @@ Status RowToArrowArrayConverter<T, R>::Reserve(arrow::ArrayBuilder* array_builde
                 binary_builder->ReserveData(INFLATION_FACTOR * reserved_sizes_[(*idx)++]));
             break;
         }
+        case arrow::Type::type::LARGE_BINARY: {
+            // reserve large binary data buffer (managed blob descriptor columns)
+            PAIMON_ASSIGN_OR_RAISE(arrow::LargeBinaryBuilder * large_binary_builder,
+                                   CastToTypedBuilder<arrow::LargeBinaryBuilder>(array_builder));
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(
+                large_binary_builder->ReserveData(INFLATION_FACTOR * reserved_sizes_[(*idx)++]));
+            break;
+        }
         case arrow::Type::type::LIST: {
             PAIMON_ASSIGN_OR_RAISE(auto* list_builder,
                                    CastToTypedBuilder<arrow::ListBuilder>(array_builder));
@@ -216,6 +224,12 @@ Status RowToArrowArrayConverter<T, R>::Accumulate(const arrow::Array* array, int
             auto binary_array = checked_cast<const arrow::BinaryArray*>(array);
             // accumulate the bytes buffer size of binary
             UpdateAccumulatedVec(binary_array->value_data()->size(), idx);
+            break;
+        }
+        case arrow::Type::type::LARGE_BINARY: {
+            auto large_binary_array = checked_cast<const arrow::LargeBinaryArray*>(array);
+            // accumulate the bytes buffer size of large binary
+            UpdateAccumulatedVec(large_binary_array->value_data()->size(), idx);
             break;
         }
         case arrow::Type::type::LIST: {
@@ -366,6 +380,27 @@ RowToArrowArrayConverter<T, R>::AppendField(bool use_view, arrow::ArrayBuilder* 
             (*reserve_count)++;
             PAIMON_ASSIGN_OR_RAISE(auto* field_builder,
                                    CastToTypedBuilder<arrow::BinaryBuilder>(array_builder));
+            if (use_view) {
+                return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                    [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                        CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                        auto view = data_getter.GetStringView(pos);
+                        return field_builder->Append(view.data(), view.size());
+                    });
+            }
+            return RowToArrowArrayConverter<T, R>::AppendValueFunc(
+                [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {
+                    CHECK_AND_APPEND_NULL(data_getter, field_builder, pos);
+                    auto bytes = data_getter.GetBinary(pos);
+                    assert(bytes);
+                    return field_builder->Append(bytes->data(), bytes->size());
+                });
+        }
+        case arrow::Type::type::LARGE_BINARY: {
+            // Managed blob descriptor columns of a primary-key table.
+            (*reserve_count)++;
+            PAIMON_ASSIGN_OR_RAISE(arrow::LargeBinaryBuilder * field_builder,
+                                   CastToTypedBuilder<arrow::LargeBinaryBuilder>(array_builder));
             if (use_view) {
                 return RowToArrowArrayConverter<T, R>::AppendValueFunc(
                     [field_builder](const DataGetters& data_getter, int32_t pos) -> arrow::Status {

--- a/src/paimon/core/io/shredding_key_value_data_file_writer_factory.cpp
+++ b/src/paimon/core/io/shredding_key_value_data_file_writer_factory.cpp
@@ -85,6 +85,7 @@ ShreddingKeyValueDataFileWriterFactory::CreateShreddedWriter(
     };
     PAIMON_ASSIGN_OR_RAISE(WriterResources resources,
                            CreateWriterResources(*format, file_schema, create_stats_extractor_));
+    std::string path = path_factory_->NewPath();
     auto writer = std::make_unique<KeyValueDataFileWriter>(
         options_.GetWriteFileCompression(level_), std::move(batch_converter), schema_id_, level_,
         file_source_, primary_keys_, resources.stats_extractor, file_schema,
@@ -94,8 +95,14 @@ ShreddingKeyValueDataFileWriterFactory::CreateShreddedWriter(
     if (file_index_writer) {
         writer->SetFileIndexWriter(std::move(file_index_writer), write_schema_);
     }
-    PAIMON_RETURN_NOT_OK(
-        writer->Init(options_.GetFileSystem(), path_factory_->NewPath(), resources.writer_builder));
+    // The collector inspects the logical key-value batch (the factory's write schema), which
+    // is what Write() receives before the shredding conversion runs.
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ManagedBlobReferenceCollector> collector,
+                           CreateBlobReferenceCollector(path));
+    if (collector) {
+        writer->SetBlobReferenceCollector(std::move(collector));
+    }
+    PAIMON_RETURN_NOT_OK(writer->Init(options_.GetFileSystem(), path, resources.writer_builder));
     ShreddingWritePlanFactory::MetadataFinalizer finalizer =
         plan_factory_->CreateMetadataFinalizer(converter, options_.GetWriteFileCompression(level_));
     if (finalizer) {

--- a/src/paimon/core/io/single_file_writer.h
+++ b/src/paimon/core/io/single_file_writer.h
@@ -61,11 +61,21 @@ class Metrics;
 template <typename T, typename R>
 class SingleFileWriter : public FileWriter<T, R> {
  public:
-    /// Abort executor to just have reference of path instead of whole writer.
+    /// Abort executor to just have reference of paths instead of whole writer. Besides the
+    /// data file itself it may carry companion files written next to it (e.g. a managed blob
+    /// reference sidecar), which an abort removes together.
     class AbortExecutor {
      public:
         AbortExecutor(const std::shared_ptr<FileSystem>& fs, const std::string& path)
             : paths_({{fs, path}}), logger_(Logger::GetLogger("AbortExecutor")) {}
+
+        AbortExecutor(const std::shared_ptr<FileSystem>& fs, const std::vector<std::string>& paths)
+            : logger_(Logger::GetLogger("AbortExecutor")) {
+            paths_.reserve(paths.size());
+            for (const std::string& path : paths) {
+                paths_.emplace_back(fs, path);
+            }
+        }
 
         void Add(const std::shared_ptr<FileSystem>& fs, const std::string& path) {
             paths_.emplace_back(fs, path);
@@ -77,7 +87,9 @@ class SingleFileWriter : public FileWriter<T, R> {
                     continue;
                 }
                 auto status = fs->Delete(path);
-                if (!status.ok()) {
+                // A path already removed by another cleanup (e.g. the writer's own Abort) is
+                // fine; only a real failure is worth a warning.
+                if (!status.ok() && !status.IsNotExist()) {
                     PAIMON_LOG_WARN(logger_, "Exception occurs when deleting %s: %s", path.c_str(),
                                     status.ToString().c_str());
                 }

--- a/src/paimon/core/io/single_file_writer_test.cpp
+++ b/src/paimon/core/io/single_file_writer_test.cpp
@@ -19,7 +19,10 @@
 #include "paimon/core/io/single_file_writer.h"
 
 #include <map>
+#include <memory>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "arrow/api.h"
 #include "arrow/c/abi.h"
@@ -30,6 +33,7 @@
 #include "paimon/core/core_options.h"
 #include "paimon/defs.h"
 #include "paimon/format/file_format.h"
+#include "paimon/fs/file_system.h"
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
@@ -79,6 +83,36 @@ TEST(SingleFileWriterTest, TestSimple) {
     abort_executor.Abort();
     ASSERT_OK_AND_ASSIGN(auto exist, file_system->Exists(file_path));
     ASSERT_FALSE(exist);
+}
+
+TEST(SingleFileWriterTest, TestAbortExecutorRemovesCompanionFiles) {
+    // Besides the data file an abort executor may carry companion files written next to it
+    // (e.g. a managed blob reference sidecar), which have to go with it. A path another
+    // cleanup already removed is not a failure, so aborting stays repeatable.
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    std::shared_ptr<FileSystem> file_system = dir->GetFileSystem();
+
+    std::string data_path = dir->Str() + "/data-0.orc";
+    std::string sidecar_path = data_path + ".blobref";
+    for (const std::string& path : {data_path, sidecar_path}) {
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<OutputStream> out,
+                             file_system->Create(path, /*overwrite=*/false));
+        ASSERT_OK(out->Close());
+    }
+    std::string absent_path = dir->Str() + "/data-1.orc";
+
+    SimpleSingleFileWriter::AbortExecutor abort_executor(
+        file_system, std::vector<std::string>{data_path, sidecar_path, absent_path});
+    abort_executor.Abort();
+
+    ASSERT_OK_AND_ASSIGN(bool data_exists, file_system->Exists(data_path));
+    ASSERT_FALSE(data_exists);
+    ASSERT_OK_AND_ASSIGN(bool sidecar_exists, file_system->Exists(sidecar_path));
+    ASSERT_FALSE(sidecar_exists);
+
+    // Everything is gone now, so a second abort has nothing left to delete and still returns.
+    abort_executor.Abort();
 }
 
 TEST(SingleFileWriterTest, TestInvalidConvert) {

--- a/src/paimon/core/mergetree/compact/compact_strategy_test.cpp
+++ b/src/paimon/core/mergetree/compact/compact_strategy_test.cpp
@@ -18,6 +18,7 @@
 
 #include "paimon/core/mergetree/compact/compact_strategy.h"
 
+#include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {

--- a/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter_test.cpp
+++ b/src/paimon/core/mergetree/compact/lookup_merge_tree_compact_rewriter_test.cpp
@@ -30,6 +30,7 @@
 #include "paimon/common/utils/path_util.h"
 #include "paimon/core/compact/noop_compact_manager.h"
 #include "paimon/core/core_options.h"
+#include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 #include "paimon/core/deletionvectors/bucketed_dv_maintainer.h"
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/mergetree/compact/aggregate/aggregate_merge_function.h"

--- a/src/paimon/core/mergetree/in_memory_sort_buffer.cpp
+++ b/src/paimon/core/mergetree/in_memory_sort_buffer.cpp
@@ -151,6 +151,14 @@ Result<int64_t> InMemorySortBuffer::EstimateMemoryUse(const std::shared_ptr<arro
             int64_t offset_length = array->length() * sizeof(int32_t);
             return null_bits_size_in_bytes + value_length + offset_length;
         }
+        case arrow::Type::type::LARGE_BINARY: {
+            // Managed blob columns of a primary-key table buffer their serialized
+            // descriptors as large binary.
+            auto large_binary_array = checked_cast<const arrow::LargeBinaryArray*>(array.get());
+            int64_t value_length = large_binary_array->total_values_length();
+            int64_t offset_length = array->length() * sizeof(int64_t);
+            return null_bits_size_in_bytes + value_length + offset_length;
+        }
         case arrow::Type::type::LIST: {
             auto list_array = checked_cast<const arrow::ListArray*>(array.get());
             PAIMON_ASSIGN_OR_RAISE(int64_t value_mem, EstimateMemoryUse(list_array->values()));

--- a/src/paimon/core/mergetree/merge_tree_writer.cpp
+++ b/src/paimon/core/mergetree/merge_tree_writer.cpp
@@ -21,8 +21,10 @@
 #include <algorithm>
 #include <cassert>
 #include <map>
+#include <string>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #include "arrow/api.h"
 #include "arrow/c/abi.h"
@@ -40,6 +42,7 @@
 #include "paimon/core/io/key_value_data_file_writer_factory.h"
 #include "paimon/core/io/key_value_meta_projection_consumer.h"
 #include "paimon/core/io/key_value_record_reader.h"
+#include "paimon/core/io/primary_key_blob_externalizer.h"
 #include "paimon/core/io/row_to_arrow_array_converter.h"
 #include "paimon/core/io/shredding_key_value_data_file_writer_factory.h"
 #include "paimon/core/manifest/file_source.h"
@@ -67,10 +70,17 @@ Result<std::shared_ptr<MergeTreeWriter>> MergeTreeWriter::Create(
                             options.GetSequenceField(), key_comparator, user_defined_seq_comparator,
                             merge_function_wrapper, options, io_manager, enable_multi_thread_spill,
                             pool));
-    return std::shared_ptr<MergeTreeWriter>(
+    std::shared_ptr<MergeTreeWriter> writer(
         new MergeTreeWriter(trimmed_primary_keys, options, path_factory, key_comparator,
                             user_defined_seq_comparator, merge_function_wrapper, schema_id,
                             write_schema, compact_manager, std::move(write_buffer), pool));
+    // Managed blob payloads leave the row before it is buffered: they are externalized into
+    // pack files and the buffered value holds a descriptor, so the write buffer and any spill
+    // never carry the payload bytes.
+    PAIMON_ASSIGN_OR_RAISE(
+        writer->blob_externalizer_,
+        PrimaryKeyBlobExternalizer::Create(options, value_schema, path_factory, pool));
+    return writer;
 }
 
 MergeTreeWriter::MergeTreeWriter(
@@ -96,6 +106,11 @@ MergeTreeWriter::MergeTreeWriter(
       metrics_(std::make_shared<MetricsImpl>()) {}
 
 Status MergeTreeWriter::DoClose() {
+    // Uncommitted managed blob packs die with the writer, mirroring the temporary data file
+    // cleanup below; packs handed over by PrepareCommit are unaffected.
+    if (blob_externalizer_) {
+        blob_externalizer_->Abort();
+    }
     // Request cancellation and wait for running compaction to exit.
     // This avoids reusing cancellation state while an old task is still running.
     compact_manager_->CancelAndWaitCompaction();
@@ -119,8 +134,11 @@ Status MergeTreeWriter::DoClose() {
         }
     }
     for (const auto& file : delete_files) {
-        // Keep Java parity: temporary file cleanup is quiet.
-        [[maybe_unused]] auto s = options_.GetFileSystem()->Delete(path_factory_->ToPath(file));
+        // Temporary file cleanup is quiet and removes the data file together with its companion
+        // files (e.g. the managed blob reference sidecar).
+        for (const auto& path : path_factory_->CollectFiles(file)) {
+            [[maybe_unused]] auto s = options_.GetFileSystem()->Delete(path);
+        }
     }
 
     write_buffer_->Clear();
@@ -146,6 +164,10 @@ Status MergeTreeWriter::FlushMemory() {
 }
 
 Status MergeTreeWriter::Write(std::unique_ptr<RecordBatch>&& moved_batch) {
+    if (blob_externalizer_) {
+        PAIMON_ASSIGN_OR_RAISE(moved_batch,
+                               blob_externalizer_->Externalize(std::move(moved_batch)));
+    }
     PAIMON_ASSIGN_OR_RAISE(bool has_remaining_quota, write_buffer_->Write(std::move(moved_batch)));
     if (!has_remaining_quota) {
         return FlushWriteBuffer(/*wait_for_latest_compaction=*/false,
@@ -201,7 +223,11 @@ Status MergeTreeWriter::UpdateCompactResult(const std::shared_ptr<CompactResult>
             if (!in_compact_before(file->file_name) &&
                 after_files.find(file->file_name) == after_files.end()) {
                 auto fs = options_.GetFileSystem();
-                [[maybe_unused]] auto s = fs->Delete(path_factory_->ToPath(file));
+                // An intermediate file's companion files (e.g. the managed blob reference
+                // sidecar) are no longer needed either.
+                for (const auto& path : path_factory_->CollectFiles(file)) {
+                    [[maybe_unused]] auto s = fs->Delete(path);
+                }
             }
         } else {
             compact_before_.push_back(file);
@@ -241,7 +267,16 @@ Result<CommitIncrement> MergeTreeWriter::PrepareCommit(bool wait_compaction) {
         wait_compaction = true;
     }
     PAIMON_RETURN_NOT_OK(TrySyncLatestCompaction(wait_compaction));
-    return DrainIncrement();
+    std::vector<std::string> owned_managed_blob_packs;
+    if (blob_externalizer_) {
+        // Seal the packs this writer created and hand them over: it no longer deletes them on
+        // close, and their paths ride along with the increment so a failed commit can roll back
+        // exactly the packs it created.
+        PAIMON_ASSIGN_OR_RAISE(owned_managed_blob_packs, blob_externalizer_->PrepareCommit());
+    }
+    PAIMON_ASSIGN_OR_RAISE(CommitIncrement increment, DrainIncrement());
+    increment.SetOwnedManagedBlobPacks(std::move(owned_managed_blob_packs));
+    return increment;
 }
 
 Result<bool> MergeTreeWriter::CompactNotCompleted() {

--- a/src/paimon/core/mergetree/merge_tree_writer.h
+++ b/src/paimon/core/mergetree/merge_tree_writer.h
@@ -51,6 +51,7 @@ class IOManager;
 class FieldsComparator;
 class MemoryPool;
 class Metrics;
+class PrimaryKeyBlobExternalizer;
 template <typename T>
 class MergeFunctionWrapper;
 
@@ -128,6 +129,12 @@ class MergeTreeWriter : public BatchWriter {
     std::shared_ptr<arrow::Schema> write_schema_;
 
     std::shared_ptr<CompactManager> compact_manager_;
+
+    /// Externalizes managed blob payloads before buffering; null unless the table is a
+    /// primary-key managed blob table. Declared before the write buffer: buffered batches
+    /// hold descriptor columns allocated from the externalizer's pool, so the buffer must be
+    /// destroyed first.
+    std::unique_ptr<PrimaryKeyBlobExternalizer> blob_externalizer_;
 
     std::unique_ptr<WriteBuffer> write_buffer_;
 

--- a/src/paimon/core/mergetree/merge_tree_writer_test.cpp
+++ b/src/paimon/core/mergetree/merge_tree_writer_test.cpp
@@ -31,17 +31,20 @@
 #include "arrow/c/bridge.h"
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
+#include "paimon/common/data/blob_utils.h"
 #include "paimon/common/data/shredding/map_shared_shredding_utils.h"
 #include "paimon/common/factories/io_hook.h"
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/fields_comparator.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/common/utils/string_utils.h"
 #include "paimon/core/compact/noop_compact_manager.h"
 #include "paimon/core/disk/io_manager.h"
 #include "paimon/core/io/compact_increment.h"
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/io/data_increment.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/core/mergetree/compact/deduplicate_merge_function.h"
 #include "paimon/core/mergetree/compact/reducer_merge_function_wrapper.h"
@@ -209,6 +212,32 @@ class MergeTreeWriterTest : public ::testing::TestWithParam<bool> {
             last_sequence_number, primary_keys_, path_factory, key_comparator_,
             user_defined_seq_comparator, merge_function_wrapper_, schema_id, value_schema_, options,
             writer_compact_manager, io_manager, /*enable_multi_thread_spill=*/false, pool_);
+    }
+
+    /// Rebuilds the fixture schema as (f0 key, b managed blob) for the managed blob tests.
+    Status UseManagedBlobSchema() {
+        value_fields_ = {DataField(0, arrow::field("f0", arrow::utf8())),
+                         DataField(1, BlobUtils::ToArrowField("b", /*nullable=*/true))};
+        value_schema_ = DataField::ConvertDataFieldsToArrowSchema(value_fields_);
+        value_type_ = DataField::ConvertDataFieldsToArrowStructType(value_fields_);
+        PAIMON_ASSIGN_OR_RAISE(key_comparator_,
+                               FieldsComparator::Create({value_fields_[0]},
+                                                        /*is_ascending_order=*/true));
+        return Status::OK();
+    }
+
+    /// The single (key, payload) row the managed blob tests externalize.
+    std::shared_ptr<arrow::Array> ManagedBlobRow() const {
+        arrow::StringBuilder key_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        EXPECT_TRUE(key_builder.Append("Alice").ok());
+        EXPECT_TRUE(blob_builder.Append("blob-payload").ok());
+        std::shared_ptr<arrow::Array> key_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(key_builder.Finish(&key_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        return arrow::StructArray::Make({key_array, blob_array}, value_schema_->fields())
+            .ValueOrDie();
     }
 
  private:
@@ -1756,6 +1785,180 @@ TEST_F(MergeTreeWriterTest, TestSpillWithIOException) {
         ASSERT_EQ(1, commit_increment.value().GetNewFilesIncrement().NewFiles().size());
         ASSERT_EQ(5, commit_increment.value().GetNewFilesIncrement().NewFiles()[0]->row_count);
 
+        ASSERT_OK(merge_writer->Close());
+        run_complete = true;
+        break;
+    }
+    ASSERT_TRUE(run_complete);
+}
+
+TEST_P(MergeTreeWriterTest, TestManagedBlobSidecarKeptAfterCommit) {
+    // The flushed file carries a sidecar in its extra files, and closing the writer after
+    // PrepareCommit keeps the data file, the sidecar and the pack.
+    ASSERT_OK(UseManagedBlobSchema());
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    auto path_factory = std::make_shared<DataFilePathFactory>();
+    ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
+
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory,
+                                           /*schema_id=*/1, options));
+    WriteBatch(ManagedBlobRow(), /*row_kinds=*/{}, merge_writer.get());
+    ASSERT_OK_AND_ASSIGN(CommitIncrement commit_increment,
+                         merge_writer->PrepareCommit(/*wait_compaction=*/false));
+
+    ASSERT_EQ(1, commit_increment.GetNewFilesIncrement().NewFiles().size());
+    const auto& flushed_file = commit_increment.GetNewFilesIncrement().NewFiles()[0];
+    ASSERT_EQ(flushed_file->extra_files.size(), 1);
+    ASSERT_TRUE(flushed_file->extra_files[0].has_value());
+    ASSERT_EQ(flushed_file->extra_files[0].value(), flushed_file->file_name + ".blobref");
+    std::string data_path = dir->Str() + "/" + flushed_file->file_name;
+    std::string sidecar_path = data_path + ".blobref";
+
+    // The pack path is recorded in the sidecar, not assumed from naming.
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> references,
+                         ManagedBlobReferenceFile::Read(file_system_, sidecar_path));
+    ASSERT_EQ(references.size(), 1);
+    std::string pack_path = references[0].ToString();
+    ASSERT_TRUE(StringUtils::EndsWith(pack_path, ManagedBlobReferenceFile::kManagedBlobSuffix));
+
+    ASSERT_OK(merge_writer->Close());
+    EXPECT_TRUE(file_system_->GetFileStatus(data_path).ok());
+    EXPECT_TRUE(file_system_->GetFileStatus(sidecar_path).ok());
+    EXPECT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+}
+
+TEST_P(MergeTreeWriterTest, TestManagedBlobSidecarRemovedWithoutCommit) {
+    // Closing the writer without PrepareCommit removes the flushed data file together with its
+    // sidecar, and the externalizer deletes the uncommitted pack.
+    ASSERT_OK(UseManagedBlobSchema());
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    auto path_factory = std::make_shared<DataFilePathFactory>();
+    ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
+
+    ASSERT_OK_AND_ASSIGN(auto merge_writer,
+                         CreateMergeWriter(/*last_sequence_number=*/-1, dir->Str(), path_factory,
+                                           /*schema_id=*/1, options));
+    WriteBatch(ManagedBlobRow(), /*row_kinds=*/{}, merge_writer.get());
+    // Force the buffer to flush without draining the increment.
+    ASSERT_OK(merge_writer->Compact(/*full_compaction=*/false));
+    ASSERT_EQ(1, merge_writer->new_files_.size());
+    const auto& flushed_file = merge_writer->new_files_[0];
+    ASSERT_EQ(flushed_file->extra_files.size(), 1);
+    ASSERT_TRUE(flushed_file->extra_files[0].has_value());
+    std::string data_path = dir->Str() + "/" + flushed_file->file_name;
+    std::string sidecar_path = dir->Str() + "/" + flushed_file->extra_files[0].value();
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> references,
+                         ManagedBlobReferenceFile::Read(file_system_, sidecar_path));
+    ASSERT_EQ(references.size(), 1);
+    std::string pack_path = references[0].ToString();
+    ASSERT_TRUE(file_system_->GetFileStatus(data_path).ok());
+    ASSERT_TRUE(file_system_->GetFileStatus(sidecar_path).ok());
+    ASSERT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+
+    ASSERT_OK(merge_writer->Close());
+    EXPECT_FALSE(file_system_->GetFileStatus(data_path).ok());
+    EXPECT_FALSE(file_system_->GetFileStatus(sidecar_path).ok());
+    EXPECT_FALSE(file_system_->GetFileStatus(pack_path).ok());
+}
+
+TEST_P(MergeTreeWriterTest, TestSharedShreddingKeepsManagedBlobSidecar) {
+    // A shredded map column and a managed blob column in one table. The reference collector
+    // reads the logical key-value batch, while the shredding conversion rewrites the batch into
+    // its physical layout afterwards, so the two must not disagree about column positions.
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({
+                             {Options::FILE_FORMAT, "orc"},
+                             {"fields.tags.map.storage-layout", "shared-shredding"},
+                             {"fields.tags.map.shared-shredding.max-columns", "3"},
+                             {"fields.tags.map.shared-shredding.column-placement-policy", "plain"},
+                         }));
+
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    auto path_factory = std::make_shared<DataFilePathFactory>();
+    ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
+
+    std::vector<DataField> value_fields = {
+        DataField(0, arrow::field("id", arrow::int32())),
+        DataField(1, arrow::field("tags", arrow::map(arrow::utf8(), arrow::int64()))),
+        DataField(2, BlobUtils::ToArrowField("b", /*nullable=*/true)),
+    };
+    auto value_schema = DataField::ConvertDataFieldsToArrowSchema(value_fields);
+    auto value_type = DataField::ConvertDataFieldsToArrowStructType(value_fields);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FieldsComparator> key_comparator,
+                         FieldsComparator::Create({value_fields[0]},
+                                                  /*is_ascending_order=*/true));
+    ASSERT_OK_AND_ASSIGN(
+        auto merge_writer,
+        MergeTreeWriter::Create(
+            /*last_sequence_number=*/-1, /*trimmed_primary_keys=*/{"id"}, path_factory,
+            key_comparator,
+            /*user_defined_seq_comparator=*/nullptr, merge_function_wrapper_, /*schema_id=*/1,
+            value_schema, options, noop_compact_manager_,
+            GetParam() ? std::make_shared<IOManager>(dir->Str() + "/tmp", file_system_) : nullptr,
+            /*enable_multi_thread_spill=*/false, pool_));
+
+    auto array = arrow::ipc::internal::json::ArrayFromJSON(value_type, R"([
+      [1, [["a", 10], ["b", 20]], "shredded-blob-payload"]
+    ])")
+                     .ValueOrDie();
+    WriteBatch(array, /*row_kinds=*/{}, merge_writer.get());
+
+    ASSERT_OK_AND_ASSIGN(CommitIncrement commit_increment,
+                         merge_writer->PrepareCommit(/*wait_compaction=*/false));
+    ASSERT_EQ(1, commit_increment.GetNewFilesIncrement().NewFiles().size());
+    const auto& flushed_file = commit_increment.GetNewFilesIncrement().NewFiles()[0];
+    ASSERT_EQ(flushed_file->extra_files.size(), 1);
+    ASSERT_TRUE(flushed_file->extra_files[0].has_value());
+
+    std::string sidecar_path = dir->Str() + "/" + flushed_file->extra_files[0].value();
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> references,
+                         ManagedBlobReferenceFile::Read(file_system_, sidecar_path));
+    ASSERT_EQ(references.size(), 1);
+    std::string pack_path = references[0].ToString();
+    EXPECT_TRUE(StringUtils::EndsWith(pack_path, ManagedBlobReferenceFile::kManagedBlobSuffix));
+    EXPECT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+    ASSERT_OK(merge_writer->Close());
+}
+
+TEST_P(MergeTreeWriterTest, TestManagedBlobIOException) {
+    // The TestIOException sweep on a managed blob schema: every injected failure must also
+    // tear down the blob reference collector, the sidecar (via the abort executor's extra
+    // paths) and the pack writers without a crash or hang, and the first clean run commits.
+    ASSERT_OK(UseManagedBlobSchema());
+    ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
+
+    bool run_complete = false;
+    auto io_hook = IOHook::GetInstance();
+    for (size_t i = 0; i < 200; i++) {
+        auto dir = UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir);
+        ScopeGuard guard([&io_hook]() { io_hook->Clear(); });
+        io_hook->Reset(i, IOHook::Mode::RETURN_ERROR);
+        auto path_factory = std::make_shared<DataFilePathFactory>();
+        ASSERT_OK(path_factory->Init(dir->Str(), "orc", options.DataFilePrefix(), nullptr));
+
+        auto merge_writer_result = CreateMergeWriter(
+            /*last_sequence_number=*/-1, dir->Str(), path_factory, /*schema_id=*/0, options);
+        CHECK_HOOK_STATUS(merge_writer_result.status(), i);
+        auto merge_writer = std::move(merge_writer_result).value();
+
+        ::ArrowArray c_array;
+        ASSERT_TRUE(arrow::ExportArray(*ManagedBlobRow(), &c_array).ok());
+        RecordBatchBuilder batch_builder(&c_array);
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch, batch_builder.Finish());
+        CHECK_HOOK_STATUS(merge_writer->Write(std::move(batch)), i);
+        auto commit_increment = merge_writer->PrepareCommit(/*wait_compaction=*/false);
+        CHECK_HOOK_STATUS(commit_increment.status(), i);
+        ASSERT_FALSE(commit_increment.value().GetNewFilesIncrement().NewFiles().empty());
         ASSERT_OK(merge_writer->Close());
         run_complete = true;
         break;

--- a/src/paimon/core/mergetree/sort_buffer_test.cpp
+++ b/src/paimon/core/mergetree/sort_buffer_test.cpp
@@ -193,6 +193,8 @@ TEST_F(SortBufferTest, TestInMemorySortBufferEstimateMemoryUse) {
         ASSERT_EQ(memory_use, expected_memory_use);
     }
     {
+        // v12 is the shape a managed blob column buffers its descriptors in: large binary,
+        // whose offsets are 8 bytes wide rather than the 4 of a binary column.
         arrow::FieldVector fields = {arrow::field("v0", arrow::boolean()),
                                      arrow::field("v1", arrow::int8()),
                                      arrow::field("v2", arrow::int16()),
@@ -204,21 +206,22 @@ TEST_F(SortBufferTest, TestInMemorySortBufferEstimateMemoryUse) {
                                      arrow::field("v8", arrow::timestamp(arrow::TimeUnit::NANO)),
                                      arrow::field("v9", arrow::decimal128(30, 20)),
                                      arrow::field("v10", arrow::utf8()),
-                                     arrow::field("v11", arrow::binary())};
+                                     arrow::field("v11", arrow::binary()),
+                                     arrow::field("v12", arrow::large_binary())};
 
         auto array = std::dynamic_pointer_cast<arrow::StructArray>(
             arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
-        [true, 10, 200, 65536, 123456789, 0.0, 0.0, 2000, -86399999999500, "2134.48690000000000000009", "difference", "Alice"],
-        [false, -128, -32768, -2147483648, -9223372036854775808, -3.4028235E38, -1.7976931348623157E308, -719528, -9223372036854775808, "-999999999999999999.99999999999999999999", "Alice", "Two"],
-        [true, 127, 32767, 2147483647, 9223372036854775807, 3.4028235E38, 1.7976931348623157E308, 2932896, 9223372036854775807, "999999999999999999.99999999999999999999", "Alice", "made"],
-        [true, 0, 0, 0, 0, 1.4E-45, 4.9E-324, 0, 0, "0.00000000000000000000", "Alice", "wood"]
+        [true, 10, 200, 65536, 123456789, 0.0, 0.0, 2000, -86399999999500, "2134.48690000000000000009", "difference", "Alice", "one"],
+        [false, -128, -32768, -2147483648, -9223372036854775808, -3.4028235E38, -1.7976931348623157E308, -719528, -9223372036854775808, "-999999999999999999.99999999999999999999", "Alice", "Two", "two"],
+        [true, 127, 32767, 2147483647, 9223372036854775807, 3.4028235E38, 1.7976931348623157E308, 2932896, 9223372036854775807, "999999999999999999.99999999999999999999", "Alice", "made", "three"],
+        [true, 0, 0, 0, 0, 1.4E-45, 4.9E-324, 0, 0, "0.00000000000000000000", "Alice", "wood", "four"]
 ])")
                 .ValueOrDie());
         ASSERT_OK_AND_ASSIGN(int64_t memory_use, InMemorySortBuffer::EstimateMemoryUse(array));
         int64_t expected_memory_use = 1 + (4 + 1) + (4 + 1) + (2 * 4 + 1) + (4 * 4 + 1) +
                                       (8 * 4 + 1) + (4 * 4 + 1) + (8 * 4 + 1) + (4 * 4 + 1) +
                                       (8 * 4 + 1) + (4 * 16 + 1) + (25 + 4 * 4 + 1) +
-                                      (16 + 4 * 4 + 1);
+                                      (16 + 4 * 4 + 1) + (15 + 8 * 4 + 1);
         ASSERT_EQ(memory_use, expected_memory_use);
     }
     {

--- a/src/paimon/core/operation/abstract_file_store_write.cpp
+++ b/src/paimon/core/operation/abstract_file_store_write.cpp
@@ -27,6 +27,8 @@
 #include "fmt/format.h"
 #include "paimon/common/data/binary_row.h"
 #include "paimon/common/metrics/metrics_impl.h"
+#include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/operation/commit/uncommitted_file_cleaner.h"
 #include "paimon/core/operation/file_store_scan.h"
 #include "paimon/core/operation/file_system_write_restore.h"
 #include "paimon/core/operation/metrics/compaction_metrics.h"
@@ -188,6 +190,22 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> AbstractFileStoreWrite::Prep
     }
 
     std::vector<std::shared_ptr<CommitMessage>> result;
+    // A writer hands its files over the moment it drains an increment, so once a message exists
+    // nothing the writer does removes its data files, sidecars or managed blob packs. Failing
+    // out of this loop never hands `result` to the caller, so the messages built so far would
+    // be stranded with no one left to clean them up.
+    ScopeGuard prepare_guard([this, &result]() {
+        if (result.empty()) {
+            return;
+        }
+        Status status = UncommittedFileCleaner::Delete(
+            file_store_path_factory_, options_.GetFileSystem(), result, logger_.get());
+        if (!status.ok()) {
+            PAIMON_LOG_WARN(logger_,
+                            "Failed to clean up the messages of a failed prepare commit: %s",
+                            status.ToString().c_str());
+        }
+    });
     auto metrics = compaction_metrics_->GetMetrics();
     for (auto partition_iter = writers_.begin(); partition_iter != writers_.end();) {
         auto& partition = partition_iter->first;
@@ -198,21 +216,32 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> AbstractFileStoreWrite::Prep
             PAIMON_ASSIGN_OR_RAISE(CommitIncrement increment,
                                    writer_container.writer->PrepareCommit(wait_compaction));
             writer_memory_manager_->RefreshWriterMemory(writer_container.writer.get());
+            // Enrolling the increment is what puts its files under the guard above, so it has
+            // to happen before anything that can fail with the increment already drained.
+            auto enroll_increment = [&partition, bucket, &writer_container,
+                                     &result](CommitIncrement* enrolled) {
+                auto committable = std::make_shared<CommitMessageImpl>(
+                    partition, bucket, writer_container.total_buckets,
+                    enrolled->GetNewFilesIncrement(), enrolled->GetCompactIncrement());
+                committable->SetOwnedManagedBlobPacks(enrolled->TakeOwnedManagedBlobPacks());
+                result.push_back(committable);
+                return committable;
+            };
             auto compact_deletion_file = increment.GetCompactDeletionFile();
             auto& compact_increment = increment.GetCompactIncrement();
             if (compact_deletion_file) {
-                PAIMON_ASSIGN_OR_RAISE(
-                    std::optional<std::shared_ptr<IndexFileMeta>> dv_index_file_meta,
-                    compact_deletion_file->GetOrCompute());
-                if (dv_index_file_meta) {
-                    compact_increment.AddNewIndexFiles({dv_index_file_meta.value()});
+                Result<std::optional<std::shared_ptr<IndexFileMeta>>> dv_index_file_meta =
+                    compact_deletion_file->GetOrCompute();
+                if (!dv_index_file_meta.ok()) {
+                    enroll_increment(&increment);
+                    return dv_index_file_meta.status();
+                }
+                if (dv_index_file_meta.value()) {
+                    compact_increment.AddNewIndexFiles({dv_index_file_meta.value().value()});
                 }
             }
 
-            auto committable = std::make_shared<CommitMessageImpl>(
-                partition, bucket, writer_container.total_buckets, increment.GetNewFilesIncrement(),
-                compact_increment);
-            result.push_back(committable);
+            std::shared_ptr<CommitMessageImpl> committable = enroll_increment(&increment);
             if (!committable->IsEmpty()) {
                 writer_container.last_modified_commit_identifier = commit_identifier;
                 metrics->Merge(writer_container.writer->GetMetrics());
@@ -261,6 +290,7 @@ Result<std::vector<std::shared_ptr<CommitMessage>>> AbstractFileStoreWrite::Prep
         }
     }
 
+    prepare_guard.Release();
     metrics_->Overwrite(metrics);
     return result;
 }
@@ -298,6 +328,21 @@ Result<std::vector<RealtimeCommitProgress>> AbstractFileStoreWrite::PrepareRealt
     }
 
     std::vector<RealtimeCommitProgress> result;
+    // Same hand-over as the batch path above: a sealed writer no longer owns the files of the
+    // message it produced, so an early return has to take them with it.
+    std::vector<std::shared_ptr<CommitMessage>> produced;
+    ScopeGuard prepare_guard([this, &produced]() {
+        if (produced.empty()) {
+            return;
+        }
+        Status status = UncommittedFileCleaner::Delete(
+            file_store_path_factory_, options_.GetFileSystem(), produced, logger_.get());
+        if (!status.ok()) {
+            PAIMON_LOG_WARN(logger_,
+                            "Failed to clean up the messages of a failed prepare commit: %s",
+                            status.ToString().c_str());
+        }
+    });
     for (const WriterSnapshot& snapshot : writer_snapshots) {
         PAIMON_ASSIGN_OR_RAISE(CommitIncrement increment,
                                snapshot.writer->PrepareCommit(/*wait_compaction=*/false));
@@ -305,6 +350,8 @@ Result<std::vector<RealtimeCommitProgress>> AbstractFileStoreWrite::PrepareRealt
         auto committable = std::make_shared<CommitMessageImpl>(
             snapshot.partition, snapshot.bucket, snapshot.total_buckets,
             increment.GetNewFilesIncrement(), increment.GetCompactIncrement());
+        committable->SetOwnedManagedBlobPacks(increment.TakeOwnedManagedBlobPacks());
+        produced.push_back(committable);
         if (!increment.GetRealtimeOffsetRange()) {
             if (!committable->IsEmpty()) {
                 return Status::Invalid("real-time commit message does not have an offset range");
@@ -323,6 +370,7 @@ Result<std::vector<RealtimeCommitProgress>> AbstractFileStoreWrite::PrepareRealt
             committable, RealtimePartitionBucket(std::move(partition), snapshot.bucket),
             increment.GetRealtimeOffsetRange().value()});
     }
+    prepare_guard.Release();
     {
         std::lock_guard<std::mutex> lock(realtime_metrics_mutex_);
         std::shared_ptr<Metrics> metrics = compaction_metrics_->GetMetrics();

--- a/src/paimon/core/operation/abstract_split_read.cpp
+++ b/src/paimon/core/operation/abstract_split_read.cpp
@@ -197,6 +197,17 @@ Result<std::unique_ptr<FileBatchReader>> AbstractSplitRead::CreateFieldMappingRe
                                               SpecialFields::ValueKind()};
         file_fields.insert(file_fields.end(), data_schema->Fields().begin(),
                            data_schema->Fields().end());
+        // Blob columns of a primary-key table are stored as plain bytes in the kv data
+        // files (managed columns hold serialized descriptors), and the format readers
+        // produce them as binary. Declare them as binary on the file side so the field
+        // mapping casts them back to the requested large_binary type.
+        std::vector<std::string> blob_field_names;
+        for (const auto& field : data_schema->Fields()) {
+            if (BlobUtils::IsBlobField(field.ArrowField())) {
+                blob_field_names.push_back(field.Name());
+            }
+        }
+        file_fields = BlobUtils::ConvertBlobInlineDataFields(file_fields, blob_field_names);
         PAIMON_ASSIGN_OR_RAISE(field_mapping,
                                field_mapping_builder->CreateFieldMapping(file_fields));
     } else {

--- a/src/paimon/core/operation/commit/conflict_detection.cpp
+++ b/src/paimon/core/operation/commit/conflict_detection.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <iterator>
 #include <map>
 #include <memory>
 #include <tuple>
@@ -46,7 +47,7 @@
 #include "paimon/core/manifest/manifest_list.h"
 #include "paimon/core/operation/commit/commit_scanner.h"
 #include "paimon/core/operation/commit/manifest_entry_changes.h"
-#include "paimon/core/operation/commit/row_id_column_conflict_checker.h"
+#include "paimon/core/operation/commit/row_id_conflict_checker.h"
 #include "paimon/core/schema/table_schema.h"
 #include "paimon/core/table/bucket_mode.h"
 #include "paimon/core/utils/field_mapping.h"
@@ -63,6 +64,17 @@ bool IsDedicatedStorageFile(const std::string& file_name) {
     return BlobUtils::IsBlobFile(file_name) || VectorStoreUtils::IsVectorStoreFile(file_name);
 }
 
+/// The message both row id existence checks report, so a file is named the same way whichever
+/// of them rejected the commit.
+Status RowIdExistenceConflict(const ManifestEntry& entry) {
+    return Status::Invalid(fmt::format(
+        "Row ID existence conflict: file '{}' references firstRowId={}, rowCount={} in bucket "
+        "{}, but no matching file exists in the current snapshot. The referenced file may have "
+        "been rewritten by a concurrent compaction or removed by an overwrite.",
+        entry.FileName(), entry.File()->first_row_id.value(), entry.File()->row_count,
+        entry.Bucket()));
+}
+
 struct PartitionBucketKey {
     BinaryRow partition;
     int32_t bucket;
@@ -77,6 +89,72 @@ struct PartitionBucketKeyHash {
         return std::hash<BinaryRow>()(key.partition) ^ (std::hash<int32_t>()(key.bucket) << 1);
     }
 };
+
+/// A data file's identity within a table. A deletion vector belongs to one file of one
+/// partition and bucket, so keying by name alone would let entries of different buckets, or of
+/// a partition this commit does not touch, stand in for one another.
+struct DataFileKey {
+    BinaryRow partition;
+    int32_t bucket;
+    std::string file_name;
+
+    bool operator==(const DataFileKey& other) const {
+        return bucket == other.bucket && file_name == other.file_name &&
+               partition == other.partition;
+    }
+};
+
+struct DataFileKeyHash {
+    size_t operator()(const DataFileKey& key) const {
+        return std::hash<BinaryRow>()(key.partition) ^ (std::hash<int32_t>()(key.bucket) << 1) ^
+               (std::hash<std::string>()(key.file_name) << 2);
+    }
+};
+
+/// Where a data file's deletion vector lives and how many rows it deletes.
+struct DeletionVectorOwner {
+    std::string index_file_name;
+    std::optional<int64_t> cardinality;
+};
+
+using DeletionVectorOwners = std::unordered_map<DataFileKey, DeletionVectorOwner, DataFileKeyHash>;
+
+/// Indexes the deletion vectors of `entries` whose kind is `kind` by the data file each covers.
+/// Deletion-vector index metadata already records both, so nothing is deserialized here.
+///
+/// A data file may hold at most one vector, which `GlobalDeletionVectorCombiner` also enforces
+/// when the index manifest is written. Two entries claiming the same file mean the metadata this
+/// check reasons about is already inconsistent, so it is refused rather than resolved by
+/// whichever entry happens to come last.
+Result<DeletionVectorOwners> CollectDeletionVectorOwners(
+    const std::vector<IndexManifestEntry>& entries, const FileKind& kind) {
+    DeletionVectorOwners result;
+    for (const IndexManifestEntry& entry : entries) {
+        if (entry.index_file->IndexType() != DeletionVectorsIndexFile::DELETION_VECTORS_INDEX ||
+            !(entry.kind == kind)) {
+            continue;
+        }
+        const std::optional<LinkedHashMap<std::string, DeletionVectorMeta>>& dv_ranges =
+            entry.index_file->DvRanges();
+        if (dv_ranges == std::nullopt) {
+            continue;
+        }
+        for (const auto& [data_file_name, dv_meta] : dv_ranges.value()) {
+            DataFileKey key{entry.partition, entry.bucket, data_file_name};
+            auto inserted = result.emplace(
+                std::move(key),
+                DeletionVectorOwner{entry.index_file->FileName(), dv_meta.GetCardinality()});
+            if (!inserted.second) {
+                return Status::Invalid(fmt::format(
+                    "Data file {} has a deletion vector in both index file {} and index file {} "
+                    "of the same partition and bucket.",
+                    data_file_name, inserted.first->second.index_file_name,
+                    entry.index_file->FileName()));
+            }
+        }
+    }
+    return result;
+}
 
 }  // namespace
 
@@ -99,23 +177,35 @@ ConflictDetection::ConflictDetection(std::shared_ptr<TableSchema> table_schema,
       table_name_(table_name) {}
 
 void ConflictDetection::SetRowIdCheckFromSnapshot(
-    const std::optional<int64_t>& row_id_check_from_snapshot) {
+    const std::optional<int64_t>& row_id_check_from_snapshot, RowIdCheckStrategy strategy) {
     row_id_check_from_snapshot_ = row_id_check_from_snapshot;
+    row_id_check_strategy_ = strategy;
 }
 
 bool ConflictDetection::HasRowIdCheckFromSnapshot() const {
     return row_id_check_from_snapshot_.has_value();
 }
 
+bool ConflictDetection::RowIdCheckAppliesTo(const Snapshot::CommitKind& commit_kind) const {
+    if (!row_id_check_from_snapshot_) {
+        return false;
+    }
+    if (row_id_check_strategy_ == RowIdCheckStrategy::kMaterializeDeletionVectors) {
+        return commit_kind == Snapshot::CommitKind::Compact();
+    }
+    return true;
+}
+
 Status ConflictDetection::CheckConflicts(
     const Snapshot& latest_snapshot, const std::vector<ManifestEntry>& base_entries,
     const std::vector<ManifestEntry>& delta_entries,
     const std::vector<IndexManifestEntry>& delta_index_entries,
-    const std::optional<std::shared_ptr<RowIdColumnConflictChecker>>&
-        row_id_column_conflict_checker,
-    const Snapshot::CommitKind& commit_kind) const {
+    const std::optional<std::shared_ptr<RowIdConflictChecker>>& row_id_conflict_checker,
+    const Snapshot::CommitKind& commit_kind,
+    const std::vector<IndexManifestEntry>& base_index_entries) const {
     std::string base_commit_user = latest_snapshot.CommitUser();
-    PAIMON_RETURN_NOT_OK(CheckDeletionVectorsNotBypassed(delta_entries));
+    PAIMON_RETURN_NOT_OK(CheckDeletionVectorsNotBypassed(delta_entries, delta_index_entries,
+                                                         base_index_entries, commit_kind));
     std::vector<ManifestEntry> all_entries = base_entries;
     all_entries.insert(all_entries.end(), delta_entries.begin(), delta_entries.end());
     PAIMON_RETURN_NOT_OK(CheckBucketKeepSame(all_entries, commit_kind, base_commit_user,
@@ -142,14 +232,12 @@ Status ConflictDetection::CheckConflicts(
         CheckDeleteInEntries(merged_entries, base_commit_user, base_entries, delta_entries));
     PAIMON_RETURN_NOT_OK(
         CheckKeyRange(merged_entries, base_commit_user, base_entries, delta_entries));
-    if (commit_kind != Snapshot::CommitKind::Compact()) {
-        PAIMON_RETURN_NOT_OK(
-            CheckRowIdExistence(base_entries, delta_entries, latest_snapshot.NextRowId()));
-    }
+    PAIMON_RETURN_NOT_OK(
+        CheckRowIdExistence(base_entries, delta_entries, latest_snapshot.NextRowId(), commit_kind));
     PAIMON_RETURN_NOT_OK(CheckRowIdRangeConflicts(commit_kind, merged_entries));
     PAIMON_RETURN_NOT_OK(CheckGlobalIndexRowIdExistence(base_entries, delta_index_entries));
-    PAIMON_RETURN_NOT_OK(CheckForRowIdFromSnapshot(
-        latest_snapshot, delta_entries, delta_index_entries, row_id_column_conflict_checker));
+    PAIMON_RETURN_NOT_OK(CheckForRowIdFromSnapshot(latest_snapshot, delta_entries,
+                                                   delta_index_entries, row_id_conflict_checker));
     return Status::OK();
 }
 
@@ -171,11 +259,84 @@ bool ConflictDetection::ShouldBeOverwriteCommit(
     return false;
 }
 
+bool ConflictDetection::IsDataEvolutionCompaction(const Snapshot::CommitKind& commit_kind) const {
+    return commit_kind == Snapshot::CommitKind::Compact() && options_.DataEvolutionEnabled();
+}
+
+std::function<Result<bool>(const IndexManifestEntry&)> ConflictDetection::BaseIndexEntryFilter(
+    const std::vector<ManifestEntry>& delta_entries,
+    const std::vector<IndexManifestEntry>& delta_index_entries,
+    const Snapshot::CommitKind& commit_kind) const {
+    if (!options_.DeletionVectorsEnabled() ||
+        ResolveBucketMode(options_.GetBucket(), table_schema_) != BucketMode::BUCKET_UNAWARE ||
+        !IsDataEvolutionCompaction(commit_kind)) {
+        return nullptr;
+    }
+    // Only a commit that actually drops data files consults them.
+    auto dropped_data_files = std::make_shared<std::unordered_set<std::string>>();
+    auto touched_partitions = std::make_shared<std::unordered_set<BinaryRow>>();
+    for (const ManifestEntry& entry : delta_entries) {
+        if (entry.Kind() == FileKind::Delete()) {
+            dropped_data_files->insert(entry.File()->file_name);
+            touched_partitions->insert(entry.Partition());
+        }
+    }
+    if (dropped_data_files->empty()) {
+        return nullptr;
+    }
+    auto removed_index_files = std::make_shared<std::unordered_set<std::string>>();
+    for (const IndexManifestEntry& entry : delta_index_entries) {
+        if (entry.index_file->IndexType() == DeletionVectorsIndexFile::DELETION_VECTORS_INDEX &&
+            entry.kind == FileKind::Delete()) {
+            removed_index_files->insert(entry.index_file->FileName());
+        }
+    }
+
+    // Of the whole index manifest, only two kinds of entry can decide the migration: one this
+    // commit replaces, whose other vectors have to be carried over, and one holding the vector
+    // of a file this commit drops. Keeping only those bounds a round's memory by its own work
+    // on a large table. The manifest file itself is still read whole; this bounds what is kept
+    // from it, not the bytes read.
+    return [dropped_data_files, touched_partitions,
+            removed_index_files](const IndexManifestEntry& entry) -> Result<bool> {
+        if (entry.index_file->IndexType() != DeletionVectorsIndexFile::DELETION_VECTORS_INDEX ||
+            touched_partitions->count(entry.partition) == 0) {
+            return false;
+        }
+        if (removed_index_files->count(entry.index_file->FileName()) != 0) {
+            return true;
+        }
+        const std::optional<LinkedHashMap<std::string, DeletionVectorMeta>>& dv_ranges =
+            entry.index_file->DvRanges();
+        if (dv_ranges == std::nullopt) {
+            return false;
+        }
+        for (const auto& [data_file_name, _] : dv_ranges.value()) {
+            if (dropped_data_files->count(data_file_name) != 0) {
+                return true;
+            }
+        }
+        return false;
+    };
+}
+
 Status ConflictDetection::CheckDeletionVectorsNotBypassed(
-    const std::vector<ManifestEntry>& delta_entries) const {
+    const std::vector<ManifestEntry>& delta_entries,
+    const std::vector<IndexManifestEntry>& delta_index_entries,
+    const std::vector<IndexManifestEntry>& base_index_entries,
+    const Snapshot::CommitKind& commit_kind) const {
     if (!options_.DeletionVectorsEnabled() ||
         ResolveBucketMode(options_.GetBucket(), table_schema_) != BucketMode::BUCKET_UNAWARE) {
         return Status::OK();
+    }
+    if (IsDataEvolutionCompaction(commit_kind)) {
+        // A data-evolution compaction preserves row ids and rewrites files without applying
+        // their deletions, so DataEvolutionCompactDeletionVectorRewriter can move the vectors of
+        // the replaced row range groups onto the rewritten file and remove the index files that
+        // held them, all inside this commit. That is the migration the refusal below stands in
+        // for, so the shape is allowed — once the migration is verified to be complete.
+        return CheckDeletionVectorMigrationIsComplete(delta_entries, delta_index_entries,
+                                                      base_index_entries);
     }
     for (const ManifestEntry& entry : delta_entries) {
         if (entry.Kind() == FileKind::Delete()) {
@@ -184,6 +345,212 @@ Status ConflictDetection::CheckDeletionVectorsNotBypassed(
                 "are enabled on a table without buckets: the conflict between it and a concurrent "
                 "commit rewriting that file's deletion vector cannot be detected yet.",
                 entry.File()->file_name));
+        }
+    }
+    return Status::OK();
+}
+
+Status ConflictDetection::CheckDeletionVectorMigrationIsComplete(
+    const std::vector<ManifestEntry>& delta_entries,
+    const std::vector<IndexManifestEntry>& delta_index_entries,
+    const std::vector<IndexManifestEntry>& base_index_entries) const {
+    // What the *latest* snapshot records for each data file: which index file holds its vector
+    // and how many rows that vector deletes. Reading it here rather than from the snapshot the
+    // compaction planned against is what makes a vector another engine wrote in between visible.
+    PAIMON_ASSIGN_OR_RAISE(DeletionVectorOwners base_vector_by_data_file,
+                           CollectDeletionVectorOwners(base_index_entries, FileKind::Add()));
+    if (base_vector_by_data_file.empty()) {
+        return Status::OK();
+    }
+    PAIMON_ASSIGN_OR_RAISE(DeletionVectorOwners new_vector_by_data_file,
+                           CollectDeletionVectorOwners(delta_index_entries, FileKind::Add()));
+    std::unordered_set<std::string> removed_index_files;
+    for (const IndexManifestEntry& entry : delta_index_entries) {
+        if (entry.index_file->IndexType() == DeletionVectorsIndexFile::DELETION_VECTORS_INDEX &&
+            entry.kind == FileKind::Delete()) {
+            removed_index_files.insert(entry.index_file->FileName());
+        }
+    }
+
+    // The files this commit writes, by the row range each covers. A data-evolution compaction
+    // rewrites one contiguous run of rows into one file, so the dropped files a given output
+    // replaces are exactly those whose rows it now holds in the same partition and bucket —
+    // which is what says where each of their vectors has to end up. Blob and vector-store files
+    // are dedicated storage: they are never rewritten and never carry a vector, so a blob file
+    // spanning the same rows must not be mistaken for the output that took them over.
+    struct CompactOutput {
+        DataFileKey key;
+        Range row_range;
+        int64_t expected_cardinality = 0;
+        bool expected_cardinality_known = true;
+    };
+    std::vector<CompactOutput> outputs;
+    // Output indices of one partition and bucket, kept sorted by row range so a dropped file
+    // finds the output covering it by binary search. A round may plan a hundred thousand files
+    // into thousands of outputs, and scanning every output per dropped file would make this
+    // check quadratic in the size of the round.
+    std::unordered_map<PartitionBucketKey, std::vector<size_t>, PartitionBucketKeyHash>
+        outputs_by_group;
+    std::unordered_set<DataFileKey, DataFileKeyHash> dropped_data_files;
+    std::vector<const ManifestEntry*> dropped_entries;
+    // A materialized compaction physically applied its deletions and wrote its rows without row
+    // ids, which the commit then assigns afresh. Its old vectors are meant to disappear rather
+    // than move, so the group accounting below does not apply to the partitions it touched.
+    // Missing row ids on the rewritten files are what identifies such a commit.
+    std::unordered_set<PartitionBucketKey, PartitionBucketKeyHash> materialized_groups;
+    std::unordered_set<PartitionBucketKey, PartitionBucketKeyHash> groups_writing_data;
+    for (const ManifestEntry& entry : delta_entries) {
+        const std::shared_ptr<DataFileMeta>& file = entry.File();
+        if (IsDedicatedStorageFile(file->file_name)) {
+            continue;
+        }
+        DataFileKey key{entry.Partition(), entry.Bucket(), file->file_name};
+        if (entry.Kind() == FileKind::Add()) {
+            groups_writing_data.insert(PartitionBucketKey{entry.Partition(), entry.Bucket()});
+            if (file->first_row_id && file->row_count > 0) {
+                outputs_by_group[PartitionBucketKey{entry.Partition(), entry.Bucket()}].push_back(
+                    outputs.size());
+                outputs.push_back(CompactOutput{
+                    std::move(key), Range(file->first_row_id.value(),
+                                          file->first_row_id.value() + file->row_count - 1)});
+            } else if (file->first_row_id == std::nullopt) {
+                materialized_groups.insert(PartitionBucketKey{entry.Partition(), entry.Bucket()});
+            }
+            continue;
+        }
+        dropped_data_files.insert(std::move(key));
+        dropped_entries.push_back(&entry);
+    }
+    // The outputs of one group cover disjoint row ranges, so sorting by their start makes the
+    // last output starting at or before a dropped file's first row the only candidate.
+    for (auto& [group, output_indices] : outputs_by_group) {
+        std::sort(output_indices.begin(), output_indices.end(),
+                  [&outputs](size_t left, size_t right) {
+                      return outputs[left].row_range.from < outputs[right].row_range.from;
+                  });
+    }
+
+    for (const ManifestEntry* entry : dropped_entries) {
+        const std::shared_ptr<DataFileMeta>& file = entry->File();
+        DataFileKey dropped_key{entry->Partition(), entry->Bucket(), file->file_name};
+        auto owner = base_vector_by_data_file.find(dropped_key);
+        if (owner == base_vector_by_data_file.end()) {
+            continue;
+        }
+        // 1. The dropped file's vector outlives it. Either another commit re-keyed that vector
+        //    after the round was planned, or the round forgot to take it. No exception for a
+        //    vector that deletes nothing: the rewriter takes a replaced file's vector away
+        //    whether or not it is empty, exactly so this stays decidable from the recorded
+        //    cardinality, which older metadata may not carry at all.
+        if (removed_index_files.count(owner->second.index_file_name) == 0) {
+            return Status::Invalid(fmt::format(
+                "Data evolution compaction drops data file {}, but its deletion vector in index "
+                "file {} is not removed by the same commit. Another commit must have written that "
+                "vector after the compaction was planned; give up committing and plan again.",
+                file->file_name, owner->second.index_file_name));
+        }
+        if (owner->second.cardinality == 0) {
+            continue;
+        }
+        // The deletions of a materialized group were applied to the rows themselves, so nothing
+        // has to receive them; removing the vector, checked above, is the whole migration. The
+        // same holds when the commit writes no data file into the group at all: every row of the
+        // range was deleted, so it rewrites to nothing and there is no output to demand.
+        PartitionBucketKey group{entry->Partition(), entry->Bucket()};
+        if (materialized_groups.count(group) != 0 || groups_writing_data.count(group) == 0) {
+            continue;
+        }
+        // 2. The rows of a dropped file whose deletions have to move are not covered by any file
+        //    this commit writes into the same partition and bucket, so those deletions have
+        //    nowhere to go.
+        CompactOutput* output = nullptr;
+        auto group_outputs = outputs_by_group.find(group);
+        if (file->first_row_id && file->row_count > 0 && group_outputs != outputs_by_group.end()) {
+            Range dropped_range(file->first_row_id.value(),
+                                file->first_row_id.value() + file->row_count - 1);
+            const std::vector<size_t>& output_indices = group_outputs->second;
+            auto candidate =
+                std::upper_bound(output_indices.begin(), output_indices.end(), dropped_range.from,
+                                 [&outputs](int64_t from, size_t index) {
+                                     return from < outputs[index].row_range.from;
+                                 });
+            if (candidate != output_indices.begin()) {
+                CompactOutput& covering = outputs[*std::prev(candidate)];
+                if (dropped_range.to <= covering.row_range.to) {
+                    output = &covering;
+                }
+            }
+        }
+        if (output == nullptr) {
+            return Status::Invalid(fmt::format(
+                "Data evolution compaction drops data file {} and removes its deletion vector, "
+                "but writes no file covering its rows. Its deleted rows would become visible "
+                "again.",
+                file->file_name));
+        }
+        if (owner->second.cardinality) {
+            output->expected_cardinality += owner->second.cardinality.value();
+        } else {
+            output->expected_cardinality_known = false;
+        }
+    }
+
+    // 3. An output file has to carry the deletions of every group it absorbed. Their row ranges
+    //    are disjoint, so the merged vector deletes exactly as many rows as they did together;
+    //    any other count means deletions were dropped, or invented, along the way. Counts are
+    //    all this can compare: the recorded cardinality is metadata, and reading the vectors to
+    //    compare them position by position is what this check exists to avoid. An equally large
+    //    but differently positioned vector therefore passes.
+    for (const CompactOutput& output : outputs) {
+        // Nothing known to be deleted moved into this output, so it owes no vector. An
+        // absorbed vector whose cardinality the metadata does not record lands here too: it
+        // may well have been empty, and demanding a vector on that basis would reject a
+        // correct commit for good rather than for a race.
+        if (output.expected_cardinality == 0) {
+            continue;
+        }
+        auto moved = new_vector_by_data_file.find(output.key);
+        if (moved == new_vector_by_data_file.end()) {
+            return Status::Invalid(fmt::format(
+                "Data evolution compaction rewrites data files carrying {} deleted rows into {}, "
+                "but writes no deletion vector for it. Those rows would become visible again.",
+                output.expected_cardinality, output.key.file_name));
+        }
+        if (output.expected_cardinality_known && moved->second.cardinality &&
+            moved->second.cardinality.value() != output.expected_cardinality) {
+            return Status::Invalid(fmt::format(
+                "Data evolution compaction rewrites data files carrying {} deleted rows into {}, "
+                "but its new deletion vector deletes {} rows. The migration lost or invented "
+                "deletions.",
+                output.expected_cardinality, output.key.file_name,
+                moved->second.cardinality.value()));
+        }
+    }
+
+    // 4. A file the commit keeps loses the vector it had, or gets one deleting a different
+    //    number of rows, because the index file holding it is replaced without its vector being
+    //    carried over. Compared by cardinality only, for the same reason as check 3.
+    for (const auto& [data_file_key, base_vector] : base_vector_by_data_file) {
+        if (removed_index_files.count(base_vector.index_file_name) == 0 ||
+            dropped_data_files.count(data_file_key) != 0) {
+            continue;
+        }
+        auto kept = new_vector_by_data_file.find(data_file_key);
+        if (kept == new_vector_by_data_file.end()) {
+            return Status::Invalid(fmt::format(
+                "Data evolution compaction removes deletion vector index file {}, but data file "
+                "{}, which the commit keeps, does not get its vector back. Its deleted rows would "
+                "become visible again.",
+                base_vector.index_file_name, data_file_key.file_name));
+        }
+        if (base_vector.cardinality && kept->second.cardinality &&
+            base_vector.cardinality.value() != kept->second.cardinality.value()) {
+            return Status::Invalid(fmt::format(
+                "Data evolution compaction rewrites the deletion vector of data file {}, which it "
+                "keeps, from {} deleted rows to {}. An untouched vector has to be carried over "
+                "with the rows it deletes.",
+                data_file_key.file_name, base_vector.cardinality.value(),
+                kept->second.cardinality.value()));
         }
     }
     return Status::OK();
@@ -434,11 +801,76 @@ Status ConflictDetection::CheckKeyRange(const std::vector<ManifestEntry>& merged
 
 Status ConflictDetection::CheckRowIdExistence(const std::vector<ManifestEntry>& base_entries,
                                               const std::vector<ManifestEntry>& delta_entries,
-                                              const std::optional<int64_t>& next_row_id) const {
+                                              const std::optional<int64_t>& next_row_id,
+                                              const Snapshot::CommitKind& commit_kind) const {
     if (!options_.DataEvolutionEnabled()) {
         return Status::OK();
     }
 
+    std::vector<const ManifestEntry*> existing_data_files;
+    existing_data_files.reserve(base_entries.size());
+    for (const ManifestEntry& entry : base_entries) {
+        if (!entry.File()->first_row_id || IsDedicatedStorageFile(entry.FileName())) {
+            continue;
+        }
+        existing_data_files.push_back(&entry);
+    }
+
+    if (commit_kind == Snapshot::CommitKind::Compact()) {
+        return CheckCompactRowIdExistence(existing_data_files, delta_entries);
+    }
+    return CheckNonCompactRowIdExistence(existing_data_files, delta_entries, next_row_id);
+}
+
+Status ConflictDetection::CheckCompactRowIdExistence(
+    const std::vector<const ManifestEntry*>& existing_data_files,
+    const std::vector<ManifestEntry>& delta_entries) const {
+    // A compaction rewrites rows that are already in the table, so every row id range it adds
+    // has to be covered by the ranges the current snapshot holds - in the same partition and
+    // bucket, since an output may only span data files of one of them. A range that is not
+    // means the round was planned against rows a concurrent commit has since reassigned: the
+    // rewritten file would move those row ids back to where they no longer belong.
+    std::unordered_map<PartitionBucketKey, std::vector<Range>, PartitionBucketKeyHash>
+        existing_ranges;
+    for (const ManifestEntry* entry : existing_data_files) {
+        int64_t range_from = entry->File()->first_row_id.value();
+        int64_t range_to = range_from + entry->File()->row_count - 1;
+        existing_ranges[PartitionBucketKey{entry->Partition(), entry->Bucket()}].emplace_back(
+            range_from, range_to);
+    }
+
+    std::unordered_map<PartitionBucketKey, RowRangeIndex, PartitionBucketKeyHash> existing_indexes;
+    for (auto& [key, ranges] : existing_ranges) {
+        // Adjacent ranges are merged: one output file may take over a contiguous run of them.
+        PAIMON_ASSIGN_OR_RAISE(RowRangeIndex index,
+                               RowRangeIndex::Create(ranges, /*merge_adjacent=*/true));
+        existing_indexes.emplace(key, std::move(index));
+    }
+
+    for (const ManifestEntry& entry : delta_entries) {
+        // A dedicated storage file is left to CheckDedicatedFileRowIdRangeConflicts, which
+        // holds it to the stricter rule: its range has to sit inside the range of a single
+        // data file, not merely inside a contiguous run of them.
+        if (!(entry.Kind() == FileKind::Add()) || !entry.File()->first_row_id ||
+            IsDedicatedStorageFile(entry.FileName())) {
+            continue;
+        }
+        int64_t range_from = entry.File()->first_row_id.value();
+        Range row_range(range_from, range_from + entry.File()->row_count - 1);
+        auto existing_index =
+            existing_indexes.find(PartitionBucketKey{entry.Partition(), entry.Bucket()});
+        if (existing_index == existing_indexes.end() ||
+            !existing_index->second.Contains(row_range)) {
+            return RowIdExistenceConflict(entry);
+        }
+    }
+    return Status::OK();
+}
+
+Status ConflictDetection::CheckNonCompactRowIdExistence(
+    const std::vector<const ManifestEntry*>& existing_data_files,
+    const std::vector<ManifestEntry>& delta_entries,
+    const std::optional<int64_t>& next_row_id) const {
     std::vector<ManifestEntry> files_to_check;
     files_to_check.reserve(delta_entries.size());
     for (const ManifestEntry& entry : delta_entries) {
@@ -453,13 +885,10 @@ Status ConflictDetection::CheckRowIdExistence(const std::vector<ManifestEntry>& 
     }
 
     std::vector<Range> existing_data_ranges;
-    existing_data_ranges.reserve(base_entries.size());
-    for (const ManifestEntry& entry : base_entries) {
-        if (!entry.File()->first_row_id || IsDedicatedStorageFile(entry.FileName())) {
-            continue;
-        }
-        int64_t range_from = entry.File()->first_row_id.value();
-        int64_t range_to = range_from + entry.File()->row_count - 1;
+    existing_data_ranges.reserve(existing_data_files.size());
+    for (const ManifestEntry* entry : existing_data_files) {
+        int64_t range_from = entry->File()->first_row_id.value();
+        int64_t range_to = range_from + entry->File()->row_count - 1;
         existing_data_ranges.emplace_back(range_from, range_to);
     }
 
@@ -480,13 +909,7 @@ Status ConflictDetection::CheckRowIdExistence(const std::vector<ManifestEntry>& 
         }
 
         if (!exists) {
-            return Status::Invalid(fmt::format(
-                "Row ID existence conflict: file '{}' references firstRowId={}, rowCount={} in "
-                "bucket {}, but no matching file exists in the current snapshot. The referenced "
-                "file may have been rewritten by a concurrent compaction or removed by an "
-                "overwrite.",
-                entry.FileName(), entry.File()->first_row_id.value(), entry.File()->row_count,
-                entry.Bucket()));
+            return RowIdExistenceConflict(entry);
         }
     }
 
@@ -624,11 +1047,10 @@ Status ConflictDetection::CheckDedicatedFileRowIdRangeConflicts(
 Status ConflictDetection::CheckForRowIdFromSnapshot(
     const Snapshot& latest_snapshot, const std::vector<ManifestEntry>& delta_entries,
     const std::vector<IndexManifestEntry>& delta_index_entries,
-    const std::optional<std::shared_ptr<RowIdColumnConflictChecker>>&
-        row_id_column_conflict_checker) const {
+    const std::optional<std::shared_ptr<RowIdConflictChecker>>& row_id_conflict_checker) const {
     if (!options_.DataEvolutionEnabled() || !row_id_check_from_snapshot_ || !snapshot_manager_ ||
-        !row_id_column_conflict_checker || !row_id_column_conflict_checker.value() ||
-        row_id_column_conflict_checker.value()->IsEmpty()) {
+        !row_id_conflict_checker || !row_id_conflict_checker.value() ||
+        row_id_conflict_checker.value()->IsEmpty()) {
         return Status::OK();
     }
 
@@ -680,9 +1102,8 @@ Status ConflictDetection::CheckForRowIdFromSnapshot(
             if (history_first_row_id >= check_next_row_id) {
                 continue;
             }
-            PAIMON_ASSIGN_OR_RAISE(
-                bool conflicts,
-                row_id_column_conflict_checker.value()->ConflictsWith(history_entry.File()));
+            PAIMON_ASSIGN_OR_RAISE(bool conflicts, row_id_conflict_checker.value()->ConflictsWith(
+                                                       history_entry.File()));
             if (conflicts) {
                 return Status::Invalid(
                     "For Data Evolution table, multiple 'MERGE INTO' operations have "

--- a/src/paimon/core/operation/commit/conflict_detection.h
+++ b/src/paimon/core/operation/commit/conflict_detection.h
@@ -42,7 +42,7 @@ class CommitScanner;
 class FileStorePathFactory;
 class ManifestFile;
 class ManifestList;
-class RowIdColumnConflictChecker;
+class RowIdConflictChecker;
 class SnapshotManager;
 class TableSchema;
 
@@ -57,17 +57,53 @@ class ConflictDetection {
                       const std::string& table_name,
                       const std::shared_ptr<FileStorePathFactory>& path_factory);
 
-    Status CheckConflicts(const Snapshot& latest_snapshot,
-                          const std::vector<ManifestEntry>& base_entries,
-                          const std::vector<ManifestEntry>& delta_entries,
-                          const std::vector<IndexManifestEntry>& delta_index_entries,
-                          const std::optional<std::shared_ptr<RowIdColumnConflictChecker>>&
-                              row_id_column_conflict_checker,
-                          const Snapshot::CommitKind& commit_kind) const;
+    /// @param base_index_entries The index entries of `latest_snapshot`, needed only by
+    ///     `CheckDeletionVectorsNotBypassed` for the one commit shape that pairs data files
+    ///     with their deletion vectors. `BaseIndexEntryFilter` says whether to read them and
+    ///     which ones; every other caller passes none.
+    Status CheckConflicts(
+        const Snapshot& latest_snapshot, const std::vector<ManifestEntry>& base_entries,
+        const std::vector<ManifestEntry>& delta_entries,
+        const std::vector<IndexManifestEntry>& delta_index_entries,
+        const std::optional<std::shared_ptr<RowIdConflictChecker>>& row_id_conflict_checker,
+        const Snapshot::CommitKind& commit_kind,
+        const std::vector<IndexManifestEntry>& base_index_entries = {}) const;
 
-    void SetRowIdCheckFromSnapshot(const std::optional<int64_t>& row_id_check_from_snapshot);
+    /// Selects the base snapshot's index entries `CheckConflicts` needs for this commit, or
+    /// returns an empty function when it needs none and the read can be skipped entirely.
+    ///
+    /// Only the entries that can decide the deletion-vector migration are kept, so a round of a
+    /// batched compaction retains what its own work touches rather than the table's whole
+    /// deletion-vector index.
+    std::function<Result<bool>(const IndexManifestEntry&)> BaseIndexEntryFilter(
+        const std::vector<ManifestEntry>& delta_entries,
+        const std::vector<IndexManifestEntry>& delta_index_entries,
+        const Snapshot::CommitKind& commit_kind) const;
+
+    /// Which rule the row id conflict check follows. The commit that enables the check picks
+    /// it, the way it picks the snapshot to check from.
+    enum class RowIdCheckStrategy {
+        /// A partial-column update: a historical file conflicts only when it wrote the same
+        /// columns over the same rows.
+        kDataEvolutionDml,
+        /// A commit that materializes deletion vectors: it takes the rows of the ranges it
+        /// rewrites away, so any historical file over those ranges conflicts.
+        kMaterializeDeletionVectors,
+    };
+
+    void SetRowIdCheckFromSnapshot(
+        const std::optional<int64_t>& row_id_check_from_snapshot,
+        RowIdCheckStrategy strategy = RowIdCheckStrategy::kDataEvolutionDml);
 
     bool HasRowIdCheckFromSnapshot() const;
+
+    /// Whether the configured check runs for this commit kind. The materialize rule only ever
+    /// applies to a compaction commit, which is the only shape that reassigns row ids.
+    bool RowIdCheckAppliesTo(const Snapshot::CommitKind& commit_kind) const;
+
+    RowIdCheckStrategy GetRowIdCheckStrategy() const {
+        return row_id_check_strategy_;
+    }
 
     bool ShouldBeOverwriteCommit(const std::vector<ManifestEntry>& append_table_files,
                                  const std::vector<IndexManifestEntry>& append_index_files) const;
@@ -84,13 +120,41 @@ class ConflictDetection {
     /// Refuses a delta that drops data files from a bucket-unaware table with deletion vectors.
     ///
     /// Such a table keeps its vectors in the index manifest, which the data file entries
-    /// compared here do not reference. Paimon Java pairs the two first
-    /// (ConflictDetection#buildBaseEntriesWithDV) so that dropping a data file conflicts with a
-    /// concurrent commit rewriting that file's vector; that pairing is not ported, so the shape
+    /// compared here do not reference. Pairing the two, so that dropping a data file conflicts
+    /// with a concurrent commit rewriting that file's vector, is not implemented, so the shape
     /// needing it is refused rather than let through unchecked. Adding files cannot orphan a
     /// vector and stays allowed, as does replacing one, which travels through the delta index
     /// entries this check does not inspect.
-    Status CheckDeletionVectorsNotBypassed(const std::vector<ManifestEntry>& delta_entries) const;
+    ///
+    /// The exception is a data-evolution compaction, which drops data files *and* carries the
+    /// migration of their vectors: it re-keys them onto the rewritten file and removes the index
+    /// files that held them in the same commit. For that shape the pairing is checked directly
+    /// against `base_index_entries`, so a vector left behind by another engine still fails the
+    /// commit rather than being orphaned together with its data file.
+    Status CheckDeletionVectorsNotBypassed(
+        const std::vector<ManifestEntry>& delta_entries,
+        const std::vector<IndexManifestEntry>& delta_index_entries,
+        const std::vector<IndexManifestEntry>& base_index_entries,
+        const Snapshot::CommitKind& commit_kind) const;
+
+    /// Whether `commit_kind` is the data-evolution compaction that migrates its own deletion
+    /// vectors, on a table whose vectors are keyed by data file alone.
+    bool IsDataEvolutionCompaction(const Snapshot::CommitKind& commit_kind) const;
+
+    /// Verifies that the deletions a data-evolution compaction inherits really do end up on the
+    /// files it writes, given the vectors the base snapshot holds and the index changes the
+    /// commit carries. Each dropped file is attributed to the output whose row range covers it,
+    /// so the accounting is per compact group rather than per partition; the four ways it can
+    /// fail are numbered in the implementation.
+    ///
+    /// Everything is decided from index metadata: which index file holds a vector and how many
+    /// rows it deletes. No vector is read, so a vector deleting the right number of *wrong*
+    /// rows passes — reading every vector back to prove otherwise is the cost this check exists
+    /// to avoid.
+    Status CheckDeletionVectorMigrationIsComplete(
+        const std::vector<ManifestEntry>& delta_entries,
+        const std::vector<IndexManifestEntry>& delta_index_entries,
+        const std::vector<IndexManifestEntry>& base_index_entries) const;
 
     Status CheckBucketKeepSame(const std::vector<ManifestEntry>& all_entries,
                                const Snapshot::CommitKind& commit_kind,
@@ -125,9 +189,24 @@ class ConflictDetection {
                          const std::vector<ManifestEntry>& base_entries,
                          const std::vector<ManifestEntry>& delta_entries) const;
 
+    /// Checks that every row id range this commit adds is one the table already holds.
+    ///
+    /// A compaction rewrites rows that exist, so its outputs are checked against the ranges of
+    /// their own partition and bucket; every other commit kind assigns fresh row ids, so only
+    /// the files reusing a row id below `next_row_id` are checked, and against the exact range
+    /// they claim to replace.
     Status CheckRowIdExistence(const std::vector<ManifestEntry>& base_entries,
                                const std::vector<ManifestEntry>& delta_entries,
-                               const std::optional<int64_t>& next_row_id) const;
+                               const std::optional<int64_t>& next_row_id,
+                               const Snapshot::CommitKind& commit_kind) const;
+
+    Status CheckCompactRowIdExistence(const std::vector<const ManifestEntry*>& existing_data_files,
+                                      const std::vector<ManifestEntry>& delta_entries) const;
+
+    Status CheckNonCompactRowIdExistence(
+        const std::vector<const ManifestEntry*>& existing_data_files,
+        const std::vector<ManifestEntry>& delta_entries,
+        const std::optional<int64_t>& next_row_id) const;
 
     Status CheckRowIdRangeConflicts(const Snapshot::CommitKind& commit_kind,
                                     const std::vector<ManifestEntry>& merged_entries) const;
@@ -142,8 +221,7 @@ class ConflictDetection {
     Status CheckForRowIdFromSnapshot(
         const Snapshot& latest_snapshot, const std::vector<ManifestEntry>& delta_entries,
         const std::vector<IndexManifestEntry>& delta_index_entries,
-        const std::optional<std::shared_ptr<RowIdColumnConflictChecker>>&
-            row_id_column_conflict_checker) const;
+        const std::optional<std::shared_ptr<RowIdConflictChecker>>& row_id_conflict_checker) const;
 
     Status CheckGlobalIndexRowIdExistence(
         const std::vector<ManifestEntry>& base_entries,
@@ -155,6 +233,7 @@ class ConflictDetection {
     std::shared_ptr<TableSchema> table_schema_;
     CoreOptions options_;
     std::optional<int64_t> row_id_check_from_snapshot_;
+    RowIdCheckStrategy row_id_check_strategy_ = RowIdCheckStrategy::kDataEvolutionDml;
     std::shared_ptr<SnapshotManager> snapshot_manager_;
     std::shared_ptr<ManifestList> manifest_list_;
     std::shared_ptr<ManifestFile> manifest_file_;

--- a/src/paimon/core/operation/commit/conflict_detection_test.cpp
+++ b/src/paimon/core/operation/commit/conflict_detection_test.cpp
@@ -19,6 +19,8 @@
 
 #include "paimon/core/operation/commit/conflict_detection.h"
 
+#include <optional>
+
 #include "arrow/c/abi.h"
 #include "arrow/c/bridge.h"
 #include "arrow/type.h"
@@ -99,7 +101,7 @@ Status CheckConflicts(const ConflictDetection& detection,
                       const Snapshot::CommitKind& commit_kind) {
     return detection.CheckConflicts(MakeSnapshot(commit_kind), base_entries, delta_entries,
                                     /*delta_index_entries=*/{},
-                                    /*row_id_column_conflict_checker=*/std::nullopt, commit_kind);
+                                    /*row_id_conflict_checker=*/std::nullopt, commit_kind);
 }
 
 Status CheckConflicts(const ConflictDetection& detection,
@@ -109,7 +111,7 @@ Status CheckConflicts(const ConflictDetection& detection,
                       const Snapshot::CommitKind& commit_kind) {
     return detection.CheckConflicts(MakeSnapshot(commit_kind), base_entries, delta_entries,
                                     delta_index_entries,
-                                    /*row_id_column_conflict_checker=*/std::nullopt, commit_kind);
+                                    /*row_id_conflict_checker=*/std::nullopt, commit_kind);
 }
 
 Status CheckConflictsWithNextRowId(const ConflictDetection& detection,
@@ -120,7 +122,7 @@ Status CheckConflictsWithNextRowId(const ConflictDetection& detection,
     return detection.CheckConflicts(MakeSnapshotWithNextRowId(commit_kind, next_row_id),
                                     base_entries, delta_entries,
                                     /*delta_index_entries=*/{},
-                                    /*row_id_column_conflict_checker=*/std::nullopt, commit_kind);
+                                    /*row_id_conflict_checker=*/std::nullopt, commit_kind);
 }
 
 }  // namespace
@@ -225,6 +227,27 @@ class ConflictDetectionTest : public testing::Test {
             DeletionVectorsIndexFile::DELETION_VECTORS_INDEX, file_name, /*file_size=*/100,
             /*row_count=*/1, /*dv_ranges=*/std::nullopt, /*external_path=*/std::nullopt);
         return IndexManifestEntry(FileKind::Add(), partition, bucket, index_file_meta);
+    }
+
+    /// A deletion-vector index entry that records a vector for each of `covered_data_files`,
+    /// which is what pairs a data file with the index file holding its deletions. A nullopt
+    /// cardinality is what index metadata written before Paimon recorded it looks like.
+    IndexManifestEntry CreateDvIndexEntry(const std::string& file_name, const BinaryRow& partition,
+                                          int32_t bucket, const FileKind& kind,
+                                          const std::vector<std::string>& covered_data_files,
+                                          std::optional<int64_t> cardinality = 1) const {
+        LinkedHashMap<std::string, DeletionVectorMeta> dv_ranges;
+        int32_t offset = 1;
+        for (const std::string& data_file : covered_data_files) {
+            dv_ranges.insert_or_assign(
+                data_file, DeletionVectorMeta(data_file, offset, /*length=*/8, cardinality));
+            offset += 8;
+        }
+        auto index_file_meta = std::make_shared<IndexFileMeta>(
+            DeletionVectorsIndexFile::DELETION_VECTORS_INDEX, file_name, /*file_size=*/100,
+            /*row_count=*/static_cast<int64_t>(covered_data_files.size()), dv_ranges,
+            /*external_path=*/std::nullopt);
+        return IndexManifestEntry(kind, partition, bucket, index_file_meta);
     }
 
     BinaryRow CreateIntRow(int32_t value) const {
@@ -602,6 +625,434 @@ TEST_F(ConflictDetectionTest, TestDeletionVectorsAllowedWithBucketUnawareMode) {
         "Committing the deletion of data file dropped.parquet is not supported");
 }
 
+namespace {
+
+/// The pieces every data-evolution compaction conflict test needs: a table whose deletion
+/// vectors are keyed by data file alone, and a detector over it.
+ConflictDetection DataEvolutionDetector(const std::shared_ptr<TableSchema>& table_schema,
+                                        const CoreOptions& core_options) {
+    return ConflictDetection(table_schema, core_options, /*snapshot_manager=*/nullptr,
+                             /*manifest_list=*/nullptr, /*manifest_file=*/nullptr,
+                             /*commit_scanner=*/nullptr, "test_user", "test_table",
+                             /*path_factory=*/nullptr);
+}
+
+Status CheckCompaction(const ConflictDetection& detection,
+                       const std::vector<ManifestEntry>& base_entries,
+                       const std::vector<ManifestEntry>& delta_entries,
+                       const std::vector<IndexManifestEntry>& delta_index_entries,
+                       const std::vector<IndexManifestEntry>& base_index_entries) {
+    return detection.CheckConflicts(MakeSnapshot(Snapshot::CommitKind::Compact()), base_entries,
+                                    delta_entries, delta_index_entries,
+                                    /*row_id_conflict_checker=*/std::nullopt,
+                                    Snapshot::CommitKind::Compact(), base_index_entries);
+}
+
+}  // namespace
+
+/// A data-evolution table whose files carry row ids, which is what lets the migration check
+/// attribute each dropped file to the output that took over its rows.
+class DataEvolutionConflictDetectionTest : public ConflictDetectionTest {
+ protected:
+    void SetUp() override {
+        ConflictDetectionTest::SetUp();
+        ASSERT_OK_AND_ASSIGN(
+            table_schema_,
+            TableSchema::Create(/*schema_id=*/0, arrow::schema(fields_), /*partition_keys=*/{"f1"},
+                                /*primary_keys=*/{}, /*options=*/{}));
+        ASSERT_OK_AND_ASSIGN(core_options_,
+                             CoreOptions::FromMap({{Options::BUCKET, "-1"},
+                                                   {Options::DELETION_VECTORS_ENABLED, "true"},
+                                                   {Options::ROW_TRACKING_ENABLED, "true"},
+                                                   {Options::DATA_EVOLUTION_ENABLED, "true"}}));
+        partition_ = CreateIntRow(10);
+    }
+
+    ManifestEntry DataFile(const std::string& file_name, const FileKind& kind, int64_t first_row_id,
+                           int64_t row_count) const {
+        return CreateManifestEntryWithFirstRowId(file_name, partition_, kind, /*bucket=*/0,
+                                                 first_row_id, row_count);
+    }
+
+    IndexManifestEntry DvIndex(const std::string& file_name, const FileKind& kind,
+                               const std::vector<std::string>& covered_data_files,
+                               std::optional<int64_t> cardinality = 1) const {
+        return CreateDvIndexEntry(file_name, partition_, /*bucket=*/0, kind, covered_data_files,
+                                  cardinality);
+    }
+
+    std::shared_ptr<TableSchema> table_schema_;
+    CoreOptions core_options_;
+    BinaryRow partition_;
+};
+
+TEST_F(DataEvolutionConflictDetectionTest, TestMayDropDataFilesWithDeletionVectors) {
+    // A data-evolution compaction is the one shape that drops data files and migrates their
+    // deletion vectors in the same commit, so the blanket refusal must not apply to it. Without
+    // this carve-out the whole compaction of such a table cannot be committed at all.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    // The files the compaction replaces have to be live in the base, or the generic delete check
+    // rejects the commit before the deletion-vector accounting is reached. That is what
+    // FileStoreCommitImpl hands in: the existing files of the changed partitions.
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("field-group.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+    std::vector<ManifestEntry> compact_delta = {
+        DataFile("anchor.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("field-group.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("compacted.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+
+    // The base holds the anchor's vector in dv-1, and the commit removes dv-1 while giving the
+    // compacted file a vector deleting the same number of rows.
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-1", FileKind::Add(), {"anchor.parquet"})};
+    std::vector<IndexManifestEntry> delta_index_entries = {
+        DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet"}),
+        DvIndex("dv-2", FileKind::Add(), {"compacted.parquet"})};
+    ASSERT_OK(CheckCompaction(detection, base_entries, compact_delta, delta_index_entries,
+                              base_index_entries));
+
+    // The base index entries are read through a filter that keeps only what can decide this
+    // migration, so a round of a batched compaction does not retain the whole table's index.
+    std::function<Result<bool>(const IndexManifestEntry&)> filter = detection.BaseIndexEntryFilter(
+        compact_delta, delta_index_entries, Snapshot::CommitKind::Compact());
+    ASSERT_TRUE(filter != nullptr);
+    // Kept: the index file this commit replaces, and one holding a dropped file's vector.
+    ASSERT_OK_AND_ASSIGN(bool kept, filter(base_index_entries[0]));
+    ASSERT_TRUE(kept);
+    ASSERT_OK_AND_ASSIGN(kept, filter(DvIndex("dv-other", FileKind::Add(), {"anchor.parquet"})));
+    ASSERT_TRUE(kept);
+    // Dropped: a vector of a file this commit does not touch, and another partition's.
+    ASSERT_OK_AND_ASSIGN(kept,
+                         filter(DvIndex("dv-elsewhere", FileKind::Add(), {"unrelated.parquet"})));
+    ASSERT_FALSE(kept);
+    ASSERT_OK_AND_ASSIGN(kept, filter(CreateDvIndexEntry("dv-p2", CreateIntRow(11), /*bucket=*/0,
+                                                         FileKind::Add(), {"anchor.parquet"})));
+    ASSERT_FALSE(kept);
+
+    // A partition with no vectors at all needs no accounting.
+    ASSERT_OK(CheckCompaction(detection, base_entries, compact_delta, delta_index_entries,
+                              /*base_index_entries=*/{}));
+
+    // An append on the same table still refuses to drop a data file: it carries no migration.
+    ASSERT_NOK_WITH_MSG(
+        CheckConflicts(detection, {CreateManifestEntry("anchor.parquet", FileKind::Add())},
+                       {CreateManifestEntry("anchor.parquet", FileKind::Delete())},
+                       Snapshot::CommitKind::Append()),
+        "Committing the deletion of data file anchor.parquet is not supported");
+    ASSERT_TRUE(detection.BaseIndexEntryFilter(compact_delta, delta_index_entries,
+                                               Snapshot::CommitKind::Append()) == nullptr);
+}
+
+TEST_F(DataEvolutionConflictDetectionTest, TestRefusesLeavingBehindADeletionVector) {
+    // Another engine wrote a vector for the anchor after the round was planned, so the
+    // compaction's own index changes do not cover it. Committing anyway would drop the anchor
+    // while the new vector kept pointing at it, and its deleted rows would come back.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+    std::vector<ManifestEntry> compact_delta = {
+        DataFile("anchor.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("compacted.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+    // The latest snapshot keys the anchor's vector by dv-concurrent, which this commit does not
+    // remove; it only adds the vector it moved onto the compacted file.
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-concurrent", FileKind::Add(), {"anchor.parquet"})};
+    std::vector<IndexManifestEntry> delta_index_entries = {
+        DvIndex("dv-2", FileKind::Add(), {"compacted.parquet"})};
+
+    ASSERT_NOK_WITH_MSG(
+        CheckCompaction(detection, base_entries, compact_delta, delta_index_entries,
+                        base_index_entries),
+        "its deletion vector in index file dv-concurrent is not removed by the same commit");
+}
+
+TEST_F(DataEvolutionConflictDetectionTest, TestRefusesLosingTheDroppedDeletions) {
+    // The commit removes the index file that held the anchor's vector but writes no vector for
+    // the file it rewrote the group into, so those deletions land nowhere.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+    std::vector<ManifestEntry> compact_delta = {
+        DataFile("anchor.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("compacted.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-1", FileKind::Add(), {"anchor.parquet"})};
+    // dv-1 goes away and nothing takes its place.
+    std::vector<IndexManifestEntry> delta_index_entries = {
+        DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet"})};
+
+    ASSERT_NOK_WITH_MSG(CheckCompaction(detection, base_entries, compact_delta, delta_index_entries,
+                                        base_index_entries),
+                        "but writes no deletion vector for it");
+
+    // A vector that deletes nothing still has to be taken away with the file it was keyed by:
+    // the rewriter removes it whether or not it is empty, so an entry outliving its data file
+    // is a migration that did not happen, not a harmless leftover.
+    ASSERT_NOK_WITH_MSG(CheckCompaction(detection, base_entries, compact_delta,
+                                        /*delta_index_entries=*/{},
+                                        {DvIndex("dv-1", FileKind::Add(), {"anchor.parquet"},
+                                                 /*cardinality=*/0)}),
+                        "its deletion vector in index file dv-1 is not removed by the same "
+                        "commit");
+
+    // Taken away, and no vector demanded of the output in return: nothing was deleted, so
+    // nothing had to move.
+    ASSERT_OK(CheckCompaction(detection, base_entries, compact_delta,
+                              {DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet"},
+                                       /*cardinality=*/0)},
+                              {DvIndex("dv-1", FileKind::Add(), {"anchor.parquet"},
+                                       /*cardinality=*/0)}));
+
+    // Index metadata old enough not to record a cardinality at all. The vector may well have
+    // been empty, so demanding one for the output would reject a correct commit for good
+    // instead of for a race - and unlike a race, replanning would never make it pass.
+    ASSERT_OK(CheckCompaction(detection, base_entries, compact_delta,
+                              {DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet"},
+                                       /*cardinality=*/std::nullopt)},
+                              {DvIndex("dv-1", FileKind::Add(), {"anchor.parquet"},
+                                       /*cardinality=*/std::nullopt)}));
+}
+
+TEST_F(DataEvolutionConflictDetectionTest, TestRefusesLosingOneGroupOfSeveral) {
+    // Two groups compacted in the same commit, both carrying deletions, but only one output gets
+    // a vector. Accounting per partition would accept this; accounting per group does not.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor-a.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("anchor-b.parquet", FileKind::Add(), /*first_row_id=*/4, /*row_count=*/2)};
+    std::vector<ManifestEntry> compact_delta = {
+        DataFile("anchor-a.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("anchor-b.parquet", FileKind::Delete(), /*first_row_id=*/4, /*row_count=*/2),
+        DataFile("compacted-a.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("compacted-b.parquet", FileKind::Add(), /*first_row_id=*/4, /*row_count=*/2)};
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-1", FileKind::Add(), {"anchor-a.parquet", "anchor-b.parquet"})};
+
+    ASSERT_NOK_WITH_MSG(CheckCompaction(detection, base_entries, compact_delta,
+                                        {DvIndex("dv-1", FileKind::Delete(),
+                                                 {"anchor-a.parquet", "anchor-b.parquet"}),
+                                         DvIndex("dv-2", FileKind::Add(), {"compacted-a.parquet"})},
+                                        base_index_entries),
+                        "compacted-b.parquet, but writes no deletion vector for it");
+
+    // Both groups carried over is what the rewriter produces, and that commit is accepted.
+    ASSERT_OK(CheckCompaction(
+        detection, base_entries, compact_delta,
+        {DvIndex("dv-1", FileKind::Delete(), {"anchor-a.parquet", "anchor-b.parquet"}),
+         DvIndex("dv-2", FileKind::Add(), {"compacted-a.parquet", "compacted-b.parquet"})},
+        base_index_entries));
+}
+
+TEST_F(DataEvolutionConflictDetectionTest, TestRefusesADroppedGroupNoOutputCoversItsRows) {
+    // The commit compacts one group of the partition and drops a second one whose rows no
+    // output covers. Its vector is removed with it, so those deletions have nowhere to go and
+    // the rows they hid would come back. The partition does write data, which is what tells
+    // this apart from a range that was rewritten to nothing at all.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor-a.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("anchor-b.parquet", FileKind::Add(), /*first_row_id=*/4, /*row_count=*/2)};
+    // Both groups are dropped, but only the second one is rewritten.
+    std::vector<ManifestEntry> compact_delta = {
+        DataFile("anchor-a.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("anchor-b.parquet", FileKind::Delete(), /*first_row_id=*/4, /*row_count=*/2),
+        DataFile("compacted-b.parquet", FileKind::Add(), /*first_row_id=*/4, /*row_count=*/2)};
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-1", FileKind::Add(), {"anchor-a.parquet"})};
+    std::vector<IndexManifestEntry> delta_index_entries = {
+        DvIndex("dv-1", FileKind::Delete(), {"anchor-a.parquet"})};
+
+    ASSERT_NOK_WITH_MSG(CheckCompaction(detection, base_entries, compact_delta, delta_index_entries,
+                                        base_index_entries),
+                        "drops data file anchor-a.parquet and removes its deletion vector, but "
+                        "writes no file covering its rows");
+
+    // Rewriting that group too, with its deletions moved onto the output, is accepted.
+    std::vector<ManifestEntry> full_compact_delta = compact_delta;
+    full_compact_delta.push_back(
+        DataFile("compacted-a.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2));
+    ASSERT_OK(CheckCompaction(detection, base_entries, full_compact_delta,
+                              {DvIndex("dv-1", FileKind::Delete(), {"anchor-a.parquet"}),
+                               DvIndex("dv-2", FileKind::Add(), {"compacted-a.parquet"})},
+                              base_index_entries));
+}
+
+TEST_F(DataEvolutionConflictDetectionTest, TestRefusesTwoIndexFilesClaimingTheSameDataFile) {
+    // A data file is covered by at most one deletion vector, so two index files of the same
+    // partition and bucket claiming the same file leave the migration undecidable: which
+    // cardinality the output has to carry over depends on which one is believed. The commit is
+    // refused rather than resolved by iteration order.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+    std::vector<ManifestEntry> compact_delta = {
+        DataFile("anchor.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("compacted.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-1", FileKind::Add(), {"anchor.parquet"}),
+        DvIndex("dv-2", FileKind::Add(), {"anchor.parquet"})};
+    std::vector<IndexManifestEntry> delta_index_entries = {
+        DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet"}),
+        DvIndex("dv-3", FileKind::Add(), {"compacted.parquet"})};
+
+    ASSERT_NOK_WITH_MSG(CheckCompaction(detection, base_entries, compact_delta, delta_index_entries,
+                                        base_index_entries),
+                        "anchor.parquet has a deletion vector in both index file");
+}
+
+TEST_F(DataEvolutionConflictDetectionTest, TestRefusesAShrunkenMigratedDeletionVector) {
+    // The vector reaches the compacted file but deletes fewer rows than the groups it absorbed.
+    // Row ranges of distinct groups are disjoint, so the merged vector has to delete exactly as
+    // many rows as they did together.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/20)};
+    std::vector<ManifestEntry> compact_delta = {
+        DataFile("anchor.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/20),
+        DataFile("compacted.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/20)};
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-1", FileKind::Add(), {"anchor.parquet"}, /*cardinality=*/10)};
+
+    ASSERT_NOK_WITH_MSG(
+        CheckCompaction(
+            detection, base_entries, compact_delta,
+            {DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet"}, /*cardinality=*/10),
+             DvIndex("dv-2", FileKind::Add(), {"compacted.parquet"}, /*cardinality=*/1)},
+            base_index_entries),
+        "carrying 10 deleted rows into compacted.parquet, but its new deletion vector deletes 1");
+
+    ASSERT_OK(CheckCompaction(
+        detection, base_entries, compact_delta,
+        {DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet"}, /*cardinality=*/10),
+         DvIndex("dv-2", FileKind::Add(), {"compacted.parquet"}, /*cardinality=*/10)},
+        base_index_entries));
+}
+
+TEST_F(DataEvolutionConflictDetectionTest, TestAcceptsAMaterializedCompaction) {
+    // Materializing applies the deletions to the rows themselves and writes them without row
+    // ids, which the commit assigns afresh. The old vectors are meant to disappear rather than
+    // move, so the group accounting must not demand a new vector for the rewritten files.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/10)};
+    // The rewritten file carries no row id: that is the materialization marker.
+    std::vector<ManifestEntry> materialize_delta = {
+        DataFile("anchor.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/10),
+        CreateManifestEntry("materialized.parquet", partition_, FileKind::Add())};
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-1", FileKind::Add(), {"anchor.parquet"}, /*cardinality=*/4)};
+    // dv-1 goes away and nothing replaces it, because the deleted rows are gone for real.
+    std::vector<IndexManifestEntry> delta_index_entries = {
+        DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet"}, /*cardinality=*/4)};
+
+    ASSERT_OK(CheckCompaction(detection, base_entries, materialize_delta, delta_index_entries,
+                              base_index_entries));
+
+    // The vector still has to be removed: leaving it behind would keep deleting rows of a file
+    // that no longer exists, and the check does not stop caring just because rows were rewritten.
+    ASSERT_NOK_WITH_MSG(CheckCompaction(detection, base_entries, materialize_delta,
+                                        /*delta_index_entries=*/{}, base_index_entries),
+                        "is not removed by the same commit");
+}
+
+TEST_F(DataEvolutionConflictDetectionTest, TestAcceptsAFullyDeletedRangeRewrittenToNothing) {
+    // Materializing a range whose rows are all deleted produces no output file at all. There is
+    // then nothing to attribute the deletions to, and nothing needs to be: the rows are gone
+    // with their files, so removing the vector is the whole migration.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+    std::vector<ManifestEntry> delta = {
+        DataFile("anchor.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/2)};
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-1", FileKind::Add(), {"anchor.parquet"}, /*cardinality=*/2)};
+    std::vector<IndexManifestEntry> delta_index_entries = {
+        DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet"}, /*cardinality=*/2)};
+
+    ASSERT_OK(
+        CheckCompaction(detection, base_entries, delta, delta_index_entries, base_index_entries));
+
+    // The vector still has to go: leaving it would keep an entry for a file that no longer
+    // exists, which is the one thing this check is here to catch.
+    ASSERT_NOK_WITH_MSG(CheckCompaction(detection, base_entries, delta,
+                                        /*delta_index_entries=*/{}, base_index_entries),
+                        "is not removed by the same commit");
+}
+
+TEST_F(DataEvolutionConflictDetectionTest, TestRefusesDroppingAKeptFilesDeletions) {
+    // The index file the compaction replaces also held a vector for a file outside the compacted
+    // groups. Removing it without writing that vector back would resurrect its deleted rows.
+    ConflictDetection detection = DataEvolutionDetector(table_schema_, core_options_);
+
+    std::vector<ManifestEntry> base_entries = {
+        DataFile("anchor.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("untouched.parquet", FileKind::Add(), /*first_row_id=*/8, /*row_count=*/2)};
+    std::vector<ManifestEntry> compact_delta = {
+        DataFile("anchor.parquet", FileKind::Delete(), /*first_row_id=*/0, /*row_count=*/2),
+        DataFile("compacted.parquet", FileKind::Add(), /*first_row_id=*/0, /*row_count=*/2)};
+    std::vector<IndexManifestEntry> base_index_entries = {
+        DvIndex("dv-1", FileKind::Add(), {"anchor.parquet", "untouched.parquet"})};
+
+    // dv-2 only carries the moved vector; untouched.parquet's vector is dropped with dv-1.
+    ASSERT_NOK_WITH_MSG(
+        CheckCompaction(
+            detection, base_entries, compact_delta,
+            {DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet", "untouched.parquet"}),
+             DvIndex("dv-2", FileKind::Add(), {"compacted.parquet"})},
+            base_index_entries),
+        "data file untouched.parquet, which the commit keeps, does not get its vector back");
+
+    // Carried over, but shrunk on the way: an untouched vector is rewritten verbatim, so this is
+    // a regression rather than a legitimate rewrite.
+    ASSERT_NOK_WITH_MSG(
+        CheckCompaction(
+            detection, base_entries, compact_delta,
+            {DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet", "untouched.parquet"}),
+             DvIndex("dv-2", FileKind::Add(), {"compacted.parquet"}),
+             DvIndex("dv-3", FileKind::Add(), {"untouched.parquet"}, /*cardinality=*/0)},
+            base_index_entries),
+        "which it keeps, from 1 deleted rows to 0");
+
+    // Carried over unchanged is what the rewriter does, and that commit is accepted.
+    ASSERT_OK(CheckCompaction(
+        detection, base_entries, compact_delta,
+        {DvIndex("dv-1", FileKind::Delete(), {"anchor.parquet", "untouched.parquet"}),
+         DvIndex("dv-2", FileKind::Add(), {"compacted.parquet", "untouched.parquet"})},
+        base_index_entries));
+}
+
+TEST_F(ConflictDetectionTest, TestCompactionOnPlainAppendTableStillRefusesDroppingDataFiles) {
+    // The carve-out is specific to data evolution: a plain append table's compaction reorders
+    // rows and has no vector migration, so it must stay refused.
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<TableSchema> table_schema,
+        TableSchema::Create(/*schema_id=*/0, arrow::schema(fields_), /*partition_keys=*/{"f1"},
+                            /*primary_keys=*/{}, /*options=*/{}));
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options,
+                         CoreOptions::FromMap({{Options::BUCKET, "-1"},
+                                               {Options::DELETION_VECTORS_ENABLED, "true"}}));
+    ConflictDetection detection(table_schema, core_options, /*snapshot_manager=*/nullptr,
+                                /*manifest_list=*/nullptr, /*manifest_file=*/nullptr,
+                                /*commit_scanner=*/nullptr, "test_user", "test_table",
+                                /*path_factory=*/nullptr);
+
+    ASSERT_NOK_WITH_MSG(
+        CheckConflicts(detection, {CreateManifestEntry("dropped.parquet", FileKind::Add())},
+                       {CreateManifestEntry("dropped.parquet", FileKind::Delete())},
+                       Snapshot::CommitKind::Compact()),
+        "Committing the deletion of data file dropped.parquet is not supported");
+}
+
 TEST_F(ConflictDetectionTest, TestDeletionVectorsDeleteAllowedWithoutBucketUnawareMode) {
     // the guard above is specific to a table whose deletion vectors the entries cannot reference:
     // a bucketed table pairs them by bucket, so deleting a data file stays allowed there
@@ -917,6 +1368,89 @@ TEST_F(ConflictDetectionTest, TestCheckRowIdExistenceDedicatedFiles) {
             CheckConflictsWithNextRowId(detection, base_entries, delta_entries,
                                         /*next_row_id=*/2, Snapshot::CommitKind::Append()),
             "Row ID existence conflict");
+    }
+}
+
+TEST_F(ConflictDetectionTest, TestCheckRowIdExistenceOnCompaction) {
+    // A compaction rewrites rows the table already holds, so every range it adds has to be
+    // covered by the current snapshot's ranges of the same partition and bucket. A range that
+    // is not means a concurrent commit reassigned those rows after the round was planned, and
+    // committing would move the row ids back onto rows that no longer carry them.
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<TableSchema> table_schema,
+        TableSchema::Create(/*schema_id=*/0, arrow::schema(fields_), /*partition_keys=*/{"f1"},
+                            /*primary_keys=*/{}, /*options=*/{}));
+    ASSERT_OK_AND_ASSIGN(CoreOptions core_options,
+                         CoreOptions::FromMap({{Options::DATA_EVOLUTION_ENABLED, "true"}}));
+    ConflictDetection detection(table_schema, core_options, /*snapshot_manager=*/nullptr,
+                                /*manifest_list=*/nullptr, /*manifest_file=*/nullptr,
+                                /*commit_scanner=*/nullptr, "test_user", "test_table",
+                                /*path_factory=*/nullptr);
+    const BinaryRow partition = CreateIntRow(10);
+
+    std::vector<ManifestEntry> base_entries;
+    base_entries.push_back(CreateManifestEntryWithFirstRowId(
+        "base-0", partition, FileKind::Add(), /*bucket=*/0, /*first_row_id=*/0, /*row_count=*/2));
+    base_entries.push_back(CreateManifestEntryWithFirstRowId(
+        "base-1", partition, FileKind::Add(), /*bucket=*/0, /*first_row_id=*/2, /*row_count=*/2));
+    std::vector<ManifestEntry> replaced = {
+        CreateManifestEntryWithFirstRowId("base-0", partition, FileKind::Delete(), /*bucket=*/0,
+                                          /*first_row_id=*/0, /*row_count=*/2),
+        CreateManifestEntryWithFirstRowId("base-1", partition, FileKind::Delete(), /*bucket=*/0,
+                                          /*first_row_id=*/2, /*row_count=*/2)};
+
+    // The output spans both base files: adjacent ranges are merged, so a contiguous run of them
+    // counts as covered. `next_row_id` is irrelevant here - a compaction reuses existing ids.
+    {
+        std::vector<ManifestEntry> delta_entries = replaced;
+        delta_entries.push_back(CreateManifestEntryWithFirstRowId("compacted", partition,
+                                                                  FileKind::Add(), /*bucket=*/0,
+                                                                  /*first_row_id=*/0,
+                                                                  /*row_count=*/4));
+        ASSERT_OK(CheckConflictsWithNextRowId(detection, base_entries, delta_entries,
+                                              /*next_row_id=*/std::nullopt,
+                                              Snapshot::CommitKind::Compact()));
+    }
+
+    // A range the snapshot no longer holds: a concurrent commit reassigned those rows to
+    // [10, 13], so committing the planned output would move the row ids back to [0, 3].
+    {
+        std::vector<ManifestEntry> reassigned_base;
+        reassigned_base.push_back(CreateManifestEntryWithFirstRowId(
+            "base-2", partition, FileKind::Add(), /*bucket=*/0, /*first_row_id=*/10,
+            /*row_count=*/4));
+        std::vector<ManifestEntry> delta_entries;
+        delta_entries.push_back(CreateManifestEntryWithFirstRowId("compacted", partition,
+                                                                  FileKind::Add(), /*bucket=*/0,
+                                                                  /*first_row_id=*/0,
+                                                                  /*row_count=*/4));
+        ASSERT_NOK_WITH_MSG(CheckConflictsWithNextRowId(detection, reassigned_base, delta_entries,
+                                                        /*next_row_id=*/std::nullopt,
+                                                        Snapshot::CommitKind::Compact()),
+                            "Row ID existence conflict");
+    }
+
+    // The rows exist, but in another bucket: an output may only take over files of its own.
+    {
+        std::vector<ManifestEntry> delta_entries = replaced;
+        delta_entries.push_back(CreateManifestEntryWithFirstRowId("compacted", partition,
+                                                                  FileKind::Add(), /*bucket=*/1,
+                                                                  /*first_row_id=*/0,
+                                                                  /*row_count=*/4));
+        ASSERT_NOK_WITH_MSG(CheckConflictsWithNextRowId(detection, base_entries, delta_entries,
+                                                        /*next_row_id=*/std::nullopt,
+                                                        Snapshot::CommitKind::Compact()),
+                            "Row ID existence conflict");
+    }
+
+    // A materialized compaction writes its files without row ids, which the commit assigns
+    // afresh, so there is nothing to look up.
+    {
+        std::vector<ManifestEntry> delta_entries = replaced;
+        delta_entries.push_back(CreateManifestEntry("materialized", partition, FileKind::Add()));
+        ASSERT_OK(CheckConflictsWithNextRowId(detection, base_entries, delta_entries,
+                                              /*next_row_id=*/std::nullopt,
+                                              Snapshot::CommitKind::Compact()));
     }
 }
 

--- a/src/paimon/core/operation/commit/materialized_index_changes_provider.cpp
+++ b/src/paimon/core/operation/commit/materialized_index_changes_provider.cpp
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/operation/commit/materialized_index_changes_provider.h"
+
+#include <memory>
+#include <vector>
+
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/index_manifest_entry.h"
+
+namespace paimon {
+
+Result<std::shared_ptr<CommitChanges>> MaterializedIndexChangesProvider::Provide(
+    const std::optional<Snapshot>& latest_snapshot) const {
+    std::vector<IndexManifestEntry> index_entries;
+    index_entries.reserve(index_entries_.size());
+    for (const IndexManifestEntry& entry : index_entries_) {
+        // Global index deletions are re-derived below against the snapshot this attempt commits
+        // on top of; the prepared ones were decided against an older one. Everything else this
+        // commit carries - the rewritten deletion vector index files, above all - stands.
+        bool prepared_global_index_deletion =
+            entry.kind == FileKind::Delete() &&
+            entry.index_file->GetGlobalIndexMeta() != std::nullopt &&
+            materialized_buckets_.count(MaterializedBucket{entry.partition, entry.bucket}) != 0;
+        if (!prepared_global_index_deletion) {
+            index_entries.push_back(entry);
+        }
+    }
+
+    if (latest_snapshot.has_value() && index_scan_) {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<IndexManifestEntry> live_entries,
+                               index_scan_(latest_snapshot.value()));
+        for (const IndexManifestEntry& entry : live_entries) {
+            if (entry.index_file->GetGlobalIndexMeta() == std::nullopt ||
+                materialized_buckets_.count(MaterializedBucket{entry.partition, entry.bucket}) ==
+                    0) {
+                continue;
+            }
+            index_entries.emplace_back(FileKind::Delete(), entry.partition, entry.bucket,
+                                       entry.index_file);
+        }
+    }
+
+    return std::make_shared<CommitChanges>(delta_files_, changelog_files_,
+                                           std::move(index_entries));
+}
+
+}  // namespace paimon

--- a/src/paimon/core/operation/commit/materialized_index_changes_provider.h
+++ b/src/paimon/core/operation/commit/materialized_index_changes_provider.h
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "paimon/common/data/binary_row.h"
+#include "paimon/core/operation/commit/commit_changes_provider.h"
+
+namespace paimon {
+
+/// One (partition, bucket) a commit materializes deletion vectors for.
+struct MaterializedBucket {
+    BinaryRow partition;
+    int32_t bucket;
+
+    bool operator==(const MaterializedBucket& other) const {
+        return bucket == other.bucket && partition == other.partition;
+    }
+};
+
+struct MaterializedBucketHash {
+    size_t operator()(const MaterializedBucket& key) const {
+        return std::hash<BinaryRow>()(key.partition) ^ (std::hash<int32_t>()(key.bucket) << 1);
+    }
+};
+
+using MaterializedBuckets = std::unordered_set<MaterializedBucket, MaterializedBucketHash>;
+
+/// Supplies the changes of a commit that materializes deletion vectors, re-deciding which
+/// global indexes it drops on every attempt.
+///
+/// Materializing gives the surviving rows new row ids, which invalidates every global index of
+/// the buckets it rewrites. The deletions prepared before the commit only cover the indexes
+/// that existed when the compaction was planned; an index committed by another writer after
+/// that would survive against row ids that no longer exist. Since `Provide` is called again for
+/// every optimistic-commit attempt, re-reading the latest snapshot's index manifest here means
+/// such an index is either dropped by this attempt or makes it retry and is dropped by the next
+/// one.
+class MaterializedIndexChangesProvider final : public CommitChangesProvider {
+ public:
+    /// Reads the index manifest of a snapshot. It is a callback so the provider stays free of
+    /// the manifest reader's dependencies, the way `OverwriteChangesProvider` does it.
+    using IndexScan =
+        std::function<Result<std::vector<IndexManifestEntry>>(const Snapshot& snapshot)>;
+
+    MaterializedIndexChangesProvider(std::vector<ManifestEntry> delta_files,
+                                     std::vector<ManifestEntry> changelog_files,
+                                     std::vector<IndexManifestEntry> index_entries,
+                                     MaterializedBuckets materialized_buckets, IndexScan index_scan)
+        : delta_files_(std::move(delta_files)),
+          changelog_files_(std::move(changelog_files)),
+          index_entries_(std::move(index_entries)),
+          materialized_buckets_(std::move(materialized_buckets)),
+          index_scan_(std::move(index_scan)) {}
+
+    Result<std::shared_ptr<CommitChanges>> Provide(
+        const std::optional<Snapshot>& latest_snapshot) const override;
+
+ private:
+    std::vector<ManifestEntry> delta_files_;
+    std::vector<ManifestEntry> changelog_files_;
+    std::vector<IndexManifestEntry> index_entries_;
+    MaterializedBuckets materialized_buckets_;
+    IndexScan index_scan_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/operation/commit/materialized_index_changes_provider_test.cpp
+++ b/src/paimon/core/operation/commit/materialized_index_changes_provider_test.cpp
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/operation/commit/materialized_index_changes_provider.h"
+
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/data/binary_row_writer.h"
+#include "paimon/core/index/global_index_meta.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/manifest/file_kind.h"
+#include "paimon/core/manifest/index_manifest_entry.h"
+#include "paimon/core/snapshot.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+namespace {
+
+BinaryRow CreateIntRow(int32_t value) {
+    BinaryRow row(1);
+    BinaryRowWriter writer(&row, 20, GetDefaultPool().get());
+    writer.WriteInt(0, value);
+    writer.Complete();
+    return row;
+}
+
+IndexManifestEntry CreateGlobalIndexEntry(const std::string& file_name, int32_t partition_value,
+                                          const FileKind& kind = FileKind::Add()) {
+    GlobalIndexMeta global_index_meta(/*row_range_start=*/0, /*row_range_end=*/1,
+                                      /*index_field_id=*/0, /*extra_field_ids=*/std::nullopt,
+                                      /*index_meta=*/nullptr);
+    auto index_file = std::make_shared<IndexFileMeta>(
+        /*index_type=*/"GLOBAL_INDEX", file_name, /*file_size=*/10, /*row_count=*/1,
+        /*dv_ranges=*/std::nullopt, /*external_path=*/std::nullopt, global_index_meta);
+    return IndexManifestEntry(kind, CreateIntRow(partition_value), /*bucket=*/0, index_file);
+}
+
+IndexManifestEntry CreateDeletionVectorEntry(const std::string& file_name, int32_t partition_value,
+                                             const FileKind& kind = FileKind::Add()) {
+    auto index_file = std::make_shared<IndexFileMeta>(
+        /*index_type=*/"DELETION_VECTORS", file_name, /*file_size=*/10, /*row_count=*/1,
+        /*dv_ranges=*/std::nullopt, /*external_path=*/std::nullopt);
+    return IndexManifestEntry(kind, CreateIntRow(partition_value), /*bucket=*/0, index_file);
+}
+
+Snapshot MakeSnapshot(const std::optional<std::string>& index_manifest) {
+    return Snapshot(
+        /*id=*/1, /*schema_id=*/0, /*base_manifest_list=*/"base",
+        /*base_manifest_list_size=*/std::nullopt, /*delta_manifest_list=*/"delta",
+        /*delta_manifest_list_size=*/std::nullopt, /*changelog_manifest_list=*/std::nullopt,
+        /*changelog_manifest_list_size=*/std::nullopt, index_manifest,
+        /*commit_user=*/"test-user", /*commit_identifier=*/1, Snapshot::CommitKind::Compact(),
+        /*time_millis=*/0, /*total_record_count=*/0, /*delta_record_count=*/0,
+        /*changelog_record_count=*/std::nullopt, /*watermark=*/std::nullopt,
+        /*statistics=*/std::nullopt, /*properties=*/std::nullopt, /*next_row_id=*/std::nullopt);
+}
+
+std::set<std::string> DeletedIndexNames(const std::vector<IndexManifestEntry>& entries) {
+    std::set<std::string> result;
+    for (const IndexManifestEntry& entry : entries) {
+        if (entry.kind == FileKind::Delete()) {
+            result.insert(entry.index_file->FileName());
+        }
+    }
+    return result;
+}
+
+}  // namespace
+
+TEST(MaterializedIndexChangesProviderTest, TestRescansGlobalIndexesOnEveryAttempt) {
+    // The commit was prepared when only `planned-index` existed. By the time it is attempted a
+    // second index is live, and the second attempt has to drop that one as well - otherwise it
+    // would survive against row ids this commit reassigns.
+    MaterializedBuckets materialized_buckets;
+    materialized_buckets.insert(MaterializedBucket{CreateIntRow(10), /*bucket=*/0});
+
+    std::vector<IndexManifestEntry> prepared = {
+        CreateGlobalIndexEntry("planned-index", /*partition_value=*/10, FileKind::Delete()),
+        CreateDeletionVectorEntry("dv-new", /*partition_value=*/10)};
+
+    int32_t scan_calls = 0;
+    MaterializedIndexChangesProvider provider(
+        /*delta_files=*/{}, /*changelog_files=*/{}, prepared, materialized_buckets,
+        [&scan_calls](const Snapshot&) -> Result<std::vector<IndexManifestEntry>> {
+            ++scan_calls;
+            std::vector<IndexManifestEntry> live = {
+                CreateGlobalIndexEntry("planned-index", /*partition_value=*/10)};
+            if (scan_calls > 1) {
+                live.push_back(CreateGlobalIndexEntry("late-index", /*partition_value=*/10));
+            }
+            return live;
+        });
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<CommitChanges> first,
+                         provider.Provide(MakeSnapshot("index-manifest-1")));
+    ASSERT_EQ(DeletedIndexNames(first->index_entries), std::set<std::string>({"planned-index"}));
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<CommitChanges> second,
+                         provider.Provide(MakeSnapshot("index-manifest-2")));
+    ASSERT_EQ(DeletedIndexNames(second->index_entries),
+              std::set<std::string>({"planned-index", "late-index"}));
+    ASSERT_EQ(scan_calls, 2);
+
+    // Whatever else the commit carries travels unchanged: the rewritten deletion vector index
+    // is not a global index and is neither dropped nor re-derived.
+    int32_t dv_additions = 0;
+    for (const IndexManifestEntry& entry : second->index_entries) {
+        if (entry.kind == FileKind::Add() && entry.index_file->FileName() == "dv-new") {
+            dv_additions++;
+        }
+    }
+    ASSERT_EQ(dv_additions, 1);
+}
+
+TEST(MaterializedIndexChangesProviderTest, TestKeepsIndexesOfOtherBuckets) {
+    // Only the buckets this commit materializes lose their global indexes; another partition's
+    // stays live, and the deletion prepared for it - if any - is left alone.
+    MaterializedBuckets materialized_buckets;
+    materialized_buckets.insert(MaterializedBucket{CreateIntRow(10), /*bucket=*/0});
+
+    std::vector<IndexManifestEntry> prepared = {CreateGlobalIndexEntry(
+        "other-partition-index", /*partition_value=*/20, FileKind::Delete())};
+
+    MaterializedIndexChangesProvider provider(
+        /*delta_files=*/{}, /*changelog_files=*/{}, prepared, materialized_buckets,
+        [](const Snapshot&) -> Result<std::vector<IndexManifestEntry>> {
+            return std::vector<IndexManifestEntry>{
+                CreateGlobalIndexEntry("elsewhere-index", /*partition_value=*/20)};
+        });
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<CommitChanges> changes,
+                         provider.Provide(MakeSnapshot("index-manifest-1")));
+    ASSERT_EQ(DeletedIndexNames(changes->index_entries),
+              std::set<std::string>({"other-partition-index"}));
+}
+
+TEST(MaterializedIndexChangesProviderTest, TestWithoutLatestSnapshotKeepsPreparedChanges) {
+    // An empty table has no index manifest to re-read; the prepared changes are what commits.
+    MaterializedBuckets materialized_buckets;
+    materialized_buckets.insert(MaterializedBucket{CreateIntRow(10), /*bucket=*/0});
+
+    int32_t scan_calls = 0;
+    MaterializedIndexChangesProvider provider(
+        /*delta_files=*/{}, /*changelog_files=*/{},
+        {CreateDeletionVectorEntry("dv-new", /*partition_value=*/10)}, materialized_buckets,
+        [&scan_calls](const Snapshot&) -> Result<std::vector<IndexManifestEntry>> {
+            ++scan_calls;
+            return std::vector<IndexManifestEntry>{};
+        });
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<CommitChanges> changes,
+                         provider.Provide(/*latest_snapshot=*/std::nullopt));
+    ASSERT_EQ(changes->index_entries.size(), 1);
+    ASSERT_EQ(scan_calls, 0);
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/operation/commit/row_id_column_conflict_checker.h
+++ b/src/paimon/core/operation/commit/row_id_column_conflict_checker.h
@@ -28,6 +28,7 @@
 #include <vector>
 
 #include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/operation/commit/row_id_conflict_checker.h"
 #include "paimon/core/schema/schema_manager.h"
 #include "paimon/utils/range.h"
 
@@ -41,13 +42,13 @@ namespace paimon {
 ///   For each checking files, do binary search to find overlapping ranges. If their updated
 ///   columns also overlap, return conflicting result.
 ///
-class RowIdColumnConflictChecker {
+class RowIdColumnConflictChecker : public RowIdConflictChecker {
  public:
     static Result<std::shared_ptr<RowIdColumnConflictChecker>> FromDataFiles(
         const std::shared_ptr<SchemaManager>& schema_manager,
         const std::vector<std::shared_ptr<DataFileMeta>>& delta_files);
 
-    bool IsEmpty() const {
+    bool IsEmpty() const override {
         return write_ranges_.empty();
     }
 
@@ -57,7 +58,7 @@ class RowIdColumnConflictChecker {
     ///
     /// @param file committed incremental data file
     /// @return true if conflict
-    Result<bool> ConflictsWith(const std::shared_ptr<DataFileMeta>& file) const;
+    Result<bool> ConflictsWith(const std::shared_ptr<DataFileMeta>& file) const override;
 
  private:
     /// Range and field id Set.

--- a/src/paimon/core/operation/commit/row_id_conflict_checker.h
+++ b/src/paimon/core/operation/commit/row_id_conflict_checker.h
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+
+#include "paimon/result.h"
+
+namespace paimon {
+
+struct DataFileMeta;
+
+/// Decides whether a data file committed after the checked snapshot conflicts with the files
+/// this commit is writing.
+///
+/// The commit that carries the check picks the rule: a partial-column update only conflicts
+/// with another update of the same columns over the same rows, while a commit that reassigns
+/// row ids conflicts with anything written over the rows it moves.
+class RowIdConflictChecker {
+ public:
+    virtual ~RowIdConflictChecker() = default;
+
+    /// Whether this checker holds nothing to conflict with, in which case the whole replay of
+    /// the snapshots since the checked one can be skipped.
+    virtual bool IsEmpty() const = 0;
+
+    virtual Result<bool> ConflictsWith(const std::shared_ptr<DataFileMeta>& file) const = 0;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/operation/commit/row_id_range_conflict_checker.cpp
+++ b/src/paimon/core/operation/commit/row_id_range_conflict_checker.cpp
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/operation/commit/row_id_range_conflict_checker.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "paimon/utils/range.h"
+
+namespace paimon {
+
+Result<std::shared_ptr<RowIdRangeConflictChecker>> RowIdRangeConflictChecker::FromDataFiles(
+    const std::vector<std::shared_ptr<DataFileMeta>>& delta_files) {
+    std::vector<Range> ranges;
+    ranges.reserve(delta_files.size());
+    for (const std::shared_ptr<DataFileMeta>& file : delta_files) {
+        if (!file || !file->first_row_id || file->row_count <= 0) {
+            continue;
+        }
+        int64_t range_from = file->first_row_id.value();
+        ranges.emplace_back(range_from, range_from + file->row_count - 1);
+    }
+    PAIMON_ASSIGN_OR_RAISE(RowRangeIndex row_range_index, RowRangeIndex::Create(ranges));
+    return std::shared_ptr<RowIdRangeConflictChecker>(
+        new RowIdRangeConflictChecker(std::move(row_range_index)));
+}
+
+Result<bool> RowIdRangeConflictChecker::ConflictsWith(
+    const std::shared_ptr<DataFileMeta>& file) const {
+    if (!file || !file->first_row_id || file->row_count <= 0) {
+        return false;
+    }
+    int64_t range_from = file->first_row_id.value();
+    return row_range_index_.Intersects(range_from, range_from + file->row_count - 1);
+}
+
+}  // namespace paimon

--- a/src/paimon/core/operation/commit/row_id_range_conflict_checker.h
+++ b/src/paimon/core/operation/commit/row_id_range_conflict_checker.h
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/operation/commit/row_id_conflict_checker.h"
+#include "paimon/utils/row_range_index.h"
+
+namespace paimon {
+
+/// Detects a row id conflict by range overlap alone.
+///
+/// This is the rule a commit needs when it does not merely update columns of the rows it
+/// touches but takes those rows away: materializing deletion vectors drops the deleted rows and
+/// lets the commit assign fresh row ids to the survivors, so anything another writer added over
+/// the old range in the meantime would be left addressing rows that no longer exist there.
+/// Which columns either side wrote does not matter, so unlike `RowIdColumnConflictChecker` this
+/// one never looks at a schema.
+class RowIdRangeConflictChecker : public RowIdConflictChecker {
+ public:
+    /// Builds a checker over the row id ranges of `delta_files`. Files without a row id hold no
+    /// range to conflict with and are ignored.
+    static Result<std::shared_ptr<RowIdRangeConflictChecker>> FromDataFiles(
+        const std::vector<std::shared_ptr<DataFileMeta>>& delta_files);
+
+    bool IsEmpty() const override {
+        return row_range_index_.Ranges().empty();
+    }
+
+    Result<bool> ConflictsWith(const std::shared_ptr<DataFileMeta>& file) const override;
+
+ private:
+    explicit RowIdRangeConflictChecker(RowRangeIndex row_range_index)
+        : row_range_index_(std::move(row_range_index)) {}
+
+    RowRangeIndex row_range_index_;
+};
+
+}  // namespace paimon

--- a/src/paimon/core/operation/commit/row_id_range_conflict_checker_test.cpp
+++ b/src/paimon/core/operation/commit/row_id_range_conflict_checker_test.cpp
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/operation/commit/row_id_range_conflict_checker.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/data/timestamp.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+namespace {
+
+std::shared_ptr<DataFileMeta> CreateFile(const std::string& file_name,
+                                         const std::optional<int64_t>& first_row_id,
+                                         int64_t row_count) {
+    return std::make_shared<DataFileMeta>(
+        file_name, /*file_size=*/1024, row_count, DataFileMeta::EmptyMinKey(),
+        DataFileMeta::EmptyMaxKey(), SimpleStats::EmptyStats(), SimpleStats::EmptyStats(),
+        /*min_seq_no=*/1, /*max_seq_no=*/2, /*schema_id=*/0, /*level=*/0,
+        /*extra_files=*/std::vector<std::optional<std::string>>(),
+        /*creation_time=*/Timestamp(0, 0), /*delete_row_count=*/std::nullopt,
+        /*embedded_index=*/nullptr, /*file_source=*/std::nullopt, /*external_path=*/std::nullopt,
+        /*value_stats_cols=*/std::nullopt, first_row_id, /*write_cols=*/std::nullopt);
+}
+
+}  // namespace
+
+TEST(RowIdRangeConflictCheckerTest, ConflictsWithAnyOverlappingRange) {
+    // The commit takes rows [0, 3] and [10, 11] away, so anything written over those rows
+    // conflicts, whatever columns it wrote - which is what tells this rule apart from the
+    // column-overlap one.
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RowIdRangeConflictChecker> checker,
+                         RowIdRangeConflictChecker::FromDataFiles(
+                             {CreateFile("dropped-0.parquet", /*first_row_id=*/0, /*row_count=*/4),
+                              CreateFile("dropped-1.parquet", /*first_row_id=*/10,
+                                         /*row_count=*/2)}));
+    ASSERT_FALSE(checker->IsEmpty());
+
+    // Fully inside, partially overlapping and spanning a taken range all conflict.
+    for (const auto& conflicting :
+         {CreateFile("inside.parquet", /*first_row_id=*/1, /*row_count=*/2),
+          CreateFile("straddling.parquet", /*first_row_id=*/3, /*row_count=*/4),
+          CreateFile("spanning.parquet", /*first_row_id=*/0, /*row_count=*/12)}) {
+        ASSERT_OK_AND_ASSIGN(bool conflicts, checker->ConflictsWith(conflicting));
+        ASSERT_TRUE(conflicts) << conflicting->file_name;
+    }
+
+    // The gap between the two ranges, and rows past the last one, are untouched.
+    for (const auto& disjoint :
+         {CreateFile("gap.parquet", /*first_row_id=*/4, /*row_count=*/6),
+          CreateFile("beyond.parquet", /*first_row_id=*/12, /*row_count=*/4)}) {
+        ASSERT_OK_AND_ASSIGN(bool conflicts, checker->ConflictsWith(disjoint));
+        ASSERT_FALSE(conflicts) << disjoint->file_name;
+    }
+
+    // A file carrying no row id claims no rows of its own.
+    ASSERT_OK_AND_ASSIGN(bool conflicts,
+                         checker->ConflictsWith(CreateFile("fresh.parquet",
+                                                           /*first_row_id=*/std::nullopt,
+                                                           /*row_count=*/4)));
+    ASSERT_FALSE(conflicts);
+}
+
+TEST(RowIdRangeConflictCheckerTest, IsEmptyWithoutRowIdRanges) {
+    // A commit that takes no existing rows away has nothing to conflict with, and the caller
+    // skips replaying the snapshots since the checked one entirely.
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RowIdRangeConflictChecker> empty,
+                         RowIdRangeConflictChecker::FromDataFiles({}));
+    ASSERT_TRUE(empty->IsEmpty());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<RowIdRangeConflictChecker> without_row_ids,
+                         RowIdRangeConflictChecker::FromDataFiles({CreateFile(
+                             "fresh.parquet", /*first_row_id=*/std::nullopt, /*row_count=*/4)}));
+    ASSERT_TRUE(without_row_ids->IsEmpty());
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/operation/commit/uncommitted_file_cleaner.cpp
+++ b/src/paimon/core/operation/commit/uncommitted_file_cleaner.cpp
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/operation/commit/uncommitted_file_cleaner.h"
+
+#include <set>
+#include <string>
+
+#include "paimon/commit_message.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/index/index_path_factory.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/logging.h"
+
+namespace paimon {
+
+Status UncommittedFileCleaner::Delete(
+    const std::shared_ptr<FileStorePathFactory>& path_factory,
+    const std::shared_ptr<FileSystem>& fs,
+    const std::vector<std::shared_ptr<CommitMessage>>& commit_messages, Logger* logger) {
+    // A message this cleaner cannot handle stops that message, never the ones after it: giving
+    // up on the whole list would strand every file the remaining messages describe, which is
+    // the leak this class exists to prevent. The first such failure is reported once the list
+    // has been walked.
+    Status first_error = Status::OK();
+    for (const auto& message : commit_messages) {
+        auto* msg = dynamic_cast<CommitMessageImpl*>(message.get());
+        if (msg == nullptr) {
+            if (first_error.ok()) {
+                first_error = Status::Invalid("fail to cast commit message to impl");
+            }
+            continue;
+        }
+        Result<std::shared_ptr<DataFilePathFactory>> data_file_path_factory_result =
+            path_factory->CreateDataFilePathFactory(msg->Partition(), msg->Bucket());
+        Result<std::unique_ptr<IndexPathFactory>> index_file_path_factory_result =
+            path_factory->CreateIndexFileFactory(msg->Partition(), msg->Bucket());
+        if (!data_file_path_factory_result.ok() || !index_file_path_factory_result.ok()) {
+            const Status& status = data_file_path_factory_result.ok()
+                                       ? index_file_path_factory_result.status()
+                                       : data_file_path_factory_result.status();
+            if (first_error.ok()) {
+                first_error = status;
+            }
+            PAIMON_LOG_WARN(logger,
+                            "Cannot resolve the paths of an uncommitted message in bucket %d: %s. "
+                            "Its files are left behind.",
+                            msg->Bucket(), status.ToString().c_str());
+            continue;
+        }
+        std::shared_ptr<DataFilePathFactory> data_file_path_factory =
+            std::move(data_file_path_factory_result).value();
+        std::unique_ptr<IndexPathFactory> index_file_path_factory =
+            std::move(index_file_path_factory_result).value();
+
+        const DataIncrement& new_files_increment = msg->GetNewFilesIncrement();
+        const CompactIncrement& compact_increment = msg->GetCompactIncrement();
+
+        std::vector<std::shared_ptr<DataFileMeta>> data_files_to_delete;
+        auto append_data_files =
+            [&data_files_to_delete](const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+                data_files_to_delete.insert(data_files_to_delete.end(), files.begin(), files.end());
+            };
+        append_data_files(new_files_increment.NewFiles());
+        append_data_files(new_files_increment.ChangelogFiles());
+        append_data_files(compact_increment.CompactAfter());
+        append_data_files(compact_increment.ChangelogFiles());
+        for (const auto& file : data_files_to_delete) {
+            // A rolled back data file takes its companion files with it (e.g. a managed blob
+            // reference sidecar), the same as everywhere else a data file is removed.
+            for (const std::string& path : data_file_path_factory->CollectFiles(file)) {
+                // Best-effort cleanup: delete failures are ignored.
+                [[maybe_unused]] Status status = fs->Delete(path, /*recursive=*/false);
+            }
+        }
+        // Only the packs this message's writer created, never the ones its files merely
+        // reference, for the reason the class documents. Nothing else collects a pack — orphan
+        // file cleaning skips `.managed.blob`, because a pack may be shared by several data
+        // files — so a failure here leaks it for good and is worth naming.
+        std::set<std::string> managed_blob_packs(msg->OwnedManagedBlobPacks().begin(),
+                                                 msg->OwnedManagedBlobPacks().end());
+        for (const std::string& pack_path : managed_blob_packs) {
+            Status status = fs->Delete(pack_path, /*recursive=*/false);
+            if (!status.ok() && !status.IsNotExist()) {
+                PAIMON_LOG_WARN(logger,
+                                "Failed to delete the managed blob pack %s of an uncommitted "
+                                "message: %s. Nothing collects it later.",
+                                pack_path.c_str(), status.ToString().c_str());
+            }
+        }
+
+        std::vector<std::shared_ptr<IndexFileMeta>> index_files_to_delete;
+        auto append_index_files = [&index_files_to_delete](
+                                      const std::vector<std::shared_ptr<IndexFileMeta>>& files) {
+            index_files_to_delete.insert(index_files_to_delete.end(), files.begin(), files.end());
+        };
+        append_index_files(new_files_increment.NewIndexFiles());
+        append_index_files(compact_increment.NewIndexFiles());
+        for (const auto& file : index_files_to_delete) {
+            [[maybe_unused]] Status status =
+                fs->Delete(index_file_path_factory->ToPath(file), /*recursive=*/false);
+        }
+    }
+    return first_error;
+}
+
+}  // namespace paimon

--- a/src/paimon/core/operation/commit/uncommitted_file_cleaner.h
+++ b/src/paimon/core/operation/commit/uncommitted_file_cleaner.h
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "paimon/result.h"
+
+namespace paimon {
+
+class CommitMessage;
+class FileStorePathFactory;
+class FileSystem;
+class Logger;
+
+/// Deletes the files a set of commit messages describes, for messages that will never be
+/// committed.
+///
+/// A writer hands its files over when it produces a commit message: `PrepareCommit` drains
+/// them, so from then on nothing the writer does removes them. Two callers have to finish that
+/// job when the commit does not happen — `FileStoreCommit::Abort`, for a commit that failed or
+/// was given up on, and the write path itself, when `PrepareCommit` fails after some of its
+/// messages were already produced. Both delete the same set, hence one implementation.
+///
+/// Removed per message: the new and rewritten data files with their companion files (a managed
+/// blob reference sidecar, for instance), the new index files, and the managed blob packs the
+/// message *owns*. Owning a pack and referencing one are different things — a compacted file's
+/// sidecar lists the packs of the files it merged, which live snapshots still read — so only
+/// `CommitMessageImpl::OwnedManagedBlobPacks` is consulted, never a sidecar.
+class UncommittedFileCleaner {
+ public:
+    UncommittedFileCleaner() = delete;
+    ~UncommittedFileCleaner() = delete;
+
+    /// Best effort throughout: an individual delete failure is ignored, or logged when nothing
+    /// would collect the file later, and a message that cannot be handled at all — one this
+    /// cleaner cannot interpret, or whose paths cannot be resolved — is skipped rather than
+    /// ending the pass, so it never strands the messages behind it. The first such failure is
+    /// returned once every message has been visited, because files were left behind.
+    static Status Delete(const std::shared_ptr<FileStorePathFactory>& path_factory,
+                         const std::shared_ptr<FileSystem>& fs,
+                         const std::vector<std::shared_ptr<CommitMessage>>& commit_messages,
+                         Logger* logger);
+};
+
+}  // namespace paimon

--- a/src/paimon/core/operation/commit/uncommitted_file_cleaner_test.cpp
+++ b/src/paimon/core/operation/commit/uncommitted_file_cleaner_test.cpp
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "paimon/core/operation/commit/uncommitted_file_cleaner.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "arrow/api.h"
+#include "gtest/gtest.h"
+#include "paimon/common/data/binary_row.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_increment.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
+#include "paimon/core/manifest/file_source.h"
+#include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/logging.h"
+#include "paimon/testing/utils/testharness.h"
+
+namespace paimon::test {
+
+namespace {
+
+/// A data file meta carrying `sidecar` in its extra files, the way a managed blob write records
+/// its `.blobref` companion.
+std::shared_ptr<DataFileMeta> CreateDataFile(const std::string& file_name,
+                                             const std::optional<std::string>& sidecar) {
+    std::vector<std::optional<std::string>> extra_files;
+    if (sidecar) {
+        extra_files.emplace_back(sidecar.value());
+    }
+    return DataFileMeta::ForAppend(file_name, /*file_size=*/1, /*row_count=*/1,
+                                   /*row_stats=*/SimpleStats::EmptyStats(),
+                                   /*min_sequence_number=*/0, /*max_sequence_number=*/1,
+                                   /*schema_id=*/0, extra_files, /*embedded_index=*/nullptr,
+                                   FileSource::Append(), /*value_stats_cols=*/std::nullopt,
+                                   /*external_path=*/std::nullopt, /*first_row_id=*/std::nullopt,
+                                   /*write_cols=*/std::nullopt)
+        .value();
+}
+
+}  // namespace
+
+class UncommittedFileCleanerTest : public ::testing::Test {
+ public:
+    void SetUp() override {
+        dir_ = UniqueTestDirectory::Create("local");
+        auto arrow_schema = arrow::schema({arrow::field("f0", arrow::int32())});
+        ASSERT_OK_AND_ASSIGN(
+            path_factory_,
+            FileStorePathFactory::Create(dir_->Str(), arrow_schema, /*partition_keys=*/{},
+                                         /*default_part_value=*/"__DEFAULT_PARTITION__",
+                                         /*identifier=*/"parquet",
+                                         /*data_file_prefix=*/"data-",
+                                         /*legacy_partition_name_enabled=*/true,
+                                         /*external_paths=*/{},
+                                         /*global_index_external_path=*/std::nullopt,
+                                         /*index_file_in_data_file_dir=*/false, GetDefaultPool()));
+        // The bucket directory is created by the writers in production; here the files are
+        // placed directly, so it has to exist first.
+        ASSERT_OK(dir_->GetFileSystem()->Mkdirs(BucketPath()));
+        logger_ = Logger::GetLogger("UncommittedFileCleanerTest");
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    /// Creates an empty file under the single bucket directory and returns its path.
+    std::string Touch(const std::string& file_name) {
+        std::string path = PathUtil::JoinPath(BucketPath(), file_name);
+        Result<std::unique_ptr<OutputStream>> out =
+            dir_->GetFileSystem()->Create(path, /*overwrite=*/true);
+        EXPECT_TRUE(out.ok());
+        if (out.ok()) {
+            EXPECT_TRUE(out.value()->Close().ok());
+        }
+        return path;
+    }
+
+    std::string BucketPath() const {
+        return PathUtil::JoinPath(dir_->Str(), "bucket-0");
+    }
+
+    bool Exists(const std::string& path) const {
+        return dir_->GetFileSystem()->GetFileStatus(path).ok();
+    }
+
+ protected:
+    std::unique_ptr<UniqueTestDirectory> dir_;
+    std::shared_ptr<FileStorePathFactory> path_factory_;
+    std::shared_ptr<Logger> logger_;
+};
+
+TEST_F(UncommittedFileCleanerTest, TestRemovesDataFilesSidecarsAndOwnedPacks) {
+    // What a managed blob write leaves behind before its commit lands: a data file, the
+    // `.blobref` sidecar in its extra files, and the pack the writer created for it.
+    std::string data_path = Touch("data-1.parquet");
+    std::string sidecar_path = Touch("data-1.parquet.blobref");
+    std::string owned_pack = Touch("data-owned.managed.blob");
+    // A pack the message only references — what a compaction output's sidecar would list.
+    // It belongs to a live snapshot and must survive.
+    std::string referenced_pack = Touch("data-referenced.managed.blob");
+
+    DataIncrement data_increment({CreateDataFile("data-1.parquet", "data-1.parquet.blobref")},
+                                 /*deleted_files=*/{}, /*changelog_files=*/{});
+    auto message = std::make_shared<CommitMessageImpl>(
+        BinaryRow::EmptyRow(), /*bucket=*/0, /*total_buckets=*/std::nullopt, data_increment,
+        CompactIncrement({}, {}, {}));
+    message->SetOwnedManagedBlobPacks({owned_pack});
+
+    ASSERT_OK(UncommittedFileCleaner::Delete(path_factory_, dir_->GetFileSystem(), {message},
+                                             logger_.get()));
+
+    EXPECT_FALSE(Exists(data_path));
+    EXPECT_FALSE(Exists(sidecar_path));
+    EXPECT_FALSE(Exists(owned_pack));
+    EXPECT_TRUE(Exists(referenced_pack));
+}
+
+TEST_F(UncommittedFileCleanerTest, TestRemovesCompactOutputsButNoInheritedPack) {
+    // A compaction output owns no pack: it rewrites blob descriptors verbatim, so the packs its
+    // sidecar lists belong to the files it merged and are still read by the base snapshot.
+    std::string compacted_path = Touch("data-compacted.parquet");
+    std::string compacted_sidecar = Touch("data-compacted.parquet.blobref");
+    std::string inherited_pack = Touch("data-inherited.managed.blob");
+
+    CompactIncrement compact_increment(
+        /*compact_before=*/{},
+        {CreateDataFile("data-compacted.parquet", "data-compacted.parquet.blobref")},
+        /*changelog_files=*/{});
+    auto message = std::make_shared<CommitMessageImpl>(
+        BinaryRow::EmptyRow(), /*bucket=*/0, /*total_buckets=*/std::nullopt,
+        DataIncrement({}, {}, {}), compact_increment);
+
+    ASSERT_OK(UncommittedFileCleaner::Delete(path_factory_, dir_->GetFileSystem(), {message},
+                                             logger_.get()));
+
+    EXPECT_FALSE(Exists(compacted_path));
+    EXPECT_FALSE(Exists(compacted_sidecar));
+    EXPECT_TRUE(Exists(inherited_pack));
+}
+
+TEST_F(UncommittedFileCleanerTest, TestToleratesMissingFilesAndRejectsForeignMessages) {
+    // Nothing on disk: a rollback runs after a failure that may have removed some files
+    // already, so a missing file is normal.
+    DataIncrement data_increment({CreateDataFile("data-gone.parquet", std::nullopt)},
+                                 /*deleted_files=*/{}, /*changelog_files=*/{});
+    auto message = std::make_shared<CommitMessageImpl>(
+        BinaryRow::EmptyRow(), /*bucket=*/0, /*total_buckets=*/std::nullopt, data_increment,
+        CompactIncrement({}, {}, {}));
+    message->SetOwnedManagedBlobPacks({PathUtil::JoinPath(BucketPath(), "data-gone.managed.blob")});
+    ASSERT_OK(UncommittedFileCleaner::Delete(path_factory_, dir_->GetFileSystem(), {message},
+                                             logger_.get()));
+
+    // A message this cleaner cannot interpret would silently leave files behind, so it fails
+    // instead of reporting success.
+    ASSERT_NOK_WITH_MSG(UncommittedFileCleaner::Delete(path_factory_, dir_->GetFileSystem(),
+                                                       {nullptr}, logger_.get()),
+                        "fail to cast commit message to impl");
+}
+
+TEST_F(UncommittedFileCleanerTest, TestAnUnusableMessageDoesNotStrandTheOnesBehindIt) {
+    // Giving up on the whole list at the first unusable message would leave every file the
+    // remaining ones describe behind - exactly the leak this cleaner exists to prevent. The
+    // failure is still reported, just after the rest has been cleaned.
+    std::string data_path = Touch("data-2.parquet");
+    std::string owned_pack = Touch("data-second.managed.blob");
+
+    DataIncrement data_increment({CreateDataFile("data-2.parquet", std::nullopt)},
+                                 /*deleted_files=*/{}, /*changelog_files=*/{});
+    auto usable = std::make_shared<CommitMessageImpl>(BinaryRow::EmptyRow(), /*bucket=*/0,
+                                                      /*total_buckets=*/std::nullopt,
+                                                      data_increment, CompactIncrement({}, {}, {}));
+    usable->SetOwnedManagedBlobPacks({owned_pack});
+
+    // The unusable message comes first, so a cleaner that stopped there would clean nothing.
+    ASSERT_NOK_WITH_MSG(UncommittedFileCleaner::Delete(path_factory_, dir_->GetFileSystem(),
+                                                       {nullptr, usable}, logger_.get()),
+                        "fail to cast commit message to impl");
+    EXPECT_FALSE(Exists(data_path));
+    EXPECT_FALSE(Exists(owned_pack));
+}
+
+}  // namespace paimon::test

--- a/src/paimon/core/operation/data_evolution_split_read.cpp
+++ b/src/paimon/core/operation/data_evolution_split_read.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <functional>
 #include <limits>
 #include <map>
 #include <set>
@@ -98,6 +99,17 @@ class PositionShiftedDeletionVector : public DeletionVector {
     Result<int64_t> GetCardinality() const override {
         PAIMON_ASSIGN_OR_RAISE(RoaringBitmap32 valid, inner_->IsValid(offset_, length_));
         return length_ - valid.Cardinality();
+    }
+
+    /// Window-local deleted positions: the group vector's positions outside `[offset_,
+    /// offset_ + length_)` belong to other files of the row range group and are skipped.
+    Status ForEachDeletedPosition(const std::function<Status(int64_t)>& consumer) const override {
+        return inner_->ForEachDeletedPosition([&](int64_t position) -> Status {
+            if (position < offset_ || position >= offset_ + length_) {
+                return Status::OK();
+            }
+            return consumer(position - offset_);
+        });
     }
 
     Status Delete(int64_t) override {

--- a/src/paimon/core/operation/data_evolution_split_read_test.cpp
+++ b/src/paimon/core/operation/data_evolution_split_read_test.cpp
@@ -821,6 +821,18 @@ TEST_F(DataEvolutionSplitReadTest, TestCreateGroupDvFactoryShiftsPositions) {
     // deleted position inside the window, probing beyond the window is rejected
     ASSERT_EQ(blob_dv->GetCardinality().value(), 1);
     ASSERT_NOK_WITH_MSG(blob_dv->IsDeleted(30), "out of window");
+    // enumerating the deletions is windowed the same way: the anchor sees both, the blob file
+    // only the one inside its window, translated to its own positions
+    std::vector<int64_t> visited;
+    auto collect = [&visited](int64_t position) -> Status {
+        visited.push_back(position);
+        return Status::OK();
+    };
+    ASSERT_OK(blob_dv->ForEachDeletedPosition(collect));
+    ASSERT_EQ(visited, (std::vector<int64_t>{5}));
+    visited.clear();
+    ASSERT_OK(anchor_dv->ForEachDeletedPosition(collect));
+    ASSERT_EQ(visited, (std::vector<int64_t>{10, 45}));
 
     // the mutating and serializing halves would silently drop the shift, so they reject
     ASSERT_NOK_WITH_MSG(blob_dv->Delete(0), "read-only");

--- a/src/paimon/core/operation/expire_snapshots.cpp
+++ b/src/paimon/core/operation/expire_snapshots.cpp
@@ -24,7 +24,9 @@
 #include <cstdint>
 #include <functional>
 #include <future>
+#include <map>
 #include <optional>
+#include <unordered_map>
 #include <utility>
 
 #include "fmt/format.h"
@@ -33,6 +35,7 @@
 #include "paimon/common/utils/date_time_utils.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/manifest/file_kind.h"
 #include "paimon/core/manifest/manifest_entry.h"
 #include "paimon/core/manifest/manifest_file.h"
@@ -277,14 +280,31 @@ Status ExpireSnapshots::CleanUnusedDataFiles(const std::string& manifest_list_na
             }
         }
 
+        // One data file path factory per (partition, bucket): creating one re-derives the
+        // partition path and external path provider, too heavy to repeat for every file.
+        std::unordered_map<BinaryRow, std::map<int32_t, std::shared_ptr<DataFilePathFactory>>>
+            data_file_path_factories;
         std::vector<std::future<void>> futures;
         ScopeGuard guard([&futures]() { Wait(futures); });
         for (const auto& [data_file_to_delete, entry] : data_files_to_delete) {
-            auto delete_file_path = data_file_to_delete;
-            futures.push_back(Via(executor_.get(), [this, delete_file_path]() {
-                auto status = fs_->Delete(delete_file_path);
-                // delete quietly will ignore any status error
-                (void)status;
+            // An expired data file takes its companion files with it (e.g. the managed blob
+            // reference sidecar). CollectFiles resolves their paths, honoring external data
+            // paths.
+            std::shared_ptr<DataFilePathFactory>& data_file_path_factory =
+                data_file_path_factories[entry.Partition()][entry.Bucket()];
+            if (data_file_path_factory == nullptr) {
+                PAIMON_ASSIGN_OR_RAISE(
+                    data_file_path_factory,
+                    path_factory_->CreateDataFilePathFactory(entry.Partition(), entry.Bucket()));
+            }
+            std::vector<std::string> delete_file_paths =
+                data_file_path_factory->CollectFiles(entry.File());
+            futures.push_back(Via(executor_.get(), [this, delete_file_paths]() {
+                for (const auto& delete_file_path : delete_file_paths) {
+                    auto status = fs_->Delete(delete_file_path);
+                    // delete quietly will ignore any status error
+                    (void)status;
+                }
             }));
             deletion_buckets_[entry.Partition()].insert(entry.Bucket());
         }
@@ -302,7 +322,6 @@ Status ExpireSnapshots::GetDataFilesToDelete(
         if (entry.Kind() == FileKind::Add()) {
             data_files_to_delete->erase(data_file_path);
         } else if (entry.Kind() == FileKind::Delete()) {
-            // TODO(jinli.zjw): do not support extra files
             data_files_to_delete->insert({data_file_path, entry});
         } else {
             return Status::Invalid(

--- a/src/paimon/core/operation/expire_snapshots_test.cpp
+++ b/src/paimon/core/operation/expire_snapshots_test.cpp
@@ -19,13 +19,17 @@
 #include "paimon/core/operation/expire_snapshots.h"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
+#include <string>
 #include <utility>
+#include <vector>
 
 #include "arrow/type.h"
 #include "gtest/gtest.h"
 #include "paimon/common/data/binary_row.h"
 #include "paimon/common/data/binary_row_writer.h"
+#include "paimon/common/utils/path_util.h"
 #include "paimon/core/core_options.h"
 #include "paimon/core/io/data_file_meta.h"
 #include "paimon/core/manifest/file_kind.h"
@@ -45,6 +49,10 @@
 #include "paimon/testing/utils/testharness.h"
 
 namespace paimon::test {
+
+/// The `(path, size)` pair `ManifestList::Write` returns. Named so it can be spelled without a
+/// comma inside an `ASSERT_OK_AND_ASSIGN` argument.
+using ManifestListFile = std::pair<std::string, int64_t>;
 
 class ExpireSnapshotsTest : public testing::Test {
  public:
@@ -130,8 +138,9 @@ class ExpireSnapshotsTest : public testing::Test {
         return path_factory;
     }
 
-    ManifestEntry CreateManifestEntry(const std::string& file_name, int32_t bucket,
-                                      const FileKind& kind) const {
+    ManifestEntry CreateManifestEntry(
+        const std::string& file_name, int32_t bucket, const FileKind& kind,
+        const std::vector<std::optional<std::string>>& extra_files = {}) const {
         int32_t arity = 2;
         BinaryRow row(arity);
         BinaryRowWriter writer(&row, 20, mem_pool_.get());
@@ -143,7 +152,7 @@ class ExpireSnapshotsTest : public testing::Test {
             file_name, 1024, 8, DataFileMeta::EmptyMinKey(), DataFileMeta::EmptyMaxKey(),
             SimpleStats::EmptyStats(), SimpleStats::EmptyStats(), /*min_seq_no=*/16,
             /*max_seq_no=*/32,
-            /*schema_id=*/1, /*level=*/2, /*extra_files=*/std::vector<std::optional<std::string>>(),
+            /*schema_id=*/1, /*level=*/2, extra_files,
             /*creation_time=*/Timestamp(0, 0), /*delete_row_count=*/3,
             /*embedded_index=*/nullptr, /*file_source=*/std::nullopt,
             /*external_path=*/std::nullopt,
@@ -250,6 +259,64 @@ TEST_F(ExpireSnapshotsTest, TestGetDataFileToDelete) {
                        {{test_data_path_ + "/f0=true/f3=3/bucket-0/file1", data_file_entries[2]},
                         {test_data_path_ + "/f0=true/f3=3/bucket-1/file2", data_file_entries[1]},
                         {test_data_path_ + "/f0=true/f3=3/bucket-2/file3", data_file_entries[3]}}));
+    }
+}
+
+TEST_F(ExpireSnapshotsTest, TestCleanUnusedDataFilesRemovesCompanionFiles) {
+    // An expired data file takes its companion files with it: a managed blob reference sidecar
+    // is written next to its data file and is only ever reachable through it, so leaving it
+    // behind would leak a file nothing can ever name again.
+    std::unique_ptr<UniqueTestDirectory> dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    ASSERT_OK_AND_ASSIGN(CoreOptions options, CoreOptions::FromMap({}));
+    std::shared_ptr<FileStorePathFactory> path_factory = CreateFactory(dir->Str());
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<ManifestList> manifest_list,
+        ManifestList::Create(fs_, options.GetManifestFormat(), options.GetManifestCompression(),
+                             path_factory, options.GetCache(), mem_pool_));
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<ManifestFile> manifest_file,
+        ManifestFile::Create(fs_, options.GetManifestFormat(), options.GetManifestCompression(),
+                             path_factory, options.GetManifestTargetFileSize(), mem_pool_, options,
+                             partition_schema_));
+
+    // Two buckets, so the per-(partition, bucket) path factory the deletion builds is exercised
+    // more than once, and one data file without a companion file next to it.
+    ManifestEntry with_sidecar =
+        CreateManifestEntry("data-0.orc", /*bucket=*/1, FileKind::Delete(), {"data-0.orc.blobref"});
+    ManifestEntry without_sidecar =
+        CreateManifestEntry("data-1.orc", /*bucket=*/1, FileKind::Delete());
+    ManifestEntry other_bucket =
+        CreateManifestEntry("data-2.orc", /*bucket=*/2, FileKind::Delete(), {"data-2.orc.blobref"});
+
+    ASSERT_OK_AND_ASSIGN(std::string bucket_1_path,
+                         path_factory->BucketPath(with_sidecar.Partition(), /*bucket=*/1));
+    ASSERT_OK_AND_ASSIGN(std::string bucket_2_path,
+                         path_factory->BucketPath(other_bucket.Partition(), /*bucket=*/2));
+    ASSERT_OK(fs_->Mkdirs(bucket_1_path));
+    ASSERT_OK(fs_->Mkdirs(bucket_2_path));
+    std::vector<std::string> written_paths = {
+        PathUtil::JoinPath(bucket_1_path, "data-0.orc"),
+        PathUtil::JoinPath(bucket_1_path, "data-0.orc.blobref"),
+        PathUtil::JoinPath(bucket_1_path, "data-1.orc"),
+        PathUtil::JoinPath(bucket_2_path, "data-2.orc"),
+        PathUtil::JoinPath(bucket_2_path, "data-2.orc.blobref")};
+    for (const std::string& path : written_paths) {
+        ASSERT_OK(fs_->WriteFile(path, "content", /*overwrite=*/true));
+    }
+
+    ASSERT_OK_AND_ASSIGN(std::vector<ManifestFileMeta> metas,
+                         manifest_file->Write({with_sidecar, without_sidecar, other_bucket}));
+    ASSERT_OK_AND_ASSIGN(ManifestListFile manifest_list_file, manifest_list->Write(metas));
+
+    auto snapshot_manager = std::make_shared<SnapshotManager>(fs_, dir->Str());
+    ExpireSnapshots expire(snapshot_manager, path_factory, manifest_list, manifest_file, fs_,
+                           options.GetExpireConfig(), executor_);
+    ASSERT_OK(expire.CleanUnusedDataFiles(manifest_list_file.first));
+
+    for (const std::string& path : written_paths) {
+        ASSERT_OK_AND_ASSIGN(bool exists, fs_->Exists(path));
+        ASSERT_FALSE(exists) << path;
     }
 }
 

--- a/src/paimon/core/operation/file_store_commit_impl.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl.cpp
@@ -44,6 +44,7 @@
 #include "paimon/common/utils/fields_comparator.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/common/utils/vector_store_utils.h"
 #include "paimon/core/catalog/catalog_snapshot_commit.h"
 #include "paimon/core/catalog/renaming_snapshot_commit.h"
 #include "paimon/core/catalog/snapshot_commit.h"
@@ -66,9 +67,11 @@
 #include "paimon/core/operation/commit/commit_changes_provider.h"
 #include "paimon/core/operation/commit/compacted_changelog_path_resolver.h"
 #include "paimon/core/operation/commit/conflict_detection.h"
+#include "paimon/core/operation/commit/materialized_index_changes_provider.h"
 #include "paimon/core/operation/commit/realtime_commit_properties.h"
 #include "paimon/core/operation/commit/row_tracking_commit_utils.h"
 #include "paimon/core/operation/commit/sequence_snapshot_properties.h"
+#include "paimon/core/operation/commit/uncommitted_file_cleaner.h"
 #include "paimon/core/operation/expire_snapshots.h"
 #include "paimon/core/operation/manifest_file_merger.h"
 #include "paimon/core/operation/metrics/commit_metrics.h"
@@ -78,9 +81,11 @@
 #include "paimon/core/schema/table_schema.h"
 #include "paimon/core/table/bucket_mode.h"
 #include "paimon/core/table/sink/commit_message_impl.h"
+#include "paimon/core/utils/data_evolution_utils.h"
 #include "paimon/core/utils/duration.h"
 #include "paimon/core/utils/file_store_path_factory.h"
 #include "paimon/core/utils/snapshot_manager.h"
+#include "paimon/defs.h"
 #include "paimon/file_store_write.h"
 #include "paimon/fs/file_system.h"
 #include "paimon/logging.h"
@@ -94,7 +99,6 @@ namespace {
 
 constexpr const char* kCommitStrictModeLastSafeSnapshot = "commit.strict-mode.last-safe-snapshot";
 constexpr const char* kSequenceSnapshotOrdering = "sequence.snapshot-ordering";
-constexpr const char* kPkClusteringOverride = "pk-clustering-override";
 
 bool MatchPartitionSpec(const std::map<std::string, std::string>& partition,
                         const std::map<std::string, std::string>& partition_spec) {
@@ -105,6 +109,26 @@ bool MatchPartitionSpec(const std::map<std::string, std::string>& partition,
         }
     }
     return true;
+}
+
+/// The (partition, bucket) pairs whose deletion vectors this commit materializes: it replaced
+/// normal files and wrote every output without a row id, so the commit assigns fresh ones and
+/// the global indexes over the old ids no longer address anything.
+MaterializedBuckets CollectMaterializedBuckets(
+    const std::vector<std::shared_ptr<CommitMessage>>& commit_messages) {
+    MaterializedBuckets result;
+    for (const std::shared_ptr<CommitMessage>& message : commit_messages) {
+        auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(message);
+        if (message_impl == nullptr) {
+            continue;
+        }
+        const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+        if (DataEvolutionUtils::IsMaterializedCompaction(compact_increment.CompactBefore(),
+                                                         compact_increment.CompactAfter())) {
+            result.insert(MaterializedBucket{message_impl->Partition(), message_impl->Bucket()});
+        }
+    }
+    return result;
 }
 
 }  // namespace
@@ -119,8 +143,9 @@ Status FileStoreCommitImpl::ValidateCommitOptions(const CoreOptions& options) {
     if (raw_options.find(kSequenceSnapshotOrdering) != raw_options.end()) {
         unsupported_options.emplace_back(kSequenceSnapshotOrdering);
     }
-    if (raw_options.find(kPkClusteringOverride) != raw_options.end()) {
-        unsupported_options.emplace_back(kPkClusteringOverride);
+    // Rejected by value: an explicit false equals the C++ behavior and is fine.
+    if (options.PkClusteringOverride()) {
+        unsupported_options.emplace_back(Options::PK_CLUSTERING_OVERRIDE);
     }
 
     if (!unsupported_options.empty()) {
@@ -214,49 +239,9 @@ Status FileStoreCommitImpl::TruncateTable(int64_t commit_identifier) {
 
 Status FileStoreCommitImpl::Abort(
     const std::vector<std::shared_ptr<CommitMessage>>& commit_messages) {
-    for (const auto& message : commit_messages) {
-        auto* msg = dynamic_cast<CommitMessageImpl*>(message.get());
-        if (msg == nullptr) {
-            return Status::Invalid("fail to cast commit message to impl");
-        }
-        PAIMON_ASSIGN_OR_RAISE(
-            std::shared_ptr<DataFilePathFactory> data_file_path_factory,
-            path_factory_->CreateDataFilePathFactory(msg->Partition(), msg->Bucket()));
-        PAIMON_ASSIGN_OR_RAISE(
-            std::unique_ptr<IndexPathFactory> index_file_path_factory,
-            path_factory_->CreateIndexFileFactory(msg->Partition(), msg->Bucket()));
-
-        const DataIncrement& new_files_increment = msg->GetNewFilesIncrement();
-        const CompactIncrement& compact_increment = msg->GetCompactIncrement();
-
-        std::vector<std::shared_ptr<DataFileMeta>> data_files_to_delete;
-        auto append_data_files =
-            [&data_files_to_delete](const std::vector<std::shared_ptr<DataFileMeta>>& files) {
-                data_files_to_delete.insert(data_files_to_delete.end(), files.begin(), files.end());
-            };
-        append_data_files(new_files_increment.NewFiles());
-        append_data_files(new_files_increment.ChangelogFiles());
-        append_data_files(compact_increment.CompactAfter());
-        append_data_files(compact_increment.ChangelogFiles());
-        for (const auto& file : data_files_to_delete) {
-            // Best-effort cleanup: ignore delete failures, aligning with Java deleteQuietly.
-            [[maybe_unused]] Status status =
-                fs_->Delete(data_file_path_factory->ToPath(file), /*recursive=*/false);
-        }
-
-        std::vector<std::shared_ptr<IndexFileMeta>> index_files_to_delete;
-        auto append_index_files = [&index_files_to_delete](
-                                      const std::vector<std::shared_ptr<IndexFileMeta>>& files) {
-            index_files_to_delete.insert(index_files_to_delete.end(), files.begin(), files.end());
-        };
-        append_index_files(new_files_increment.NewIndexFiles());
-        append_index_files(compact_increment.NewIndexFiles());
-        for (const auto& file : index_files_to_delete) {
-            [[maybe_unused]] Status status =
-                fs_->Delete(index_file_path_factory->ToPath(file), /*recursive=*/false);
-        }
-    }
-    return Status::OK();
+    // Shared with the write path, which has to remove the same set when PrepareCommit fails
+    // after producing some of its messages.
+    return UncommittedFileCleaner::Delete(path_factory_, fs_, commit_messages, logger_.get());
 }
 
 Result<std::vector<ManifestEntry>> FileStoreCommitImpl::ReadAddManifestEntries(
@@ -373,7 +358,16 @@ Result<bool> FileStoreCommitImpl::RollbackToAsLatest(int64_t target_snapshot_id)
 
 FileStoreCommit& FileStoreCommitImpl::RowIdCheckConflict(
     std::optional<int64_t> row_id_check_from_snapshot) {
-    conflict_detection_.SetRowIdCheckFromSnapshot(row_id_check_from_snapshot);
+    conflict_detection_.SetRowIdCheckFromSnapshot(
+        row_id_check_from_snapshot, ConflictDetection::RowIdCheckStrategy::kDataEvolutionDml);
+    return *this;
+}
+
+FileStoreCommit& FileStoreCommitImpl::RowIdCheckConflictForMaterializeDeletionVectors(
+    std::optional<int64_t> row_id_check_from_snapshot) {
+    conflict_detection_.SetRowIdCheckFromSnapshot(
+        row_id_check_from_snapshot,
+        ConflictDetection::RowIdCheckStrategy::kMaterializeDeletionVectors);
     return *this;
 }
 
@@ -847,7 +841,7 @@ Status FileStoreCommitImpl::Commit(
             commit_kind = Snapshot::CommitKind::Overwrite();
             check_append_files = true;
         }
-        if (conflict_detection_.HasRowIdCheckFromSnapshot()) {
+        if (conflict_detection_.RowIdCheckAppliesTo(commit_kind)) {
             check_append_files = true;
         }
         if (changes.HasGlobalIndexFileAdditions()) {
@@ -865,12 +859,40 @@ Status FileStoreCommitImpl::Commit(
     }
 
     if (changes.HasCompactChanges()) {
-        PAIMON_ASSIGN_OR_RAISE(int32_t cnt,
-                               TryCommit(changes.compact_table_files, changes.compact_changelog,
-                                         changes.compact_index_files, committable->Identifier(),
-                                         committable->Watermark(), committable->Properties(),
-                                         /*realtime_ranges=*/{}, Snapshot::CommitKind::Compact(),
-                                         /*detect_conflicts=*/true, retry_on_conflict));
+        // A materializing commit re-decides which global indexes it drops on every attempt, so
+        // one committed concurrently is dropped by this attempt or by the retry it causes.
+        MaterializedBuckets materialized_buckets =
+            CollectMaterializedBuckets(committable->FileCommittables());
+        int32_t cnt = 0;
+        if (materialized_buckets.empty()) {
+            PAIMON_ASSIGN_OR_RAISE(
+                cnt, TryCommit(changes.compact_table_files, changes.compact_changelog,
+                               changes.compact_index_files, committable->Identifier(),
+                               committable->Watermark(), committable->Properties(),
+                               /*realtime_ranges=*/{}, Snapshot::CommitKind::Compact(),
+                               /*detect_conflicts=*/true, retry_on_conflict));
+        } else {
+            auto index_scan =
+                [this](const Snapshot& snapshot) -> Result<std::vector<IndexManifestEntry>> {
+                std::vector<IndexManifestEntry> entries;
+                if (!snapshot.IndexManifest()) {
+                    return entries;
+                }
+                PAIMON_RETURN_NOT_OK(index_manifest_file_->Read(snapshot.IndexManifest().value(),
+                                                                /*filter=*/nullptr, &entries));
+                return entries;
+            };
+            std::shared_ptr<CommitChangesProvider> changes_provider =
+                std::make_shared<MaterializedIndexChangesProvider>(
+                    changes.compact_table_files, changes.compact_changelog,
+                    changes.compact_index_files, std::move(materialized_buckets),
+                    std::move(index_scan));
+            PAIMON_ASSIGN_OR_RAISE(
+                cnt, TryCommit(changes_provider, committable->Identifier(),
+                               committable->Watermark(), committable->Properties(),
+                               /*realtime_ranges=*/{}, Snapshot::CommitKind::Compact(),
+                               /*detect_conflicts=*/true, retry_on_conflict));
+        }
         attempt += cnt;
         generated_snapshot += 1;
     }
@@ -1127,23 +1149,55 @@ Result<bool> FileStoreCommitImpl::TryCommitOnce(
                 delta_files.end());
         }
 
-        std::optional<std::shared_ptr<RowIdColumnConflictChecker>> row_id_column_conflict_checker =
-            std::nullopt;
-        if (conflict_detection_.HasRowIdCheckFromSnapshot()) {
-            std::vector<std::shared_ptr<DataFileMeta>> delta_data_files;
-            delta_data_files.reserve(delta_files.size());
-            for (const auto& entry : delta_files) {
-                delta_data_files.push_back(entry.File());
+        std::optional<std::shared_ptr<RowIdConflictChecker>> row_id_conflict_checker = std::nullopt;
+        if (conflict_detection_.RowIdCheckAppliesTo(commit_kind)) {
+            if (conflict_detection_.GetRowIdCheckStrategy() ==
+                ConflictDetection::RowIdCheckStrategy::kMaterializeDeletionVectors) {
+                // Materializing rewrites whole row ranges and lets this commit assign new row
+                // ids to what survives, so the rows it takes away are the ones another writer
+                // must not have written over: the check is built from the normal files this
+                // commit drops, not from what it adds.
+                std::vector<std::shared_ptr<DataFileMeta>> dropped_data_files;
+                for (const auto& entry : delta_files) {
+                    if (!(entry.Kind() == FileKind::Delete()) || !entry.File()->first_row_id ||
+                        BlobUtils::IsBlobFile(entry.FileName()) ||
+                        VectorStoreUtils::IsVectorStoreFile(entry.FileName())) {
+                        continue;
+                    }
+                    dropped_data_files.push_back(entry.File());
+                }
+                PAIMON_ASSIGN_OR_RAISE(
+                    std::shared_ptr<RowIdRangeConflictChecker> checker,
+                    RowIdRangeConflictChecker::FromDataFiles(dropped_data_files));
+                row_id_conflict_checker = checker;
+            } else {
+                std::vector<std::shared_ptr<DataFileMeta>> delta_data_files;
+                delta_data_files.reserve(delta_files.size());
+                for (const auto& entry : delta_files) {
+                    delta_data_files.push_back(entry.File());
+                }
+                PAIMON_ASSIGN_OR_RAISE(
+                    std::shared_ptr<RowIdColumnConflictChecker> checker,
+                    RowIdColumnConflictChecker::FromDataFiles(schema_manager_, delta_data_files));
+                row_id_conflict_checker = checker;
             }
-            PAIMON_ASSIGN_OR_RAISE(
-                std::shared_ptr<RowIdColumnConflictChecker> checker,
-                RowIdColumnConflictChecker::FromDataFiles(schema_manager_, delta_data_files));
-            row_id_column_conflict_checker = checker;
+        }
+
+        // Read only for the commit shape that pairs a dropped data file with its deletion
+        // vector, so every other commit keeps its current I/O, and even then keep only the
+        // entries that shape can be decided by.
+        std::vector<IndexManifestEntry> base_index_entries;
+        std::function<Result<bool>(const IndexManifestEntry&)> base_index_filter =
+            conflict_detection_.BaseIndexEntryFilter(delta_files, index_entries, commit_kind);
+        if (base_index_filter && latest_snapshot.value().IndexManifest().has_value()) {
+            PAIMON_RETURN_NOT_OK(
+                index_manifest_file_->Read(latest_snapshot.value().IndexManifest().value(),
+                                           base_index_filter, &base_index_entries));
         }
 
         PAIMON_RETURN_NOT_OK(conflict_detection_.CheckConflicts(
             latest_snapshot.value(), base_data_files, delta_files, index_entries,
-            row_id_column_conflict_checker, commit_kind));
+            row_id_conflict_checker, commit_kind, base_index_entries));
     }
 
     std::vector<ManifestFileMeta> merge_before_manifests;

--- a/src/paimon/core/operation/file_store_commit_impl.h
+++ b/src/paimon/core/operation/file_store_commit_impl.h
@@ -36,6 +36,8 @@
 #include "paimon/core/operation/commit/manifest_entry_changes.h"
 #include "paimon/core/operation/commit/retry_waiter.h"
 #include "paimon/core/operation/commit/row_id_column_conflict_checker.h"
+#include "paimon/core/operation/commit/row_id_conflict_checker.h"
+#include "paimon/core/operation/commit/row_id_range_conflict_checker.h"
 #include "paimon/core/snapshot.h"
 #include "paimon/core/table/bucket_mode.h"
 #include "paimon/file_store_commit.h"
@@ -139,6 +141,9 @@ class FileStoreCommitImpl : public FileStoreCommit {
     Result<bool> RollbackToAsLatest(int64_t target_snapshot_id) override;
 
     FileStoreCommit& RowIdCheckConflict(std::optional<int64_t> row_id_check_from_snapshot) override;
+
+    FileStoreCommit& RowIdCheckConflictForMaterializeDeletionVectors(
+        std::optional<int64_t> row_id_check_from_snapshot) override;
 
     std::shared_ptr<Metrics> GetCommitMetrics() const override {
         return metrics_;

--- a/src/paimon/core/operation/file_store_commit_impl_test.cpp
+++ b/src/paimon/core/operation/file_store_commit_impl_test.cpp
@@ -1547,7 +1547,11 @@ TEST_F(FileStoreCommitImplTest, TestAbortDeletesDataAndIndexFiles) {
 
     const BinaryRow partition = CreateIntRow(10);
     const int32_t bucket = 0;
-    auto new_data_file = CreateAppendDataFileMeta("abort-new-data", 1);
+    // The new data file carries a companion file - a managed blob reference sidecar - which has
+    // to go with it: a rolled back commit that leaves the sidecar behind orphans it.
+    const std::string sidecar_file_name = "abort-new-data.blobref";
+    auto new_data_file =
+        CreateAppendDataFileMeta("abort-new-data", 1)->CopyWithExtraFiles({sidecar_file_name});
     auto compact_data_file = CreateAppendDataFileMeta("abort-compact-data", 1);
     auto new_index_file = CreateIndexFileMeta("abort-new-index");
     auto compact_index_file = CreateIndexFileMeta("abort-compact-index");
@@ -1568,8 +1572,9 @@ TEST_F(FileStoreCommitImplTest, TestAbortDeletesDataAndIndexFiles) {
     ASSERT_OK_AND_ASSIGN(std::unique_ptr<IndexPathFactory> index_pf,
                          commit_impl->path_factory_->CreateIndexFileFactory(partition, bucket));
     std::vector<std::string> paths = {
-        data_pf->ToPath(new_data_file), data_pf->ToPath(compact_data_file),
-        index_pf->ToPath(new_index_file), index_pf->ToPath(compact_index_file)};
+        data_pf->ToPath(new_data_file), data_pf->ToAlignedPath(sidecar_file_name, new_data_file),
+        data_pf->ToPath(compact_data_file), index_pf->ToPath(new_index_file),
+        index_pf->ToPath(compact_index_file)};
     for (const auto& path : paths) {
         ASSERT_OK(file_system_->WriteFile(path, /*content=*/"", /*overwrite=*/false));
         ASSERT_OK_AND_ASSIGN(bool exist, file_system_->Exists(path));
@@ -2549,6 +2554,12 @@ TEST_F(FileStoreCommitImplTest, ValidateCommitOptionsRejectsUnsupportedOptions) 
     ASSERT_OK_AND_ASSIGN(CoreOptions ok_options,
                          CoreOptions::FromMap({{Options::FILE_SYSTEM, "local"}}));
     ASSERT_OK(FileStoreCommitImpl::ValidateCommitOptions(ok_options));
+
+    // 'pk-clustering-override' is rejected by value: an explicit false equals the C++
+    // behavior and is allowed.
+    ASSERT_OK_AND_ASSIGN(CoreOptions pk_clustering_false,
+                         CoreOptions::FromMap({{Options::PK_CLUSTERING_OVERRIDE, "false"}}));
+    ASSERT_OK(FileStoreCommitImpl::ValidateCommitOptions(pk_clustering_false));
 }
 
 TEST_F(FileStoreCommitImplTest, ValidateCommitOptionsAllowsManifestDeleteFileDropStats) {
@@ -3094,6 +3105,31 @@ TEST_F(FileStoreCommitImplTest, RowIdCheckConflictSetsCheckSnapshotAndReturnsSel
     FileStoreCommit& returned = commit_impl->RowIdCheckConflict(/*row_id_check_from_snapshot=*/5);
     ASSERT_EQ(commit_impl.get(), &returned);
     ASSERT_TRUE(commit_impl->conflict_detection_.HasRowIdCheckFromSnapshot());
+    // The column-overlap rule is the one a partial-column update needs, and it applies to every
+    // commit kind.
+    ASSERT_EQ(commit_impl->conflict_detection_.GetRowIdCheckStrategy(),
+              ConflictDetection::RowIdCheckStrategy::kDataEvolutionDml);
+    ASSERT_TRUE(
+        commit_impl->conflict_detection_.RowIdCheckAppliesTo(Snapshot::CommitKind::Append()));
+
+    // Materializing deletion vectors takes rows away instead of updating columns, so it records
+    // the range rule, and only a compaction commit can carry it.
+    FileStoreCommit& materialize_returned =
+        commit_impl->RowIdCheckConflictForMaterializeDeletionVectors(
+            /*row_id_check_from_snapshot=*/7);
+    ASSERT_EQ(commit_impl.get(), &materialize_returned);
+    ASSERT_EQ(commit_impl->conflict_detection_.GetRowIdCheckStrategy(),
+              ConflictDetection::RowIdCheckStrategy::kMaterializeDeletionVectors);
+    ASSERT_TRUE(
+        commit_impl->conflict_detection_.RowIdCheckAppliesTo(Snapshot::CommitKind::Compact()));
+    ASSERT_FALSE(
+        commit_impl->conflict_detection_.RowIdCheckAppliesTo(Snapshot::CommitKind::Append()));
+
+    // Disabling it stops every kind from being checked.
+    commit_impl->RowIdCheckConflictForMaterializeDeletionVectors(std::nullopt);
+    ASSERT_FALSE(commit_impl->conflict_detection_.HasRowIdCheckFromSnapshot());
+    ASSERT_FALSE(
+        commit_impl->conflict_detection_.RowIdCheckAppliesTo(Snapshot::CommitKind::Compact()));
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/operation/merge_file_split_read.cpp
+++ b/src/paimon/core/operation/merge_file_split_read.cpp
@@ -226,9 +226,11 @@ Result<std::unique_ptr<FileBatchReader>> MergeFileSplitRead::ApplyIndexAndDvRead
                                                                 deletion_vector);
     }
     if (deletion_vector && !deletion && !deletion_vector->IsEmpty()) {
-        // TODO(xinyu.lxy): if deletion vector is bitmap64, use ApplyBitmapIndexBatchReader to
-        // filter result
-        return Status::NotImplemented("Only support BitmapDeletionVector");
+        // A bitmap64 vector has no RoaringBitmap32 to push down as a precise selection, so its
+        // deletions are applied to the rows the reader returns instead. Correct but not
+        // pushed down, which only costs the rows a selection would have skipped.
+        return std::make_unique<ApplyDeletionVectorBatchReader>(std::move(file_reader),
+                                                                deletion_vector);
     }
     return std::move(file_reader);
 }

--- a/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
+++ b/src/paimon/core/operation/orphan_files_cleaner_impl.cpp
@@ -31,6 +31,7 @@
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
 #include "paimon/common/utils/string_utils.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
 #include "paimon/core/manifest/manifest_entry.h"
 #include "paimon/core/manifest/manifest_file.h"
 #include "paimon/core/manifest/manifest_file_meta.h"
@@ -70,6 +71,13 @@ OrphanFilesCleanerImpl::OrphanFilesCleanerImpl(
       metrics_(std::make_shared<MetricsImpl>()) {}
 
 bool OrphanFilesCleanerImpl::SupportToClean(const std::string& file_name) {
+    // Managed blob packs may be shared by several data files and are referenced through
+    // `.blobref` sidecars the cleaner does not resolve, so they are never treated as orphans.
+    // Both blob rules are defensive today: the cleaner only supports append tables (see
+    // OrphanFilesCleaner), and managed blobs only exist in primary-key tables.
+    if (StringUtils::EndsWith(file_name, ManagedBlobReferenceFile::kManagedBlobSuffix)) {
+        return false;
+    }
     static std::vector<std::pair<std::string, std::string>> supported_pattern = {
         {"manifest-", ""}, {"manifest-list-", ""}, {".", ".tmp"}};
     for (const auto& pattern : supported_pattern) {
@@ -78,7 +86,10 @@ bool OrphanFilesCleanerImpl::SupportToClean(const std::string& file_name) {
             return true;
         }
     }
-    static std::vector<std::string> supported_formats = {".orc", ".parquet", ".avro"};
+    // Blob reference sidecars are cleanable: live ones are protected through the used-file
+    // set, which registers every manifest entry's extra files.
+    static std::vector<std::string> supported_formats = {
+        ".orc", ".parquet", ".avro", ManagedBlobReferenceFile::kReferenceFileSuffix};
     for (const auto& format : supported_formats) {
         if (StringUtils::StartsWith(file_name, "data-") &&
             StringUtils::EndsWith(file_name, format)) {
@@ -307,6 +318,13 @@ Result<std::set<std::string>> OrphanFilesCleanerImpl::GetUsedFilesBySnapshot(
             manifest.FileName(), /*filter=*/nullptr, &manifest_entries));
         for (const auto& manifest_entry : manifest_entries) {
             used_files.insert(manifest_entry.FileName());
+            // Extra files (e.g. managed blob reference sidecars) live and die with their data
+            // file and must never be treated as orphans while the data file is live.
+            for (const auto& extra_file : manifest_entry.File()->extra_files) {
+                if (extra_file) {
+                    used_files.insert(extra_file.value());
+                }
+            }
         }
     }
 

--- a/src/paimon/core/operation/orphan_files_cleaner_test.cpp
+++ b/src/paimon/core/operation/orphan_files_cleaner_test.cpp
@@ -47,6 +47,14 @@ TEST(OrphanFilesCleanerTest, TestSupportToClean) {
         "manifest-list-469f3a0f-f6f1-4027-91bf-d1e897e8ea23-1"));
     ASSERT_TRUE(OrphanFilesCleanerImpl::SupportToClean(
         ".snapshot-2.13c988c3-784d-493d-8884-016ddddb1fc2.tmp"));
+    // A blob reference sidecar is cleanable: a live one is protected through its data file's
+    // extra files, so an unreferenced one is genuinely orphaned.
+    ASSERT_TRUE(OrphanFilesCleanerImpl::SupportToClean(
+        "data-2d5ea1ea-77c1-47ff-bb87-19a509962a37-0.parquet.blobref"));
+    // A managed blob pack may be shared by several data files through sidecars the cleaner
+    // does not resolve, so it is never treated as an orphan.
+    ASSERT_FALSE(OrphanFilesCleanerImpl::SupportToClean(
+        "data-2d5ea1ea-77c1-47ff-bb87-19a509962a37-0.managed.blob"));
     ASSERT_FALSE(OrphanFilesCleanerImpl::SupportToClean("tmp"));
     ASSERT_FALSE(OrphanFilesCleanerImpl::SupportToClean("snapshot-1"));
     ASSERT_FALSE(OrphanFilesCleanerImpl::SupportToClean("schema-0"));

--- a/src/paimon/core/operation/raw_file_split_read.cpp
+++ b/src/paimon/core/operation/raw_file_split_read.cpp
@@ -32,6 +32,7 @@
 #include "paimon/common/utils/arrow/status_utils.h"
 #include "paimon/common/utils/object_utils.h"
 #include "paimon/core/core_options.h"
+#include "paimon/core/deletionvectors/apply_deletion_vector_batch_reader.h"
 #include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 #include "paimon/core/deletionvectors/deletion_vector.h"
 #include "paimon/core/global_index/indexed_split_impl.h"
@@ -268,9 +269,11 @@ Result<std::unique_ptr<FileBatchReader>> RawFileSplitRead::ApplyIndexAndDvReader
     }
 
     if (deletion_vector && !deletion && !deletion_vector->IsEmpty()) {
-        // TODO(xinyu.lxy): if deletion vector is bitmap64, use ApplyBitmapIndexBatchReader to
-        // filter result
-        return Status::NotImplemented("Only support BitmapDeletionVector");
+        // A bitmap64 vector has no RoaringBitmap32 to push down as a precise selection, so its
+        // deletions are applied to the rows the reader returns instead. Correct but not
+        // pushed down, which only costs the rows a selection would have skipped.
+        return std::unique_ptr<FileBatchReader>(
+            std::make_unique<ApplyDeletionVectorBatchReader>(std::move(reader), deletion_vector));
     }
     return std::move(reader);
 }

--- a/src/paimon/core/postpone/postpone_bucket_writer.cpp
+++ b/src/paimon/core/postpone/postpone_bucket_writer.cpp
@@ -20,6 +20,8 @@
 
 #include <cassert>
 #include <cstring>
+#include <string>
+#include <vector>
 
 #include "arrow/api.h"
 #include "arrow/array/array_base.h"
@@ -44,6 +46,7 @@
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/io/data_increment.h"
 #include "paimon/core/io/key_value_data_file_writer_factory.h"
+#include "paimon/core/io/primary_key_blob_externalizer.h"
 #include "paimon/core/io/shredding_key_value_data_file_writer_factory.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/core/utils/commit_increment.h"
@@ -76,8 +79,14 @@ Result<std::unique_ptr<PostponeBucketWriter>> PostponeBucketWriter::Create(
     const std::shared_ptr<arrow::Schema>& value_schema, const CoreOptions& options,
     const std::shared_ptr<MemoryPool>& pool) {
     auto write_schema = BuildPostponeBucketWriteSchema(value_schema);
-    return std::unique_ptr<PostponeBucketWriter>(new PostponeBucketWriter(
+    std::unique_ptr<PostponeBucketWriter> writer(new PostponeBucketWriter(
         trimmed_primary_keys, path_factory, schema_id, value_schema, write_schema, options, pool));
+    // Managed blob payloads are externalized before buffering, exactly as in the merge-tree
+    // writer, so postpone-bucket files hold descriptors too. Null without managed blob fields.
+    PAIMON_ASSIGN_OR_RAISE(
+        writer->blob_externalizer_,
+        PrimaryKeyBlobExternalizer::Create(options, value_schema, path_factory, pool));
+    return writer;
 }
 
 PostponeBucketWriter::PostponeBucketWriter(const std::vector<std::string>& trimmed_primary_keys,
@@ -95,13 +104,17 @@ PostponeBucketWriter::PostponeBucketWriter(const std::vector<std::string>& trimm
       schema_id_(schema_id),
       value_type_(arrow::struct_(value_schema->fields())),
       write_schema_(write_schema),
-      metrics_(std::make_shared<MetricsImpl>()) {}
+      metrics_(std::make_shared<MetricsImpl>()),
+      logger_(Logger::GetLogger("PostponeBucketWriter")) {}
 
 Status PostponeBucketWriter::Write(std::unique_ptr<RecordBatch>&& moved_batch) {
     if (moved_batch->GetData()->length == 0) {
         return Status::OK();
     }
     std::unique_ptr<RecordBatch> batch = std::move(moved_batch);
+    if (blob_externalizer_) {
+        PAIMON_ASSIGN_OR_RAISE(batch, blob_externalizer_->Externalize(std::move(batch)));
+    }
     // check input array
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::StructArray> value_struct_array,
                            CheckAndCastValueArray(batch->GetData()));
@@ -147,7 +160,16 @@ Status PostponeBucketWriter::Write(std::unique_ptr<RecordBatch>&& moved_batch) {
 
 Result<CommitIncrement> PostponeBucketWriter::PrepareCommit(bool wait_compaction) {
     PAIMON_RETURN_NOT_OK(Flush());
-    return DrainIncrement();
+    std::vector<std::string> owned_managed_blob_packs;
+    if (blob_externalizer_) {
+        // Seal the packs this writer created and hand them over, exactly as the merge-tree
+        // writer does: their paths ride along with the increment so a failed commit can roll
+        // back exactly the packs it created.
+        PAIMON_ASSIGN_OR_RAISE(owned_managed_blob_packs, blob_externalizer_->PrepareCommit());
+    }
+    PAIMON_ASSIGN_OR_RAISE(CommitIncrement increment, DrainIncrement());
+    increment.SetOwnedManagedBlobPacks(std::move(owned_managed_blob_packs));
+    return increment;
 }
 
 Result<std::shared_ptr<arrow::StructArray>> PostponeBucketWriter::CheckAndCastValueArray(

--- a/src/paimon/core/postpone/postpone_bucket_writer.h
+++ b/src/paimon/core/postpone/postpone_bucket_writer.h
@@ -30,10 +30,12 @@
 #include "paimon/core/core_options.h"
 #include "paimon/core/io/data_file_meta.h"
 #include "paimon/core/io/data_file_path_factory.h"
+#include "paimon/core/io/primary_key_blob_externalizer.h"
 #include "paimon/core/io/rolling_file_writer.h"
 #include "paimon/core/key_value.h"
 #include "paimon/core/utils/batch_writer.h"
 #include "paimon/core/utils/commit_increment.h"
+#include "paimon/logging.h"
 #include "paimon/record_batch.h"
 #include "paimon/result.h"
 #include "paimon/status.h"
@@ -97,6 +99,23 @@ class PostponeBucketWriter : public BatchWriter {
 
  private:
     Status DoClose() {
+        // Uncommitted managed blob packs die with the writer; packs handed over by
+        // PrepareCommit are unaffected.
+        if (blob_externalizer_) {
+            blob_externalizer_->Abort();
+        }
+        // Flushed files not drained by PrepareCommit were never committed: remove them
+        // together with their companion files, mirroring the merge-tree writer cleanup.
+        for (const auto& file : new_files_) {
+            for (const auto& path : path_factory_->CollectFiles(file)) {
+                auto status = options_.GetFileSystem()->Delete(path);
+                if (!status.ok()) {
+                    PAIMON_LOG_WARN(logger_, "Failed to delete uncommitted postpone file %s: %s",
+                                    path.c_str(), status.ToString().c_str());
+                }
+            }
+        }
+        new_files_.clear();
         sequence_number_array_.reset();
         row_kind_array_.reset();
         if (writer_) {
@@ -142,6 +161,10 @@ class PostponeBucketWriter : public BatchWriter {
     std::shared_ptr<arrow::DataType> value_type_;
     std::shared_ptr<arrow::Schema> write_schema_;
     std::shared_ptr<Metrics> metrics_;
+    std::unique_ptr<Logger> logger_;
+    /// Externalizes managed blob payloads before buffering; null unless the table is a
+    /// primary-key managed blob table.
+    std::unique_ptr<PrimaryKeyBlobExternalizer> blob_externalizer_;
     std::vector<std::shared_ptr<DataFileMeta>> new_files_;
     std::unique_ptr<RollingFileWriter<KeyValueBatch, std::shared_ptr<DataFileMeta>>> writer_;
     std::shared_ptr<arrow::Array> sequence_number_array_;

--- a/src/paimon/core/postpone/postpone_bucket_writer_test.cpp
+++ b/src/paimon/core/postpone/postpone_bucket_writer_test.cpp
@@ -28,6 +28,7 @@
 #include "arrow/c/bridge.h"
 #include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
+#include "paimon/common/data/blob_utils.h"
 #include "paimon/common/data/data_define.h"
 #include "paimon/common/data/shredding/map_shared_shredding_utils.h"
 #include "paimon/common/data/shredding/map_shredding_defs.h"
@@ -36,9 +37,11 @@
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/common/utils/string_utils.h"
 #include "paimon/core/io/compact_increment.h"
 #include "paimon/core/io/data_file_path_factory.h"
 #include "paimon/core/io/data_increment.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/core/stats/simple_stats.h"
 #include "paimon/core/utils/commit_increment.h"
@@ -80,6 +83,38 @@ class PostponeBucketWriterTest : public ::testing::Test,
         write_type_ = DataField::ConvertDataFieldsToArrowStructType(write_fields);
     }
     void TearDown() override {}
+
+    /// The (key, managed blob) schema shared by the managed blob writer tests.
+    static arrow::FieldVector ManagedBlobFields() {
+        return {arrow::field("key", arrow::utf8()),
+                BlobUtils::ToArrowField("b", /*nullable=*/true)};
+    }
+
+    /// A postpone writer over `ManagedBlobFields()` writing into `dir_path`.
+    Result<std::unique_ptr<PostponeBucketWriter>> CreateManagedBlobWriter(
+        const std::string& file_format, const std::string& dir_path) const {
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options,
+                               CoreOptions::FromMap({{Options::FILE_FORMAT, file_format}}));
+        auto path_factory = std::make_shared<DataFilePathFactory>();
+        PAIMON_RETURN_NOT_OK(
+            path_factory->Init(dir_path, file_format, options.DataFilePrefix(), nullptr));
+        return PostponeBucketWriter::Create(std::vector<std::string>{"key"}, path_factory,
+                                            /*schema_id=*/1, arrow::schema(ManagedBlobFields()),
+                                            options, pool_);
+    }
+
+    /// The single (key, payload) row the managed blob writer tests externalize.
+    static std::shared_ptr<arrow::Array> ManagedBlobBatch() {
+        arrow::StringBuilder key_builder;
+        arrow::LargeBinaryBuilder blob_builder;
+        EXPECT_TRUE(key_builder.Append("Lucy").ok());
+        EXPECT_TRUE(blob_builder.Append("postpone-payload").ok());
+        std::shared_ptr<arrow::Array> key_array;
+        std::shared_ptr<arrow::Array> blob_array;
+        EXPECT_TRUE(key_builder.Finish(&key_array).ok());
+        EXPECT_TRUE(blob_builder.Finish(&blob_array).ok());
+        return arrow::StructArray::Make({key_array, blob_array}, ManagedBlobFields()).ValueOrDie();
+    }
 
     void WriteBatch(const std::shared_ptr<arrow::Array>& array,
                     const std::vector<RecordBatch::RowKind>& row_kinds,
@@ -762,6 +797,63 @@ TEST_P(PostponeBucketWriterTest, TestIOException) {
         break;
     }
     ASSERT_TRUE(run_complete);
+}
+
+TEST_P(PostponeBucketWriterTest, TestManagedBlobExternalizedWithSidecar) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PostponeBucketWriter> postpone_bucket_writer,
+                         CreateManagedBlobWriter(GetParam(), dir->Str()));
+    WriteBatch(ManagedBlobBatch(), /*row_kinds=*/{}, postpone_bucket_writer.get());
+
+    ASSERT_OK_AND_ASSIGN(CommitIncrement commit_increment,
+                         postpone_bucket_writer->PrepareCommit(/*wait_compaction=*/false));
+    ASSERT_EQ(1, commit_increment.GetNewFilesIncrement().NewFiles().size());
+    const auto& flushed_file = commit_increment.GetNewFilesIncrement().NewFiles()[0];
+
+    ASSERT_EQ(flushed_file->extra_files.size(), 1);
+    ASSERT_TRUE(flushed_file->extra_files[0].has_value());
+    ASSERT_EQ(flushed_file->extra_files[0].value(), flushed_file->file_name + ".blobref");
+    std::string sidecar_path = dir->Str() + "/" + flushed_file->extra_files[0].value();
+
+    // The pack path is recorded in the sidecar, not assumed from naming.
+    ASSERT_OK_AND_ASSIGN(std::vector<ManagedBlobReferenceFile::Reference> references,
+                         ManagedBlobReferenceFile::Read(file_system_, sidecar_path));
+    ASSERT_EQ(references.size(), 1);
+    std::string pack_path = references[0].ToString();
+    ASSERT_TRUE(StringUtils::EndsWith(pack_path, ManagedBlobReferenceFile::kManagedBlobSuffix));
+    ASSERT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+
+    // A committed pack survives the writer teardown.
+    ASSERT_OK(postpone_bucket_writer->Close());
+    ASSERT_TRUE(file_system_->GetFileStatus(pack_path).ok());
+}
+
+TEST_P(PostponeBucketWriterTest, TestManagedBlobAbortedWithoutCommit) {
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<PostponeBucketWriter> postpone_bucket_writer,
+                         CreateManagedBlobWriter(GetParam(), dir->Str()));
+    WriteBatch(ManagedBlobBatch(), /*row_kinds=*/{}, postpone_bucket_writer.get());
+
+    // Find the uncommitted pack by listing the directory rather than assuming its name.
+    std::vector<std::string> pack_paths;
+    {
+        std::vector<BasicFileStatus> statuses;
+        ASSERT_OK(file_system_->ListDir(dir->Str(), &statuses));
+        for (const auto& status : statuses) {
+            if (StringUtils::EndsWith(status.GetPath(),
+                                      ManagedBlobReferenceFile::kManagedBlobSuffix)) {
+                pack_paths.push_back(status.GetPath());
+            }
+        }
+    }
+    ASSERT_EQ(pack_paths.size(), 1);
+    ASSERT_TRUE(file_system_->GetFileStatus(pack_paths[0]).ok());
+
+    // Closing without PrepareCommit aborts the write: the uncommitted pack is removed.
+    ASSERT_OK(postpone_bucket_writer->Close());
+    ASSERT_FALSE(file_system_->GetFileStatus(pack_paths[0]).ok());
 }
 
 }  // namespace paimon::test

--- a/src/paimon/core/schema/schema_validation.cpp
+++ b/src/paimon/core/schema/schema_validation.cpp
@@ -44,6 +44,7 @@
 #include "paimon/common/utils/preconditions.h"
 #include "paimon/common/utils/string_utils.h"
 #include "paimon/core/core_options.h"
+#include "paimon/core/mergetree/compact/aggregate/field_last_value_agg.h"
 #include "paimon/core/options/changelog_producer.h"
 #include "paimon/core/options/expire_config.h"
 #include "paimon/core/options/map_storage_layout.h"
@@ -197,6 +198,8 @@ Status SchemaValidation::ValidateTableSchema(const TableSchema& schema) {
 
     PAIMON_RETURN_NOT_OK(ValidateRowTracking(schema, options));
     PAIMON_RETURN_NOT_OK(ValidateBlobFields(schema, options));
+    PAIMON_RETURN_NOT_OK(ValidatePrimaryKeyBlobConfiguration(schema, options));
+    PAIMON_RETURN_NOT_OK(ValidateSequenceGroupOrderingFields(schema, options));
     PAIMON_RETURN_NOT_OK(ValidateMapStorageLayout(schema, options));
     PAIMON_RETURN_NOT_OK(ValidateVectorFields(schema, options));
     return Status::OK();
@@ -508,13 +511,156 @@ Status SchemaValidation::ValidateRowTracking(const TableSchema& table_schema,
             }
         }
 
-        // Validate data evolution must be enabled when blob-field is configured
-        PAIMON_RETURN_NOT_OK(Preconditions::CheckState(
-            options.DataEvolutionEnabled(),
-            "Data evolution config must be enabled for table with BLOB type column."));
+        // A primary-key table manages its blob payloads itself (table-managed packs plus
+        // reference sidecars); only append tables need data evolution for BLOB columns.
+        bool primary_key_managed_blob = !table_schema.PrimaryKeys().empty();
+        if (!primary_key_managed_blob) {
+            PAIMON_RETURN_NOT_OK(Preconditions::CheckState(
+                options.DataEvolutionEnabled(),
+                "Data evolution config must be enabled for table with BLOB type column."));
+        }
         PAIMON_RETURN_NOT_OK(Preconditions::CheckState(
             table_schema.Fields().size() > blob_names.size(),
             "Table with BLOB type column must have other normal columns."));
+    }
+    return Status::OK();
+}
+
+Status SchemaValidation::ValidatePrimaryKeyBlobConfiguration(const TableSchema& table_schema,
+                                                             const CoreOptions& options) {
+    if (table_schema.PrimaryKeys().empty()) {
+        return Status::OK();
+    }
+    std::vector<std::string> inline_field_names = options.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> managed_blob_fields = BlobUtils::ManagedBlobFieldNames(
+        DataField::ConvertDataFieldsToArrowSchema(table_schema.Fields()), inline_fields);
+    if (managed_blob_fields.empty()) {
+        return Status::OK();
+    }
+
+    // Managed blob fields cannot serve as keys or ordering fields: the stored descriptor
+    // identifies where a payload lives, not a stable logical value — re-externalizing an
+    // equal payload yields different bytes (compaction itself rewrites descriptors
+    // verbatim).
+    for (const auto& field_name : managed_blob_fields) {
+        if (std::find(table_schema.PrimaryKeys().begin(), table_schema.PrimaryKeys().end(),
+                      field_name) != table_schema.PrimaryKeys().end()) {
+            return Status::Invalid(fmt::format(
+                "Managed BLOB field {} cannot be part of the primary key.", field_name));
+        }
+        // Defensive, and untestable through this entry point: a primary-key table's bucket keys
+        // are its primary keys unless `bucket-key` names a subset of them
+        // (TableSchema::OriginalBucketKeys enforces that), and the check above already refuses a
+        // managed blob field in the primary key. Kept for a future bucket key that does not
+        // have to come from the primary key.
+        if (std::find(table_schema.BucketKeys().begin(), table_schema.BucketKeys().end(),
+                      field_name) != table_schema.BucketKeys().end()) {
+            return Status::Invalid(
+                fmt::format("Managed BLOB field {} cannot be a bucket key.", field_name));
+        }
+        const auto& sequence_fields = options.GetSequenceField();
+        if (std::find(sequence_fields.begin(), sequence_fields.end(), field_name) !=
+            sequence_fields.end()) {
+            return Status::Invalid(
+                fmt::format("Managed BLOB field {} cannot be a sequence field.", field_name));
+        }
+    }
+
+    if (options.GetBlobTargetFileSize() <= 0) {
+        return Status::Invalid(
+            fmt::format("'{}' must be positive for tables with managed BLOB fields, but is {}.",
+                        Options::BLOB_TARGET_FILE_SIZE, options.GetBlobTargetFileSize()));
+    }
+    MergeEngine merge_engine = options.GetMergeEngine();
+    if (merge_engine != MergeEngine::DEDUPLICATE && merge_engine != MergeEngine::PARTIAL_UPDATE &&
+        merge_engine != MergeEngine::FIRST_ROW) {
+        return Status::Invalid(
+            "Primary-key tables with managed BLOB fields only support the deduplicate, "
+            "partial-update and first-row merge engines.");
+    }
+    if (options.GetChangelogProducer() != ChangelogProducer::NONE) {
+        return Status::Invalid(
+            "Primary-key tables with managed BLOB fields do not support changelog producers.");
+    }
+    // Checked on the raw option: resolving the paths would surface unrelated strategy errors
+    // instead of this rule, and configuring the option at all — even as an empty string — is
+    // rejected.
+    if (options.ToMap().count(Options::DATA_FILE_EXTERNAL_PATHS) != 0) {
+        return Status::Invalid(
+            "Primary-key tables with managed BLOB fields do not support data file external "
+            "paths.");
+    }
+    // Only an effective "true" is rejected; an explicit "false" equals the default behavior.
+    if (options.PkClusteringOverride()) {
+        return Status::Invalid(
+            fmt::format("Primary-key tables with managed BLOB fields do not support '{}'.",
+                        Options::PK_CLUSTERING_OVERRIDE));
+    }
+    // The option names a source table whose own file system the descriptors would have to be
+    // re-materialized through; Paimon C++ always uses the table's own, so accepting it would
+    // silently change credential semantics. Fail loudly until the capability is supported.
+    if (options.ToMap().count(Options::BLOB_DESCRIPTOR_SOURCE_TABLE) != 0) {
+        return Status::NotImplemented(
+            fmt::format("Paimon C++ does not support '{}' for primary-key tables with managed "
+                        "BLOB fields; descriptors are always read through the table's own file "
+                        "system.",
+                        Options::BLOB_DESCRIPTOR_SOURCE_TABLE));
+    }
+
+    // A retract row drops its managed BLOB payload, so an aggregate function that has to see
+    // the retracted value cannot protect a managed BLOB field through a sequence group.
+    if (merge_engine == MergeEngine::PARTIAL_UPDATE && !options.IgnoreDelete()) {
+        std::set<std::string> sequence_group_protected_fields;
+        for (const auto& [ordering_fields, protected_fields] : options.GetFieldsSequenceGroups()) {
+            for (const auto& protected_field :
+                 StringUtils::Split(protected_fields, Options::FIELDS_SEPARATOR)) {
+                sequence_group_protected_fields.insert(protected_field);
+            }
+        }
+        for (const auto& field_name : managed_blob_fields) {
+            if (sequence_group_protected_fields.count(field_name) == 0) {
+                continue;
+            }
+            PAIMON_ASSIGN_OR_RAISE(std::optional<std::string> aggregate_function,
+                                   options.GetFieldAggFunc(field_name));
+            if (!aggregate_function) {
+                aggregate_function = options.GetFieldsDefaultFunc();
+            }
+            PAIMON_ASSIGN_OR_RAISE(bool ignore_retract, options.FieldAggIgnoreRetract(field_name));
+            if (aggregate_function && aggregate_function.value() != FieldLastValueAgg::NAME &&
+                !ignore_retract) {
+                return Status::Invalid(fmt::format(
+                    "Managed BLOB field '{}' cannot use aggregate function '{}' because "
+                    "managed BLOB payloads are not retained in retract messages. Set "
+                    "'fields.{}.ignore-retract' to true to ignore retract messages.",
+                    field_name, aggregate_function.value(), field_name));
+            }
+        }
+    }
+    return Status::OK();
+}
+
+Status SchemaValidation::ValidateSequenceGroupOrderingFields(const TableSchema& table_schema,
+                                                             const CoreOptions& options) {
+    if (options.GetMergeEngine() != MergeEngine::PARTIAL_UPDATE) {
+        return Status::OK();
+    }
+    for (const auto& [ordering_fields, protected_fields] : options.GetFieldsSequenceGroups()) {
+        std::vector<std::string> ordering_field_names =
+            StringUtils::Split(ordering_fields, Options::FIELDS_SEPARATOR);
+        PAIMON_ASSIGN_OR_RAISE(std::vector<DataField> fields,
+                               table_schema.GetFields(ordering_field_names));
+        for (const auto& field : fields) {
+            // A BLOB value cannot order rows: for managed fields it is a storage descriptor,
+            // not a stable logical value.
+            if (BlobUtils::IsBlobField(field.ArrowField())) {
+                return Status::Invalid(fmt::format(
+                    "Field '{}' with BLOB type cannot be used as a sequence-group ordering "
+                    "field in option 'fields.{}.sequence-group'.",
+                    field.Name(), ordering_fields));
+            }
+        }
     }
     return Status::OK();
 }

--- a/src/paimon/core/schema/schema_validation.h
+++ b/src/paimon/core/schema/schema_validation.h
@@ -71,6 +71,19 @@ class SchemaValidation {
 
     static Status ValidateRowTracking(const TableSchema& table_schema, const CoreOptions& options);
 
+    /// Validates the managed BLOB configuration of a primary-key table: managed blob fields
+    /// cannot be key or ordering fields, only merge engines and options compatible with
+    /// externally stored payloads are allowed, a sequence-group-protected managed blob
+    /// field cannot use an aggregate function that needs the retracted payload, and the
+    /// capabilities Paimon C++ has not ported are rejected by value or presence
+    /// (`pk-clustering-override` set to true, `blob-descriptor.source-table`).
+    static Status ValidatePrimaryKeyBlobConfiguration(const TableSchema& table_schema,
+                                                      const CoreOptions& options);
+
+    /// Validates that no partial-update sequence-group ordering field is a BLOB column.
+    static Status ValidateSequenceGroupOrderingFields(const TableSchema& table_schema,
+                                                      const CoreOptions& options);
+
     static Status ValidateBlobFields(const TableSchema& schema, const CoreOptions& options);
 
     static Status ValidateMapStorageLayout(const TableSchema& schema, const CoreOptions& options);

--- a/src/paimon/core/schema/schema_validation_test.cpp
+++ b/src/paimon/core/schema/schema_validation_test.cpp
@@ -313,6 +313,263 @@ TEST(SchemaValidationTest, TestWithBlobField) {
     }
 }
 
+TEST(SchemaValidationTest, TestPrimaryKeyManagedBlob) {
+    auto f0 = arrow::field("f0", arrow::utf8(), /*nullable=*/false);
+    auto f1 = arrow::field("f1", arrow::int32());
+    std::shared_ptr<arrow::Field> f2 = BlobUtils::ToArrowField("f2", true);
+    arrow::FieldVector fields = {f0, f1, f2};
+    auto schema = arrow::schema(fields);
+    std::vector<std::string> primary_keys = {"f0"};
+    std::vector<std::string> partition_keys = {};
+    {
+        // A primary-key table manages its blob payloads itself: neither row tracking nor data
+        // evolution is required.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // first-row is an allowed merge engine for managed blob tables.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::MERGE_ENGINE, "first-row"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::MERGE_ENGINE, "aggregation"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "only support the deduplicate, partial-update and first-row merge "
+                            "engines");
+    }
+    {
+        // A managed blob descriptor is rewritten by compaction and cannot produce a changelog.
+        // The table-wide rule that Paimon C++ supports no changelog producer at all rejects
+        // this first; the managed blob rule behind it stays a second line of defence for when
+        // changelog producers arrive.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::CHANGELOG_PRODUCER, "input"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "keep changelog-producer as 'none'");
+    }
+    {
+        // An explicit "none" is the default behaviour and stays allowed, so neither rule can
+        // degrade into rejecting the option itself.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::CHANGELOG_PRODUCER, "none"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // Declaring every blob column inline leaves the table without managed blob fields, so
+        // none of the managed restrictions apply — here the otherwise rejected clustering
+        // override and source table are both accepted.
+        std::map<std::string, std::string> options = {
+            {Options::BUCKET, "2"},
+            {Options::BUCKET_KEY, "f0"},
+            {Options::BLOB_DESCRIPTOR_FIELD, "f2"},
+            {Options::PK_CLUSTERING_OVERRIDE, "true"},
+            {Options::BLOB_DESCRIPTOR_SOURCE_TABLE, "foo.bar"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // The blob target file size drives pack rolling and must be positive.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::BLOB_TARGET_FILE_SIZE, "0"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "must be positive for tables with managed BLOB fields");
+    }
+    {
+        // A managed blob field stores a storage descriptor, not a stable logical value, so
+        // it cannot identify a row.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"}};
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, partition_keys,
+                                                 /*primary_keys=*/{"f0", "f2"}, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot be part of the primary key");
+    }
+    {
+        // Nor can it order rows.
+        std::map<std::string, std::string> options = {
+            {Options::BUCKET, "2"}, {Options::BUCKET_KEY, "f0"}, {Options::SEQUENCE_FIELD, "f2"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot be a sequence field");
+    }
+    {
+        // The option would re-materialize descriptors through another table's credentials;
+        // C++ rejects it instead of silently using the table's own file system.
+        std::map<std::string, std::string> options = {
+            {Options::BUCKET, "2"},
+            {Options::BUCKET_KEY, "f0"},
+            {Options::BLOB_DESCRIPTOR_SOURCE_TABLE, "foo.bar"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "does not support 'blob-descriptor.source-table'");
+    }
+    {
+        // The unsupported clustering override is rejected by value: only "true"
+        // fails, an explicit "false" equals the default behavior.
+        std::map<std::string, std::string> options = {{Options::BUCKET, "2"},
+                                                      {Options::BUCKET_KEY, "f0"},
+                                                      {Options::PK_CLUSTERING_OVERRIDE, "true"}};
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<TableSchema> table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "do not support 'pk-clustering-override'");
+
+        options[Options::PK_CLUSTERING_OVERRIDE] = "false";
+        ASSERT_OK_AND_ASSIGN(
+            table_schema,
+            TableSchema::Create(/*schema_id=*/0, schema, partition_keys, primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // Managed packs stay in the default bucket directory; external data paths are
+        // rejected on the raw option: configuring the option at all — even
+        // as an empty string — fails.
+        for (const std::string& external_paths : {std::string("file:///tmp/data"), std::string()}) {
+            std::map<std::string, std::string> options = {
+                {Options::BUCKET, "2"},
+                {Options::BUCKET_KEY, "f0"},
+                {Options::DATA_FILE_EXTERNAL_PATHS, external_paths}};
+            ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                                 TableSchema::Create(/*schema_id=*/0, schema, partition_keys,
+                                                     primary_keys, options));
+            ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                                "do not support data file external paths");
+        }
+    }
+}
+
+TEST(SchemaValidationTest, TestPrimaryKeyManagedBlobSequenceGroups) {
+    auto f0 = arrow::field("f0", arrow::utf8(), /*nullable=*/false);
+    auto f1 = arrow::field("f1", arrow::int32());
+    std::shared_ptr<arrow::Field> f2 = BlobUtils::ToArrowField("f2", true);
+    arrow::FieldVector fields = {f0, f1, f2};
+    auto schema = arrow::schema(fields);
+    std::vector<std::string> primary_keys = {"f0"};
+    std::map<std::string, std::string> base_options = {{Options::BUCKET, "2"},
+                                                       {Options::BUCKET_KEY, "f0"},
+                                                       {Options::MERGE_ENGINE, "partial-update"}};
+    {
+        // A sequence group may protect the managed blob field without an aggregate function.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // An aggregate function that needs the retracted value is rejected: retract rows drop
+        // the managed blob payload.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace("fields.f2.aggregate-function", "listagg");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot use aggregate function");
+    }
+    {
+        // With ignore-delete the retract messages never reach the merge function, so the
+        // payload can no longer be lost and the aggregate function is accepted.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace("fields.f2.aggregate-function", "listagg");
+        options.emplace(Options::IGNORE_DELETE, "true");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // last_value never needs the retracted value.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace("fields.f2.aggregate-function", "last_value");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // ignore-retract explicitly accepts the dropped payload.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace("fields.f2.aggregate-function", "listagg");
+        options.emplace("fields.f2.ignore-retract", "true");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // Without a per-field function the default aggregate function applies and is checked
+        // through the same rule.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace(Options::FIELDS_DEFAULT_AGG_FUNC, "listagg");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot use aggregate function");
+    }
+    {
+        // A last_value default aggregate function never needs the retracted value.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f1.sequence-group", "f2");
+        options.emplace(Options::FIELDS_DEFAULT_AGG_FUNC, "last_value");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+    }
+    {
+        // A BLOB column cannot order a sequence group.
+        std::map<std::string, std::string> options = base_options;
+        options.emplace("fields.f2.sequence-group", "f1");
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<TableSchema> table_schema,
+                             TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                                 primary_keys, options));
+        ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
+                            "cannot be used as a sequence-group ordering field");
+    }
+}
+
 TEST(SchemaValidationTest, TestDuplicateField) {
     auto f0 = arrow::field("f0", arrow::map(arrow::utf8(), arrow::int32()));
     auto f1 = arrow::field("f1", arrow::int32());

--- a/src/paimon/core/table/sink/commit_message_impl.h
+++ b/src/paimon/core/table/sink/commit_message_impl.h
@@ -22,6 +22,8 @@
 #include <cstdint>
 #include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "paimon/commit_message.h"
 #include "paimon/common/data/binary_row.h"
@@ -64,6 +66,25 @@ class CommitMessageImpl : public CommitMessage {
         return data_increment_.IsEmpty() && compact_increment_.IsEmpty();
     }
 
+    /// Paths of the managed blob packs this message's writer created, which
+    /// `FileStoreCommit::Abort` deletes when the commit never lands.
+    ///
+    /// The packs a message *references* cannot be used instead: a compaction rewrites blob
+    /// descriptors verbatim, so a compacted file's `.blobref` sidecar lists the packs of the
+    /// files it merged, which older snapshots still read.
+    ///
+    /// Deliberately outside the serialized form, which other engines read too: a message that
+    /// crosses a process boundary loses the list, so the far side's rollback leaves the packs
+    /// behind rather than deleting the wrong ones. Leaking is the failure this trades for, and
+    /// it is the one the rest of the design already tolerates.
+    const std::vector<std::string>& OwnedManagedBlobPacks() const {
+        return owned_managed_blob_packs_;
+    }
+
+    void SetOwnedManagedBlobPacks(std::vector<std::string> packs) {
+        owned_managed_blob_packs_ = std::move(packs);
+    }
+
     std::string ToString() const;
 
     bool operator==(const CommitMessageImpl& other) const;
@@ -76,6 +97,7 @@ class CommitMessageImpl : public CommitMessage {
     std::optional<int32_t> total_buckets_;
     DataIncrement data_increment_;
     CompactIncrement compact_increment_;
+    std::vector<std::string> owned_managed_blob_packs_;
 };
 
 }  // namespace paimon

--- a/src/paimon/core/table/source/key_value_table_read.cpp
+++ b/src/paimon/core/table/source/key_value_table_read.cpp
@@ -19,9 +19,16 @@
 
 #include "paimon/core/table/source/key_value_table_read.h"
 
+#include <set>
+#include <string>
 #include <utility>
+#include <vector>
 
+#include "arrow/type.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/reader/managed_blob_resolving_batch_reader.h"
 #include "paimon/core/global_index/indexed_split_impl.h"
+#include "paimon/core/operation/internal_read_context.h"
 #include "paimon/core/operation/merge_file_split_read.h"
 #include "paimon/core/operation/raw_file_split_read.h"
 #include "paimon/core/table/source/data_split_impl.h"
@@ -95,7 +102,9 @@ Result<std::unique_ptr<BatchReader>> KeyValueTableRead::CreateReader(
                     PAIMON_ASSIGN_OR_RAISE(bool matched,
                                            read->Match(indexed_split, /*force_keep_delete=*/false));
                     if (matched) {
-                        return read->CreateReader(indexed_split);
+                        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> reader,
+                                               read->CreateReader(indexed_split));
+                        return WrapWithManagedBlobResolverIfNeeded(std::move(reader));
                     }
                     // A manually supplied or deserialized indexed split can still reference
                     // legacy files. Preserve merge semantics when raw-read safety is uncertain.
@@ -120,10 +129,30 @@ Result<std::unique_ptr<BatchReader>> KeyValueTableRead::CreateReader(
     for (const auto& read : split_reads_) {
         PAIMON_ASSIGN_OR_RAISE(bool matched, read->Match(data_split, force_keep_delete_));
         if (matched) {
-            return read->CreateReader(data_split);
+            PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<BatchReader> reader,
+                                   read->CreateReader(data_split));
+            return WrapWithManagedBlobResolverIfNeeded(std::move(reader));
         }
     }
     return Status::Invalid("create reader failed, not read match with data split.");
+}
+
+Result<std::unique_ptr<BatchReader>> KeyValueTableRead::WrapWithManagedBlobResolverIfNeeded(
+    std::unique_ptr<BatchReader>&& reader) const {
+    const CoreOptions& options = context_->GetCoreOptions();
+    // With blob-as-descriptor the caller wants the descriptors themselves.
+    if (options.BlobAsDescriptor()) {
+        return std::move(reader);
+    }
+    std::vector<std::string> inline_field_names = options.GetBlobInlineFields();
+    std::set<std::string> inline_fields(inline_field_names.begin(), inline_field_names.end());
+    std::vector<std::string> managed_fields =
+        BlobUtils::ManagedBlobFieldNames(context_->GetReadSchema(), inline_fields);
+    if (managed_fields.empty()) {
+        return std::move(reader);
+    }
+    return std::make_unique<ManagedBlobResolvingBatchReader>(
+        std::move(reader), std::move(managed_fields), options.GetFileSystem(), GetMemoryPool());
 }
 
 Result<std::unique_ptr<CountReader>> KeyValueTableRead::CreateCountReader(

--- a/src/paimon/core/table/source/key_value_table_read.h
+++ b/src/paimon/core/table/source/key_value_table_read.h
@@ -57,6 +57,11 @@ class KeyValueTableRead : public TableRead {
                       const std::shared_ptr<MemoryPool>& memory_pool,
                       const std::shared_ptr<Executor>& executor);
 
+    /// Wraps the split reader with the managed blob resolver when the read schema holds
+    /// managed blob fields and the read wants payload bytes rather than descriptors.
+    Result<std::unique_ptr<BatchReader>> WrapWithManagedBlobResolverIfNeeded(
+        std::unique_ptr<BatchReader>&& reader) const;
+
     std::vector<std::unique_ptr<SplitRead>> split_reads_;
     std::shared_ptr<FileStorePathFactory> path_factory_;
     std::shared_ptr<InternalReadContext> context_;

--- a/src/paimon/core/utils/commit_increment.h
+++ b/src/paimon/core/utils/commit_increment.h
@@ -21,6 +21,9 @@
 
 #include <memory>
 #include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "paimon/core/compact/compact_deletion_file.h"
 #include "paimon/core/io/compact_increment.h"
@@ -66,11 +69,26 @@ class CommitIncrement {
         realtime_offset_range_ = offset_range;
     }
 
+    /// Paths of the managed blob packs this increment's writer created and handed over, which a
+    /// rollback of the resulting commit has to delete. Empty for every table without managed
+    /// blob fields.
+    ///
+    /// Taking rather than reading: ownership moves on to the commit message built from this
+    /// increment, and leaving a second copy behind would invite two owners deleting one pack.
+    std::vector<std::string> TakeOwnedManagedBlobPacks() {
+        return std::move(owned_managed_blob_packs_);
+    }
+
+    void SetOwnedManagedBlobPacks(std::vector<std::string> packs) {
+        owned_managed_blob_packs_ = std::move(packs);
+    }
+
  private:
     DataIncrement data_increment_;
     CompactIncrement compact_increment_;
     std::shared_ptr<CompactDeletionFile> compact_deletion_file_;
     std::optional<OffsetRange> realtime_offset_range_;
+    std::vector<std::string> owned_managed_blob_packs_;
 };
 
 }  // namespace paimon

--- a/src/paimon/core/utils/data_evolution_utils.cpp
+++ b/src/paimon/core/utils/data_evolution_utils.cpp
@@ -18,6 +18,12 @@
 
 #include "paimon/core/utils/data_evolution_utils.h"
 
+#include <algorithm>
+#include <limits>
+#include <optional>
+
+#include "fmt/format.h"
+#include "fmt/ranges.h"
 #include "paimon/common/data/blob_utils.h"
 #include "paimon/common/utils/vector_store_utils.h"
 #include "paimon/core/io/data_file_meta.h"
@@ -27,6 +33,25 @@ namespace paimon {
 
 bool DataEvolutionUtils::IsNormalFile(const std::string& file_name) {
     return !BlobUtils::IsBlobFile(file_name) && !VectorStoreUtils::IsVectorStoreFile(file_name);
+}
+
+bool DataEvolutionUtils::HasNormalFile(const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+    return std::any_of(files.begin(), files.end(), [](const std::shared_ptr<DataFileMeta>& file) {
+        return file != nullptr && IsNormalFile(file->file_name);
+    });
+}
+
+bool DataEvolutionUtils::IsMaterializedCompaction(
+    const std::vector<std::shared_ptr<DataFileMeta>>& before,
+    const std::vector<std::shared_ptr<DataFileMeta>>& after) {
+    if (!HasNormalFile(before)) {
+        return false;
+    }
+    // Every output is looked at, dedicated files included: a materialized rewrite assigns no
+    // row id to any of them.
+    return std::all_of(after.begin(), after.end(), [](const std::shared_ptr<DataFileMeta>& file) {
+        return file != nullptr && file->first_row_id == std::nullopt;
+    });
 }
 
 Result<std::shared_ptr<DataFileMeta>> DataEvolutionUtils::RetrieveAnchorFile(
@@ -48,6 +73,44 @@ Result<std::shared_ptr<DataFileMeta>> DataEvolutionUtils::RetrieveAnchorFile(
             "group.");
     }
     return anchor;
+}
+
+Result<Range> DataEvolutionUtils::CheckContiguousRowRange(
+    const std::vector<std::shared_ptr<DataFileMeta>>& files) {
+    if (files.empty()) {
+        return Status::Invalid("Data evolution compact files should not be empty.");
+    }
+    std::vector<Range> ranges;
+    ranges.reserve(files.size());
+    for (const auto& file : files) {
+        // A public entry, so the row id range is validated here as well, not only by the
+        // compaction planner's input checks.
+        if (file == nullptr) {
+            return Status::Invalid("Data evolution compact files must not be null.");
+        }
+        PAIMON_ASSIGN_OR_RAISE(int64_t first_row_id, file->NonNullFirstRowId());
+        if (file->row_count <= 0 || first_row_id < 0 ||
+            first_row_id > std::numeric_limits<int64_t>::max() - file->row_count) {
+            return Status::Invalid(
+                fmt::format("Invalid data evolution compact input {}: first row id {} and row "
+                            "count {} must form a valid row id range.",
+                            file->file_name, first_row_id, file->row_count));
+        }
+        ranges.emplace_back(first_row_id, first_row_id + file->row_count - 1);
+    }
+    std::vector<Range> merged = Range::SortAndMergeOverlap(ranges, /*adjacent=*/true);
+    if (merged.size() != 1) {
+        std::vector<std::string> range_strings;
+        range_strings.reserve(merged.size());
+        for (const auto& range : merged) {
+            range_strings.push_back(range.ToString());
+        }
+        return Status::Invalid(
+            fmt::format("Data evolution compact files should have a contiguous row range, "
+                        "but got [{}].",
+                        fmt::join(range_strings, ", ")));
+    }
+    return merged[0];
 }
 
 }  // namespace paimon

--- a/src/paimon/core/utils/data_evolution_utils.h
+++ b/src/paimon/core/utils/data_evolution_utils.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "paimon/result.h"
+#include "paimon/utils/range.h"
 
 namespace paimon {
 struct DataFileMeta;
@@ -38,10 +39,9 @@ class DataEvolutionUtils {
     /// pairs. A group's deletion vector is maintained against its anchor, so the vector's
     /// positions are relative to the anchor's row id range.
     ///
-    /// The rule has to stay identical to the engine that writes the vectors, which keys them by
-    /// the same file (Paimon Java's DataEvolutionUtils#retrieveAnchorFile). A vector keyed by
-    /// any other file of the group, or one whose anchor a pruning dropped, is never found here
-    /// and its deleted rows silently come back.
+    /// The rule has to stay identical to every engine that writes the vectors, since they key
+    /// them by the same file. A vector keyed by any other file of the group, or one whose
+    /// anchor a pruning dropped, is never found here and its deleted rows silently come back.
     ///
     /// @param files The files of one row range group, in any order.
     /// @return The anchor file, or an error when the group holds no normal file.
@@ -51,6 +51,28 @@ class DataEvolutionUtils {
     /// Whether the file can anchor a row range group, that is neither a blob file nor a
     /// vector-store file.
     static bool IsNormalFile(const std::string& file_name);
+
+    /// Whether `files` holds at least one normal file.
+    static bool HasNormalFile(const std::vector<std::shared_ptr<DataFileMeta>>& files);
+
+    /// Whether a compact increment materialized its deletions rather than keeping them
+    /// logical: it replaced at least one normal file and wrote every output *without* a row
+    /// id, which the commit then assigns afresh.
+    ///
+    /// An empty output counts as materialized too: a row range whose rows were all deleted
+    /// rewrites to nothing at all, and every side of the commit — the deletion vector
+    /// rewrite, the global index drop and the conflict check — has to recognise that without
+    /// an output file to look at, which is why they share this rule.
+    static bool IsMaterializedCompaction(const std::vector<std::shared_ptr<DataFileMeta>>& before,
+                                         const std::vector<std::shared_ptr<DataFileMeta>>& after);
+
+    /// Checks that the row id ranges of `files` merge into one contiguous range and returns it.
+    ///
+    /// Both halves of data-evolution compaction depend on this: a compact task may only
+    /// rewrite a contiguous run of rows, and the deletion vector rewrite relies on the same
+    /// property to map a group's deleted positions onto the compacted file.
+    static Result<Range> CheckContiguousRowRange(
+        const std::vector<std::shared_ptr<DataFileMeta>>& files);
 };
 
 }  // namespace paimon

--- a/src/paimon/core/utils/data_evolution_utils_test.cpp
+++ b/src/paimon/core/utils/data_evolution_utils_test.cpp
@@ -18,6 +18,7 @@
 
 #include "paimon/core/utils/data_evolution_utils.h"
 
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -39,6 +40,19 @@ std::shared_ptr<DataFileMeta> CreateFile(const std::string& file_name,
                                    /*schema_id=*/0, FileSource::Append(),
                                    /*value_stats_cols=*/std::nullopt,
                                    /*external_path=*/std::nullopt, /*first_row_id=*/0,
+                                   /*write_cols=*/std::nullopt)
+        .value();
+}
+
+std::shared_ptr<DataFileMeta> CreateRangeFile(const std::string& file_name,
+                                              const std::optional<int64_t>& first_row_id,
+                                              int64_t row_count) {
+    return DataFileMeta::ForAppend(file_name, /*file_size=*/1, row_count,
+                                   /*row_stats=*/SimpleStats::EmptyStats(),
+                                   /*min_sequence_number=*/0, /*max_sequence_number=*/1,
+                                   /*schema_id=*/0, FileSource::Append(),
+                                   /*value_stats_cols=*/std::nullopt,
+                                   /*external_path=*/std::nullopt, first_row_id,
                                    /*write_cols=*/std::nullopt)
         .value();
 }
@@ -82,6 +96,90 @@ TEST(DataEvolutionUtilsTest, TestRetrieveAnchorFileTieBreaksWithFileName) {
         std::shared_ptr<DataFileMeta> anchor,
         DataEvolutionUtils::RetrieveAnchorFile({larger_file_name, smaller_file_name}));
     ASSERT_EQ(anchor, smaller_file_name);
+}
+
+TEST(DataEvolutionUtilsTest, TestCheckContiguousRowRangeMergesOverlappingAndAdjacentFiles) {
+    // The shape a compact task hands over: two evolved field groups covering the same rows,
+    // followed by the group after them. Overlapping and adjacent ranges both merge, and the
+    // result is the range the rewritten file has to end up covering.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateRangeFile("group-a-full.parquet", /*first_row_id=*/0, /*row_count=*/4),
+        CreateRangeFile("group-a-f2.parquet", /*first_row_id=*/0, /*row_count=*/4),
+        CreateRangeFile("group-b.parquet", /*first_row_id=*/4, /*row_count=*/2)};
+
+    ASSERT_OK_AND_ASSIGN(Range range, DataEvolutionUtils::CheckContiguousRowRange(files));
+    ASSERT_EQ(range.from, 0);
+    ASSERT_EQ(range.to, 5);
+
+    // A single file is contiguous by itself.
+    ASSERT_OK_AND_ASSIGN(Range single, DataEvolutionUtils::CheckContiguousRowRange(
+                                           {CreateRangeFile("only.parquet", 7, 3)}));
+    ASSERT_EQ(single.from, 7);
+    ASSERT_EQ(single.to, 9);
+}
+
+TEST(DataEvolutionUtilsTest, TestCheckContiguousRowRangeRejectsAGap) {
+    // A hole between the inputs would leave the rows in the hole claimed by a file that does
+    // not hold them, so the merged ranges must collapse into exactly one.
+    std::vector<std::shared_ptr<DataFileMeta>> files = {
+        CreateRangeFile("a.parquet", /*first_row_id=*/0, /*row_count=*/2),
+        CreateRangeFile("b.parquet", /*first_row_id=*/100, /*row_count=*/2)};
+    ASSERT_NOK_WITH_MSG(DataEvolutionUtils::CheckContiguousRowRange(files),
+                        "should have a contiguous row range");
+}
+
+TEST(DataEvolutionUtilsTest, TestCheckContiguousRowRangeRejectsInvalidFileMeta) {
+    // A public entry validates its own input; each case must fail for its own reason.
+    ASSERT_NOK_WITH_MSG(DataEvolutionUtils::CheckContiguousRowRange({}),
+                        "compact files should not be empty");
+    ASSERT_NOK_WITH_MSG(DataEvolutionUtils::CheckContiguousRowRange({nullptr}),
+                        "compact files must not be null");
+    // A file without a row id has no range to preserve.
+    ASSERT_NOK_WITH_MSG(DataEvolutionUtils::CheckContiguousRowRange(
+                            {CreateRangeFile("f1.parquet", /*first_row_id=*/std::nullopt,
+                                             /*row_count=*/2)}),
+                        "First row id of f1.parquet should not be null");
+    // Zero row count.
+    ASSERT_NOK_WITH_MSG(DataEvolutionUtils::CheckContiguousRowRange(
+                            {CreateRangeFile("f1.parquet", /*first_row_id=*/0, /*row_count=*/0)}),
+                        "must form a valid row id range");
+    // Negative first row id.
+    ASSERT_NOK_WITH_MSG(DataEvolutionUtils::CheckContiguousRowRange({CreateRangeFile(
+                            "f1.parquet", /*first_row_id=*/-5, /*row_count=*/100)}),
+                        "must form a valid row id range");
+    // A row range overflowing int64.
+    ASSERT_NOK_WITH_MSG(DataEvolutionUtils::CheckContiguousRowRange({CreateRangeFile(
+                            "f1.parquet", /*first_row_id=*/std::numeric_limits<int64_t>::max() - 1,
+                            /*row_count=*/100)}),
+                        "must form a valid row id range");
+}
+
+TEST(DataEvolutionUtilsTest, TestIsMaterializedCompaction) {
+    std::shared_ptr<DataFileMeta> normal_before =
+        CreateRangeFile("before.parquet", /*first_row_id=*/0, /*row_count=*/2);
+    std::shared_ptr<DataFileMeta> blob_before =
+        CreateRangeFile("before.blob", /*first_row_id=*/0, /*row_count=*/2);
+    std::shared_ptr<DataFileMeta> keeps_row_id =
+        CreateRangeFile("after.parquet", /*first_row_id=*/0, /*row_count=*/2);
+    std::shared_ptr<DataFileMeta> renumbered =
+        CreateRangeFile("after.parquet", /*first_row_id=*/std::nullopt, /*row_count=*/2);
+
+    // Outputs written without a row id: the commit assigns fresh ones, which is materializing.
+    ASSERT_TRUE(DataEvolutionUtils::IsMaterializedCompaction({normal_before}, {renumbered}));
+    // A range whose rows were all deleted rewrites to nothing at all, and still counts.
+    ASSERT_TRUE(DataEvolutionUtils::IsMaterializedCompaction({normal_before}, {}));
+    // A normal compaction keeps the row ids of what it replaced.
+    ASSERT_FALSE(DataEvolutionUtils::IsMaterializedCompaction({normal_before}, {keeps_row_id}));
+    // One output keeping its row id is enough not to be a materialized rewrite.
+    ASSERT_FALSE(
+        DataEvolutionUtils::IsMaterializedCompaction({normal_before}, {renumbered, keeps_row_id}));
+    // Replacing no normal file at all is neither: an index-only or dedicated-file-only message.
+    ASSERT_FALSE(DataEvolutionUtils::IsMaterializedCompaction({}, {renumbered}));
+    ASSERT_FALSE(DataEvolutionUtils::IsMaterializedCompaction({blob_before}, {renumbered}));
+
+    ASSERT_TRUE(DataEvolutionUtils::HasNormalFile({blob_before, normal_before}));
+    ASSERT_FALSE(DataEvolutionUtils::HasNormalFile({blob_before}));
+    ASSERT_FALSE(DataEvolutionUtils::HasNormalFile({}));
 }
 
 }  // namespace paimon::test

--- a/src/paimon/format/blob/blob_format_writer.cpp
+++ b/src/paimon/format/blob/blob_format_writer.cpp
@@ -19,11 +19,14 @@
 #include "paimon/format/blob/blob_format_writer.h"
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "arrow/api.h"
 #include "arrow/c/bridge.h"
+#include "fmt/format.h"
 #include "paimon/common/data/blob_defs.h"
 #include "paimon/common/data/blob_descriptor.h"
 #include "paimon/common/data/blob_utils.h"
@@ -33,6 +36,7 @@
 #include "paimon/common/utils/checked_cast.h"
 #include "paimon/common/utils/delta_varint_compressor.h"
 #include "paimon/data/blob.h"
+#include "paimon/defs.h"
 #include "paimon/fs/file_system.h"
 #include "paimon/io/byte_array_input_stream.h"
 #include "paimon/logging.h"
@@ -44,7 +48,8 @@ BlobFormatWriter::BlobFormatWriter(const std::shared_ptr<OutputStream>& out, con
                                    bool write_null_on_missing_file,
                                    bool write_null_on_fetch_failure, bool write_placeholder,
                                    const std::shared_ptr<FileSystem>& fs,
-                                   const std::shared_ptr<MemoryPool>& pool)
+                                   const std::shared_ptr<MemoryPool>& pool,
+                                   int64_t copy_buffer_size)
     : out_(out),
       uri_(uri),
       data_type_(data_type),
@@ -53,10 +58,11 @@ BlobFormatWriter::BlobFormatWriter(const std::shared_ptr<OutputStream>& out, con
       write_null_on_missing_file_(write_null_on_missing_file),
       write_null_on_fetch_failure_(write_null_on_fetch_failure),
       write_placeholder_(write_placeholder) {
-    // Create() has already checked that data_type has exactly one BLOB field.
+    // Create() has already checked that data_type has exactly one BLOB field and that
+    // copy_buffer_size is within range.
     blob_field_name_ = data_type_->field(0)->name();
     metrics_ = std::make_shared<MetricsImpl>();
-    tmp_buffer_ = Bytes::AllocateBytes(kTmpBufferSize, pool_.get());
+    tmp_buffer_ = Bytes::AllocateBytes(copy_buffer_size, pool_.get());
     magic_number_bytes_ = IntegerToLittleEndian<int32_t>(BlobDefs::kMagicNumber, pool_);
     logger_ = Logger::GetLogger("BlobFormatWriter");
 }
@@ -64,9 +70,15 @@ BlobFormatWriter::BlobFormatWriter(const std::shared_ptr<OutputStream>& out, con
 Result<std::unique_ptr<BlobFormatWriter>> BlobFormatWriter::Create(
     const std::shared_ptr<OutputStream>& out, const std::shared_ptr<arrow::DataType>& data_type,
     bool write_null_on_missing_file, bool write_null_on_fetch_failure, bool write_placeholder,
-    const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool) {
+    const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool,
+    int64_t copy_buffer_size) {
     if (out == nullptr) {
         return Status::Invalid("blob format writer create failed. out is nullptr");
+    }
+    if (copy_buffer_size <= 0 || copy_buffer_size > std::numeric_limits<int32_t>::max()) {
+        return Status::Invalid(fmt::format(
+            "'{}' must be between 1 byte and {} bytes, but was {} bytes.",
+            Options::BLOB_COPY_BUFFER_SIZE, std::numeric_limits<int32_t>::max(), copy_buffer_size));
     }
     if (data_type == nullptr) {
         return Status::Invalid("blob format writer create failed. data_type is nullptr");
@@ -86,9 +98,9 @@ Result<std::unique_ptr<BlobFormatWriter>> BlobFormatWriter::Create(
             fmt::format("field {} is not BLOB", data_type->field(0)->ToString()));
     }
     PAIMON_ASSIGN_OR_RAISE(std::string uri, out->GetUri());
-    return std::unique_ptr<BlobFormatWriter>(
-        new BlobFormatWriter(out, uri, data_type, write_null_on_missing_file,
-                             write_null_on_fetch_failure, write_placeholder, fs, pool));
+    return std::unique_ptr<BlobFormatWriter>(new BlobFormatWriter(
+        out, uri, data_type, write_null_on_missing_file, write_null_on_fetch_failure,
+        write_placeholder, fs, pool, copy_buffer_size));
 }
 
 Status BlobFormatWriter::AddBatch(ArrowArray* batch) {
@@ -98,6 +110,9 @@ Status BlobFormatWriter::AddBatch(ArrowArray* batch) {
     if (batch->length != 1) {
         return Status::Invalid("BlobFormatWriter only supports batch with a row count of 1");
     }
+    // Only a record that stores payload bytes publishes a range; NULL and placeholder
+    // entries leave it empty.
+    last_payload_range_.reset();
     PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Array> arrow_array,
                                       arrow::ImportArray(batch, data_type_));
 
@@ -161,6 +176,11 @@ Status BlobFormatWriter::Finish() {
 }
 
 Status BlobFormatWriter::WriteBlob(std::string_view blob_data) {
+    // Probe the output position before any stream is opened, so a probe failure has nothing
+    // to leak: from the moment the input stream exists, every path runs through the explicit
+    // Close below.
+    PAIMON_ASSIGN_OR_RAISE(int64_t previous_pos, out_->GetPos());
+
     // Open the blob input stream before writing any bytes, so that a failed fetch can be
     // converted to a NULL element without leaving partial data in the output stream.
     // Whether blob_data is a serialized BlobDescriptor is detected by its magic header rather
@@ -180,33 +200,43 @@ Status BlobFormatWriter::WriteBlob(std::string_view blob_data) {
     } else {
         in = std::make_unique<ByteArrayInputStream>(blob_data.data(), blob_data.size());
     }
-    PAIMON_ASSIGN_OR_RAISE(int64_t file_length, in->Length());
-
     crc32_ = 0;
-    PAIMON_ASSIGN_OR_RAISE(int64_t previous_pos, out_->GetPos());
 
-    // write magic number
-    PAIMON_RETURN_NOT_OK(WriteWithCrc32(magic_number_bytes_->data(), magic_number_bytes_->size()));
-    int64_t total_read_length = 0;
-    int64_t read_len = std::min(file_length, static_cast<int64_t>(tmp_buffer_->size()));
-    while (read_len > 0) {
-        PAIMON_ASSIGN_OR_RAISE(int64_t actual_read_len, in->Read(tmp_buffer_->data(), read_len));
-        if (actual_read_len != read_len) {
-            return Status::Invalid(
-                fmt::format("actual read length {}, not match with expect length {}",
-                            actual_read_len, read_len));
+    // Copy the payload; the source stream is closed on every path and a failed copy keeps its
+    // own error. Partial reads are legal for a file system and are simply continued.
+    Status copy_status = [&]() -> Status {
+        PAIMON_ASSIGN_OR_RAISE(int64_t file_length, in->Length());
+        // write magic number
+        PAIMON_RETURN_NOT_OK(
+            WriteWithCrc32(magic_number_bytes_->data(), magic_number_bytes_->size()));
+        int64_t total_read_length = 0;
+        while (total_read_length < file_length) {
+            int64_t read_len = std::min(file_length - total_read_length,
+                                        static_cast<int64_t>(tmp_buffer_->size()));
+            PAIMON_ASSIGN_OR_RAISE(int64_t actual_read_len,
+                                   in->Read(tmp_buffer_->data(), read_len));
+            if (actual_read_len <= 0 || actual_read_len > read_len) {
+                return Status::IOError(fmt::format("unexpected read length {} after {} of {} bytes",
+                                                   actual_read_len, total_read_length,
+                                                   file_length));
+            }
+            PAIMON_RETURN_NOT_OK(WriteWithCrc32(tmp_buffer_->data(), actual_read_len));
+            total_read_length += actual_read_len;
         }
-        PAIMON_RETURN_NOT_OK(WriteWithCrc32(tmp_buffer_->data(), actual_read_len));
-        total_read_length += actual_read_len;
-        read_len =
-            std::min(file_length - total_read_length, static_cast<int64_t>(tmp_buffer_->size()));
+        return Status::OK();
+    }();
+    Status in_close_status = in->Close();
+    if (copy_status.ok()) {
+        copy_status = in_close_status;
     }
+    PAIMON_RETURN_NOT_OK(copy_status);
 
     // write bin length
     PAIMON_ASSIGN_OR_RAISE(int64_t current_pos, out_->GetPos());
     /// magic number(4) + blob content(bin length - 16) + bin length(8) + crc32(4)
     /// ↑                                             ↑
     /// previous_pos                               current_pos
+    last_payload_range_ = std::make_pair(previous_pos + 4, current_pos - previous_pos - 4);
     int64_t bin_length = current_pos - previous_pos + 8 + 4;
     bin_lengths_.push_back(bin_length);
     PAIMON_UNIQUE_PTR<Bytes> bin_length_bytes = IntegerToLittleEndian<int64_t>(bin_length, pool_);
@@ -290,10 +320,16 @@ Result<std::unique_ptr<InputStream>> BlobFormatWriter::HandleFetchFailure(
 }
 
 Status BlobFormatWriter::WriteBytes(const char* data, int64_t length) {
-    PAIMON_ASSIGN_OR_RAISE(int64_t actual, out_->Write(data, length));
-    if (actual != length) {
-        return Status::Invalid(
-            fmt::format("unexpected actual length {} not match with expect {}", actual, length));
+    int64_t total_written = 0;
+    while (total_written < length) {
+        PAIMON_ASSIGN_OR_RAISE(int64_t actual,
+                               out_->Write(data + total_written, length - total_written));
+        // Like the read path, reject a backend claiming more than was requested.
+        if (actual <= 0 || actual > length - total_written) {
+            return Status::IOError(fmt::format("unexpected written length {} after {} of {} bytes",
+                                               actual, total_written, length));
+        }
+        total_written += actual;
     }
     return Status::OK();
 }

--- a/src/paimon/format/blob/blob_format_writer.h
+++ b/src/paimon/format/blob/blob_format_writer.h
@@ -21,12 +21,15 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "arrow/api.h"
 #include "arrow/util/crc32.h"
+#include "paimon/common/data/blob_defs.h"
 #include "paimon/format/format_writer.h"
 #include "paimon/logging.h"
 #include "paimon/memory/bytes.h"
@@ -76,10 +79,14 @@ class BlobFormatWriter : public FormatWriter {
     /// BlobDefs::kPlaceholderSentinel as a placeholder entry (bin_length -2, no data bytes);
     /// any other value is stored verbatim. When disabled, values are never interpreted and can
     /// never be turned into placeholder entries.
+    ///
+    /// `copy_buffer_size` is the payload copy buffer size in bytes (see
+    /// Options::BLOB_COPY_BUFFER_SIZE); production callers should pass the configured value.
     static Result<std::unique_ptr<BlobFormatWriter>> Create(
         const std::shared_ptr<OutputStream>& out, const std::shared_ptr<arrow::DataType>& data_type,
         bool write_null_on_missing_file, bool write_null_on_fetch_failure, bool write_placeholder,
-        const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool);
+        const std::shared_ptr<FileSystem>& fs, const std::shared_ptr<MemoryPool>& pool,
+        int64_t copy_buffer_size = BlobDefs::kDefaultCopyBufferSize);
 
     Status AddBatch(ArrowArray* batch) override;
 
@@ -88,6 +95,14 @@ class BlobFormatWriter : public FormatWriter {
     Status Finish() override;
 
     Result<bool> ReachTargetSize(bool suggested_check, int64_t target_size) const override;
+
+    /// The (offset, length) of the payload bytes stored by the last AddBatch, or nullopt when
+    /// that record kept no payload (a NULL or placeholder entry). This is the byte range a
+    /// BlobDescriptor for the record must point at; exposing it here keeps the record layout
+    /// out of callers.
+    std::optional<std::pair<int64_t, int64_t>> LastPayloadRange() const override {
+        return last_payload_range_;
+    }
 
     std::shared_ptr<Metrics> GetWriterMetrics() const override {
         return metrics_;
@@ -100,7 +115,7 @@ class BlobFormatWriter : public FormatWriter {
                      const std::shared_ptr<arrow::DataType>& data_type,
                      bool write_null_on_missing_file, bool write_null_on_fetch_failure,
                      bool write_placeholder, const std::shared_ptr<FileSystem>& fs,
-                     const std::shared_ptr<MemoryPool>& pool);
+                     const std::shared_ptr<MemoryPool>& pool, int64_t copy_buffer_size);
 
     Status WriteBlob(std::string_view blob_data);
 
@@ -127,8 +142,6 @@ class BlobFormatWriter : public FormatWriter {
                                                           const std::shared_ptr<MemoryPool>& pool);
 
  private:
-    static constexpr uint32_t kTmpBufferSize = 1024 * 1024;
-
     uint32_t crc32_ = 0;
     std::vector<int64_t> bin_lengths_;
     std::shared_ptr<OutputStream> out_;
@@ -144,6 +157,7 @@ class BlobFormatWriter : public FormatWriter {
     bool write_null_on_missing_file_ = false;
     bool write_null_on_fetch_failure_ = false;
     bool write_placeholder_ = false;
+    std::optional<std::pair<int64_t, int64_t>> last_payload_range_;
     uint64_t null_on_missing_file_count_ = 0;
     uint64_t null_on_fetch_failure_count_ = 0;
     std::unique_ptr<Logger> logger_;

--- a/src/paimon/format/blob/blob_format_writer_test.cpp
+++ b/src/paimon/format/blob/blob_format_writer_test.cpp
@@ -18,6 +18,7 @@
 
 #include "paimon/format/blob/blob_format_writer.h"
 
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -109,6 +110,99 @@ class VanishingFileSystem : public LocalFileSystem {
 
  private:
     mutable int64_t exists_call_count_ = 0;
+};
+
+/// An input stream that delegates to a real one but reports a read length the copy loop has to
+/// refuse: zero, standing in for a backend that returns nothing while bytes remain, or one byte
+/// more than was asked for, standing in for one claiming to have filled past the buffer.
+class BadReadInputStream : public InputStream {
+ public:
+    BadReadInputStream(std::unique_ptr<InputStream>&& wrapped, bool read_more)
+        : wrapped_(std::move(wrapped)), read_more_(read_more) {}
+
+    Status Seek(int64_t offset, SeekOrigin origin) override {
+        return wrapped_->Seek(offset, origin);
+    }
+
+    Result<int64_t> GetPos() const override {
+        return wrapped_->GetPos();
+    }
+
+    Result<int64_t> Read(char* buffer, int64_t size) override {
+        PAIMON_ASSIGN_OR_RAISE(int64_t actual_read_len, wrapped_->Read(buffer, size));
+        return read_more_ ? actual_read_len + 1 : 0;
+    }
+
+    Result<int64_t> Read(char* buffer, int64_t size, int64_t offset) override {
+        return wrapped_->Read(buffer, size, offset);
+    }
+
+    void ReadAsync(char* buffer, int64_t size, int64_t offset,
+                   std::function<void(Status)>&& callback) override {
+        wrapped_->ReadAsync(buffer, size, offset, std::move(callback));
+    }
+
+    Status Close() override {
+        return wrapped_->Close();
+    }
+
+    Result<std::string> GetUri() const override {
+        return wrapped_->GetUri();
+    }
+
+    Result<int64_t> Length() const override {
+        return wrapped_->Length();
+    }
+
+ private:
+    std::unique_ptr<InputStream> wrapped_;
+    bool read_more_;
+};
+
+/// A file system handing out those streams, so a test can drive the copy loop's read guard.
+class BadReadFileSystem : public LocalFileSystem {
+ public:
+    explicit BadReadFileSystem(bool read_more) : read_more_(read_more) {}
+
+    Result<std::unique_ptr<InputStream>> Open(const std::string& path) const override {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<InputStream> wrapped, real_fs_.Open(path));
+        return std::unique_ptr<InputStream>(
+            std::make_unique<BadReadInputStream>(std::move(wrapped), read_more_));
+    }
+
+ private:
+    LocalFileSystem real_fs_;
+    bool read_more_;
+};
+
+/// An output stream that stores nothing while reporting a written length the write loop has to
+/// refuse: zero, or one byte more than it was handed.
+class BadWriteOutputStream : public OutputStream {
+ public:
+    explicit BadWriteOutputStream(bool write_more) : write_more_(write_more) {}
+
+    Result<int64_t> GetPos() const override {
+        return 0;
+    }
+
+    Result<int64_t> Write(const char* buffer, int64_t size) override {
+        return write_more_ ? size + 1 : 0;
+    }
+
+    Status Flush() override {
+        return Status::OK();
+    }
+
+    Status Close() override {
+        return Status::OK();
+    }
+
+    Result<std::string> GetUri() const override {
+        return std::string("mock://bad-write");
+    }
+
+ private:
+    bool write_more_;
 };
 
 class BlobFormatWriterTestBase : public ::testing::Test {
@@ -340,6 +434,20 @@ TEST_P(BlobFormatWriterTest, TestCreateWithInvalidParameters) {
                                                  /*write_null_on_fetch_failure=*/false,
                                                  /*write_placeholder=*/false, file_system_, pool_),
                         "field regular_col: binary is not BLOB");
+
+    // Test with out-of-range copy buffer sizes
+    ASSERT_NOK_WITH_MSG(
+        BlobFormatWriter::Create(output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/false,
+                                 /*write_placeholder=*/false, file_system_, pool_,
+                                 /*copy_buffer_size=*/0),
+        "must be between 1 byte and");
+    ASSERT_NOK_WITH_MSG(
+        BlobFormatWriter::Create(output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/false,
+                                 /*write_placeholder=*/false, file_system_, pool_,
+                                 static_cast<int64_t>(std::numeric_limits<int32_t>::max()) + 1),
+        "must be between 1 byte and");
 }
 
 TEST_P(BlobFormatWriterTest, TestInvalidCase) {
@@ -443,8 +551,8 @@ TEST_P(BlobFormatWriterTest, TestLargeBlob) {
     ASSERT_OK_AND_ASSIGN(auto large_file_stream,
                          file_system_->Create(large_file_path, /*overwrite=*/true));
 
-    // Write data larger than TMP_BUFFER_SIZE (1MB)
-    const size_t large_size = BlobFormatWriter::kTmpBufferSize * 2 + 1000;  // ~2MB
+    // Write data larger than the default copy buffer so the copy loops over several chunks
+    const size_t large_size = BlobDefs::kDefaultCopyBufferSize * 2 + 1000;  // ~9KB
     std::vector<char> large_data(large_size, 'A');
     ASSERT_OK_AND_ASSIGN(int64_t written, large_file_stream->Write(large_data.data(), large_size));
     ASSERT_EQ(written, large_size);
@@ -970,6 +1078,71 @@ TEST_P(BlobFormatWriterTest, TestAddBatchWithZeroLengthBlob) {
 /// Placeholder tests always feed the sentinel bytes of the placeholder write protocol, so
 /// they do not depend on the blob_as_descriptor_ parameter and run once on the
 /// non-parameterized fixture.
+using BlobFormatWriterCopyBufferTest = BlobFormatWriterTestBase;
+
+TEST_F(BlobFormatWriterCopyBufferTest, TestTinyCopyBufferCopiesInChunks) {
+    // A one-byte copy buffer forces the payload copy to loop chunk by chunk; the record must
+    // still round-trip byte for byte.
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<BlobFormatWriter> writer,
+        BlobFormatWriter::Create(output_stream_, struct_type_, /*write_null_on_missing_file=*/false,
+                                 /*write_null_on_fetch_failure=*/false,
+                                 /*write_placeholder=*/false, file_system_, pool_,
+                                 /*copy_buffer_size=*/1));
+    const std::string payload = "tiny-buffer-payload";
+    ASSERT_OK_AND_ASSIGN(auto blob_array, MakeBlobArrayFromBytes(payload));
+    ASSERT_OK(AddBatchOnce(writer, blob_array));
+    ASSERT_OK(writer->Flush());
+    ASSERT_OK(writer->Finish());
+
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::StructArray> struct_array, ReadBackAsData());
+    ASSERT_EQ(struct_array->length(), 1);
+    auto binary_array =
+        arrow::internal::checked_pointer_cast<arrow::LargeBinaryArray>(struct_array->field(0));
+    ASSERT_FALSE(binary_array->IsNull(0));
+    ASSERT_EQ(binary_array->GetString(0), payload);
+}
+
+TEST_F(BlobFormatWriterCopyBufferTest, TestImpossibleReadLengthIsRejected) {
+    // The copy loop continues a partial read, but a read returning nothing would spin forever and
+    // one claiming more than the buffer holds would checksum bytes that were never read. Both are
+    // refused instead of continued.
+    std::string payload_file = paimon::test::GetDataDir() + "/xxhash.data";
+    for (bool read_more : {false, true}) {
+        auto bad_fs = std::make_shared<BadReadFileSystem>(read_more);
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<OutputStream> out,
+            file_system_->Create(dir_->Str() + (read_more ? "/read-more.blob" : "/read-none.blob"),
+                                 /*overwrite=*/true));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<BlobFormatWriter> writer,
+                             BlobFormatWriter::Create(out, struct_type_,
+                                                      /*write_null_on_missing_file=*/false,
+                                                      /*write_null_on_fetch_failure=*/false,
+                                                      /*write_placeholder=*/false, bad_fs, pool_));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<Blob> blob,
+                             Blob::FromPath(payload_file, /*offset=*/0, /*length=*/91));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::Array> array, PrepareDescriptorArray(blob));
+        ASSERT_NOK_WITH_MSG(AddBatchOnce(writer, array), "unexpected read length");
+        ASSERT_OK(out->Close());
+    }
+}
+
+TEST_F(BlobFormatWriterCopyBufferTest, TestImpossibleWrittenLengthIsRejected) {
+    // The same on the writing side: a backend that stores nothing, or claims to have taken more
+    // than it was handed, would leave the record framing wrong, so neither is continued.
+    for (bool write_more : {false, true}) {
+        auto out = std::make_shared<BadWriteOutputStream>(write_more);
+        ASSERT_OK_AND_ASSIGN(
+            std::shared_ptr<BlobFormatWriter> writer,
+            BlobFormatWriter::Create(out, struct_type_, /*write_null_on_missing_file=*/false,
+                                     /*write_null_on_fetch_failure=*/false,
+                                     /*write_placeholder=*/false, file_system_, pool_));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::Array> array,
+                             MakeBlobArrayFromBytes("payload-bytes"));
+        ASSERT_NOK_WITH_MSG(AddBatchOnce(writer, array), "unexpected written length");
+    }
+}
+
 using BlobFormatWriterPlaceholderTest = BlobFormatWriterTestBase;
 
 std::string PlaceholderSentinelBytes() {

--- a/src/paimon/format/blob/blob_writer_builder.h
+++ b/src/paimon/format/blob/blob_writer_builder.h
@@ -27,6 +27,7 @@
 
 #include "arrow/api.h"
 #include "paimon/common/data/blob_defs.h"
+#include "paimon/common/options/memory_size.h"
 #include "paimon/common/utils/options_utils.h"
 #include "paimon/defs.h"
 #include "paimon/format/blob/blob_format_writer.h"
@@ -79,8 +80,15 @@ class BlobWriterBuilder : public SpecificFSWriterBuilder {
         PAIMON_ASSIGN_OR_RAISE(
             bool write_placeholder,
             OptionsUtils::GetValueFromMap<bool>(options_, BlobDefs::kWritePlaceholderKey, false));
+        int64_t copy_buffer_size = BlobDefs::kDefaultCopyBufferSize;
+        auto copy_buffer_iter = options_.find(Options::BLOB_COPY_BUFFER_SIZE);
+        if (copy_buffer_iter != options_.end()) {
+            PAIMON_ASSIGN_OR_RAISE(copy_buffer_size,
+                                   MemorySize::ParseBytes(copy_buffer_iter->second));
+        }
         return BlobFormatWriter::Create(out, data_type_, write_null_on_missing_file,
-                                        write_null_on_fetch_failure, write_placeholder, fs_, pool_);
+                                        write_null_on_fetch_failure, write_placeholder, fs_, pool_,
+                                        copy_buffer_size);
     }
 
  private:

--- a/src/paimon/format/blob/blob_writer_builder_test.cpp
+++ b/src/paimon/format/blob/blob_writer_builder_test.cpp
@@ -59,6 +59,24 @@ TEST_F(BlobWriterBuilderTest, TestSimple) {
     ASSERT_OK(builder.Build(output_stream_, "none"));
 }
 
+TEST_F(BlobWriterBuilderTest, TestCopyBufferSizeOption) {
+    // An out-of-range value fails the build: the option string reaches the writer's
+    // range validation.
+    BlobWriterBuilder invalid_builder(struct_type_, {{Options::BLOB_COPY_BUFFER_SIZE, "0"}});
+    invalid_builder.WithFileSystem(file_system_);
+    ASSERT_NOK_WITH_MSG(invalid_builder.Build(output_stream_, "none"),
+                        "must be between 1 byte and");
+
+    // A memory-size string parses and builds.
+    ASSERT_OK_AND_ASSIGN(
+        std::shared_ptr<OutputStream> out,
+        file_system_->Create(dir_->Str() + "/file-copy-buffer.blob", /*overwrite=*/true));
+    BlobWriterBuilder builder(struct_type_, {{Options::BLOB_COPY_BUFFER_SIZE, "8 kb"}});
+    builder.WithFileSystem(file_system_);
+    ASSERT_OK(builder.Build(out, "none"));
+    ASSERT_OK(out->Close());
+}
+
 TEST_F(BlobWriterBuilderTest, TestWriteNullOptions) {
     auto prepare_batch = [&](const std::shared_ptr<Blob>& blob, ArrowArray* c_array) -> Status {
         PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Array> array,

--- a/src/paimon/testing/utils/deletion_vector_test_helper.h
+++ b/src/paimon/testing/utils/deletion_vector_test_helper.h
@@ -31,7 +31,6 @@
 #include "paimon/common/types/data_field.h"
 #include "paimon/common/utils/range_helper.h"
 #include "paimon/core/core_options.h"
-#include "paimon/core/deletionvectors/bitmap_deletion_vector.h"
 #include "paimon/core/deletionvectors/deletion_vector.h"
 #include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
 #include "paimon/core/index/index_file_meta.h"
@@ -48,7 +47,6 @@
 #include "paimon/memory/memory_pool.h"
 #include "paimon/result.h"
 #include "paimon/status.h"
-#include "paimon/utils/roaring_bitmap32.h"
 
 namespace paimon::test {
 
@@ -117,7 +115,10 @@ class DeletionVectorTestHelper {
         for (const auto& [file_name, deleted_positions] : deleted_positions_by_file) {
             // deleting through the vector itself applies the same position bound a writer is
             // held to, instead of narrowing to the bitmap's index type and wrapping silently
-            auto deletion_vector = std::make_shared<BitmapDeletionVector>(RoaringBitmap32());
+            // Follow the table's configured vector kind, so a bitmap64 table is exercised
+            // through the 64 bit path rather than silently getting 32 bit vectors.
+            std::shared_ptr<DeletionVector> deletion_vector =
+                DeletionVector::Create(core_options.DeletionVectorsBitmap64());
             for (int64_t position : deleted_positions) {
                 if (position < 0) {
                     return Status::Invalid(fmt::format(

--- a/test/inte/CMakeLists.txt
+++ b/test/inte/CMakeLists.txt
@@ -22,6 +22,13 @@ if(PAIMON_BUILD_TESTS)
                     test_utils_static
                     ${GTEST_LINK_TOOLCHAIN})
 
+    add_paimon_test(pk_blob_table_inte_test
+                    STATIC_LINK_LIBS
+                    paimon_shared
+                    ${TEST_STATIC_LINK_LIBS}
+                    test_utils_static
+                    ${GTEST_LINK_TOOLCHAIN})
+
     add_paimon_test(variant_table_inte_test
                     STATIC_LINK_LIBS
                     paimon_shared

--- a/test/inte/blob_table_inte_test.cpp
+++ b/test/inte/blob_table_inte_test.cpp
@@ -40,6 +40,7 @@
 #include "arrow/ipc/json_simple.h"
 #include "arrow/type.h"
 #include "gtest/gtest.h"
+#include "paimon/append/append_compact_coordinator.h"
 #include "paimon/commit_context.h"
 #include "paimon/common/data/binary_array_writer.h"
 #include "paimon/common/data/binary_row.h"
@@ -54,9 +55,12 @@
 #include "paimon/common/utils/checked_cast.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/common/utils/string_utils.h"
 #include "paimon/core/global_index/indexed_split_impl.h"
+#include "paimon/core/io/compact_increment.h"
 #include "paimon/core/snapshot.h"
 #include "paimon/core/stats/simple_stats.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
 #include "paimon/core/table/source/data_split_impl.h"
 #include "paimon/core/utils/file_utils.h"
 #include "paimon/core/utils/snapshot_manager.h"
@@ -670,6 +674,65 @@ TEST_P(BlobTableInteTest, TestAppendTableWriteWithBlobAsDescriptorFalse) {
 
     // BLOB_AS_DESCRIPTOR=false: blob data is stored inline, read result should match input
     ASSERT_OK(ScanAndRead(table_path, schema->field_names(), write_array));
+}
+
+TEST_P(BlobTableInteTest, TestDataEvolutionCompactionLeavesBlobFilesInPlace) {
+    CreateTable();
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    // Two commits build two evolved field groups over contiguous row ids; each write stores
+    // its blob column in a dedicated .blob file next to the normal data file.
+    auto array1 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [0, "blob-0", "s0"],
+        [1, "blob-1", "s1"]
+    ])")
+            .ValueOrDie());
+    auto array2 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [2, "blob-2", "s2"],
+        [3, "blob-3", "s3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs1,
+                         WriteArray(table_path, {}, schema->field_names(), {array1}));
+    ASSERT_OK(Commit(table_path, commit_msgs1));
+    ASSERT_OK_AND_ASSIGN(auto commit_msgs2,
+                         WriteArray(table_path, {}, schema->field_names(), {array2}));
+    ASSERT_OK(Commit(table_path, commit_msgs2));
+
+    // The coordinator rewrites only the normal files; the dedicated blob files never enter
+    // the task and stay in place, still covering the rewritten file's row range.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), pool_));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 2);
+    for (const auto& file : compact_increment.CompactBefore()) {
+        ASSERT_FALSE(StringUtils::EndsWith(file->file_name, ".blob")) << file->file_name;
+    }
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    ASSERT_FALSE(StringUtils::EndsWith(compact_increment.CompactAfter()[0]->file_name, ".blob"));
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // The blob payloads still resolve after the rewrite: the read serves the normal columns
+    // from the compacted file and the blob column from the untouched .blob files.
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [0, "blob-0", "s0"],
+        [1, "blob-1", "s1"],
+        [2, "blob-2", "s2"],
+        [3, "blob-3", "s3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, schema->field_names(), expected_array));
 }
 
 TEST_P(BlobTableInteTest, TestWriteNullOnMissingFile) {

--- a/test/inte/clean_inte_test.cpp
+++ b/test/inte/clean_inte_test.cpp
@@ -48,10 +48,14 @@
 #include "paimon/common/utils/checked_cast.h"
 #include "paimon/common/utils/date_time_utils.h"
 #include "paimon/common/utils/path_util.h"
+#include "paimon/core/io/compact_increment.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/data_increment.h"
 #include "paimon/core/manifest/manifest_file_meta.h"
 #include "paimon/core/manifest/manifest_list.h"
 #include "paimon/core/operation/file_store_commit_impl.h"
 #include "paimon/core/snapshot.h"
+#include "paimon/core/table/sink/commit_message_impl.h"
 #include "paimon/core/utils/snapshot_manager.h"
 #include "paimon/defs.h"
 #include "paimon/file_store_commit.h"
@@ -685,6 +689,98 @@ TEST_F(CleanInteTest, TestOrphanFilesClean) {
         ASSERT_OK_AND_ASSIGN(std::set<std::string> cleaned_paths, cleaner->Clean());
         ASSERT_TRUE(CheckEqual(
             cleaned_paths, {"data-orphan2.orc", "manifest-orphan", ".manifest-orphan.uuid.tmp"}));
+    }
+}
+
+TEST_F(CleanInteTest, TestOrphanFilesCleanKeepsCompanionFilesOfLiveDataFiles) {
+    // A data file's extra files - a managed blob reference sidecar, for instance - live and die
+    // with the data file itself. They are cleanable on their own, so the used-file set has to
+    // register every manifest entry's extra files: a sidecar of a live data file must survive
+    // the clean, while one nothing references is genuinely orphaned.
+    auto string_field = arrow::field("f0", arrow::utf8());
+    auto int_field = arrow::field("f1", arrow::int32());
+    auto int_field1 = arrow::field("f2", arrow::int32());
+    auto double_field = arrow::field("f3", arrow::float64());
+    auto schema =
+        arrow::schema(arrow::FieldVector({string_field, int_field, int_field1, double_field}));
+
+    std::string commit_user = "commit_user_1";
+    ::ArrowSchema arrow_schema;
+    ASSERT_TRUE(arrow::ExportSchema(*schema, &arrow_schema).ok());
+
+    std::map<std::string, std::string> options = {
+        {Options::MANIFEST_FORMAT, "orc"}, {Options::FILE_FORMAT, "orc"},
+        {Options::FILE_SYSTEM, "local"},   {Options::BUCKET, "1"},
+        {Options::BUCKET_KEY, "f3"},
+    };
+
+    auto dir = UniqueTestDirectory::Create();
+    ASSERT_TRUE(dir);
+    ASSERT_OK_AND_ASSIGN(std::string table_path,
+                         CreateTestTable(dir->Str(), /*db_name=*/"foo",
+                                         /*table_name=*/"bar", &arrow_schema,
+                                         /*partition_keys=*/{},
+                                         /*primary_keys=*/{}, options));
+
+    WriteContextBuilder context_builder(table_path, commit_user);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<WriteContext> write_context,
+                         context_builder.SetOptions(options).WithStreamingMode(true).Finish());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreWrite> file_store_write,
+                         FileStoreWrite::Create(std::move(write_context)));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<RecordBatch> batch,
+                         MakeRecordBatch({{"Alice", 10, 1, 11.1}, {"Bob", 10, 0, 12.1}},
+                                         /*partition_map=*/{}, /*bucket=*/0));
+    ASSERT_OK(file_store_write->Write(std::move(batch)));
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> results,
+                         file_store_write->PrepareCommit(/*wait_compaction=*/false, 0));
+    ASSERT_FALSE(results.empty());
+
+    // Give every written data file a companion sidecar next to it, and carry it in the manifest
+    // entry the same way a managed blob write does.
+    std::vector<std::shared_ptr<CommitMessage>> messages_with_sidecars;
+    std::vector<std::string> live_sidecar_paths;
+    for (const auto& message : results) {
+        auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(message);
+        ASSERT_TRUE(message_impl);
+        std::vector<std::shared_ptr<DataFileMeta>> new_files;
+        for (const auto& file : message_impl->GetNewFilesIncrement().NewFiles()) {
+            std::string sidecar_file_name = file->file_name + ".blobref";
+            std::string sidecar_path = PathUtil::JoinPath(
+                table_path, fmt::format("bucket-{}/{}", message_impl->Bucket(), sidecar_file_name));
+            ASSERT_OK(file_system_->WriteFile(sidecar_path, "sidecar", /*overwrite=*/true));
+            live_sidecar_paths.push_back(sidecar_path);
+            new_files.push_back(file->CopyWithExtraFiles({sidecar_file_name}));
+        }
+        ASSERT_FALSE(new_files.empty());
+        messages_with_sidecars.push_back(std::make_shared<CommitMessageImpl>(
+            message_impl->Partition(), message_impl->Bucket(), message_impl->TotalBuckets(),
+            DataIncrement(std::move(new_files), /*deleted_files=*/{}, /*changelog_files=*/{}),
+            message_impl->GetCompactIncrement()));
+    }
+
+    CommitContextBuilder commit_context_builder(table_path, commit_user);
+    ASSERT_OK_AND_ASSIGN(
+        std::unique_ptr<CommitContext> commit_context,
+        commit_context_builder.WithFileSystem(file_system_).IgnoreEmptyCommit(false).Finish());
+    ASSERT_OK_AND_ASSIGN(auto commit, FileStoreCommit::Create(std::move(commit_context)));
+    ASSERT_OK(commit->Commit(messages_with_sidecars, 0));
+
+    // A sidecar whose data file no snapshot records: nothing protects it.
+    std::string orphan_sidecar_path =
+        PathUtil::JoinPath(table_path, "bucket-0/data-orphan.orc.blobref");
+    ASSERT_OK(file_system_->WriteFile(orphan_sidecar_path, "orphan", /*overwrite=*/true));
+
+    CleanContextBuilder clean_context_builder(table_path);
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<CleanContext> clean_context,
+                         clean_context_builder.WithFileSystem(file_system_)
+                             .WithOlderThanMs(std::numeric_limits<int64_t>::max())
+                             .Finish());
+    ASSERT_OK_AND_ASSIGN(auto cleaner, OrphanFilesCleaner::Create(std::move(clean_context)));
+    ASSERT_OK_AND_ASSIGN(std::set<std::string> cleaned_paths, cleaner->Clean());
+    ASSERT_TRUE(CheckEqual(cleaned_paths, {"data-orphan.orc.blobref"}));
+    for (const auto& sidecar_path : live_sidecar_paths) {
+        ASSERT_OK_AND_ASSIGN(bool exist, file_system_->Exists(sidecar_path));
+        ASSERT_TRUE(exist) << sidecar_path;
     }
 }
 

--- a/test/inte/data_evolution_table_test.cpp
+++ b/test/inte/data_evolution_table_test.cpp
@@ -17,24 +17,42 @@
  * under the License.
  */
 #include <algorithm>
+#include <set>
 #include <tuple>
+#include <utility>
 
 #include "arrow/type.h"
 #include "fmt/format.h"
 #include "gtest/gtest.h"
+#include "paimon/append/append_compact_coordinator.h"
 #include "paimon/common/factories/io_hook.h"
 #include "paimon/common/io/cache/lru_cache.h"
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/binary_row_partition_computer.h"
 #include "paimon/common/utils/date_time_utils.h"
+#include "paimon/common/utils/linked_hash_map.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
+#include "paimon/core/append/data_evolution_compact_global_index_dropper.h"
+#include "paimon/core/deletionvectors/deletion_vectors_index_file.h"
 #include "paimon/core/global_index/indexed_split_impl.h"
+#include "paimon/core/index/deletion_vector_meta.h"
+#include "paimon/core/index/global_index_meta.h"
+#include "paimon/core/index/index_file_handler.h"
+#include "paimon/core/index/index_file_meta.h"
+#include "paimon/core/manifest/index_manifest_entry.h"
+#include "paimon/core/manifest/index_manifest_file.h"
+#include "paimon/core/schema/schema_manager.h"
 #include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/core/utils/file_store_path_factory.h"
+#include "paimon/core/utils/index_file_path_factories.h"
+#include "paimon/core/utils/snapshot_manager.h"
 #include "paimon/defs.h"
 #include "paimon/fs/file_system.h"
 #include "paimon/global_index/bitmap_global_index_result.h"
 #include "paimon/global_index/indexed_split.h"
+#include "paimon/memory/bytes.h"
 #include "paimon/predicate/literal.h"
 #include "paimon/predicate/predicate_builder.h"
 #include "paimon/result.h"
@@ -179,6 +197,18 @@ class DataEvolutionTableTest : public ::testing::Test,
         return commit_message;
     }
 
+    /// The row id the next commit hands out, 0 for a table without a snapshot. A commit only
+    /// advances it over the row ids it assigned itself, so a group stamped past it does not
+    /// move it.
+    Result<int64_t> NextRowId(const std::string& table_path) const {
+        SnapshotManager snapshot_manager(dir_->GetFileSystem(), table_path);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> snapshot, snapshot_manager.LatestSnapshot());
+        if (!snapshot.has_value() || !snapshot.value().NextRowId()) {
+            return 0;
+        }
+        return snapshot.value().NextRowId().value();
+    }
+
     /// Writes one row range group holding `f0_values`, starting at `first_row_id`: a full-row
     /// write plus a partial f2 write over the same rows, so the group's split merges columns
     /// from two files and is not raw convertible. When `partition` is set the files land in that
@@ -187,9 +217,15 @@ class DataEvolutionTableTest : public ::testing::Test,
     /// The f2 write starts only once the full-row write is committed, which is what makes the
     /// f2 file the newer of the pair. Writing both before either commit left the column merge
     /// free to serve f2 from the full-row write instead.
+    ///
+    /// With `assign_row_ids_by_commit` the full-row write takes the row ids the commit hands
+    /// out, which keeps the table's next row id in step with the rows it holds. A caller that
+    /// places a group past that, to leave a row id gap, stamps the ids itself instead and
+    /// leaves the next row id where it was.
     Result<std::vector<std::shared_ptr<CommitMessage>>> WriteAndCommitGroup(
         const std::string& table_path, int64_t first_row_id, const std::vector<int32_t>& f0_values,
-        const std::map<std::string, std::string>& partition = {}) const {
+        const std::map<std::string, std::string>& partition = {},
+        bool assign_row_ids_by_commit = false) const {
         auto partition_f1 = partition.find("f1");
         std::string base_json = "[";
         std::string f2_json = "[";
@@ -212,10 +248,23 @@ class DataEvolutionTableTest : public ::testing::Test,
         PAIMON_ASSIGN_OR_RAISE(
             std::vector<std::shared_ptr<CommitMessage>> base_msgs,
             WriteArray(table_path, partition, arrow::schema(fields_)->field_names(), base_array));
-        // both writes are stamped with the same first row id, so their files cover the same row
-        // id range and form one row range group
+        // both writes cover the same first row id, so their files cover the same row id range
+        // and form one row range group
+        if (assign_row_ids_by_commit) {
+            PAIMON_ASSIGN_OR_RAISE(int64_t next_row_id, NextRowId(table_path));
+            if (next_row_id != first_row_id) {
+                return Status::Invalid(fmt::format(
+                    "The commit assigns row ids from {}, so it cannot place a group at {}.",
+                    next_row_id, first_row_id));
+            }
+            PAIMON_RETURN_NOT_OK(Commit(table_path, base_msgs));
+        } else {
+            SetFirstRowId(first_row_id, base_msgs);
+            PAIMON_RETURN_NOT_OK(Commit(table_path, base_msgs));
+        }
+        // The commit assigns row ids onto its own copies of the metas, so the caller's copies
+        // are stamped either way.
         SetFirstRowId(first_row_id, base_msgs);
-        PAIMON_RETURN_NOT_OK(Commit(table_path, base_msgs));
 
         arrow::FieldVector f2_fields = {fields_[2]};
         auto f2_array = std::dynamic_pointer_cast<arrow::StructArray>(
@@ -342,6 +391,138 @@ class DataEvolutionTableTest : public ::testing::Test,
             }
         }
         return DeletionVectorTestHelper::RetrieveAnchorFileNames(data_files);
+    }
+
+    /// Compaction of one row range group whose deletions have to survive it, for either vector
+    /// kind. The moved vector is rebuilt as the kind the table stores, because the two
+    /// serialize differently and refuse to merge into one another.
+    void CompactKeepsDeletionVectorsOfOneRowRangeGroup(bool bitmap64) {
+        std::map<std::string, std::string> extra_options;
+        if (bitmap64) {
+            extra_options.emplace(Options::DELETION_VECTOR_BITMAP64, "true");
+        }
+        std::map<std::string, std::string> options =
+            CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true, extra_options);
+        std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+        ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> group_msgs,
+                             WriteAndCommitGroup(table_path, /*first_row_id=*/0,
+                                                 /*f0_values=*/{1, 2, 3, 4}));
+
+        // Delete row ids 1 and 3 through the group's anchor file, the file the vector is keyed
+        // by.
+        ASSERT_OK_AND_ASSIGN(std::string anchor_file_name, PlannedAnchorFileName(table_path));
+        ASSERT_OK(CommitDeletionVectors(table_path, group_msgs[0],
+                                        {{anchor_file_name, /*deleted_positions=*/{1, 3}}}));
+        auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(
+                arrow::struct_({fields_[0], SpecialFields::RowId().field_}),
+                R"([
+        [1, 0],
+        [3, 2]
+    ])")
+                .ValueOrDie());
+        ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+
+        // The compaction rewrites the group's two files into one and re-keys their deletions
+        // onto it, so the round produces the data message plus one index-only message.
+        std::map<std::string, std::string> compact_options = options;
+        compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+        ASSERT_OK_AND_ASSIGN(
+            std::vector<std::shared_ptr<CommitMessage>> messages,
+            AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                          dir_->GetFileSystem(), GetDefaultPool()));
+        ASSERT_EQ(messages.size(), 2);
+        auto index_message = std::dynamic_pointer_cast<CommitMessageImpl>(messages[1]);
+        ASSERT_TRUE(index_message);
+        EXPECT_TRUE(index_message->GetCompactIncrement().CompactBefore().empty());
+        EXPECT_TRUE(index_message->GetCompactIncrement().CompactAfter().empty());
+        EXPECT_EQ(index_message->GetCompactIncrement().NewIndexFiles().size(), 1);
+        EXPECT_FALSE(index_message->GetCompactIncrement().DeletedIndexFiles().empty());
+        ASSERT_OK(Commit(table_path, messages));
+
+        // Same rows, same row ids: the deletions followed their rows onto the compacted file
+        // instead of being dropped by the rewrite.
+        ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+    }
+
+    /// RunAndCommit over several rounds on a table whose deletion vectors move in every
+    /// round, for either vector kind.
+    ///
+    /// This is where the snapshot each round re-reads and the index files each round rewrites
+    /// have to line up: round N+1 must see the index files round N wrote, not the ones it
+    /// replaced. Each group also gets its deletion vector in its own commit, so the partition
+    /// starts with one index file per group rather than a single shared one.
+    void RunAndCommitMovesDeletionVectorsEveryRound(bool bitmap64) {
+        std::map<std::string, std::string> extra_options;
+        if (bitmap64) {
+            extra_options.emplace(Options::DELETION_VECTOR_BITMAP64, "true");
+        }
+        std::map<std::string, std::string> options =
+            CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true, extra_options);
+        std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+        // Three groups at row ids [0,1], [4,5] and [8,9], each with a deletion on its own
+        // anchor, each deletion committed separately so it lands in its own index file. The row
+        // id gaps keep the groups in contiguous runs of their own, so a round merges the files
+        // of one group and never packs two groups into one file.
+        std::vector<std::string> known_anchors;
+        for (int32_t group = 0; group < 3; group++) {
+            int64_t first_row_id = group * 4;
+            ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> group_msgs,
+                                 WriteAndCommitGroup(table_path, first_row_id,
+                                                     /*f0_values=*/
+                                                     {static_cast<int32_t>(first_row_id + 1),
+                                                      static_cast<int32_t>(first_row_id + 2)}));
+            ASSERT_OK_AND_ASSIGN(std::vector<std::string> anchors,
+                                 PlannedAnchorFileNames(table_path));
+            std::string new_anchor;
+            for (const std::string& anchor : anchors) {
+                if (std::find(known_anchors.begin(), known_anchors.end(), anchor) ==
+                    known_anchors.end()) {
+                    new_anchor = anchor;
+                }
+            }
+            ASSERT_FALSE(new_anchor.empty());
+            known_anchors.push_back(new_anchor);
+            // Delete the group's second row, so every round has a vector to move.
+            ASSERT_OK(CommitDeletionVectors(table_path, group_msgs[0],
+                                            {{new_anchor, /*deleted_positions=*/{1}}}));
+        }
+
+        auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(
+                arrow::struct_({fields_[0], SpecialFields::RowId().field_}),
+                R"([
+        [1, 0],
+        [5, 4],
+        [9, 8]
+    ])")
+                .ValueOrDie());
+        ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+
+        std::map<std::string, std::string> compact_options = options;
+        compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+        ASSERT_OK_AND_ASSIGN(int32_t rounds, AppendCompactCoordinator::RunAndCommit(
+                                                 table_path, compact_options,
+                                                 /*partitions=*/{},
+                                                 /*commit_user=*/"commit_user_1",
+                                                 dir_->GetFileSystem(), GetDefaultPool(),
+                                                 /*candidate_files_per_round=*/1));
+        // Every group is compacted, and each round commits on its own.
+        ASSERT_GT(rounds, 1);
+
+        // The deletions followed their rows through every round: had a round read a stale
+        // index, or replaced index files another round still owned, rows would come back.
+        ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+
+        // Every group is one file now and no two of them are contiguous, so a further run -
+        // this one over the whole row id space at once - commits no round at all.
+        ASSERT_OK_AND_ASSIGN(
+            rounds, AppendCompactCoordinator::RunAndCommit(
+                        table_path, compact_options, /*partitions=*/{},
+                        /*commit_user=*/"commit_user_1", dir_->GetFileSystem(), GetDefaultPool()));
+        ASSERT_EQ(rounds, 0);
+        ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
     }
 
     /// PlannedAnchorFileNames for a table holding a single row range group.
@@ -536,6 +717,155 @@ class DataEvolutionTableTest : public ::testing::Test,
         return std::dynamic_pointer_cast<arrow::StructArray>(
             arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), data_str)
                 .ValueOrDie());
+    }
+
+    /// Creates the (f0, f1, f2) data evolution table partitioned by f1, with deletion vectors
+    /// on, and returns the options it was created with.
+    std::map<std::string, std::string> CreatePartitionedDataEvolutionTable() const {
+        std::map<std::string, std::string> options = {
+            {Options::MANIFEST_FORMAT, "orc"},         {Options::FILE_FORMAT, FileFormat()},
+            {Options::FILE_SYSTEM, "local"},           {Options::ROW_TRACKING_ENABLED, "true"},
+            {Options::DATA_EVOLUTION_ENABLED, "true"}, {Options::DELETION_VECTORS_ENABLED, "true"}};
+        CreateTable(/*partition_keys=*/{"f1"}, options);
+        return options;
+    }
+
+    /// Commits a global index over `row_range`, without building a real index file: the dropper
+    /// only ever looks at the manifest metadata, so a placeholder name is enough to observe
+    /// whether the entry survives a materialization.
+    Status CommitFakeGlobalIndex(const std::string& table_path, const std::string& index_file_name,
+                                 const std::map<std::string, std::string>& partition,
+                                 int64_t row_range_start, int64_t row_range_end) const {
+        GlobalIndexMeta global_index_meta(
+            row_range_start, row_range_end, /*index_field_id=*/1,
+            /*extra_field_ids=*/std::nullopt,
+            std::make_shared<Bytes>(std::string("{}"), GetDefaultPool().get()));
+        auto index_file_meta = std::make_shared<IndexFileMeta>(
+            "bitmap", index_file_name, /*file_size=*/10,
+            /*row_count=*/row_range_end - row_range_start + 1, /*dv_ranges=*/std::nullopt,
+            /*external_path=*/std::nullopt, global_index_meta);
+        PAIMON_ASSIGN_OR_RAISE(BinaryRow partition_row, BuildPartitionRow(partition));
+        DataIncrement data_increment({index_file_meta});
+        auto message = std::make_shared<CommitMessageImpl>(
+            partition_row, /*bucket=*/0, /*total_buckets=*/std::nullopt, data_increment,
+            CompactIncrement({}, {}, {}));
+        return Commit(table_path, {message});
+    }
+
+    /// The names of the global index files the latest snapshot still holds, so a test can tell
+    /// whether materializing dropped them.
+    Result<std::set<std::string>> ScanGlobalIndexFileNames(const std::string& table_path) const {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<IndexFileHandler> index_file_handler,
+                               CreateIndexFileHandler(table_path));
+        SnapshotManager snapshot_manager(dir_->GetFileSystem(), table_path);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> snapshot, snapshot_manager.LatestSnapshot());
+        std::set<std::string> result;
+        if (!snapshot.has_value()) {
+            return result;
+        }
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<IndexManifestEntry> entries,
+            index_file_handler->Scan(
+                snapshot.value(), [](const IndexManifestEntry& entry) -> Result<bool> {
+                    return entry.index_file->GetGlobalIndexMeta() != std::nullopt;
+                }));
+        for (const IndexManifestEntry& entry : entries) {
+            result.insert(entry.index_file->FileName());
+        }
+        return result;
+    }
+
+    /// The deletion-vector index the latest snapshot holds: which data files each index file
+    /// stores a vector for. Lets a test tell a rewritten index file from an untouched one, and
+    /// see whether a vector the rewrite had to carry over is still recorded.
+    Result<std::map<std::string, std::set<std::string>>> ScanDeletionVectorIndex(
+        const std::string& table_path) const {
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<IndexFileHandler> index_file_handler,
+                               CreateIndexFileHandler(table_path));
+        SnapshotManager snapshot_manager(dir_->GetFileSystem(), table_path);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<Snapshot> snapshot, snapshot_manager.LatestSnapshot());
+        std::map<std::string, std::set<std::string>> result;
+        if (!snapshot.has_value()) {
+            return result;
+        }
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<IndexManifestEntry> entries,
+            index_file_handler->Scan(snapshot.value(),
+                                     [](const IndexManifestEntry& entry) -> Result<bool> {
+                                         return entry.index_file->IndexType() ==
+                                                DeletionVectorsIndexFile::DELETION_VECTORS_INDEX;
+                                     }));
+        for (const IndexManifestEntry& entry : entries) {
+            std::set<std::string>& data_files = result[entry.index_file->FileName()];
+            const std::optional<LinkedHashMap<std::string, DeletionVectorMeta>>& dv_ranges =
+                entry.index_file->DvRanges();
+            if (dv_ranges == std::nullopt) {
+                return Status::Invalid("deletion vector index file has no deletion vector metas");
+            }
+            for (const auto& [data_file_name, dv_meta] : dv_ranges.value()) {
+                data_files.insert(data_file_name);
+            }
+        }
+        return result;
+    }
+
+    Result<BinaryRow> BuildPartitionRow(const std::map<std::string, std::string>& partition) const {
+        if (partition.empty()) {
+            return BinaryRow::EmptyRow();
+        }
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<TableSchema> table_schema,
+                               ReadLatestSchema(PathUtil::JoinPath(dir_->Str(), "foo.db/bar")));
+        auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+        PAIMON_ASSIGN_OR_RAISE(
+            CoreOptions core_options,
+            CoreOptions::FromMap(table_schema->Options(), dir_->GetFileSystem()));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<BinaryRowPartitionComputer> computer,
+            BinaryRowPartitionComputer::Create(
+                table_schema->PartitionKeys(), arrow_schema, core_options.GetPartitionDefaultName(),
+                core_options.LegacyPartitionNameEnabled(), GetDefaultPool()));
+        return computer->ToBinaryRow(partition);
+    }
+
+    Result<std::shared_ptr<TableSchema>> ReadLatestSchema(const std::string& table_path) const {
+        SchemaManager schema_manager(dir_->GetFileSystem(), table_path);
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::shared_ptr<TableSchema>> latest,
+                               schema_manager.Latest());
+        if (latest == std::nullopt) {
+            return Status::Invalid("table schema does not exist");
+        }
+        return latest.value();
+    }
+
+    Result<std::unique_ptr<IndexFileHandler>> CreateIndexFileHandler(
+        const std::string& table_path) const {
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<TableSchema> table_schema,
+                               ReadLatestSchema(table_path));
+        PAIMON_ASSIGN_OR_RAISE(
+            CoreOptions core_options,
+            CoreOptions::FromMap(table_schema->Options(), dir_->GetFileSystem()));
+        auto arrow_schema = DataField::ConvertDataFieldsToArrowSchema(table_schema->Fields());
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::string> external_paths,
+                               core_options.CreateExternalPaths());
+        PAIMON_ASSIGN_OR_RAISE(std::optional<std::string> global_index_external_path,
+                               core_options.CreateGlobalIndexExternalPath());
+        PAIMON_ASSIGN_OR_RAISE(
+            std::shared_ptr<FileStorePathFactory> path_factory,
+            FileStorePathFactory::Create(table_path, arrow_schema, table_schema->PartitionKeys(),
+                                         core_options.GetPartitionDefaultName(), FileFormat(),
+                                         core_options.DataFilePrefix(),
+                                         core_options.LegacyPartitionNameEnabled(), external_paths,
+                                         global_index_external_path,
+                                         core_options.IndexFileInDataFileDir(), GetDefaultPool()));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<IndexManifestFile> index_manifest_file,
+                               IndexManifestFile::Create(
+                                   core_options.GetFileSystem(), core_options.GetManifestFormat(),
+                                   core_options.GetManifestCompression(), path_factory,
+                                   core_options.GetBucket(), GetDefaultPool(), core_options));
+        return std::make_unique<IndexFileHandler>(
+            core_options.GetFileSystem(), std::move(index_manifest_file),
+            std::make_shared<IndexFilePathFactories>(path_factory),
+            core_options.DeletionVectorsBitmap64(), GetDefaultPool());
     }
 
  private:
@@ -3093,6 +3423,1430 @@ TEST_P(DataEvolutionTableTest, TestLimitPushDownDisabledByRowRangeIndex) {
     ASSERT_EQ(limited.splits.size(), 2);
     ASSERT_OK_AND_ASSIGN(std::vector<int32_t> values, CollectF0Values(limited.rows));
     ASSERT_EQ(values, (std::vector<int32_t>{3, 101, 102}));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactAcrossEvolvedFieldGroups) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // Two evolved field groups (row id ranges [0, 1] and [2, 3]), each made of a full-column
+    // file and a newer partial f2 file over the exact same rows.
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4}));
+
+    // The coordinator merges the four contiguous files into one full-column file.
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 4);
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    const std::shared_ptr<DataFileMeta>& compacted_file = compact_increment.CompactAfter()[0];
+    // Row ids and the merged sequence number range of the inputs are preserved, so the rewrite
+    // does not disturb row tracking metadata.
+    ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id, compacted_file->NonNullFirstRowId());
+    ASSERT_EQ(compacted_first_row_id, 0);
+    ASSERT_EQ(compacted_file->row_count, 4);
+    ASSERT_EQ(compacted_file->min_sequence_number, 1);
+    ASSERT_EQ(compacted_file->max_sequence_number, 4);
+    ASSERT_TRUE(compacted_file->file_source.has_value());
+    ASSERT_EQ(compacted_file->file_source.value(), FileSource::Compact());
+    ASSERT_EQ(compacted_file->write_cols, std::nullopt);
+    // Contract for data-evolution compact messages: total buckets stay unset.
+    ASSERT_EQ(message_impl->TotalBuckets(), std::nullopt);
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // The merged rows keep the newest f2 values and their row ids. The read now serves from
+    // the single compacted file.
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [1, "a0", "y0", 0],
+        [2, "a1", "y1", 1],
+        [3, "a0", "y0", 2],
+        [4, "a1", "y1", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
+
+    // The compacted file carries the merged sequence range, so every row now reads the group
+    // maximum sequence number (4), where rows 0-1 read 2 before the compaction.
+    auto expected_sequence_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], SpecialFields::RowId().field_,
+                            SpecialFields::SequenceNumber().field_}),
+            R"([
+        [1, 0, 4],
+        [2, 1, 4],
+        [3, 2, 4],
+        [4, 3, 4]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(
+        ScanAndRead(table_path, {"f0", "_ROW_ID", "_SEQUENCE_NUMBER"}, expected_sequence_array));
+
+    // A second coordinator run finds a single file and plans nothing.
+    ASSERT_OK_AND_ASSIGN(messages, AppendCompactCoordinator::Run(
+                                       table_path, compact_options,
+                                       /*partitions=*/{}, dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_TRUE(messages.empty());
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactKeepsDeletionVectorsOfOneRowRangeGroup) {
+    CompactKeepsDeletionVectorsOfOneRowRangeGroup(/*bitmap64=*/false);
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactKeepsBitmap64DeletionVectors) {
+    CompactKeepsDeletionVectorsOfOneRowRangeGroup(/*bitmap64=*/true);
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactShiftsDeletionVectorsAcrossRowRangeGroups) {
+    // Two groups compacted into one file: the second group's deletions are stored relative to
+    // its own anchor, so they have to shift by the distance between the two row ranges.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> first_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0,
+                                             /*f0_values=*/{1, 2}));
+    ASSERT_OK_AND_ASSIGN(std::string first_anchor, PlannedAnchorFileName(table_path));
+    // Row id 1, which is position 1 of the first group.
+    ASSERT_OK(CommitDeletionVectors(table_path, first_msgs[0],
+                                    {{first_anchor, /*deleted_positions=*/{1}}}));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> second_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/2,
+                                             /*f0_values=*/{3, 4}));
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> anchors, PlannedAnchorFileNames(table_path));
+    ASSERT_EQ(anchors.size(), 2);
+    std::string second_anchor;
+    for (const std::string& anchor : anchors) {
+        if (anchor != first_anchor) {
+            second_anchor = anchor;
+        }
+    }
+    ASSERT_FALSE(second_anchor.empty());
+    // Row id 2, which is position 0 of the second group — the position that has to move.
+    ASSERT_OK(CommitDeletionVectors(table_path, second_msgs[0],
+                                    {{second_anchor, /*deleted_positions=*/{0}}}));
+
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], SpecialFields::RowId().field_}),
+            R"([
+        [1, 0],
+        [4, 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_FALSE(messages.empty());
+    ASSERT_OK(Commit(table_path, messages));
+
+    // Row ids 1 and 2 stay deleted: position 0 of the second group became position 2 of the
+    // compacted file, and only a correct shift keeps row id 3 alive.
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactRejectsADeletionOutsideTheGroupItBelongsTo) {
+    // A deleted position is recorded relative to its own row range group. One past that group
+    // - a corrupt or mis-keyed vector - would land on another group's rows after the shift, so
+    // the rewrite refuses it rather than moving it.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> first_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0,
+                                             /*f0_values=*/{1, 2}));
+    ASSERT_OK_AND_ASSIGN(std::string first_anchor, PlannedAnchorFileName(table_path));
+    // Position 4 of a two row group: past its own rows, and past the four rows the two groups
+    // compact into.
+    ASSERT_OK(CommitDeletionVectors(table_path, first_msgs[0],
+                                    {{first_anchor, /*deleted_positions=*/{4}}}));
+
+    // A second group right behind the first, so the two are compacted into one file and the
+    // first group's deletions have to be moved rather than merged unchanged.
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4}));
+
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    ASSERT_NOK_WITH_MSG(
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool())
+            .status(),
+        "Cannot move deletion position");
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactRewritesOnlyTheTouchedDeletionVectorIndexFile) {
+    // A partition holding two deletion-vector index files where the compaction touches only
+    // one: the untouched file must survive the commit instead of being rewritten with it.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    // A two-file group at row ids 0-3, which the compaction will merge.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> group_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0,
+                                             /*f0_values=*/{1, 2, 3, 4}));
+    ASSERT_OK_AND_ASSIGN(std::string group_anchor, PlannedAnchorFileName(table_path));
+    ASSERT_OK(CommitDeletionVectors(table_path, group_msgs[0],
+                                    {{group_anchor, /*deleted_positions=*/{1}}}));
+
+    // A lone file at row ids 8-9. The row id gap keeps it out of the group's bin, and on its
+    // own it stays below `compaction.min.file-num`, so the compaction leaves it alone.
+    auto lone_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [9, "i", "p"],
+        [10, "j", "q"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> lone_msgs,
+                         WriteArray(table_path, schema->field_names(), lone_array));
+    SetFirstRowId(/*reset_first_row_id=*/8, lone_msgs);
+    ASSERT_OK(Commit(table_path, lone_msgs));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> anchors, PlannedAnchorFileNames(table_path));
+    ASSERT_EQ(anchors.size(), 2);
+    std::string lone_anchor;
+    for (const std::string& anchor_name : anchors) {
+        if (anchor_name != group_anchor) {
+            lone_anchor = anchor_name;
+        }
+    }
+    ASSERT_FALSE(lone_anchor.empty());
+    // Row id 8, stored in a second index file because it is committed on its own.
+    ASSERT_OK(CommitDeletionVectors(table_path, lone_msgs[0],
+                                    {{lone_anchor, /*deleted_positions=*/{0}}}));
+
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], SpecialFields::RowId().field_}),
+            R"([
+        [1, 0],
+        [3, 2],
+        [4, 3],
+        [10, 9]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    // Exactly one data message for the merged group plus one index-only message; the lone
+    // file was not planned, so it contributes neither.
+    ASSERT_EQ(messages.size(), 2);
+    auto index_message = std::dynamic_pointer_cast<CommitMessageImpl>(messages[1]);
+    ASSERT_TRUE(index_message);
+    // Only the index file that stored the group's vector is replaced. Rewriting the whole
+    // partition would delete the lone file's index file here as well.
+    EXPECT_EQ(index_message->GetCompactIncrement().DeletedIndexFiles().size(), 1);
+    EXPECT_EQ(index_message->GetCompactIncrement().NewIndexFiles().size(), 1);
+    ASSERT_OK(Commit(table_path, messages));
+
+    // Both deletions still apply: the moved one on the compacted file and the untouched one
+    // on the lone file.
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactCarriesSiblingDeletionVectorsOfTheTouchedIndexFile) {
+    // The counterpart of the test above: there the two vectors sat in different index files,
+    // here they share one and the compaction touches only one of them. The file is replaced
+    // whole, so the sibling vector has to be read back out of it and written into the
+    // replacement - the one path where the rewrite re-reads a vector it is not moving.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto schema = arrow::schema(fields_);
+
+    // A two-file group at row ids 0-3, which the compaction will merge.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> group_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0,
+                                             /*f0_values=*/{1, 2, 3, 4}));
+
+    // A lone file at row ids 8-9. The row id gap keeps it out of the group's bin, and on its
+    // own it stays below `compaction.min.file-num`, so the compaction leaves it alone.
+    auto lone_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [9, "i", "p"],
+        [10, "j", "q"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> lone_msgs,
+                         WriteArray(table_path, schema->field_names(), lone_array));
+    SetFirstRowId(/*reset_first_row_id=*/8, lone_msgs);
+    ASSERT_OK(Commit(table_path, lone_msgs));
+
+    // Ordered by ascending first row id, so the group's anchor comes first.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> anchors, PlannedAnchorFileNames(table_path));
+    ASSERT_EQ(anchors.size(), 2);
+    // One commit for both vectors, which is what puts them in the same index file: row id 1 of
+    // the group and row id 8 of the lone file.
+    ASSERT_OK(CommitDeletionVectors(
+        table_path, group_msgs[0],
+        {{anchors[0], /*deleted_positions=*/{1}}, {anchors[1], /*deleted_positions=*/{0}}}));
+    std::map<std::string, std::set<std::string>> index_before;
+    ASSERT_OK_AND_ASSIGN(index_before, ScanDeletionVectorIndex(table_path));
+    ASSERT_EQ(index_before.size(), 1);
+    ASSERT_EQ(index_before.begin()->second, std::set<std::string>({anchors[0], anchors[1]}));
+
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], SpecialFields::RowId().field_}),
+            R"([
+        [1, 0],
+        [3, 2],
+        [4, 3],
+        [10, 9]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 2);
+    ASSERT_OK(Commit(table_path, messages));
+
+    // The shared index file is gone and everything it still owed is in its replacement: the
+    // lone file's vector, carried over untouched, and the group's, re-keyed onto the compacted
+    // file. The old group anchor is not recorded any more, its file no longer exists.
+    std::map<std::string, std::set<std::string>> index_after;
+    ASSERT_OK_AND_ASSIGN(index_after, ScanDeletionVectorIndex(table_path));
+    ASSERT_FALSE(index_after.empty());
+    std::set<std::string> covered;
+    for (const auto& [index_file_name, data_files] : index_after) {
+        ASSERT_EQ(index_before.count(index_file_name), 0);
+        covered.insert(data_files.begin(), data_files.end());
+    }
+    ASSERT_EQ(covered.size(), 2);
+    ASSERT_EQ(covered.count(anchors[1]), 1);
+    ASSERT_EQ(covered.count(anchors[0]), 0);
+
+    // Both deletions still apply: the moved one on the compacted file and the carried-over one
+    // on the lone file.
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+}
+
+TEST_P(DataEvolutionTableTest, TestMaterializeDeletionVectorsReassignsRowIds) {
+    // The default compaction keeps every row and re-keys the deletions. Materializing instead
+    // drops the deleted rows for real, so the survivors are renumbered from the table's next row
+    // id and the vectors disappear rather than moving.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> group_msgs,
+        WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2, 3, 4},
+                            /*partition=*/{}, /*assign_row_ids_by_commit=*/true));
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name, PlannedAnchorFileName(table_path));
+    ASSERT_OK(CommitDeletionVectors(table_path, group_msgs[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{1, 3}}}));
+
+    // Before: rows 2 and 4 are logically deleted, and the survivors keep their original row ids.
+    auto before = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], SpecialFields::RowId().field_}),
+            R"([
+        [1, 0],
+        [3, 2]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, before));
+
+    ASSERT_OK_AND_ASSIGN(int32_t commits, AppendCompactCoordinator::MaterializeDeletionVectors(
+                                              table_path, options, /*partitions=*/{},
+                                              /*commit_user=*/"commit_user_1",
+                                              dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(commits, 1);
+
+    // After: the same two rows, but renumbered. The commit handed out row ids 0-3 for the
+    // originals, so those four are spent and the survivors start at the table's next row id, 4.
+    auto after = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], SpecialFields::RowId().field_}),
+            R"([
+        [1, 4],
+        [3, 5]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, after));
+
+    // The deletions are gone, not merely moved: nothing is left for a second run to do.
+    ASSERT_OK_AND_ASSIGN(
+        commits, AppendCompactCoordinator::MaterializeDeletionVectors(
+                     table_path, options, /*partitions=*/{},
+                     /*commit_user=*/"commit_user_1", dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(commits, 0);
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, after));
+}
+
+TEST_P(DataEvolutionTableTest, TestMaterializeDeletionVectorsIsANoOpWithoutDeletions) {
+    // No vector anywhere means nothing to apply, and in particular no rewrite: a table without
+    // deletions must not have its row ids churned just because the entry point was called.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], SpecialFields::RowId().field_}),
+            R"([
+        [1, 0],
+        [2, 1]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+
+    ASSERT_OK_AND_ASSIGN(int32_t commits, AppendCompactCoordinator::MaterializeDeletionVectors(
+                                              table_path, options, /*partitions=*/{},
+                                              /*commit_user=*/"commit_user_1",
+                                              dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(commits, 0);
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+}
+
+TEST_P(DataEvolutionTableTest, TestMaterializeDeletionVectorsLeavesUndeletedRangesAlone) {
+    // Two groups, only one carrying deletions. The untouched group must keep its row ids, or
+    // every reference into it would break for no reason.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> first_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2},
+                                             /*partition=*/{}, /*assign_row_ids_by_commit=*/true));
+    ASSERT_OK_AND_ASSIGN(std::string first_anchor, PlannedAnchorFileName(table_path));
+    ASSERT_OK(CommitDeletionVectors(table_path, first_msgs[0],
+                                    {{first_anchor, /*deleted_positions=*/{0}}}));
+
+    // A second group beyond a row id gap, so it forms its own contiguous run. Its row ids are
+    // stamped rather than handed out by the commit, which leaves the table's next row id at 2.
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/8, /*f0_values=*/{9, 10}));
+
+    ASSERT_OK_AND_ASSIGN(int32_t commits, AppendCompactCoordinator::MaterializeDeletionVectors(
+                                              table_path, options, /*partitions=*/{},
+                                              /*commit_user=*/"commit_user_1",
+                                              dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(commits, 1);
+
+    // Row id 1 survived the first group and was renumbered from the table's next row id, which
+    // the rewritten range left at 2; the second group is untouched at 8 and 9.
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], SpecialFields::RowId().field_}),
+            R"([
+        [2, 2],
+        [9, 8],
+        [10, 9]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, expected));
+}
+
+TEST_P(DataEvolutionTableTest, TestMaterializeDeletionVectorsDropsGlobalIndexes) {
+    // Materializing renumbers the surviving rows, so every global index of the partition now
+    // points at row ids that moved or no longer exist. There is no way to fix such an index up
+    // from the compaction's own metadata, so it has to go in the same commit as the rewrite.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> group_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0,
+                                             /*f0_values=*/{1, 2, 3, 4}));
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name, PlannedAnchorFileName(table_path));
+    ASSERT_OK(CommitDeletionVectors(table_path, group_msgs[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{1, 3}}}));
+    ASSERT_OK(CommitFakeGlobalIndex(table_path, "fake_index_file", /*partition=*/{},
+                                    /*row_range_start=*/0, /*row_range_end=*/3));
+
+    ASSERT_OK_AND_ASSIGN(std::set<std::string> before, ScanGlobalIndexFileNames(table_path));
+    ASSERT_EQ(before, std::set<std::string>({"fake_index_file"}));
+
+    ASSERT_OK_AND_ASSIGN(int32_t commits, AppendCompactCoordinator::MaterializeDeletionVectors(
+                                              table_path, options, /*partitions=*/{},
+                                              /*commit_user=*/"commit_user_1",
+                                              dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(commits, 1);
+
+    // Gone, in the very snapshot that renumbered the rows: no reader can see the new row ids
+    // through the stale index.
+    ASSERT_OK_AND_ASSIGN(std::set<std::string> after, ScanGlobalIndexFileNames(table_path));
+    ASSERT_TRUE(after.empty());
+}
+
+TEST_P(DataEvolutionTableTest, TestMaterializeDeletionVectorsKeepsOtherPartitionsUntouched) {
+    // Two partitions, only one carrying deletions. Materializing must rewrite and renumber only
+    // that one, and drop only its global index — dropping the other partition's would throw
+    // away an index that is still perfectly valid.
+    std::map<std::string, std::string> options = CreatePartitionedDataEvolutionTable();
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> deleted_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2},
+                                             /*partition=*/{{"f1", "2024"}}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4},
+                                  /*partition=*/{{"f1", "2025"}}));
+
+    // Only the 2024 partition's anchor gets a vector.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::string> anchors, PlannedAnchorFileNames(table_path));
+    ASSERT_EQ(anchors.size(), 2);
+    ASSERT_OK(CommitDeletionVectors(table_path, deleted_msgs[0],
+                                    {{anchors[0], /*deleted_positions=*/{0}}}));
+
+    ASSERT_OK(CommitFakeGlobalIndex(table_path, "index_2024", /*partition=*/{{"f1", "2024"}},
+                                    /*row_range_start=*/0, /*row_range_end=*/1));
+    ASSERT_OK(CommitFakeGlobalIndex(table_path, "index_2025", /*partition=*/{{"f1", "2025"}},
+                                    /*row_range_start=*/2, /*row_range_end=*/3));
+    ASSERT_OK_AND_ASSIGN(std::set<std::string> before, ScanGlobalIndexFileNames(table_path));
+    ASSERT_EQ(before, std::set<std::string>({"index_2024", "index_2025"}));
+
+    ASSERT_OK_AND_ASSIGN(int32_t commits, AppendCompactCoordinator::MaterializeDeletionVectors(
+                                              table_path, options, /*partitions=*/{},
+                                              /*commit_user=*/"commit_user_1",
+                                              dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(commits, 1);
+
+    // The untouched partition keeps its index; only the materialized one loses it.
+    ASSERT_OK_AND_ASSIGN(std::set<std::string> after, ScanGlobalIndexFileNames(table_path));
+    ASSERT_EQ(after, std::set<std::string>({"index_2025"}));
+}
+
+TEST_P(DataEvolutionTableTest, TestDropGlobalIndexesTakesEveryIndexOfTheSnapshotItIsGiven) {
+    // The dropper scans the snapshot it is handed rather than the one the compaction planned
+    // against, so an index another writer committed in between - one nothing in the round's
+    // messages refers to - is dropped as well instead of surviving as a silently wrong index.
+    // Both indexes go in a single message, since an index file is addressed by partition and
+    // bucket and these two share both.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> group_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+    auto group_msg = std::dynamic_pointer_cast<CommitMessageImpl>(group_msgs[0]);
+    ASSERT_TRUE(group_msg);
+    ASSERT_FALSE(group_msg->GetNewFilesIncrement().NewFiles().empty());
+
+    ASSERT_OK(CommitFakeGlobalIndex(table_path, "planned_index", /*partition=*/{},
+                                    /*row_range_start=*/0, /*row_range_end=*/1));
+    ASSERT_OK(CommitFakeGlobalIndex(table_path, "late_index", /*partition=*/{},
+                                    /*row_range_start=*/0, /*row_range_end=*/1));
+
+    // A range whose rows were all deleted rewrites to nothing, which is a materialized shape: the
+    // row ids it replaced are gone for good, so every index over them is invalid.
+    std::vector<std::shared_ptr<DataFileMeta>> replaced = {
+        group_msg->GetNewFilesIncrement().NewFiles()[0]};
+    std::vector<std::shared_ptr<CommitMessage>> compact_messages = {
+        std::make_shared<CommitMessageImpl>(
+            group_msg->Partition(), group_msg->Bucket(), /*total_buckets=*/std::nullopt,
+            DataIncrement(/*new_files=*/{}, /*deleted_files=*/{}, /*changelog_files=*/{}),
+            CompactIncrement(std::move(replaced), /*compact_after=*/{}, /*changelog_files=*/{}))};
+
+    SnapshotManager snapshot_manager(dir_->GetFileSystem(), table_path);
+    ASSERT_OK_AND_ASSIGN(std::optional<Snapshot> latest_snapshot,
+                         snapshot_manager.LatestSnapshot());
+    ASSERT_TRUE(latest_snapshot.has_value());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<IndexFileHandler> index_file_handler,
+                         CreateIndexFileHandler(table_path));
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> dropped,
+                         DataEvolutionCompactGlobalIndexDropper::DropGlobalIndexes(
+                             compact_messages, latest_snapshot.value(),
+                             std::shared_ptr<IndexFileHandler>(std::move(index_file_handler))));
+    ASSERT_EQ(dropped.size(), 1);
+    auto dropped_impl = std::dynamic_pointer_cast<CommitMessageImpl>(dropped[0]);
+    ASSERT_TRUE(dropped_impl);
+    ASSERT_TRUE(dropped_impl->Partition() == group_msg->Partition());
+    ASSERT_EQ(dropped_impl->Bucket(), 0);
+
+    std::set<std::string> dropped_names;
+    for (const auto& index_file : dropped_impl->GetCompactIncrement().DeletedIndexFiles()) {
+        dropped_names.insert(index_file->FileName());
+    }
+    ASSERT_EQ(dropped_names, std::set<std::string>({"planned_index", "late_index"}));
+
+    // The message carries the index deletions and nothing else: the rewrite itself travels in the
+    // compaction's own messages.
+    ASSERT_TRUE(dropped_impl->GetCompactIncrement().CompactBefore().empty());
+    ASSERT_TRUE(dropped_impl->GetCompactIncrement().CompactAfter().empty());
+    ASSERT_TRUE(dropped_impl->GetCompactIncrement().NewIndexFiles().empty());
+}
+
+TEST_P(DataEvolutionTableTest, TestMaterializeDeletionVectorsOnAFullyDeletedRange) {
+    // Every row of the range is deleted, so materializing rewrites it to nothing at all: the
+    // one shape where the compaction produces no output file, which the rewriter, the index
+    // dropper and the commit check all have to recognise without an output to look at.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> group_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0,
+                                             /*f0_values=*/{1, 2}));
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name, PlannedAnchorFileName(table_path));
+    ASSERT_OK(CommitDeletionVectors(table_path, group_msgs[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{0, 1}}}));
+    ASSERT_OK(CommitFakeGlobalIndex(table_path, "fake_index_file", /*partition=*/{},
+                                    /*row_range_start=*/0, /*row_range_end=*/1));
+
+    // Nothing is readable already; the rows are only logically gone.
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, /*expected_array=*/nullptr,
+                          /*predicate=*/nullptr, /*row_ranges=*/{},
+                          /*check_scan_plan_when_empty_result=*/false));
+
+    ASSERT_OK_AND_ASSIGN(int32_t commits, AppendCompactCoordinator::MaterializeDeletionVectors(
+                                              table_path, options, /*partitions=*/{},
+                                              /*commit_user=*/"commit_user_1",
+                                              dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(commits, 1);
+
+    // Still nothing to read, but now the files, their vectors and the index over their row ids
+    // are all gone rather than merely masked.
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "_ROW_ID"}, /*expected_array=*/nullptr));
+    ASSERT_OK_AND_ASSIGN(std::set<std::string> indexes, ScanGlobalIndexFileNames(table_path));
+    ASSERT_TRUE(indexes.empty());
+
+    // And it is idempotent: with no vector left there is nothing to materialize.
+    ASSERT_OK_AND_ASSIGN(
+        commits, AppendCompactCoordinator::MaterializeDeletionVectors(
+                     table_path, options, /*partitions=*/{},
+                     /*commit_user=*/"commit_user_1", dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(commits, 0);
+}
+
+TEST_P(DataEvolutionTableTest, TestMaterializeDeletionVectorsRejectsNonDataEvolutionOptions) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    // A commit user is required, since this entry point commits on its own.
+    ASSERT_NOK_WITH_MSG(AppendCompactCoordinator::MaterializeDeletionVectors(
+                            table_path, options, /*partitions=*/{},
+                            /*commit_user=*/"", dir_->GetFileSystem(), GetDefaultPool())
+                            .status(),
+                        "needs a commit user");
+
+    // Turning deletion vectors off here would make the rewrite ignore the deletion files and
+    // silently resurrect the deleted rows, so the immutable-option guard rejects it.
+    std::map<std::string, std::string> without_dv = options;
+    without_dv[Options::DELETION_VECTORS_ENABLED] = "false";
+    ASSERT_NOK_WITH_MSG(
+        AppendCompactCoordinator::MaterializeDeletionVectors(
+            table_path, without_dv, /*partitions=*/{},
+            /*commit_user=*/"commit_user_1", dir_->GetFileSystem(), GetDefaultPool())
+            .status(),
+        "immutable table options");
+}
+
+TEST_P(DataEvolutionTableTest, TestMaterializeKeepsAnUpdateOnAnUntouchedRange) {
+    // Materializing renumbers the rows of the ranges carrying deletions. A partial update on a
+    // range it does not touch has to come through unchanged: its rows keep their ids and its
+    // columns stay on top, while only the deleted range is rewritten and renumbered.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> first_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2},
+                                             /*partition=*/{}, /*assign_row_ids_by_commit=*/true));
+    ASSERT_OK_AND_ASSIGN(std::string first_anchor, PlannedAnchorFileName(table_path));
+    // Only the first group carries a deletion, so only it is materialized.
+    ASSERT_OK(CommitDeletionVectors(table_path, first_msgs[0],
+                                    {{first_anchor, /*deleted_positions=*/{1}}}));
+
+    // The second group sits beyond a row id gap: materializing rewrites the whole contiguous
+    // run a deletion falls in, so a group adjacent to the deleted one would be rewritten and
+    // renumbered along with it. Its row ids are stamped rather than handed out by the commit,
+    // which leaves the table's next row id at 2.
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/8, /*f0_values=*/{3, 4}));
+
+    // A partial update over the second group's rows, committed before the materialization runs.
+    auto concurrent_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields_[2]}), R"([
+        ["z2"],
+        ["z3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> concurrent_msgs,
+                         WriteArray(table_path, {"f2"}, concurrent_array));
+    SetFirstRowId(/*reset_first_row_id=*/8, concurrent_msgs);
+    ASSERT_OK(Commit(table_path, concurrent_msgs));
+
+    ASSERT_OK_AND_ASSIGN(int32_t commits, AppendCompactCoordinator::MaterializeDeletionVectors(
+                                              table_path, options, /*partitions=*/{},
+                                              /*commit_user=*/"commit_user_1",
+                                              dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(commits, 1);
+
+    // Row ids 8 and 9 keep their updated f2; the survivor of the first group is renumbered from
+    // the table's next row id and keeps the columns it had.
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [1, "y0", 2],
+        [3, "z2", 8],
+        [4, "z3", 9]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f2", "_ROW_ID"}, expected));
+}
+
+TEST_P(DataEvolutionTableTest, TestMaterializeDeletionVectorsNeedsDeletionVectorsEnabled) {
+    // A table that never stored a deletion vector has nothing to materialize, and the rewrite
+    // would renumber its row ids for no gain. Saying so is more useful than scanning the table
+    // and reporting zero commits, which reads as "there was nothing to do this time".
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    ASSERT_NOK_WITH_MSG(
+        AppendCompactCoordinator::MaterializeDeletionVectors(
+            table_path, options, /*partitions=*/{},
+            /*commit_user=*/"commit_user_1", dir_->GetFileSystem(), GetDefaultPool())
+            .status(),
+        "needs 'deletion-vectors.enabled' to be set");
+}
+
+TEST_P(DataEvolutionTableTest, TestRunAndCommitCommitsWithoutCallerCommit) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4}));
+
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    ASSERT_OK_AND_ASSIGN(int32_t rounds, AppendCompactCoordinator::RunAndCommit(
+                                             table_path, compact_options, /*partitions=*/{},
+                                             /*commit_user=*/"commit_user_1", dir_->GetFileSystem(),
+                                             GetDefaultPool()));
+    ASSERT_EQ(rounds, 1);
+
+    // No caller commit ran, so the rows below are served by the snapshot RunAndCommit wrote.
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [1, "y0", 0],
+        [2, "y1", 1],
+        [3, "y0", 2],
+        [4, "y1", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f2", "_ROW_ID"}, expected));
+
+    // Nothing is left to merge, so a second call commits no round at all.
+    ASSERT_OK_AND_ASSIGN(
+        rounds, AppendCompactCoordinator::RunAndCommit(
+                    table_path, compact_options, /*partitions=*/{},
+                    /*commit_user=*/"commit_user_1", dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(rounds, 0);
+}
+
+TEST_P(DataEvolutionTableTest, TestRunAndCommitSplitsRowIdSpaceIntoRounds) {
+    // Each group below lands in its own manifest, so a one-file-per-round budget cuts the row
+    // id space between them and every group is compacted and committed on its own.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/4, /*f0_values=*/{5, 6}));
+
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    ASSERT_OK_AND_ASSIGN(int32_t rounds, AppendCompactCoordinator::RunAndCommit(
+                                             table_path, compact_options, /*partitions=*/{},
+                                             /*commit_user=*/"commit_user_1", dir_->GetFileSystem(),
+                                             GetDefaultPool(),
+                                             /*candidate_files_per_round=*/1));
+    // More than one commit, and every group still merged.
+    ASSERT_GT(rounds, 1);
+
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [1, "y0", 0],
+        [2, "y1", 1],
+        [3, "y0", 2],
+        [4, "y1", 3],
+        [5, "y0", 4],
+        [6, "y1", 5]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f2", "_ROW_ID"}, expected));
+}
+
+TEST_P(DataEvolutionTableTest, TestRunAndCommitAfterMaterializingAFullyDeletedRange) {
+    // Materializing a fully deleted range leaves a manifest holding nothing but deletions, and
+    // a hole in the row id space where its rows used to be. The rounds are planned over that
+    // snapshot: the groups written afterwards still compact one round each, and the rows the
+    // materialization removed stay removed.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> deleted_msgs,
+                         WriteAndCommitGroup(table_path, /*first_row_id=*/0,
+                                             /*f0_values=*/{1, 2}));
+    ASSERT_OK_AND_ASSIGN(std::string anchor_file_name, PlannedAnchorFileName(table_path));
+    ASSERT_OK(CommitDeletionVectors(table_path, deleted_msgs[0],
+                                    {{anchor_file_name, /*deleted_positions=*/{0, 1}}}));
+    ASSERT_OK_AND_ASSIGN(
+        int32_t materialize_commits,
+        AppendCompactCoordinator::MaterializeDeletionVectors(
+            table_path, options, /*partitions=*/{},
+            /*commit_user=*/"commit_user_1", dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(materialize_commits, 1);
+
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/4, /*f0_values=*/{5, 6}));
+
+    std::map<std::string, std::string> compact_options = options;
+    compact_options[Options::COMPACTION_MIN_FILE_NUM] = "2";
+    ASSERT_OK_AND_ASSIGN(int32_t rounds, AppendCompactCoordinator::RunAndCommit(
+                                             table_path, compact_options, /*partitions=*/{},
+                                             /*commit_user=*/"commit_user_1", dir_->GetFileSystem(),
+                                             GetDefaultPool(),
+                                             /*candidate_files_per_round=*/1));
+    ASSERT_GT(rounds, 1);
+
+    auto expected = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [3, "y0", 2],
+        [4, "y1", 3],
+        [5, "y0", 4],
+        [6, "y1", 5]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f2", "_ROW_ID"}, expected));
+}
+
+TEST_P(DataEvolutionTableTest, TestRunAndCommitWithPartitionFilterSplitsOnlyThatPartition) {
+    // Exercises the partition-aware half of the round split: manifests the filter rules out
+    // are left out of the row id split, so the rounds follow the selected partition's rows
+    // rather than the whole table's.
+    CreateTable(/*partition_keys=*/{"f1"});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2},
+                                  /*partition=*/{{"f1", "2024"}}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4},
+                                  /*partition=*/{{"f1", "2025"}}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/4, /*f0_values=*/{5, 6},
+                                  /*partition=*/{{"f1", "2024"}}));
+
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(int32_t rounds, AppendCompactCoordinator::RunAndCommit(
+                                             table_path, compact_options,
+                                             /*partitions=*/{{{"f1", "2024"}}},
+                                             /*commit_user=*/"commit_user_1", dir_->GetFileSystem(),
+                                             GetDefaultPool(),
+                                             /*candidate_files_per_round=*/1));
+    // The two 2024 groups sit either side of the 2025 group in row id order, so a
+    // one-file-per-round budget still splits them into separate rounds.
+    ASSERT_GT(rounds, 1);
+
+    auto read_type =
+        arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_});
+    auto expected_2024 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "2024", "y0", 0],
+        [2, "2024", "y1", 1],
+        [5, "2024", "y0", 4],
+        [6, "2024", "y1", 5]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2024,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2024", 4))));
+
+    // The unselected partition was never planned, so its rows read back untouched.
+    auto expected_2025 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [3, "2025", "y0", 2],
+        [4, "2025", "y1", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2025,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2025", 4))));
+}
+
+TEST_P(DataEvolutionTableTest, TestRunAndCommitMovesDeletionVectorsEveryRoundBitmap32) {
+    RunAndCommitMovesDeletionVectorsEveryRound(/*bitmap64=*/false);
+}
+
+TEST_P(DataEvolutionTableTest, TestRunAndCommitMovesDeletionVectorsEveryRoundBitmap64) {
+    RunAndCommitMovesDeletionVectorsEveryRound(/*bitmap64=*/true);
+}
+
+TEST_P(DataEvolutionTableTest, TestRunAndCommitRejectsEmptyCommitUser) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_NOK_WITH_MSG(AppendCompactCoordinator::RunAndCommit(
+                            table_path, options, /*partitions=*/{}, /*commit_user=*/"",
+                            dir_->GetFileSystem(), GetDefaultPool())
+                            .status(),
+                        "needs a commit user");
+    ASSERT_NOK_WITH_MSG(AppendCompactCoordinator::RunAndCommit(
+                            table_path, options, /*partitions=*/{},
+                            /*commit_user=*/"commit_user_1", dir_->GetFileSystem(),
+                            GetDefaultPool(), /*candidate_files_per_round=*/0)
+                            .status(),
+                        "must be positive");
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactRejectsImmutableOptionOverrides) {
+    // Turning data evolution off at the compaction entry point would route the table into
+    // the plain append rewrite, which reorders row ids; the override is rejected before any
+    // scanning. The same guard covers the other path-deciding and layout options, checked
+    // here against the same table.
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/true);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    const std::vector<std::pair<std::string, std::string>> overrides = {
+        {Options::DATA_EVOLUTION_ENABLED, "false"},
+        {Options::ROW_TRACKING_ENABLED, "false"},
+        {Options::BUCKET, "2"},
+        {Options::BLOB_FIELD, "f0"},
+        // Turning deletion vectors off would let the rewrite ignore the deletion files
+        // entirely, resurrecting every deleted row.
+        {Options::DELETION_VECTORS_ENABLED, "false"},
+        // Flipping the deletion vector kind would either fail the rewrite on a merge or
+        // quietly replace the table's vectors with the other kind.
+        {Options::DELETION_VECTOR_BITMAP64, "true"},
+    };
+    for (const auto& [key, value] : overrides) {
+        SCOPED_TRACE(key);
+        std::map<std::string, std::string> compact_options = options;
+        compact_options[key] = value;
+        ASSERT_NOK_WITH_MSG(
+            AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                          dir_->GetFileSystem(), GetDefaultPool())
+                .status(),
+            "immutable table options");
+    }
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactRejectsLegacyRewriteRowIdsOption) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    // The legacy row-id rewriting mode is gone; the coordinator fails instead of silently
+    // ignoring the option.
+    std::map<std::string, std::string> compact_options = options;
+    compact_options.emplace("data-evolution.compaction.rewrite-row-ids", "true");
+    ASSERT_NOK_WITH_MSG(
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool())
+            .status(),
+        "no longer supported");
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactAcrossEvolvedFieldGroupsWithPartitions) {
+    CreateTable(/*partition_keys=*/{"f1"});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // One evolved field group per partition, each made of a full-column file and a newer
+    // partial f2 file over the same rows.
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2},
+                                  /*partition=*/{{"f1", "2024"}}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4},
+                                  /*partition=*/{{"f1", "2025"}}));
+
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    // Bins never span partitions: one task per partition, each merging the two files of its
+    // field group.
+    ASSERT_EQ(messages.size(), 2);
+    std::set<int64_t> compacted_first_row_ids;
+    for (const auto& message : messages) {
+        auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(message);
+        ASSERT_TRUE(message_impl);
+        const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+        ASSERT_EQ(compact_increment.CompactBefore().size(), 2);
+        ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+        ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id,
+                             compact_increment.CompactAfter()[0]->NonNullFirstRowId());
+        compacted_first_row_ids.insert(compacted_first_row_id);
+    }
+    ASSERT_EQ(compacted_first_row_ids, (std::set<int64_t>{0, 2}));
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // Split order across partitions does not follow row ids, so each partition is verified
+    // through its own partition predicate.
+    auto read_type =
+        arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_});
+    auto expected_2024 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "2024", "y0", 0],
+        [2, "2024", "y1", 1]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2024,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2024", 4))));
+    auto expected_2025 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [3, "2025", "y0", 2],
+        [4, "2025", "y1", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2025,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2025", 4))));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactWithPartitionFilter) {
+    CreateTable(/*partition_keys=*/{"f1"});
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2},
+                                  /*partition=*/{{"f1", "2024"}}));
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/2, /*f0_values=*/{3, 4},
+                                  /*partition=*/{{"f1", "2025"}}));
+
+    // Only the selected partition is planned; the other partition's field group stays as it
+    // is and keeps serving reads from its original files.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> messages,
+                         AppendCompactCoordinator::Run(table_path, compact_options,
+                                                       /*partitions=*/{{{"f1", "2024"}}},
+                                                       dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 2);
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id,
+                         compact_increment.CompactAfter()[0]->NonNullFirstRowId());
+    ASSERT_EQ(compacted_first_row_id, 0);
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // Split order across partitions does not follow row ids, so each partition is verified
+    // through its own partition predicate: the compacted 2024 rows and the untouched 2025
+    // rows read back unchanged.
+    auto read_type =
+        arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_});
+    auto expected_2024 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "2024", "y0", 0],
+        [2, "2024", "y1", 1]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2024,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2024", 4))));
+    auto expected_2025 = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [3, "2025", "y0", 2],
+        [4, "2025", "y1", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(
+        table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_2025,
+        PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"f1", FieldType::STRING,
+                                Literal(FieldType::STRING, "2025", 4))));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactAcrossSchemaEvolution) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // Schema 0: two full-row commits, row ids [0, 1] and [2, 3], sequence numbers 1 and 2.
+    for (const std::string& rows_json : {std::string(R"([[1, "a0", "x0"], [2, "a1", "x1"]])"),
+                                         std::string(R"([[3, "a2", "x2"], [4, "a3", "x3"]])")}) {
+        auto schema0_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), rows_json)
+                .ValueOrDie());
+        ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> schema0_msgs,
+                             WriteArray(table_path, {"f0", "f1", "f2"}, schema0_array));
+        ASSERT_OK(Commit(table_path, schema0_msgs));
+    }
+
+    // Evolve the schema: change f0 INT -> BIGINT (keeps field id 0, a type change) and add
+    // f3 INT with the fresh field id 3.
+    arrow::FieldVector evolved_fields = {
+        arrow::field("f0", arrow::int64()),
+        arrow::field("f1", arrow::utf8()),
+        arrow::field("f2", arrow::utf8()),
+        arrow::field("f3", arrow::int32()),
+    };
+    ASSERT_OK(TestHelper::WriteNextSchema(
+        dir_->GetFileSystem(), table_path,
+        {DataField(0, evolved_fields[0]), DataField(1, evolved_fields[1]),
+         DataField(2, evolved_fields[2]), DataField(3, evolved_fields[3])},
+        /*highest_field_id=*/3, options));
+
+    // Schema 1: two more full rows, row ids [4, 5], sequence number 3 (rows [2, 3] from the
+    // second schema-0 commit above stay untouched and keep their added f3 as NULL).
+    auto schema1_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(evolved_fields), R"([
+        [5, "a4", "x4", 50],
+        [6, "a5", "x5", 60]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> schema1_msgs,
+                         WriteArray(table_path, {"f0", "f1", "f2", "f3"}, schema1_array));
+    ASSERT_OK(Commit(table_path, schema1_msgs));
+
+    // A schema-1 partial write fills the added f3 for the first schema-0 rows: the [0, 1]
+    // field group now merges files written under different schema ids, sequence number 4.
+    auto f3_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({evolved_fields[3]}), R"([
+        [100],
+        [200]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> f3_msgs,
+                         WriteArray(table_path, {"f3"}, f3_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, f3_msgs);
+    ASSERT_OK(Commit(table_path, f3_msgs));
+
+    // Pre-compaction read through the latest schema: f0 is cast to BIGINT everywhere, the
+    // added f3 is NULL for the untouched schema-0 rows [2, 3] and filled through the
+    // cross-schema field group for rows [0, 1].
+    auto read_type =
+        arrow::struct_({evolved_fields[0], evolved_fields[1], evolved_fields[2], evolved_fields[3],
+                        SpecialFields::RowId().field_, SpecialFields::SequenceNumber().field_});
+    std::vector<std::string> read_names = {"f0", "f1", "f2", "f3", "_ROW_ID", "_SEQUENCE_NUMBER"};
+    auto expected_before = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "a0", "x0", 100, 0, 4],
+        [2, "a1", "x1", 200, 1, 4],
+        [3, "a2", "x2", null, 2, 2],
+        [4, "a3", "x3", null, 3, 2],
+        [5, "a4", "x4", 50, 4, 3],
+        [6, "a5", "x5", 60, 5, 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, read_names, expected_before));
+
+    // The coordinator merges all four files — schema-0, schema-1 and the cross-schema
+    // partial — into one file written with the latest schema.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 4);
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    const std::shared_ptr<DataFileMeta>& compacted_file = compact_increment.CompactAfter()[0];
+    // The rewritten file holds every column of the latest schema and carries its schema id;
+    // row ids and the merged sequence range of the inputs are preserved.
+    ASSERT_EQ(compacted_file->schema_id, 1);
+    ASSERT_EQ(compacted_file->write_cols, std::nullopt);
+    ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id, compacted_file->NonNullFirstRowId());
+    ASSERT_EQ(compacted_first_row_id, 0);
+    ASSERT_EQ(compacted_file->row_count, 6);
+    ASSERT_EQ(compacted_file->min_sequence_number, 1);
+    ASSERT_EQ(compacted_file->max_sequence_number, 4);
+
+    ASSERT_OK(Commit(table_path, messages));
+
+    // After the rewrite the merged values survive: the cast f0, the NULL-filled f3 and the
+    // cross-schema f3 fill are now materialized in the compacted file, and every row reads
+    // the group's maximum sequence number.
+    auto expected_after = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "a0", "x0", 100, 0, 4],
+        [2, "a1", "x1", 200, 1, 4],
+        [3, "a2", "x2", null, 2, 4],
+        [4, "a3", "x3", null, 3, 4],
+        [5, "a4", "x4", 50, 4, 4],
+        [6, "a5", "x5", 60, 5, 4]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, read_names, expected_after));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactAfterDropColumn) {
+    std::map<std::string, std::string> options =
+        CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // Schema 0: two full rows, row ids [0, 1], sequence number 1.
+    auto schema0_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [1, "a0", "x0"],
+        [2, "a1", "x1"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> schema0_msgs,
+                         WriteArray(table_path, {"f0", "f1", "f2"}, schema0_array));
+    ASSERT_OK(Commit(table_path, schema0_msgs));
+
+    // Drop f2. The surviving fields keep their ids, and the highest field id stays 2 so a
+    // later added column cannot recycle the dropped id.
+    ASSERT_OK(TestHelper::WriteNextSchema(dir_->GetFileSystem(), table_path,
+                                          {DataField(0, fields_[0]), DataField(1, fields_[1])},
+                                          /*highest_field_id=*/2, options));
+
+    // Schema 1: two more rows without f2, row ids [2, 3], sequence number 2.
+    arrow::FieldVector remaining_fields = {fields_[0], fields_[1]};
+    auto schema1_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(remaining_fields), R"([
+        [3, "a2"],
+        [4, "a3"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> schema1_msgs,
+                         WriteArray(table_path, {"f0", "f1"}, schema1_array));
+    ASSERT_OK(Commit(table_path, schema1_msgs));
+
+    auto read_type =
+        arrow::struct_({remaining_fields[0], remaining_fields[1], SpecialFields::RowId().field_});
+    std::vector<std::string> read_names = {"f0", "f1", "_ROW_ID"};
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(read_type, R"([
+        [1, "a0", 0],
+        [2, "a1", 1],
+        [3, "a2", 2],
+        [4, "a3", 3]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, read_names, expected_array));
+
+    // The rewrite reads the schema-0 file with the dropped column projected away and writes
+    // the latest two-column schema.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+    auto message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(messages[0]);
+    ASSERT_TRUE(message_impl);
+    const CompactIncrement& compact_increment = message_impl->GetCompactIncrement();
+    ASSERT_EQ(compact_increment.CompactBefore().size(), 2);
+    ASSERT_EQ(compact_increment.CompactAfter().size(), 1);
+    const std::shared_ptr<DataFileMeta>& compacted_file = compact_increment.CompactAfter()[0];
+    ASSERT_EQ(compacted_file->schema_id, 1);
+    ASSERT_EQ(compacted_file->write_cols, std::nullopt);
+    ASSERT_OK_AND_ASSIGN(int64_t compacted_first_row_id, compacted_file->NonNullFirstRowId());
+    ASSERT_EQ(compacted_first_row_id, 0);
+    ASSERT_EQ(compacted_file->row_count, 4);
+
+    ASSERT_OK(Commit(table_path, messages));
+    ASSERT_OK(ScanAndRead(table_path, read_names, expected_array));
+}
+
+TEST_P(DataEvolutionTableTest, TestStaleCompactMessagePreservesConcurrentPartialUpdate) {
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    // One evolved field group over rows [0, 1]: a full-column file and a newer partial f2
+    // file ("y0"/"y1").
+    ASSERT_OK(WriteAndCommitGroup(table_path, /*first_row_id=*/0, /*f0_values=*/{1, 2}));
+
+    // Plan and execute the compaction but hold its commit message back, so the commit below
+    // races it with a stale view of the files.
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+
+    // A concurrent partial update lands on the same rows after the compaction has read its
+    // input.
+    auto concurrent_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields_[2]}), R"([
+        ["z0"],
+        ["z1"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> concurrent_msgs,
+                         WriteArray(table_path, {"f2"}, concurrent_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, concurrent_msgs);
+    ASSERT_OK(Commit(table_path, concurrent_msgs));
+
+    // The stale compact message still commits: its before-files are still live, and the
+    // rewritten file keeps the input group's sequence range, so the newer update stays on
+    // top instead of being swallowed.
+    ASSERT_OK(Commit(table_path, messages));
+
+    // f2 serves from the concurrent update (newest sequence), the other columns from the
+    // compacted file, and row ids are unchanged.
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [1, "a0", "z0", 0],
+        [2, "a1", "z1", 1]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
+}
+
+TEST_P(DataEvolutionTableTest, TestSmallFileCompactConflictsWithConcurrentPartialUpdate) {
+    // Merging the groups [0, 0] and [1, 1] into one [0, 1] file moves the field group boundary,
+    // so a concurrent partial update aligned with the OLD boundary must conflict — committing
+    // the stale compact would leave the update's file misaligned with its new group.
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    for (const std::string& row_json :
+         {std::string(R"([[10, "a0", "b0"]])"), std::string(R"([[11, "a1", "b1"]])")}) {
+        auto row_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), row_json)
+                .ValueOrDie());
+        ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> row_msgs,
+                             WriteArray(table_path, {"f0", "f1", "f2"}, row_array));
+        ASSERT_OK(Commit(table_path, row_msgs));
+    }
+
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+
+    // The concurrent update lands on row 0 only, aligned with the pre-compaction boundary.
+    auto concurrent_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields_[2]}), R"([
+        ["upd0"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> concurrent_msgs,
+                         WriteArray(table_path, {"f2"}, concurrent_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, concurrent_msgs);
+    ASSERT_OK(Commit(table_path, concurrent_msgs));
+
+    // The compact-kind commit always runs the row range alignment check on data-evolution
+    // tables, so the stale message is rejected and the table keeps serving the update.
+    ASSERT_NOK_WITH_MSG(Commit(table_path, messages),
+                        "'COMPACT' operations have encountered conflicts");
+
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [10, "a0", "upd0", 0],
+        [11, "a1", "b1", 1]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
+}
+
+TEST_P(DataEvolutionTableTest, TestCompactKeepsConcurrentAppendForNextSmallFileMerge) {
+    // An append outside the task's row id range neither conflicts with nor is consumed by the
+    // stale compact message; the next coordinator round merges it with the compacted file.
+    CreateDataEvolutionTable(/*deletion_vectors_enabled=*/false);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+
+    for (const std::string& row_json :
+         {std::string(R"([[10, "a0", "b0"]])"), std::string(R"([[11, "a1", "b1"]])")}) {
+        auto row_array = std::dynamic_pointer_cast<arrow::StructArray>(
+            arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), row_json)
+                .ValueOrDie());
+        ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> row_msgs,
+                             WriteArray(table_path, {"f0", "f1", "f2"}, row_array));
+        ASSERT_OK(Commit(table_path, row_msgs));
+    }
+
+    std::map<std::string, std::string> compact_options = {{Options::COMPACTION_MIN_FILE_NUM, "2"}};
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        AppendCompactCoordinator::Run(table_path, compact_options, /*partitions=*/{},
+                                      dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(messages.size(), 1);
+
+    // The concurrent append takes the next row id range [2, 2], outside the task's range.
+    auto append_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_), R"([
+        [12, "a2", "b2"]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> append_msgs,
+                         WriteArray(table_path, {"f0", "f1", "f2"}, append_array));
+    ASSERT_OK(Commit(table_path, append_msgs));
+
+    // The stale compact message still commits: the appended range does not overlap the
+    // rewritten one.
+    ASSERT_OK(Commit(table_path, messages));
+
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(
+            arrow::struct_({fields_[0], fields_[1], fields_[2], SpecialFields::RowId().field_}),
+            R"([
+        [10, "a0", "b0", 0],
+        [11, "a1", "b1", 1],
+        [12, "a2", "b2", 2]
+    ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
+
+    // The next round packs the compacted file [0, 1] and the appended file [2, 2] — adjacent
+    // ranges — into one task and merges them.
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> next_messages,
+        AppendCompactCoordinator::Run(table_path, compact_options,
+                                      /*partitions=*/{}, dir_->GetFileSystem(), GetDefaultPool()));
+    ASSERT_EQ(next_messages.size(), 1);
+    auto next_message_impl = std::dynamic_pointer_cast<CommitMessageImpl>(next_messages[0]);
+    ASSERT_TRUE(next_message_impl);
+    const CompactIncrement& next_increment = next_message_impl->GetCompactIncrement();
+    ASSERT_EQ(next_increment.CompactBefore().size(), 2);
+    ASSERT_EQ(next_increment.CompactAfter().size(), 1);
+    ASSERT_OK_AND_ASSIGN(int64_t next_first_row_id,
+                         next_increment.CompactAfter()[0]->NonNullFirstRowId());
+    ASSERT_EQ(next_first_row_id, 0);
+    ASSERT_EQ(next_increment.CompactAfter()[0]->row_count, 3);
+    ASSERT_OK(Commit(table_path, next_messages));
+    ASSERT_OK(ScanAndRead(table_path, {"f0", "f1", "f2", "_ROW_ID"}, expected_array));
 }
 
 std::vector<DataEvolutionTableParam> GetTestValuesForDataEvolutionTableTest() {

--- a/test/inte/pk_blob_table_inte_test.cpp
+++ b/test/inte/pk_blob_table_inte_test.cpp
@@ -1,0 +1,701 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
+#include "arrow/api.h"
+#include "arrow/c/bridge.h"
+#include "arrow/type.h"
+#include "gtest/gtest.h"
+#include "paimon/catalog/catalog.h"
+#include "paimon/commit_context.h"
+#include "paimon/common/data/blob_descriptor.h"
+#include "paimon/common/data/blob_utils.h"
+#include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/path_util.h"
+#include "paimon/common/utils/string_utils.h"
+#include "paimon/core/io/data_file_meta.h"
+#include "paimon/core/io/managed_blob_reference_file.h"
+#include "paimon/core/table/source/data_split_impl.h"
+#include "paimon/data/blob.h"
+#include "paimon/defs.h"
+#include "paimon/file_store_commit.h"
+#include "paimon/file_store_write.h"
+#include "paimon/fs/file_system.h"
+#include "paimon/memory/bytes.h"
+#include "paimon/memory/memory_pool.h"
+#include "paimon/read_context.h"
+#include "paimon/record_batch.h"
+#include "paimon/result.h"
+#include "paimon/scan_context.h"
+#include "paimon/status.h"
+#include "paimon/table/source/startup_mode.h"
+#include "paimon/table/source/table_read.h"
+#include "paimon/table/source/table_scan.h"
+#include "paimon/testing/utils/read_result_collector.h"
+#include "paimon/testing/utils/testharness.h"
+#include "paimon/write_context.h"
+
+namespace paimon::test {
+
+/// One read-back row of the (pk, v, b) table; nullopt marks a NULL cell.
+using PkBlobRow = std::tuple<std::string, std::optional<int32_t>, std::optional<std::string>>;
+
+/// End-to-end tests for table-managed BLOB storage in primary-key tables: payloads are
+/// externalized to `.managed.blob` packs at write time, data files carry `.blobref` sidecars,
+/// reads resolve descriptors back to payload bytes, and compaction rewrites descriptors
+/// verbatim while rebuilding the exact reference set of the surviving rows.
+class PkBlobTableInteTest : public ::testing::Test,
+                            public ::testing::WithParamInterface<std::string> {
+ public:
+    void SetUp() override {
+        pool_ = GetDefaultPool();
+        dir_ = UniqueTestDirectory::Create("local");
+        fields_ = {arrow::field("pk", arrow::utf8(), /*nullable=*/false),
+                   arrow::field("v", arrow::int32()),
+                   BlobUtils::ToArrowField("b", /*nullable=*/true)};
+    }
+
+    void TearDown() override {
+        dir_.reset();
+    }
+
+    std::string FileFormat() const {
+        return GetParam();
+    }
+
+    void CreateTable(const std::map<std::string, std::string>& extra_options) {
+        std::map<std::string, std::string> options = {{Options::FILE_FORMAT, FileFormat()},
+                                                      {Options::FILE_SYSTEM, "local"},
+                                                      {Options::BUCKET, "1"}};
+        options.insert(extra_options.begin(), extra_options.end());
+        auto schema = arrow::schema(fields_);
+        ::ArrowSchema c_schema;
+        ASSERT_TRUE(arrow::ExportSchema(*schema, &c_schema).ok());
+        ASSERT_OK_AND_ASSIGN(auto catalog, Catalog::Create(dir_->Str(), options));
+        ASSERT_OK(catalog->CreateDatabase("foo", {}, /*ignore_if_exists=*/false));
+        ASSERT_OK(catalog->CreateTable(Identifier("foo", "bar"), &c_schema,
+                                       /*partition_keys=*/{}, /*primary_keys=*/{"pk"}, options,
+                                       /*ignore_if_exists=*/false));
+    }
+
+    std::string TablePath() const {
+        return PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    }
+
+    std::string BucketPath() const {
+        return PathUtil::JoinPath(TablePath(), "bucket-0");
+    }
+
+    std::shared_ptr<arrow::Array> MakeArray(const std::vector<PkBlobRow>& rows) {
+        arrow::StringBuilder pk_builder;
+        arrow::Int32Builder v_builder;
+        arrow::LargeBinaryBuilder b_builder;
+        for (const auto& [pk, v, blob] : rows) {
+            EXPECT_TRUE(pk_builder.Append(pk).ok());
+            if (v) {
+                EXPECT_TRUE(v_builder.Append(v.value()).ok());
+            } else {
+                EXPECT_TRUE(v_builder.AppendNull().ok());
+            }
+            if (blob) {
+                EXPECT_TRUE(b_builder.Append(blob.value()).ok());
+            } else {
+                EXPECT_TRUE(b_builder.AppendNull().ok());
+            }
+        }
+        std::shared_ptr<arrow::Array> pk_array;
+        std::shared_ptr<arrow::Array> v_array;
+        std::shared_ptr<arrow::Array> b_array;
+        EXPECT_TRUE(pk_builder.Finish(&pk_array).ok());
+        EXPECT_TRUE(v_builder.Finish(&v_array).ok());
+        EXPECT_TRUE(b_builder.Finish(&b_array).ok());
+        return arrow::StructArray::Make({pk_array, v_array, b_array}, fields_).ValueOrDie();
+    }
+
+    Result<std::vector<std::shared_ptr<CommitMessage>>> WriteArray(
+        const std::shared_ptr<arrow::Array>& write_array, int64_t commit_identifier,
+        const std::vector<RecordBatch::RowKind>& row_kinds = {}) const {
+        WriteContextBuilder write_builder(TablePath(), "commit_user_1");
+        write_builder.WithStreamingMode(true)
+            .WithTempDirectory(PathUtil::JoinPath(dir_->Str(), "tmp"))
+            .AddOption(Options::WRITE_ONLY, "true");
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<WriteContext> write_context, write_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreWrite> file_store_write,
+                               FileStoreWrite::Create(std::move(write_context)));
+        ArrowArray c_array;
+        PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*write_array, &c_array));
+        auto record_batch = std::make_unique<RecordBatch>(std::map<std::string, std::string>(),
+                                                          /*bucket=*/0, row_kinds, &c_array);
+        PAIMON_RETURN_NOT_OK(file_store_write->Write(std::move(record_batch)));
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<CommitMessage>> commit_msgs,
+                               file_store_write->PrepareCommit(
+                                   /*wait_compaction=*/false, commit_identifier));
+        PAIMON_RETURN_NOT_OK(file_store_write->Close());
+        return commit_msgs;
+    }
+
+    Status Commit(const std::vector<std::shared_ptr<CommitMessage>>& commit_msgs) const {
+        CommitContextBuilder commit_builder(TablePath(), "commit_user_1");
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> commit_context,
+                               commit_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> file_store_commit,
+                               FileStoreCommit::Create(std::move(commit_context)));
+        return file_store_commit->Commit(commit_msgs);
+    }
+
+    Status WriteAndCommit(const std::vector<PkBlobRow>& rows, int64_t commit_identifier,
+                          const std::vector<RecordBatch::RowKind>& row_kinds = {}) {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<CommitMessage>> commit_msgs,
+                               WriteArray(MakeArray(rows), commit_identifier, row_kinds));
+        return Commit(commit_msgs);
+    }
+
+    /// Full-compacts the single bucket and returns the commit messages *without* committing
+    /// them. `also_write`, when set, is written through the same writer first, so one message
+    /// carries both newly written files and a compaction output.
+    Result<std::vector<std::shared_ptr<CommitMessage>>> FullCompact(
+        int64_t commit_identifier,
+        const std::shared_ptr<arrow::Array>& also_write = nullptr) const {
+        WriteContextBuilder write_builder(TablePath(), "commit_user_1");
+        write_builder.WithStreamingMode(true).WithTempDirectory(
+            PathUtil::JoinPath(dir_->Str(), "tmp"));
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<WriteContext> write_context, write_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreWrite> file_store_write,
+                               FileStoreWrite::Create(std::move(write_context)));
+        if (also_write != nullptr) {
+            ArrowArray c_array;
+            PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportArray(*also_write, &c_array));
+            auto record_batch =
+                std::make_unique<RecordBatch>(std::map<std::string, std::string>(), /*bucket=*/0,
+                                              std::vector<RecordBatch::RowKind>(), &c_array);
+            PAIMON_RETURN_NOT_OK(file_store_write->Write(std::move(record_batch)));
+        }
+        PAIMON_RETURN_NOT_OK(file_store_write->Compact(/*partition=*/{}, /*bucket=*/0,
+                                                       /*full_compaction=*/true));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::vector<std::shared_ptr<CommitMessage>> commit_messages,
+            file_store_write->PrepareCommit(/*wait_compaction=*/true, commit_identifier));
+        PAIMON_RETURN_NOT_OK(file_store_write->Close());
+        return commit_messages;
+    }
+
+    Status FullCompactAndCommit(int64_t commit_identifier) {
+        PAIMON_ASSIGN_OR_RAISE(std::vector<std::shared_ptr<CommitMessage>> commit_messages,
+                               FullCompact(commit_identifier));
+        return Commit(commit_messages);
+    }
+
+    /// Reads every row through the public read path (rows come back in key order within the
+    /// single bucket). With `blob_as_descriptor` the managed blob column holds the serialized
+    /// descriptors instead of the payload bytes. With `prefetch` the data file is read through
+    /// the prefetch reader and the shared read-ahead cache instead of a plain stream.
+    void ReadRows(bool blob_as_descriptor, std::vector<PkBlobRow>* rows, bool prefetch = false) {
+        rows->clear();
+        std::map<std::string, std::string> options = {{Options::FILE_SYSTEM, "local"}};
+        if (blob_as_descriptor) {
+            options.emplace(Options::BLOB_AS_DESCRIPTOR, "true");
+        }
+        ScanContextBuilder scan_context_builder(TablePath());
+        scan_context_builder.WithStreamingMode(false).SetOptions(options).AddOption(
+            Options::SCAN_MODE, StartupMode::LatestFull().ToString());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<ScanContext> scan_context,
+                             scan_context_builder.Finish());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableScan> table_scan,
+                             TableScan::Create(std::move(scan_context)));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> result_plan, table_scan->CreatePlan());
+
+        ReadContextBuilder read_context_builder(TablePath());
+        read_context_builder.SetOptions(options);
+        if (prefetch) {
+            read_context_builder.EnablePrefetch(true).SetReadAheadCacheEnabled(true);
+        }
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<ReadContext> read_context,
+                             read_context_builder.Finish());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableRead> table_read,
+                             TableRead::Create(std::move(read_context)));
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<BatchReader> batch_reader,
+                             table_read->CreateReader(result_plan->Splits()));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::ChunkedArray> result,
+                             ReadResultCollector::CollectResult(batch_reader.get()));
+        // The collector reports an empty read (no batches at all) as a null chunked array.
+        if (result == nullptr) {
+            return;
+        }
+        // Copy the cell values out while the reader that owns the buffers is still alive.
+        for (const std::shared_ptr<arrow::Array>& chunk : result->chunks()) {
+            auto struct_array = std::dynamic_pointer_cast<arrow::StructArray>(chunk);
+            ASSERT_TRUE(struct_array != nullptr);
+            auto pk_array =
+                std::dynamic_pointer_cast<arrow::StringArray>(struct_array->GetFieldByName("pk"));
+            auto v_array =
+                std::dynamic_pointer_cast<arrow::Int32Array>(struct_array->GetFieldByName("v"));
+            auto b_array = std::dynamic_pointer_cast<arrow::LargeBinaryArray>(
+                struct_array->GetFieldByName("b"));
+            ASSERT_TRUE(pk_array != nullptr);
+            ASSERT_TRUE(v_array != nullptr);
+            ASSERT_TRUE(b_array != nullptr);
+            for (int64_t row = 0; row < struct_array->length(); row++) {
+                std::optional<int32_t> v;
+                if (!v_array->IsNull(row)) {
+                    v = v_array->Value(row);
+                }
+                std::optional<std::string> blob;
+                if (!b_array->IsNull(row)) {
+                    blob = std::string(b_array->GetView(row));
+                }
+                rows->emplace_back(std::string(pk_array->GetView(row)), v, std::move(blob));
+            }
+        }
+    }
+
+    /// The live data files of the single bucket, from a fresh scan.
+    void CollectDataFiles(std::vector<std::shared_ptr<DataFileMeta>>* files) {
+        files->clear();
+        std::map<std::string, std::string> options = {{Options::FILE_SYSTEM, "local"}};
+        ScanContextBuilder scan_context_builder(TablePath());
+        scan_context_builder.WithStreamingMode(false).SetOptions(options).AddOption(
+            Options::SCAN_MODE, StartupMode::LatestFull().ToString());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<ScanContext> scan_context,
+                             scan_context_builder.Finish());
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<TableScan> table_scan,
+                             TableScan::Create(std::move(scan_context)));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<Plan> result_plan, table_scan->CreatePlan());
+        for (const auto& split : result_plan->Splits()) {
+            auto split_impl = dynamic_cast<DataSplitImpl*>(split.get());
+            ASSERT_TRUE(split_impl != nullptr);
+            files->insert(files->end(), split_impl->DataFiles().begin(),
+                          split_impl->DataFiles().end());
+        }
+    }
+
+    /// Reads the `.blobref` sidecar carried in `file`'s extra files.
+    void ReadSidecar(const std::shared_ptr<DataFileMeta>& file,
+                     std::vector<ManagedBlobReferenceFile::Reference>* references) {
+        references->clear();
+        ASSERT_EQ(file->extra_files.size(), 1);
+        ASSERT_TRUE(file->extra_files[0].has_value());
+        const std::string& sidecar_name = file->extra_files[0].value();
+        ASSERT_TRUE(
+            StringUtils::EndsWith(sidecar_name, ManagedBlobReferenceFile::kReferenceFileSuffix));
+        ASSERT_EQ(sidecar_name, file->file_name + ManagedBlobReferenceFile::kReferenceFileSuffix);
+        ASSERT_OK_AND_ASSIGN(*references, ManagedBlobReferenceFile::Read(
+                                              dir_->GetFileSystem(),
+                                              PathUtil::JoinPath(BucketPath(), sidecar_name)));
+    }
+
+    /// Asserts the bucket holds a single data file whose sidecar references exactly
+    /// `expected_packs`. Reads deduplicate, so the set is the full reference list.
+    void AssertSingleFileSidecar(const std::set<std::string>& expected_packs) {
+        std::vector<std::shared_ptr<DataFileMeta>> files;
+        CollectDataFiles(&files);
+        ASSERT_EQ(files.size(), 1);
+        std::vector<ManagedBlobReferenceFile::Reference> references;
+        ReadSidecar(files[0], &references);
+        std::set<std::string> referenced;
+        for (const auto& reference : references) {
+            referenced.insert(reference.ToString());
+        }
+        ASSERT_EQ(referenced, expected_packs);
+    }
+
+    bool FileExists(const std::string& path) {
+        return dir_->GetFileSystem()->GetFileStatus(path).ok();
+    }
+
+    /// The bucket's files whose name ends with `suffix`, sorted, as bare file names.
+    std::vector<std::string> BucketFilesWithSuffix(const std::string& suffix) {
+        std::vector<BasicFileStatus> statuses;
+        EXPECT_TRUE(dir_->GetFileSystem()->ListDir(BucketPath(), &statuses).ok());
+        std::vector<std::string> names;
+        for (const auto& status : statuses) {
+            std::string name = PathUtil::GetName(status.GetPath());
+            if (!status.IsDir() && StringUtils::EndsWith(name, suffix)) {
+                names.push_back(std::move(name));
+            }
+        }
+        std::sort(names.begin(), names.end());
+        return names;
+    }
+
+    Status Abort(const std::vector<std::shared_ptr<CommitMessage>>& commit_msgs) const {
+        CommitContextBuilder commit_builder(TablePath(), "commit_user_1");
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<CommitContext> commit_context,
+                               commit_builder.Finish());
+        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileStoreCommit> file_store_commit,
+                               FileStoreCommit::Create(std::move(commit_context)));
+        return file_store_commit->Abort(commit_msgs);
+    }
+
+    /// Resolves serialized descriptor bytes to (payload, pack uri).
+    Result<std::string> ResolveDescriptor(const std::string& descriptor_bytes, std::string* uri) {
+        PAIMON_ASSIGN_OR_RAISE(
+            bool is_descriptor,
+            BlobDescriptor::IsBlobDescriptor(descriptor_bytes.data(), descriptor_bytes.size()));
+        if (!is_descriptor) {
+            return Status::Invalid("value is not a serialized blob descriptor");
+        }
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<Blob> blob,
+            Blob::FromDescriptor(descriptor_bytes.data(), descriptor_bytes.size()));
+        *uri = blob->Uri();
+        PAIMON_ASSIGN_OR_RAISE(PAIMON_UNIQUE_PTR<Bytes> payload,
+                               blob->ToData(dir_->GetFileSystem(), pool_));
+        return std::string(payload->data(), payload->size());
+    }
+
+ protected:
+    std::shared_ptr<MemoryPool> pool_;
+    std::unique_ptr<UniqueTestDirectory> dir_;
+    arrow::FieldVector fields_;
+};
+
+TEST_P(PkBlobTableInteTest, TestWriteAndReadManagedBlob) {
+    CreateTable({});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("payload-1")}, {"k2", 2, std::nullopt}},
+                             /*commit_identifier=*/0));
+
+    // The default read resolves the managed blob descriptors back to payload bytes.
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 1, std::string("payload-1")},
+                                       {"k2", 2, std::nullopt}};
+    ASSERT_EQ(rows, expected);
+
+    // With blob-as-descriptor the column holds serialized descriptors that resolve to the
+    // same payload through a ranged read of the pack.
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 2);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    std::string pack_uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload,
+                         ResolveDescriptor(std::get<2>(rows[0]).value(), &pack_uri));
+    ASSERT_EQ(payload, "payload-1");
+    ASSERT_TRUE(StringUtils::EndsWith(PathUtil::GetName(pack_uri),
+                                      ManagedBlobReferenceFile::kManagedBlobSuffix));
+    ASSERT_TRUE(FileExists(pack_uri));
+    ASSERT_FALSE(std::get<2>(rows[1]).has_value());
+
+    // The single data file carries a sidecar listing exactly the referenced pack.
+    AssertSingleFileSidecar({pack_uri});
+}
+
+TEST_P(PkBlobTableInteTest, TestReadWithPrefetchAndReadAheadCache) {
+    // The data file is read through the prefetch reader and the shared read-ahead cache, while
+    // the managed packs are opened directly - `AbstractSplitRead::CreateFileBatchReader` keeps
+    // the blob format off the prefetch path. Descriptor resolution sits above both, so neither
+    // may change what a read hands back.
+    CreateTable({});
+    // The last payload is larger than one blob copy buffer, so externalizing and resolving it
+    // both span several chunks.
+    std::string large_payload(64 * 1024, 'x');
+    ASSERT_OK(WriteAndCommit(
+        {{"k1", 1, std::string("payload-1")}, {"k2", 2, std::nullopt}, {"k3", 3, large_payload}},
+        /*commit_identifier=*/0));
+
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows, /*prefetch=*/true);
+    std::vector<PkBlobRow> expected = {
+        {"k1", 1, std::string("payload-1")}, {"k2", 2, std::nullopt}, {"k3", 3, large_payload}};
+    ASSERT_EQ(rows, expected);
+
+    // Asking for the descriptors instead resolves to the very same bytes, through a pack the
+    // prefetch path never touched.
+    ReadRows(/*blob_as_descriptor=*/true, &rows, /*prefetch=*/true);
+    ASSERT_EQ(rows.size(), 3);
+    ASSERT_TRUE(std::get<2>(rows[2]).has_value());
+    std::string pack_uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload,
+                         ResolveDescriptor(std::get<2>(rows[2]).value(), &pack_uri));
+    ASSERT_EQ(payload, large_payload);
+    ASSERT_TRUE(FileExists(pack_uri));
+    ASSERT_FALSE(std::get<2>(rows[1]).has_value());
+}
+
+TEST_P(PkBlobTableInteTest, TestCompactionRebuildsExactBlobReferences) {
+    // A one-byte blob target size seals a pack per value, so the reference sets of the
+    // surviving and the overwritten payloads are distinguishable.
+    CreateTable({{Options::BLOB_TARGET_FILE_SIZE, "1"}});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("v1-old")}}, /*commit_identifier=*/0));
+    ASSERT_OK(WriteAndCommit({{"k1", 2, std::string("v1-new")}, {"k2", 3, std::string("k2-val")}},
+                             /*commit_identifier=*/1));
+
+    // The merged pre-compaction descriptors: the newest version wins.
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 2);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    ASSERT_TRUE(std::get<2>(rows[1]).has_value());
+    std::string k1_descriptor_before = std::get<2>(rows[0]).value();
+
+    ASSERT_OK(FullCompactAndCommit(/*commit_identifier=*/2));
+
+    // The compacted file rewrites descriptors verbatim: same descriptor bytes, same pack.
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 2);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    ASSERT_EQ(std::get<2>(rows[0]).value(), k1_descriptor_before);
+    std::string k1_uri;
+    std::string k2_uri;
+    ASSERT_OK_AND_ASSIGN(std::string k1_payload,
+                         ResolveDescriptor(std::get<2>(rows[0]).value(), &k1_uri));
+    ASSERT_OK_AND_ASSIGN(std::string k2_payload,
+                         ResolveDescriptor(std::get<2>(rows[1]).value(), &k2_uri));
+    ASSERT_EQ(k1_payload, "v1-new");
+    ASSERT_EQ(k2_payload, "k2-val");
+
+    // The rebuilt sidecar lists exactly the packs of the surviving rows; the overwritten
+    // payload's pack is no longer referenced.
+    AssertSingleFileSidecar({k1_uri, k2_uri});
+
+    // The full read still resolves the payloads.
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 2, std::string("v1-new")},
+                                       {"k2", 3, std::string("k2-val")}};
+    ASSERT_EQ(rows, expected);
+}
+
+TEST_P(PkBlobTableInteTest, TestFirstRowManagedBlobKeepsFirstValue) {
+    CreateTable({{Options::MERGE_ENGINE, "first-row"}, {Options::BLOB_TARGET_FILE_SIZE, "1"}});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("first")}}, /*commit_identifier=*/0));
+    ASSERT_OK(WriteAndCommit({{"k1", 2, std::string("second")}}, /*commit_identifier=*/1));
+
+    // Batch reads of a first-row table only see compacted (level > 0) files, so the
+    // write-only level-0 commits are not visible yet.
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    ASSERT_TRUE(rows.empty());
+
+    ASSERT_OK(FullCompactAndCommit(/*commit_identifier=*/2));
+
+    // first-row keeps the first payload; the later write only produced an unused pack.
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 1, std::string("first")}};
+    ASSERT_EQ(rows, expected);
+
+    // After compaction the sidecar holds exactly the first payload's pack: the reference to
+    // the losing write's pack is gone.
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 1);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    std::string first_uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload,
+                         ResolveDescriptor(std::get<2>(rows[0]).value(), &first_uri));
+    ASSERT_EQ(payload, "first");
+    AssertSingleFileSidecar({first_uri});
+}
+
+TEST_P(PkBlobTableInteTest, TestPartialUpdateManagedBlob) {
+    CreateTable({{Options::MERGE_ENGINE, "partial-update"}});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("payload")}}, /*commit_identifier=*/0));
+    // Partial update: a NULL cell leaves the previous value in place, so the merged row keeps
+    // the descriptor externalized by the first write. The second write produces no pack.
+    ASSERT_OK(WriteAndCommit({{"k1", 2, std::nullopt}}, /*commit_identifier=*/1));
+
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 2, std::string("payload")}};
+    ASSERT_EQ(rows, expected);
+
+    ASSERT_OK(FullCompactAndCommit(/*commit_identifier=*/2));
+
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    ASSERT_EQ(rows, expected);
+
+    // The compacted file's sidecar lists exactly the surviving payload's pack.
+    ReadRows(/*blob_as_descriptor=*/true, &rows);
+    ASSERT_EQ(rows.size(), 1);
+    ASSERT_TRUE(std::get<2>(rows[0]).has_value());
+    std::string pack_uri;
+    ASSERT_OK_AND_ASSIGN(std::string payload,
+                         ResolveDescriptor(std::get<2>(rows[0]).value(), &pack_uri));
+    ASSERT_EQ(payload, "payload");
+    AssertSingleFileSidecar({pack_uri});
+}
+
+TEST_P(PkBlobTableInteTest, TestSnapshotExpirationRemovesSidecar) {
+    CreateTable({});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("one")}}, /*commit_identifier=*/0));
+    ASSERT_OK(WriteAndCommit({{"k2", 2, std::string("two")}}, /*commit_identifier=*/1));
+
+    std::vector<std::shared_ptr<DataFileMeta>> files;
+    CollectDataFiles(&files);
+    ASSERT_EQ(files.size(), 2);
+    std::vector<std::string> old_data_paths;
+    std::vector<std::string> old_sidecar_paths;
+    std::set<std::string> pack_paths;
+    for (const auto& file : files) {
+        old_data_paths.push_back(PathUtil::JoinPath(BucketPath(), file->file_name));
+        std::vector<ManagedBlobReferenceFile::Reference> references;
+        ReadSidecar(file, &references);
+        // ReadSidecar's assertions only return from the helper, so stop here rather than
+        // dereference the extra file it just failed to validate.
+        ASSERT_FALSE(HasFatalFailure());
+        old_sidecar_paths.push_back(PathUtil::JoinPath(BucketPath(), file->extra_files[0].value()));
+        for (const auto& reference : references) {
+            pack_paths.insert(reference.ToString());
+        }
+    }
+    ASSERT_EQ(pack_paths.size(), 2);
+
+    // Rewrite both files into one; snapshot 3 marks the two originals as deleted.
+    ASSERT_OK(FullCompactAndCommit(/*commit_identifier=*/2));
+
+    CommitContextBuilder commit_builder(TablePath(), "commit_user_1");
+    commit_builder.SetOptions({{Options::FILE_SYSTEM, "local"},
+                               {Options::SNAPSHOT_NUM_RETAINED_MAX, "1"},
+                               {Options::SNAPSHOT_NUM_RETAINED_MIN, "1"}});
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<CommitContext> commit_context, commit_builder.Finish());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileStoreCommit> file_store_commit,
+                         FileStoreCommit::Create(std::move(commit_context)));
+    ASSERT_OK_AND_ASSIGN(int32_t expired_snapshots, file_store_commit->Expire());
+    ASSERT_EQ(expired_snapshots, 2);
+
+    // The expired data files took their `.blobref` sidecars with them, while the shared packs
+    // are only referenced and never deleted by snapshot expiration: the compacted file still
+    // resolves its payloads from them.
+    for (const auto& path : old_data_paths) {
+        EXPECT_FALSE(FileExists(path));
+    }
+    for (const auto& path : old_sidecar_paths) {
+        EXPECT_FALSE(FileExists(path));
+    }
+    for (const auto& path : pack_paths) {
+        EXPECT_TRUE(FileExists(path));
+    }
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 1, std::string("one")},
+                                       {"k2", 2, std::string("two")}};
+    ASSERT_EQ(rows, expected);
+}
+
+TEST_P(PkBlobTableInteTest, TestDeleteDropsRow) {
+    CreateTable({});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("payload")}}, /*commit_identifier=*/0));
+
+    // A retract row never keeps a payload; the delete removes the key entirely on read.
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::nullopt}}, /*commit_identifier=*/1,
+                             {RecordBatch::RowKind::DELETE}));
+
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    ASSERT_TRUE(rows.empty());
+}
+
+TEST_P(PkBlobTableInteTest, TestAbortOfACompactionKeepsTheHistoricalPacks) {
+    // The counterpart of the append rollback below, and the reason a rollback cannot derive
+    // pack ownership from the `.blobref` sidecars of the files it removes: compaction rewrites
+    // blob descriptors verbatim, so its output references the packs of the files it merged.
+    // Deleting those would break the snapshot the compaction was planned against, which the
+    // rollback never touched.
+    CreateTable({{Options::BLOB_TARGET_FILE_SIZE, "1"}});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("v1")}}, /*commit_identifier=*/0));
+    ASSERT_OK(WriteAndCommit({{"k2", 2, std::string("v2")}}, /*commit_identifier=*/1));
+    std::vector<std::string> packs_before =
+        BucketFilesWithSuffix(ManagedBlobReferenceFile::kManagedBlobSuffix);
+    ASSERT_EQ(packs_before.size(), 2);
+
+    // The compaction produces an output file but no pack of its own, so it owns nothing to roll
+    // back.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> compact_msgs,
+                         FullCompact(/*commit_identifier=*/2));
+    ASSERT_OK(Abort(compact_msgs));
+
+    ASSERT_EQ(BucketFilesWithSuffix(ManagedBlobReferenceFile::kManagedBlobSuffix), packs_before);
+    // The pre-compaction snapshot is still the latest one, and its payloads still resolve.
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 1, std::string("v1")}, {"k2", 2, std::string("v2")}};
+    ASSERT_EQ(rows, expected);
+}
+
+TEST_P(PkBlobTableInteTest, TestAbortOfAWriteAndCompactionKeepsOnlyTheHistoricalPacks) {
+    // One message carrying both: newly written rows, whose packs this writer created, and a
+    // compaction output, whose packs it only inherited. The rollback has to split them.
+    CreateTable({{Options::BLOB_TARGET_FILE_SIZE, "1"}});
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("v1")}}, /*commit_identifier=*/0));
+    ASSERT_OK(WriteAndCommit({{"k2", 2, std::string("v2")}}, /*commit_identifier=*/1));
+    std::vector<std::string> packs_before =
+        BucketFilesWithSuffix(ManagedBlobReferenceFile::kManagedBlobSuffix);
+    ASSERT_EQ(packs_before.size(), 2);
+
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> messages,
+        FullCompact(/*commit_identifier=*/2, MakeArray({{"k3", 3, std::string("v3")}})));
+    // The write created a third pack before the rollback runs.
+    ASSERT_EQ(BucketFilesWithSuffix(ManagedBlobReferenceFile::kManagedBlobSuffix).size(), 3);
+
+    ASSERT_OK(Abort(messages));
+    // Exactly the new one is gone; the two the compaction merely referenced stay.
+    ASSERT_EQ(BucketFilesWithSuffix(ManagedBlobReferenceFile::kManagedBlobSuffix), packs_before);
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 1, std::string("v1")}, {"k2", 2, std::string("v2")}};
+    ASSERT_EQ(rows, expected);
+}
+
+TEST_P(PkBlobTableInteTest, TestAbortDeletesTheManagedBlobPacksItRollsBack) {
+    CreateTable({});
+    // PrepareCommit seals the packs and hands them over: from here on the writer no longer
+    // deletes them, so whoever gives up on the commit has to. Nothing else ever collects a
+    // `.managed.blob` — orphan file cleaning skips them on purpose, because a pack may be
+    // shared by several data files — so a pack the rollback leaves behind leaks for good.
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> commit_msgs,
+                         WriteArray(MakeArray({{"k1", 1, std::string("payload-1")},
+                                               {"k2", 2, std::string("payload-2")}}),
+                                    /*commit_identifier=*/0));
+    std::vector<std::string> packs =
+        BucketFilesWithSuffix(ManagedBlobReferenceFile::kManagedBlobSuffix);
+    ASSERT_FALSE(packs.empty());
+    ASSERT_FALSE(BucketFilesWithSuffix(ManagedBlobReferenceFile::kReferenceFileSuffix).empty());
+
+    // The snapshot never lands. Aborting must leave the bucket as it was before the write.
+    ASSERT_OK(Abort(commit_msgs));
+    ASSERT_TRUE(BucketFilesWithSuffix(ManagedBlobReferenceFile::kManagedBlobSuffix).empty());
+    ASSERT_TRUE(BucketFilesWithSuffix(ManagedBlobReferenceFile::kReferenceFileSuffix).empty());
+
+    // The table is still usable and the next commit brings its own packs.
+    ASSERT_OK(WriteAndCommit({{"k1", 1, std::string("payload-3")}}, /*commit_identifier=*/1));
+    std::vector<PkBlobRow> rows;
+    ReadRows(/*blob_as_descriptor=*/false, &rows);
+    std::vector<PkBlobRow> expected = {{"k1", 1, std::string("payload-3")}};
+    ASSERT_EQ(rows, expected);
+    ASSERT_EQ(BucketFilesWithSuffix(ManagedBlobReferenceFile::kManagedBlobSuffix).size(), 1);
+}
+
+std::vector<std::string> GetTestValuesForPkBlobTableInteTest() {
+    std::vector<std::string> values;
+    values.emplace_back("parquet");
+#ifdef PAIMON_ENABLE_ORC
+    values.emplace_back("orc");
+#endif
+    return values;
+}
+
+INSTANTIATE_TEST_SUITE_P(FileFormat, PkBlobTableInteTest,
+                         ::testing::ValuesIn(GetTestValuesForPkBlobTableInteTest()));
+
+}  // namespace paimon::test

--- a/test/inte/pk_compaction_inte_test.cpp
+++ b/test/inte/pk_compaction_inte_test.cpp
@@ -379,6 +379,9 @@ class PkCompactionInteTest : public ::testing::Test,
         return split.value();
     }
 
+    /// Body of the deduplicate-with-deletion-vectors test, run once per vector kind.
+    void RunDeduplicateWithDeletionVectors(bool bitmap64);
+
  private:
     std::shared_ptr<MemoryPool> pool_;
     std::unique_ptr<UniqueTestDirectory> dir_;
@@ -641,7 +644,7 @@ TEST_P(PkCompactionInteTest, TestKeyValueTableDvCompactionWithMapSharedShredding
 //   7. ScanAndVerify after DV compact (data read with DV applied)
 //   8. Full compact to merge everything
 //   9. ScanAndVerify after full compact (all data merged)
-TEST_F(PkCompactionInteTest, DeduplicateWithDeletionVectors) {
+void PkCompactionInteTest::RunDeduplicateWithDeletionVectors(bool bitmap64) {
     // f4 is a large padding field to make the initial file substantially bigger than
     // subsequent small level-0 files, preventing PickForSizeRatio from merging them all.
     arrow::FieldVector fields = {
@@ -655,6 +658,11 @@ TEST_F(PkCompactionInteTest, DeduplicateWithDeletionVectors) {
                                                   {Options::BUCKET_KEY, "f2"},
                                                   {Options::FILE_SYSTEM, "local"},
                                                   {Options::DELETION_VECTORS_ENABLED, "true"}};
+    if (bitmap64) {
+        // A 64 bit vector cannot be pushed down as a 32 bit selection, so the read applies it
+        // to the rows it returns instead. What the table reads back must not differ.
+        options[Options::DELETION_VECTOR_BITMAP64] = "true";
+    }
     CreateTable(fields, partition_keys, primary_keys, options);
     std::string table_path = TablePath();
     auto data_type = arrow::struct_(fields);
@@ -753,6 +761,14 @@ TEST_F(PkCompactionInteTest, DeduplicateWithDeletionVectors) {
         // clang-format on
         ScanAndVerify(table_path, fields, expected_data);
     }
+}
+
+TEST_F(PkCompactionInteTest, DeduplicateWithDeletionVectors) {
+    RunDeduplicateWithDeletionVectors(/*bitmap64=*/false);
+}
+
+TEST_F(PkCompactionInteTest, DeduplicateWithBitmap64DeletionVectors) {
+    RunDeduplicateWithDeletionVectors(/*bitmap64=*/true);
 }
 
 // Test: PK table compact writes output files to external path.


### PR DESCRIPTION
### Purpose

Linked issue: close #204

Adds two independent capabilities to the write and compaction paths.

**1. Managed BLOB storage for primary-key tables**

A BLOB column of a primary-key table can now keep its payload out of the data file
entirely. Payloads are externalized into rolling `.managed.blob` packs *before* they
reach the merge-tree write buffer, so neither the buffer nor its spill ever carries
payload bytes — only the fixed-size descriptor that replaces them.

- `PrimaryKeyBlobExternalizer` sits in front of the merge-tree writer, seals a pack when
  it reaches `blob.target-file-size`, and hands the packs it opened to the commit message
  its writer produces. A retract row drops its payload rather than storing one, and a
  batch of nothing but retracts opens no pack at all. An input that already holds a
  descriptor is re-materialized so the value is stored under this table's own packs.
- Each data file keeps a `.blobref` sidecar (`ManagedBlobReferenceFile`, a versioned
  binary format with a golden-bytes test against the Java writer) listing the packs its
  rows reference. `ManagedBlobReferenceCollector` writes it on close; it travels in the
  data file's `extra_files`, so snapshot expiration, orphan cleaning and abort all treat
  it as part of the data file.
- Reads go through `ManagedBlobResolvingBatchReader`, which resolves each stored
  descriptor back to payload bytes with one ranged read per value.
- Ownership is explicit: a pack belongs to the commit message whose writer created it, and
  a compaction that merely inherits a pack does not own it. `UncommittedFileCleaner` rolls
  back exactly the packs a failed commit — or a `PrepareCommit` that gives up partway —
  created, and leaves the inherited ones alone.
- `SchemaValidation` enforces the merge-engine, primary-key, sequence-group ordering and
  option rules the layout relies on, so an unsupported combination (`pk-clustering-override`,
  `blob-descriptor.source-table`, a managed BLOB in a key or ordering field) is rejected at
  schema time rather than silently changing semantics.

Only top-level scalar BLOB columns are managed; a BLOB nested in a ROW/MAP/ARRAY and the
existing inline descriptor/view fields are untouched.

**2. Compaction across the evolved field groups of a data-evolution table**

`AppendCompactCoordinator` previously refused a data-evolution table. It now plans such a
table with `DataEvolutionCompactPlanner`: files covering the exact same rows form one
evolved field group, the groups of a contiguous row-id run are bin-packed, and each task
rewrites one bin into a single normal file holding every non-dedicated column — preserving
row ids and the merged file-level sequence-number range.

- Because the rewrite keeps every input row, the deletions of the replaced groups are
  *re-keyed* onto the rewritten file and committed in the same snapshot rather than
  dropped. `DataEvolutionCompactDeletionVectorRewriter` performs the migration and
  `ConflictDetection` verifies it: a vector that went missing, shrank, or was left behind
  fails the commit instead of resurrecting deleted rows. Both bitmap32 and bitmap64 vectors
  are supported.
- `MaterializeDeletionVectors` is the heavy alternative entry point: it applies the
  deletions physically, which reassigns the row ids of the surviving rows and therefore
  drops the global indexes over the touched partitions in the same commit. It is never done
  automatically, and a range covered by a dedicated blob or vector-store file is rejected
  rather than corrupted. Its commit uses the new
  `RowIdCheckConflictForMaterializeDeletionVectors` range rule, since a rewrite of whole
  row ranges cannot rely on the narrower column-overlap check.
- Both `RunAndCommit` and `MaterializeDeletionVectors` split the row id space into bounded
  rounds and commit each round on its own, so only one round's file metadata is live at a
  time. The split is a soft target: a cut can only land where one data manifest's row id
  coverage ends before the next one's begins, and a snapshot without usable row id
  statistics falls back to a single round. Rounds are independent — a failed round leaves
  the committed ones committed and a later call re-plans the rest.
- Options that decide the compaction path or the physical layout (row tracking, data
  evolution, deletion vectors, bucket, blob layout) are now rejected when an override would
  contradict the persisted schema, and the legacy
  `data-evolution.compaction.rewrite-row-ids=true` mode fails instead of being ignored.

### Tests

**Managed BLOB — unit**

| Case group | Covers |
| --- | --- |
| `PrimaryKeyBlobExternalizerTest` (13) | descriptor replacement, per-field packs, pack rolling by target size, retract-only batches, `PrepareCommit` hand-over, seal failure still closing the pack stream, inline descriptor fields left alone, re-materializing descriptor input, IO failure |
| `ManagedBlobReferenceFileTest` (14) | round trip with sort + dedup, empty list, non-ASCII, **Java golden bytes**, and rejection of corruption, trailing bytes, bad magic, unsupported version, negative/oversized count, malformed surrogate, nested relative path |
| `ManagedBlobReferenceCollectorTest` (8) | collecting only declared columns, ignoring non-descriptor values, empty sidecar, abort deleting the sidecar, use-after-close and unknown-field rejection |
| `ManagedBlobResolvingBatchReaderTest` (7) | descriptor resolution preserving nulls, declared-columns-only, pass-through without managed fields, missing pack / non-struct / wrong-type / non-descriptor rejection |
| `UncommittedFileCleanerTest` (4) | rolling back data files, sidecars and *owned* packs; not touching an inherited pack; tolerating missing files; one unusable message not stranding the rest |
| `SchemaValidationTest.TestPrimaryKeyManagedBlob{,SequenceGroups}` | merge-engine, key, ordering and unsupported-option rules |
| `SingleFileWriterTest.TestAbortExecutorRemovesCompanionFiles` | an abort executor removes companion files and stays repeatable |

**Managed BLOB — integration (`PkBlobTableInteTest`, 10 cases)**

`TestWriteAndReadManagedBlob`, `TestReadWithPrefetchAndReadAheadCache`,
`TestCompactionRebuildsExactBlobReferences`, `TestFirstRowManagedBlobKeepsFirstValue`,
`TestPartialUpdateManagedBlob`, `TestDeleteDropsRow`,
`TestSnapshotExpirationRemovesSidecar`, `TestAbortDeletesTheManagedBlobPacksItRollsBack`,
`TestAbortOfACompactionKeepsTheHistoricalPacks`,
`TestAbortOfAWriteAndCompactionKeepsOnlyTheHistoricalPacks`.
Plus `CleanInteTest.TestOrphanFilesCleanKeepsCompanionFilesOfLiveDataFiles`.

**Compaction — unit**

| Case group | Covers |
| --- | --- |
| `DataEvolutionCompactPlannerTest` (19) | bin packing by target size and open-file cost, row-id gaps and large files cutting a bin, evolved groups packing together, mismatched group ranges / vector-store files rejected, blob files excluded, per-partition planning, `min-file-num`, and the round windowing (cut only at coverage gaps, file budget, fallback without row id statistics, delete-only manifests ignored) |
| `DataEvolutionNormalCompactTaskTest` (3), `DataEvolutionMaterializeDeletionCompactTaskTest` (5) | input union, discontiguous / misaligned / dedicated-storage rejection |
| `DataEvolutionCompactDeletionVectorRewriterTest` (6) | short-circuit without vectors, and rejection of a message that already changed the index, a bucketed message, a rewrite that moved its rows, several normal outputs |
| `DataEvolutionCompactGlobalIndexDropperTest` (2) | nothing dropped for a normal compaction or without replaced normal files |
| `DataEvolutionConflictDetectionTest` (10) | the migration check — a left-behind vector, lost deletions, a shrunken vector, two index files claiming one data file, an uncovered dropped group; accepting a materialized compaction and a fully deleted range |
| `ConflictDetectionTest` (+2), `AppendCompactCoordinatorTest` (+2) | plain append table still refuses dropping data files; row-id existence on compaction; `RunAndCommit` / `MaterializeDeletionVectors` on a plain append table |
| `RowIdRangeConflictCheckerTest` (2), `MaterializedIndexChangesProviderTest` (3) | range overlap rule; global indexes rescanned every attempt, other buckets kept |

**Compaction — integration (`DataEvolutionTableTest`, 33 new cases)**

Field-group compaction (`TestCompactAcrossEvolvedFieldGroups`, with partitions, with a
partition filter, across schema evolution, after a dropped column), deletion-vector
migration (`TestCompactKeepsDeletionVectorsOfOneRowRangeGroup`, bitmap64, shifts across
groups, only the touched index file rewritten, sibling vectors carried, out-of-group
deletion rejected), materialization (`TestMaterializeDeletionVectorsReassignsRowIds`,
no-op without deletions, untouched ranges left alone, global indexes dropped, other
partitions untouched, fully deleted range, option guards), bounded rounds
(`TestRunAndCommitSplitsRowIdSpaceIntoRounds`, with a partition filter, moving deletion
vectors every round for both bitmap kinds), and concurrency
(`TestStaleCompactMessagePreservesConcurrentPartialUpdate`,
`TestSmallFileCompactConflictsWithConcurrentPartialUpdate`,
`TestCompactKeepsConcurrentAppendForNextSmallFileMerge`).
Plus `PkCompactionInteTest.DeduplicateWith{,Bitmap64}DeletionVectors`.

### API and Format

Yes — additive public API, plus one new on-disk file kind.

- `include/paimon/append/append_compact_coordinator.h`: two new static entry points,
  `RunAndCommit` and `MaterializeDeletionVectors`, and `kDefaultCandidateFilesPerRound`.
  `Run` keeps its signature; its contract is documented more tightly — on a data-evolution
  table with deletion vectors the returned vector also holds index-only messages and the
  caller must commit the whole vector in one commit.
- `include/paimon/file_store_commit.h`: new pure virtual
  `RowIdCheckConflictForMaterializeDeletionVectors`. This is a source-breaking change for
  an out-of-tree implementer of the interface; there is none in this repository.
- `include/paimon/format/format_writer.h`: new `LastPayloadRange()` with a `std::nullopt`
  default, so the externalizer can point a descriptor at the bytes it just wrote without
  downcasting the writer the format factory handed it.
- `include/paimon/defs.h`: adds `BLOB_COPY_BUFFER_SIZE`, `BLOB_DESCRIPTOR_SOURCE_TABLE`,
  `PK_CLUSTERING_OVERRIDE` and `DATA_EVOLUTION_COMPACTION_REWRITE_ROW_IDS` (the last three
  documenting rejected configurations), and updates the `DELETION_VECTORS_ENABLED` and
  `DELETION_VECTOR_BITMAP64` notes now that a data-evolution table is compactable and
  bitmap64 is supported.
- **Format**: the `.managed.blob` pack is the existing blob file format. New is the
  `.blobref` sidecar, a versioned binary file with magic, version and a length-prefixed
  reference list; `ManagedBlobReferenceFileTest.TestJavaGoldenBytes` pins it against the
  Java bytes. The sidecar is referenced from `DataFileMeta::extra_files`, an existing field,
  so the manifest format is unchanged. Deletion vector index files, snapshots and manifests
  are unchanged.

### Documentation

Yes.

- `docs/source/user_guide/primary_key_table.rst` gains *Managed BLOB Storage*: how the
  payload is externalized and resolved, the `.blobref` sidecar, pack ownership versus
  reference, and the supported surface (top-level scalar BLOB columns only) with the option
  and merge-engine rules.
- `docs/source/user_guide/compaction.rst` gains *Data-Evolution Table Compaction*, covering
  evolved field groups, the deletion-vector migration and the commit check that verifies it,
  *Materializing Deletions* and why it is a separate opt-in, and *Bounded Rounds and
  Committing*. The previous note that such a table is never compacted is removed.
- `docs/source/user_guide/read.rst` is updated where it stated the same limitation.

### Generative AI tooling

Generated-by: Claude Opus 5 (Claude Code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
