### PR TITLE
fix(rest): support libcurl versions before 7.49

### DIFF
--- a/src/paimon/rest/rest_http_client.cpp
+++ b/src/paimon/rest/rest_http_client.cpp
@@ -123,7 +123,9 @@ bool IsRetriableTransportError(CURLcode code) {
         case CURLE_RECV_ERROR:
         case CURLE_PARTIAL_FILE:
         case CURLE_HTTP2:
+#if CURL_AT_LEAST_VERSION(7, 49, 0)
         case CURLE_HTTP2_STREAM:
+#endif
             return true;
         default:
             return false;


### PR DESCRIPTION
### Purpose

Linked issue: #164 .

Paimon enables REST with `find_package(CURL REQUIRED)` and does not declare a minimum libcurl version. However, `IsRetriableTransportError` unconditionally references `CURLE_HTTP2_STREAM`, which was added in libcurl 7.49.0. Building REST support with an older supported libcurl, such as 7.46.0, therefore fails at compile time.

Guard the enum case with `CURL_AT_LEAST_VERSION(7, 49, 0)`. Builds using libcurl 7.49 or newer retain the existing retry classification; older libcurl versions cannot return an error code they do not define.

### Tests

- `git diff --check` passes.
- The same source change builds in an x86 downstream Blade configuration against libcurl 7.46.0.
- Downstream `core_test`: 1809/1809 passed.
- Downstream `RestHttpClientTest.*`: 26/26 passed.

### Coverage

The curl 7.46.0 build validates the pre-7.49 compile-time branch. Existing builds with newer libcurl retain the `CURLE_HTTP2_STREAM` case. No separate line or branch coverage report was generated.

### API and Format

This change does not affect public APIs, storage formats, or protocols.

### Documentation

This change does not introduce a user-visible feature; no documentation update is required.

### Generative AI tooling

Generated-by: Codex (GPT-5)
