### PR TITLE
feat(vector): support data evolution reads and writes

### DIFF
--- a/docs/source/user_guide/data_types.rst
+++ b/docs/source/user_guide/data_types.rst
@@ -197,8 +197,11 @@ and `Arrow DataTypes <https://arrow.apache.org/docs/format/Columnar.html#data-ty
        Paimon C++ supports VECTOR value columns in append-only and primary-key
        tables backed by Parquet data files. They use the standard Parquet LIST
        representation on disk and are restored as Arrow ``FixedSizeList``
-       values on read. VECTOR is not supported in data-evolution tables. VECTOR
-       columns cannot be primary, partition, or bucket keys, nor comparator-based
+       values on read. Row-tracking append-only tables with data evolution also
+       support full-row and partial-column VECTOR writes, including reads across
+       schema versions that add or drop VECTOR columns. Changing a VECTOR's
+       dimension or element type is not supported. VECTOR columns cannot be
+       primary, partition, or bucket keys, nor comparator-based
        ordering fields such as sequence and sequence-group fields. Dedicated
        vector storage is not included yet.
 

--- a/src/paimon/common/utils/arrow/vector_utils.cpp
+++ b/src/paimon/common/utils/arrow/vector_utils.cpp
@@ -112,6 +112,26 @@ bool VectorUtils::ContainsVector(const std::shared_ptr<arrow::Schema>& schema) {
     return false;
 }
 
+Status VectorUtils::ValidateVectorEvolution(const std::shared_ptr<arrow::DataType>& read_type,
+                                            const std::shared_ptr<arrow::DataType>& data_type) {
+    bool read_is_vector = read_type->id() == arrow::Type::FIXED_SIZE_LIST;
+    bool data_is_vector = data_type->id() == arrow::Type::FIXED_SIZE_LIST;
+    if (!read_is_vector && !data_is_vector) {
+        return Status::OK();
+    }
+    if (read_is_vector && data_is_vector) {
+        const auto& read_vector = checked_cast<const arrow::FixedSizeListType&>(*read_type);
+        const auto& data_vector = checked_cast<const arrow::FixedSizeListType&>(*data_type);
+        if (read_vector.list_size() == data_vector.list_size() &&
+            read_vector.value_type()->Equals(data_vector.value_type())) {
+            return Status::OK();
+        }
+    }
+    return Status::Invalid(
+        fmt::format("VECTOR type mismatch during schema evolution: data {} vs read {}",
+                    data_type->ToString(), read_type->ToString()));
+}
+
 Status VectorUtils::ValidateVectorElements(const arrow::Array& array) {
     switch (array.type_id()) {
         case arrow::Type::LIST:

--- a/src/paimon/common/utils/arrow/vector_utils.h
+++ b/src/paimon/common/utils/arrow/vector_utils.h
@@ -46,6 +46,11 @@ class PAIMON_EXPORT VectorUtils {
 
     static bool ContainsVector(const std::shared_ptr<arrow::Schema>& schema);
 
+    /// Rejects VECTOR dimension or element type changes and VECTOR/non-VECTOR conversions.
+    /// Checks only these types; callers validate nested children recursively.
+    static Status ValidateVectorEvolution(const std::shared_ptr<arrow::DataType>& read_type,
+                                          const std::shared_ptr<arrow::DataType>& data_type);
+
     /// Rejects VECTOR values whose elements are not fully materialized or contain nulls.
     /// `array` must be the List or FixedSizeList array holding the VECTOR values.
     static Status ValidateVectorElements(const arrow::Array& array);

--- a/src/paimon/common/utils/arrow/vector_utils_test.cpp
+++ b/src/paimon/common/utils/arrow/vector_utils_test.cpp
@@ -20,6 +20,7 @@
 #include "paimon/common/utils/arrow/vector_utils.h"
 
 #include <memory>
+#include <vector>
 
 #include "arrow/api.h"
 #include "arrow/ipc/json_simple.h"
@@ -56,6 +57,33 @@ TEST(VectorUtilsTest, TestContainsVector) {
         arrow::schema({arrow::field("id", arrow::int32()), arrow::field("v", vector_type)})));
     ASSERT_FALSE(VectorUtils::ContainsVector(arrow::schema({arrow::field("id", arrow::int32())})));
     ASSERT_FALSE(VectorUtils::ContainsVector(nullptr));
+}
+
+TEST(VectorUtilsTest, TestValidateVectorEvolution) {
+    auto vector_type = arrow::fixed_size_list(arrow::float32(), 3);
+    ASSERT_OK(VectorUtils::ValidateVectorEvolution(vector_type, vector_type));
+    auto read_type =
+        arrow::fixed_size_list(arrow::field("element", arrow::float32(), /*nullable=*/false), 3);
+    ASSERT_OK(VectorUtils::ValidateVectorEvolution(read_type, vector_type));
+    ASSERT_OK(VectorUtils::ValidateVectorEvolution(vector_type, read_type));
+    ASSERT_OK(VectorUtils::ValidateVectorEvolution(arrow::int64(), arrow::int32()));
+}
+
+TEST(VectorUtilsTest, TestValidateVectorEvolutionRejectsIncompatibleTypes) {
+    auto vector_type = arrow::fixed_size_list(arrow::float32(), 3);
+    std::vector<std::shared_ptr<arrow::DataType>> incompatible_types = {
+        arrow::fixed_size_list(arrow::float32(), 5),
+        arrow::fixed_size_list(arrow::float64(), 3),
+        arrow::list(arrow::float32()),
+        arrow::int32(),
+    };
+    for (const auto& incompatible_type : incompatible_types) {
+        SCOPED_TRACE(incompatible_type->ToString());
+        ASSERT_NOK_WITH_MSG(VectorUtils::ValidateVectorEvolution(incompatible_type, vector_type),
+                            "VECTOR type mismatch during schema evolution");
+        ASSERT_NOK_WITH_MSG(VectorUtils::ValidateVectorEvolution(vector_type, incompatible_type),
+                            "VECTOR type mismatch during schema evolution");
+    }
 }
 
 TEST(VectorUtilsTest, TestValidateVectorElements) {

--- a/src/paimon/core/schema/schema_validation.cpp
+++ b/src/paimon/core/schema/schema_validation.cpp
@@ -789,10 +789,6 @@ Status SchemaValidation::ValidateVectorFields(const TableSchema& schema,
     if (!has_vector) {
         return Status::OK();
     }
-    if (options.DataEvolutionEnabled()) {
-        return Status::NotImplemented(
-            "VECTOR fields in data-evolution tables are not implemented yet.");
-    }
     PAIMON_RETURN_NOT_OK(
         ValidateVectorFileFormat(Options::FILE_FORMAT, options.GetFileFormat()->Identifier()));
     return ValidatePerLevelOption(options.ToMap(), Options::FILE_FORMAT_PER_LEVEL,

--- a/src/paimon/core/schema/schema_validation_test.cpp
+++ b/src/paimon/core/schema/schema_validation_test.cpp
@@ -156,14 +156,19 @@ TEST(SchemaValidationTest, TestVectorType) {
                          TableSchema::Create(/*schema_id=*/0, schema,
                                              /*partition_keys=*/{},
                                              /*primary_keys=*/{}, data_evolution_options));
-    ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
-                        "VECTOR fields in data-evolution tables are not implemented yet.");
+    ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
     ASSERT_OK_AND_ASSIGN(
         table_schema,
         TableSchema::Create(/*schema_id=*/0, nested_schema,
                             /*partition_keys=*/{}, /*primary_keys=*/{}, data_evolution_options));
+    ASSERT_OK(SchemaValidation::ValidateTableSchema(*table_schema));
+
+    data_evolution_options[Options::FILE_FORMAT] = "orc";
+    ASSERT_OK_AND_ASSIGN(table_schema,
+                         TableSchema::Create(/*schema_id=*/0, schema, /*partition_keys=*/{},
+                                             /*primary_keys=*/{}, data_evolution_options));
     ASSERT_NOK_WITH_MSG(SchemaValidation::ValidateTableSchema(*table_schema),
-                        "VECTOR fields in data-evolution tables are not implemented yet.");
+                        "VECTOR currently only supports parquet data files");
 }
 
 #ifdef PAIMON_ENABLE_MOSAIC

--- a/src/paimon/core/utils/nested_projection_utils.cpp
+++ b/src/paimon/core/utils/nested_projection_utils.cpp
@@ -165,6 +165,13 @@ Result<bool> EqualWithFieldIds(const std::shared_ptr<arrow::DataType>& a,
     if (a->id() != b->id() || a->num_fields() != b->num_fields()) {
         return false;
     }
+    if (a->id() == arrow::Type::FIXED_SIZE_LIST) {
+        const auto& vector_a = checked_cast<const arrow::FixedSizeListType&>(*a);
+        const auto& vector_b = checked_cast<const arrow::FixedSizeListType&>(*b);
+        if (vector_a.list_size() != vector_b.list_size()) {
+            return false;
+        }
+    }
     if (a->num_fields() == 0) {
         return a->Equals(*b);
     }
@@ -193,10 +200,31 @@ Result<bool> EqualWithFieldIds(const std::shared_ptr<arrow::DataType>& a,
     return true;
 }
 
+Status ValidateVectorEvolution(const std::shared_ptr<arrow::DataType>& read_type,
+                               const std::shared_ptr<arrow::DataType>& data_type) {
+    bool read_is_vector = read_type->id() == arrow::Type::FIXED_SIZE_LIST;
+    bool data_is_vector = data_type->id() == arrow::Type::FIXED_SIZE_LIST;
+    if (!read_is_vector && !data_is_vector) {
+        return Status::OK();
+    }
+    if (read_is_vector && data_is_vector) {
+        const auto& read_vector = checked_cast<const arrow::FixedSizeListType&>(*read_type);
+        const auto& data_vector = checked_cast<const arrow::FixedSizeListType&>(*data_type);
+        if (read_vector.list_size() == data_vector.list_size() &&
+            read_vector.value_type()->Equals(data_vector.value_type())) {
+            return Status::OK();
+        }
+    }
+    return Status::Invalid(
+        fmt::format("VECTOR type mismatch during schema evolution: data {} vs read {}",
+                    data_type->ToString(), read_type->ToString()));
+}
+
 /// Whether `read_type` is `data_type` with variant columns replaced by their variant-access
 /// projections and nothing else changed (matching paimon field IDs).
 Result<bool> IsVariantAccessSubstitution(const std::shared_ptr<arrow::DataType>& read_type,
                                          const std::shared_ptr<arrow::DataType>& data_type) {
+    PAIMON_RETURN_NOT_OK(ValidateVectorEvolution(read_type, data_type));
     PAIMON_ASSIGN_OR_RAISE(bool equal, EqualWithFieldIds(read_type, data_type));
     if (equal) {
         return true;
@@ -239,6 +267,7 @@ Result<bool> IsVariantAccessSubstitution(const std::shared_ptr<arrow::DataType>&
 Result<std::shared_ptr<arrow::DataType>> PruneRepeatedItemType(
     const std::shared_ptr<arrow::DataType>& read_type,
     const std::shared_ptr<arrow::DataType>& data_type, const char* container) {
+    PAIMON_RETURN_NOT_OK(ValidateVectorEvolution(read_type, data_type));
     PAIMON_ASSIGN_OR_RAISE(bool same, EqualWithFieldIds(read_type, data_type));
     if (same) {
         return data_type;
@@ -316,6 +345,7 @@ Result<std::shared_ptr<arrow::DataType>> PruneRepeatedItemType(
 Result<std::optional<std::shared_ptr<arrow::DataType>>> NestedProjectionUtils::PruneDataType(
     const std::shared_ptr<arrow::DataType>& read_type,
     const std::shared_ptr<arrow::DataType>& data_type) {
+    PAIMON_RETURN_NOT_OK(ValidateVectorEvolution(read_type, data_type));
     // Identical types (including paimon field IDs) need no pruning.
     PAIMON_ASSIGN_OR_RAISE(bool same, EqualWithFieldIds(read_type, data_type));
     if (same) {

--- a/src/paimon/core/utils/nested_projection_utils.cpp
+++ b/src/paimon/core/utils/nested_projection_utils.cpp
@@ -36,6 +36,7 @@
 #include "paimon/common/data/blob_utils.h"
 #include "paimon/common/data/variant/variant_access_utils.h"
 #include "paimon/common/data/variant/variant_type_utils.h"
+#include "paimon/common/utils/arrow/vector_utils.h"
 #include "paimon/common/utils/checked_cast.h"
 #include "paimon/common/utils/string_utils.h"
 #include "paimon/core/casting/casting_utils.h"
@@ -200,31 +201,11 @@ Result<bool> EqualWithFieldIds(const std::shared_ptr<arrow::DataType>& a,
     return true;
 }
 
-Status ValidateVectorEvolution(const std::shared_ptr<arrow::DataType>& read_type,
-                               const std::shared_ptr<arrow::DataType>& data_type) {
-    bool read_is_vector = read_type->id() == arrow::Type::FIXED_SIZE_LIST;
-    bool data_is_vector = data_type->id() == arrow::Type::FIXED_SIZE_LIST;
-    if (!read_is_vector && !data_is_vector) {
-        return Status::OK();
-    }
-    if (read_is_vector && data_is_vector) {
-        const auto& read_vector = checked_cast<const arrow::FixedSizeListType&>(*read_type);
-        const auto& data_vector = checked_cast<const arrow::FixedSizeListType&>(*data_type);
-        if (read_vector.list_size() == data_vector.list_size() &&
-            read_vector.value_type()->Equals(data_vector.value_type())) {
-            return Status::OK();
-        }
-    }
-    return Status::Invalid(
-        fmt::format("VECTOR type mismatch during schema evolution: data {} vs read {}",
-                    data_type->ToString(), read_type->ToString()));
-}
-
 /// Whether `read_type` is `data_type` with variant columns replaced by their variant-access
 /// projections and nothing else changed (matching paimon field IDs).
 Result<bool> IsVariantAccessSubstitution(const std::shared_ptr<arrow::DataType>& read_type,
                                          const std::shared_ptr<arrow::DataType>& data_type) {
-    PAIMON_RETURN_NOT_OK(ValidateVectorEvolution(read_type, data_type));
+    PAIMON_RETURN_NOT_OK(VectorUtils::ValidateVectorEvolution(read_type, data_type));
     PAIMON_ASSIGN_OR_RAISE(bool equal, EqualWithFieldIds(read_type, data_type));
     if (equal) {
         return true;
@@ -267,7 +248,7 @@ Result<bool> IsVariantAccessSubstitution(const std::shared_ptr<arrow::DataType>&
 Result<std::shared_ptr<arrow::DataType>> PruneRepeatedItemType(
     const std::shared_ptr<arrow::DataType>& read_type,
     const std::shared_ptr<arrow::DataType>& data_type, const char* container) {
-    PAIMON_RETURN_NOT_OK(ValidateVectorEvolution(read_type, data_type));
+    PAIMON_RETURN_NOT_OK(VectorUtils::ValidateVectorEvolution(read_type, data_type));
     PAIMON_ASSIGN_OR_RAISE(bool same, EqualWithFieldIds(read_type, data_type));
     if (same) {
         return data_type;
@@ -345,7 +326,7 @@ Result<std::shared_ptr<arrow::DataType>> PruneRepeatedItemType(
 Result<std::optional<std::shared_ptr<arrow::DataType>>> NestedProjectionUtils::PruneDataType(
     const std::shared_ptr<arrow::DataType>& read_type,
     const std::shared_ptr<arrow::DataType>& data_type) {
-    PAIMON_RETURN_NOT_OK(ValidateVectorEvolution(read_type, data_type));
+    PAIMON_RETURN_NOT_OK(VectorUtils::ValidateVectorEvolution(read_type, data_type));
     // Identical types (including paimon field IDs) need no pruning.
     PAIMON_ASSIGN_OR_RAISE(bool same, EqualWithFieldIds(read_type, data_type));
     if (same) {

--- a/src/paimon/core/utils/nested_projection_utils_test.cpp
+++ b/src/paimon/core/utils/nested_projection_utils_test.cpp
@@ -106,6 +106,60 @@ TEST(NestedProjectionUtilsTest, PruneDataTypeAtomicType) {
     ASSERT_TRUE(result.value()->Equals(data_type));
 }
 
+TEST(NestedProjectionUtilsTest, PruneDataTypeVector) {
+    auto data_type = arrow::fixed_size_list(arrow::float32(), 3);
+    auto read_type =
+        arrow::fixed_size_list(arrow::field("element", arrow::float32(), /*nullable=*/false), 3);
+    ASSERT_OK_AND_ASSIGN(auto result, NestedProjectionUtils::PruneDataType(read_type, data_type));
+    ASSERT_TRUE(result.has_value());
+    ASSERT_TRUE(result.value()->Equals(data_type));
+}
+
+TEST(NestedProjectionUtilsTest, PruneDataTypeRejectsIncompatibleVectorEvolution) {
+    auto vector_type = arrow::fixed_size_list(arrow::float32(), 3);
+    std::vector<std::shared_ptr<arrow::DataType>> incompatible_types = {
+        arrow::fixed_size_list(arrow::float32(), 5),
+        arrow::fixed_size_list(arrow::float64(), 3),
+        arrow::list(arrow::float32()),
+        arrow::int32(),
+    };
+    for (const auto& incompatible_type : incompatible_types) {
+        SCOPED_TRACE(incompatible_type->ToString());
+        ASSERT_NOK_WITH_MSG(NestedProjectionUtils::PruneDataType(incompatible_type, vector_type),
+                            "VECTOR type mismatch during schema evolution");
+        ASSERT_NOK_WITH_MSG(NestedProjectionUtils::PruneDataType(vector_type, incompatible_type),
+                            "VECTOR type mismatch during schema evolution");
+    }
+}
+
+TEST(NestedProjectionUtilsTest, PruneDataTypeRejectsNestedVectorEvolution) {
+    auto data_vector = arrow::fixed_size_list(arrow::float32(), 3);
+    for (const auto& read_vector : {arrow::fixed_size_list(arrow::float32(), 5),
+                                    arrow::fixed_size_list(arrow::float64(), 3)}) {
+        SCOPED_TRACE(read_vector->ToString());
+        ASSERT_NOK_WITH_MSG(NestedProjectionUtils::PruneDataType(
+                                arrow::struct_({MakeField("embedding", read_vector, 1)}),
+                                arrow::struct_({MakeField("embedding", data_vector, 1)})),
+                            "VECTOR type mismatch during schema evolution");
+        ASSERT_NOK_WITH_MSG(NestedProjectionUtils::PruneDataType(arrow::list(read_vector),
+                                                                 arrow::list(data_vector)),
+                            "VECTOR type mismatch during schema evolution");
+        ASSERT_NOK_WITH_MSG(
+            NestedProjectionUtils::PruneDataType(arrow::map(arrow::utf8(), read_vector),
+                                                 arrow::map(arrow::utf8(), data_vector)),
+            "VECTOR type mismatch during schema evolution");
+        auto read_struct = arrow::struct_({MakeField("embedding", read_vector, 1)});
+        auto data_struct = arrow::struct_({MakeField("embedding", data_vector, 1)});
+        ASSERT_NOK_WITH_MSG(NestedProjectionUtils::PruneDataType(arrow::list(read_struct),
+                                                                 arrow::list(data_struct)),
+                            "VECTOR type mismatch during schema evolution");
+        ASSERT_NOK_WITH_MSG(
+            NestedProjectionUtils::PruneDataType(arrow::map(arrow::utf8(), read_struct),
+                                                 arrow::map(arrow::utf8(), data_struct)),
+            "VECTOR type mismatch during schema evolution");
+    }
+}
+
 TEST(NestedProjectionUtilsTest, PruneDataTypeStructPruneSubset) {
     // data: STRUCT<x:INT(id=1), y:STRING(id=2), z:DOUBLE(id=3)>
     // read: STRUCT<x:INT(id=1)>

--- a/test/inte/data_evolution_table_test.cpp
+++ b/test/inte/data_evolution_table_test.cpp
@@ -1651,6 +1651,251 @@ TEST_P(DataEvolutionTableTest, TestPartitionWithPredicate) {
     }
 }
 
+TEST_P(DataEvolutionTableTest, TestVectorReadWrite) {
+    if (FileFormat() != "parquet") {
+        GTEST_SKIP() << "VECTOR currently only supports Parquet data files";
+    }
+    auto vector_type =
+        arrow::fixed_size_list(arrow::field("item", arrow::float32(), /*nullable=*/false), 3);
+    arrow::FieldVector fields = {arrow::field("id", arrow::int32()),
+                                 arrow::field("embedding", vector_type),
+                                 arrow::field("tag", arrow::utf8())};
+    std::map<std::string, std::string> options = {
+        {Options::FILE_FORMAT, "parquet"},
+        {Options::FILE_SYSTEM, "local"},
+        {Options::BUCKET, "-1"},
+        {Options::ROW_TRACKING_ENABLED, "true"},
+        {Options::DATA_EVOLUTION_ENABLED, "true"},
+        {Options::READ_BATCH_SIZE, "2"},
+    };
+    CreateTable(fields, /*partition_keys=*/{}, options);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto field_names = arrow::schema(fields)->field_names();
+    auto initial_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+            [1, [1, 2, 3], "a"],
+            [2, null, "b"],
+            [3, [7, 8, 9], "c"],
+            [4, [10, 11, 12], "d"],
+            [5, null, "e"]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> initial_msgs,
+                         WriteArray(table_path, field_names, initial_array));
+    ASSERT_OK(Commit(table_path, initial_msgs));
+    ASSERT_OK(ScanAndRead(table_path, field_names, initial_array));
+
+    auto appended_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+            [6, [16, 17, 18], "f"], [7, null, "g"]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> appended_msgs,
+                         WriteArray(table_path, field_names, appended_array));
+    ASSERT_OK(Commit(table_path, appended_msgs));
+
+    // Replace only the first row range, including transitions to and from NULL VECTOR values.
+    auto updated_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields[1]}), R"([
+            [null], [[4, 5, 6]], [[70, 80, 90]], [null], [[13, 14, 15]]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> update_msgs,
+                         WriteArray(table_path, {"embedding"}, updated_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, update_msgs);
+    ASSERT_OK(Commit(table_path, update_msgs));
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+            [1, null, "a"],
+            [2, [4, 5, 6], "b"],
+            [3, [70, 80, 90], "c"],
+            [4, null, "d"],
+            [5, [13, 14, 15], "e"],
+            [6, [16, 17, 18], "f"],
+            [7, null, "g"]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, field_names, expected_array));
+
+    auto projected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields[1]}), R"([
+            [[4, 5, 6]], [[70, 80, 90]], [null]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"embedding"}, projected_array, /*predicate=*/nullptr,
+                          /*row_ranges=*/{Range(1, 3)}));
+
+    auto null_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields[1]}), R"([
+            [null], [null], [null], [null], [null]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> null_msgs,
+                         WriteArray(table_path, {"embedding"}, null_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, null_msgs);
+    ASSERT_OK(Commit(table_path, null_msgs));
+    auto expected_null_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+            [1, null, "a"], [2, null, "b"], [3, null, "c"], [4, null, "d"],
+            [5, null, "e"], [6, [16, 17, 18], "f"], [7, null, "g"]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, field_names, expected_null_array));
+}
+
+TEST_P(DataEvolutionTableTest, TestNestedVectorReadWrite) {
+    if (FileFormat() != "parquet") {
+        GTEST_SKIP() << "VECTOR currently only supports Parquet data files";
+    }
+    auto vector_type =
+        arrow::fixed_size_list(arrow::field("item", arrow::float32(), /*nullable=*/false), 3);
+    arrow::FieldVector fields = {
+        arrow::field("id", arrow::int32()),
+        arrow::field("payload", arrow::struct_({arrow::field("embedding", vector_type),
+                                                arrow::field("tag", arrow::utf8())})),
+    };
+    std::map<std::string, std::string> options = {
+        {Options::FILE_FORMAT, "parquet"},
+        {Options::FILE_SYSTEM, "local"},
+        {Options::BUCKET, "-1"},
+        {Options::ROW_TRACKING_ENABLED, "true"},
+        {Options::DATA_EVOLUTION_ENABLED, "true"},
+        {Options::READ_BATCH_SIZE, "2"},
+    };
+    CreateTable(fields, /*partition_keys=*/{}, options);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto initial_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+            [1, [[1, 2, 3], "a"]], [2, [null, "b"]], [3, null]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> initial_msgs,
+                         WriteArray(table_path, {"id", "payload"}, initial_array));
+    ASSERT_OK(Commit(table_path, initial_msgs));
+    ASSERT_OK(ScanAndRead(table_path, {"id", "payload"}, initial_array));
+
+    auto updated_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields[1]}), R"([
+            [null], [[[4, 5, 6], "updated"]], [[null, "c"]]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> update_msgs,
+                         WriteArray(table_path, {"payload"}, updated_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, update_msgs);
+    ASSERT_OK(Commit(table_path, update_msgs));
+    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+            [1, null], [2, [[4, 5, 6], "updated"]], [3, [null, "c"]]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, {"id", "payload"}, expected_array));
+}
+
+TEST_P(DataEvolutionTableTest, TestVectorSchemaEvolution) {
+    if (FileFormat() != "parquet") {
+        GTEST_SKIP() << "VECTOR currently only supports Parquet data files";
+    }
+    auto retained_vector_type =
+        arrow::fixed_size_list(arrow::field("item", arrow::float32(), /*nullable=*/false), 3);
+    auto dropped_vector_type =
+        arrow::fixed_size_list(arrow::field("item", arrow::int64(), /*nullable=*/false), 2);
+    auto added_vector_type =
+        arrow::fixed_size_list(arrow::field("item", arrow::float64(), /*nullable=*/false), 2);
+    arrow::FieldVector fields_v0 = {
+        arrow::field("id", arrow::int32()),
+        arrow::field("retained_embedding", retained_vector_type),
+        arrow::field("dropped_embedding", dropped_vector_type),
+    };
+    std::map<std::string, std::string> options = {
+        {Options::FILE_FORMAT, "parquet"},
+        {Options::FILE_SYSTEM, "local"},
+        {Options::BUCKET, "-1"},
+        {Options::ROW_TRACKING_ENABLED, "true"},
+        {Options::DATA_EVOLUTION_ENABLED, "true"},
+        {Options::READ_BATCH_SIZE, "1"},
+    };
+    CreateTable(fields_v0, /*partition_keys=*/{}, options);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto initial_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_v0), R"([
+            [1, [1, 2, 3], [10, 11]], [2, null, [20, 21]]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(
+        std::vector<std::shared_ptr<CommitMessage>> initial_msgs,
+        WriteArray(table_path, arrow::schema(fields_v0)->field_names(), initial_array));
+    ASSERT_OK(Commit(table_path, initial_msgs));
+
+    arrow::FieldVector fields_v1 = {fields_v0[0], fields_v0[1],
+                                    arrow::field("added_embedding", added_vector_type)};
+    ASSERT_OK(TestHelper::WriteNextSchema(
+        dir_->GetFileSystem(), table_path,
+        {DataField(0, fields_v1[0]), DataField(1, fields_v1[1]), DataField(3, fields_v1[2])},
+        /*highest_field_id=*/3, options));
+    auto expected_after_evolution = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_v1), R"([
+            [1, [1, 2, 3], null], [2, null, null]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK(
+        ScanAndRead(table_path, arrow::schema(fields_v1)->field_names(), expected_after_evolution));
+
+    auto added_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields_v1[2]}), R"([
+            [[100, 101]], [null]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> added_msgs,
+                         WriteArray(table_path, {"added_embedding"}, added_array));
+    SetFirstRowId(/*reset_first_row_id=*/0, added_msgs);
+    ASSERT_OK(Commit(table_path, added_msgs));
+    auto expected_after_partial_write = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_v1), R"([
+            [1, [1, 2, 3], [100, 101]], [2, null, null]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK(ScanAndRead(table_path, arrow::schema(fields_v1)->field_names(),
+                          expected_after_partial_write));
+}
+
+TEST_P(DataEvolutionTableTest, TestVectorSchemaEvolutionRejectsTypeChange) {
+    if (FileFormat() != "parquet") {
+        GTEST_SKIP() << "VECTOR currently only supports Parquet data files";
+    }
+    auto vector_type =
+        arrow::fixed_size_list(arrow::field("item", arrow::float32(), /*nullable=*/false), 3);
+    arrow::FieldVector fields = {arrow::field("id", arrow::int32()),
+                                 arrow::field("embedding", vector_type)};
+    std::map<std::string, std::string> options = {
+        {Options::FILE_FORMAT, "parquet"},
+        {Options::FILE_SYSTEM, "local"},
+        {Options::BUCKET, "-1"},
+        {Options::ROW_TRACKING_ENABLED, "true"},
+        {Options::DATA_EVOLUTION_ENABLED, "true"},
+    };
+    CreateTable(fields, /*partition_keys=*/{}, options);
+    std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
+    auto initial_array = std::dynamic_pointer_cast<arrow::StructArray>(
+        arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
+            [1, [1, 2, 3]], [2, null]
+        ])")
+            .ValueOrDie());
+    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<CommitMessage>> initial_msgs,
+                         WriteArray(table_path, {"id", "embedding"}, initial_array));
+    ASSERT_OK(Commit(table_path, initial_msgs));
+
+    for (const auto& incompatible_type : {arrow::fixed_size_list(arrow::float32(), 5),
+                                          arrow::fixed_size_list(arrow::float64(), 3)}) {
+        SCOPED_TRACE(incompatible_type->ToString());
+        ASSERT_OK(TestHelper::WriteNextSchema(
+            dir_->GetFileSystem(), table_path,
+            {DataField(0, fields[0]), DataField(1, arrow::field("embedding", incompatible_type))},
+            /*highest_field_id=*/1, options));
+        ASSERT_NOK_WITH_MSG(ScanAndRead(table_path, {"id", "embedding"}, initial_array),
+                            "VECTOR type mismatch during schema evolution");
+    }
+}
+
 TEST_P(DataEvolutionTableTest, TestAlterTable) {
     auto file_format = FileFormat();
     if (file_format == "mosaic") {
@@ -2044,8 +2289,8 @@ TEST_P(DataEvolutionTableTest, TestDataEvolutionPredicatePushDownBoundaries) {
     }
     {
         // System fields are completed after reading and cannot be pushed into data files.
-        auto predicate = PredicateBuilder::Equal(/*field_index=*/1, /*field_name=*/"_ROW_ID",
-                                                 FieldType::BIGINT, Literal(99l));
+        auto predicate = PredicateBuilder::Equal(
+            /*field_index=*/1, /*field_name=*/"_ROW_ID", FieldType::BIGINT, Literal(int64_t{99}));
         auto read_type =
             arrow::struct_({arrow::field("f2", arrow::int32()), SpecialFields::RowId().field_});
         auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
@@ -2068,7 +2313,7 @@ TEST_P(DataEvolutionTableTest, TestDataEvolutionPredicatePushDownBoundaries) {
         auto data_predicate = PredicateBuilder::Equal(
             /*field_index=*/0, /*field_name=*/"f2", FieldType::INT, Literal(103));
         auto system_predicate = PredicateBuilder::Equal(
-            /*field_index=*/1, /*field_name=*/"_ROW_ID", FieldType::BIGINT, Literal(0l));
+            /*field_index=*/1, /*field_name=*/"_ROW_ID", FieldType::BIGINT, Literal(int64_t{0}));
         ASSERT_OK_AND_ASSIGN(auto predicate,
                              PredicateBuilder::And({data_predicate, system_predicate}));
         ASSERT_OK(ScanAndRead(table_path, {"f2", "_ROW_ID"}, /*expected_array=*/nullptr, predicate,

--- a/test/inte/data_evolution_table_test.cpp
+++ b/test/inte/data_evolution_table_test.cpp
@@ -26,6 +26,7 @@
 #include "paimon/common/io/cache/lru_cache.h"
 #include "paimon/common/table/special_fields.h"
 #include "paimon/common/types/data_field.h"
+#include "paimon/common/utils/checked_cast.h"
 #include "paimon/common/utils/date_time_utils.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/common/utils/scope_guard.h"
@@ -1671,7 +1672,7 @@ TEST_P(DataEvolutionTableTest, TestVectorReadWrite) {
     CreateTable(fields, /*partition_keys=*/{}, options);
     std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
     auto field_names = arrow::schema(fields)->field_names();
-    auto initial_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto initial_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
             [1, [1, 2, 3], "a"],
             [2, null, "b"],
@@ -1685,7 +1686,7 @@ TEST_P(DataEvolutionTableTest, TestVectorReadWrite) {
     ASSERT_OK(Commit(table_path, initial_msgs));
     ASSERT_OK(ScanAndRead(table_path, field_names, initial_array));
 
-    auto appended_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto appended_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
             [6, [16, 17, 18], "f"], [7, null, "g"]
         ])")
@@ -1695,7 +1696,7 @@ TEST_P(DataEvolutionTableTest, TestVectorReadWrite) {
     ASSERT_OK(Commit(table_path, appended_msgs));
 
     // Replace only the first row range, including transitions to and from NULL VECTOR values.
-    auto updated_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto updated_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields[1]}), R"([
             [null], [[4, 5, 6]], [[70, 80, 90]], [null], [[13, 14, 15]]
         ])")
@@ -1704,7 +1705,7 @@ TEST_P(DataEvolutionTableTest, TestVectorReadWrite) {
                          WriteArray(table_path, {"embedding"}, updated_array));
     SetFirstRowId(/*reset_first_row_id=*/0, update_msgs);
     ASSERT_OK(Commit(table_path, update_msgs));
-    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto expected_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
             [1, null, "a"],
             [2, [4, 5, 6], "b"],
@@ -1717,7 +1718,7 @@ TEST_P(DataEvolutionTableTest, TestVectorReadWrite) {
             .ValueOrDie());
     ASSERT_OK(ScanAndRead(table_path, field_names, expected_array));
 
-    auto projected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto projected_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields[1]}), R"([
             [[4, 5, 6]], [[70, 80, 90]], [null]
         ])")
@@ -1725,7 +1726,7 @@ TEST_P(DataEvolutionTableTest, TestVectorReadWrite) {
     ASSERT_OK(ScanAndRead(table_path, {"embedding"}, projected_array, /*predicate=*/nullptr,
                           /*row_ranges=*/{Range(1, 3)}));
 
-    auto null_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto null_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields[1]}), R"([
             [null], [null], [null], [null], [null]
         ])")
@@ -1734,7 +1735,7 @@ TEST_P(DataEvolutionTableTest, TestVectorReadWrite) {
                          WriteArray(table_path, {"embedding"}, null_array));
     SetFirstRowId(/*reset_first_row_id=*/0, null_msgs);
     ASSERT_OK(Commit(table_path, null_msgs));
-    auto expected_null_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto expected_null_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
             [1, null, "a"], [2, null, "b"], [3, null, "c"], [4, null, "d"],
             [5, null, "e"], [6, [16, 17, 18], "f"], [7, null, "g"]
@@ -1764,7 +1765,7 @@ TEST_P(DataEvolutionTableTest, TestNestedVectorReadWrite) {
     };
     CreateTable(fields, /*partition_keys=*/{}, options);
     std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
-    auto initial_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto initial_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
             [1, [[1, 2, 3], "a"]], [2, [null, "b"]], [3, null]
         ])")
@@ -1774,7 +1775,7 @@ TEST_P(DataEvolutionTableTest, TestNestedVectorReadWrite) {
     ASSERT_OK(Commit(table_path, initial_msgs));
     ASSERT_OK(ScanAndRead(table_path, {"id", "payload"}, initial_array));
 
-    auto updated_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto updated_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields[1]}), R"([
             [null], [[[4, 5, 6], "updated"]], [[null, "c"]]
         ])")
@@ -1783,7 +1784,7 @@ TEST_P(DataEvolutionTableTest, TestNestedVectorReadWrite) {
                          WriteArray(table_path, {"payload"}, updated_array));
     SetFirstRowId(/*reset_first_row_id=*/0, update_msgs);
     ASSERT_OK(Commit(table_path, update_msgs));
-    auto expected_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto expected_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
             [1, null], [2, [[4, 5, 6], "updated"]], [3, [null, "c"]]
         ])")
@@ -1816,7 +1817,7 @@ TEST_P(DataEvolutionTableTest, TestVectorSchemaEvolution) {
     };
     CreateTable(fields_v0, /*partition_keys=*/{}, options);
     std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
-    auto initial_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto initial_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_v0), R"([
             [1, [1, 2, 3], [10, 11]], [2, null, [20, 21]]
         ])")
@@ -1832,7 +1833,7 @@ TEST_P(DataEvolutionTableTest, TestVectorSchemaEvolution) {
         dir_->GetFileSystem(), table_path,
         {DataField(0, fields_v1[0]), DataField(1, fields_v1[1]), DataField(3, fields_v1[2])},
         /*highest_field_id=*/3, options));
-    auto expected_after_evolution = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto expected_after_evolution = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_v1), R"([
             [1, [1, 2, 3], null], [2, null, null]
         ])")
@@ -1840,7 +1841,7 @@ TEST_P(DataEvolutionTableTest, TestVectorSchemaEvolution) {
     ASSERT_OK(
         ScanAndRead(table_path, arrow::schema(fields_v1)->field_names(), expected_after_evolution));
 
-    auto added_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto added_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_({fields_v1[2]}), R"([
             [[100, 101]], [null]
         ])")
@@ -1849,7 +1850,7 @@ TEST_P(DataEvolutionTableTest, TestVectorSchemaEvolution) {
                          WriteArray(table_path, {"added_embedding"}, added_array));
     SetFirstRowId(/*reset_first_row_id=*/0, added_msgs);
     ASSERT_OK(Commit(table_path, added_msgs));
-    auto expected_after_partial_write = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto expected_after_partial_write = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields_v1), R"([
             [1, [1, 2, 3], [100, 101]], [2, null, null]
         ])")
@@ -1875,7 +1876,7 @@ TEST_P(DataEvolutionTableTest, TestVectorSchemaEvolutionRejectsTypeChange) {
     };
     CreateTable(fields, /*partition_keys=*/{}, options);
     std::string table_path = PathUtil::JoinPath(dir_->Str(), "foo.db/bar");
-    auto initial_array = std::dynamic_pointer_cast<arrow::StructArray>(
+    auto initial_array = checked_pointer_cast<arrow::StructArray>(
         arrow::ipc::internal::json::ArrayFromJSON(arrow::struct_(fields), R"([
             [1, [1, 2, 3]], [2, null]
         ])")


### PR DESCRIPTION
### Purpose

Related issue: #197

Enable VECTOR columns in Parquet-backed, row-tracking append-only tables
with data evolution.

The existing Parquet VECTOR read/write path can support data evolution,
but schema validation currently rejects VECTOR fields in these tables.
This change removes that restriction and adds end-to-end coverage for
full-row writes, partial-column updates, and reads across schema versions.

This PR also:
- Includes VECTOR dimensions in nested type equality checks.
- Rejects incompatible VECTOR dimensions, element types, and conversions
  between VECTOR and non-VECTOR types when projecting historical schemas,
  including nested fields.
- Replaces two long-suffixed BIGINT literals in the existing Data Evolution
  predicate tests with explicit int64_t values to fix macOS linking.

Support remains limited to Parquet. Dedicated vector storage and
schema-commit validation for VECTOR type changes are outside this PR.

### Tests

Added end-to-end tests:
- `TestVectorReadWrite`: full writes, appended row groups, partial VECTOR
  updates, NULL transitions, all-NULL updates, and projected row-range reads.
- `TestNestedVectorReadWrite`: full and partial writes of a nullable STRUCT
  containing a VECTOR field.
- `TestVectorSchemaEvolution`: adding and dropping VECTOR columns,
  null-filling added columns in historical files, and partial writes
  across schema versions.
- `TestVectorSchemaEvolutionRejectsTypeChange`: read-time rejection of
  incompatible VECTOR dimensions and element types.

Added projection unit tests:
- `PruneDataTypeVector`
- `PruneDataTypeRejectsIncompatibleVectorEvolution`
- `PruneDataTypeRejectsNestedVectorEvolution`

Updated schema-validation coverage to accept VECTOR in Parquet Data
Evolution tables while retaining the ORC restriction.

Local validation on macOS arm64:
- Standard CMake builds of `paimon-core-test` and
  `paimon-data-evolution-table-test` succeeded.
- Related core tests: 108 passed.
- Full Data Evolution suite: 204 passed, 18 skipped.
- Related ordinary read/write tests: 33 passed.
- Related BLOB tests: 48 passed.
- cpplint, codespell, sphinx-lint, changed-line clang-format checks,
  and `git diff --check` passed.

Runtime results above use statically relinked test executables, without
a Literal compatibility shim. The default mixed-link Data Evolution
executable still aborts during Arrow JSON builder construction.
The full repository suite and Linux CI were not run locally.

New VECTOR integration tests explicitly skip non-Parquet configurations.

### API and Format

No public API, storage format, or protocol changes.

VECTOR values continue to use the existing Parquet LIST representation
and are restored as Arrow FixedSizeList values on read.

Changing a VECTOR's dimension or element type is not supported;
incompatible historical schemas are rejected during read projection.

### Documentation

Updated the VECTOR section of the data types user guide to document
Data Evolution read/write support, adding and dropping VECTOR columns,
and the restrictions on dimension and element-type changes.

### Generative AI tooling

Generated-by: OpenAI Codex CLI 0.153.4