### PR TITLE
perf(read): reduce snapshot and option parsing overhead

### DIFF
--- a/src/paimon/common/utils/options_utils.h
+++ b/src/paimon/common/utils/options_utils.h
@@ -50,28 +50,18 @@ class OptionsUtils {
     template <typename T>
     static Result<T> GetValueFromMap(const std::map<std::string, std::string>& key_value_map,
                                      const std::string& key, const T& default_value) {
-        auto value = GetValueFromMap<T>(key_value_map, key);
-        if (value.ok()) {
-            return value.value();
-        } else if (value.status().IsNotExist()) {
-            return default_value;
-        }
-        return value.status();
+        PAIMON_ASSIGN_OR_RAISE(std::optional<T> value,
+                               GetOptionalValueFromMap<T>(key_value_map, key));
+        return value.value_or(default_value);
     }
 
     template <typename T>
     static Result<T> GetValueFromMap(const std::map<std::string, std::string>& key_value_map,
                                      const std::string& key) {
-        static_assert(is_supported_type<T>::value, "T must be trivially copyable or string");
-        auto iter = key_value_map.find(key);
-        if (iter == key_value_map.end()) {
+        PAIMON_ASSIGN_OR_RAISE(std::optional<T> value,
+                               GetOptionalValueFromMap<T>(key_value_map, key));
+        if (!value) {
             return Status::NotExist(fmt::format("key {} does not exist in map", key));
-        }
-        const auto& value_str = iter->second;
-        std::optional<T> value = StringUtils::StringToValue<T>(value_str);
-        if (value == std::nullopt) {
-            return Status::Invalid(fmt::format("convert key {}, value {} to {} failed", key,
-                                               value_str, GetTypeName<T>()));
         }
         return value.value();
     }
@@ -79,14 +69,18 @@ class OptionsUtils {
     template <typename T>
     static Result<std::optional<T>> GetOptionalValueFromMap(
         const std::map<std::string, std::string>& key_value_map, const std::string& key) {
-        Result<T> value = GetValueFromMap<T>(key_value_map, key);
-        if (value.ok()) {
-            return std::optional<T>(value.value());
-        }
-        if (value.status().IsNotExist()) {
+        static_assert(is_supported_type<T>::value, "T must be trivially copyable or string");
+        auto iter = key_value_map.find(key);
+        if (iter == key_value_map.end()) {
             return std::optional<T>();
         }
-        return value.status();
+        const auto& value_str = iter->second;
+        std::optional<T> value = StringUtils::StringToValue<T>(value_str);
+        if (value == std::nullopt) {
+            return Status::Invalid(fmt::format("convert key {}, value {} to {} failed", key,
+                                               value_str, GetTypeName<T>()));
+        }
+        return value;
     }
 
     static Result<std::string> GetNonEmptyValueFromMap(

--- a/src/paimon/common/utils/options_utils_test.cpp
+++ b/src/paimon/common/utils/options_utils_test.cpp
@@ -61,6 +61,16 @@ TEST(OptionsUtilsTest, TestGetValueFromMap) {
     ASSERT_OK_AND_ASSIGN(auto empty,
                          OptionsUtils::GetValueFromMap<int32_t>(key_value_map, "", 999));
     ASSERT_EQ(999, empty);
+
+    ASSERT_OK_AND_ASSIGN(auto present,
+                         OptionsUtils::GetValueFromMap<int32_t>(key_value_map, "key_int", 233));
+    ASSERT_EQ(10, present);
+    ASSERT_TRUE(
+        OptionsUtils::GetValueFromMap<int32_t>(key_value_map, "missing").status().IsNotExist());
+    key_value_map["empty_string"] = "";
+    ASSERT_OK_AND_ASSIGN(std::string empty_string, OptionsUtils::GetValueFromMap<std::string>(
+                                                       key_value_map, "empty_string", "default"));
+    ASSERT_TRUE(empty_string.empty());
 }
 
 TEST(OptionsUtilsTest, TestGetOptionalValueFromMap) {

--- a/src/paimon/core/operation/file_store_scan.h
+++ b/src/paimon/core/operation/file_store_scan.h
@@ -108,6 +108,10 @@ class FileStoreScan {
         return this;
     }
 
+    const std::optional<Snapshot>& GetSpecifiedSnapshot() const {
+        return specified_snapshot_;
+    }
+
     FileStoreScan* WithLevelFilter(const std::function<bool(int32_t)>& level_filter) {
         level_filter_ = level_filter;
         return this;

--- a/src/paimon/core/table/source/primary_key_index_batch_scan.cpp
+++ b/src/paimon/core/table/source/primary_key_index_batch_scan.cpp
@@ -86,7 +86,11 @@ Result<std::shared_ptr<Plan>> PrimaryKeyIndexBatchScan::CreatePlan() {
     int64_t snapshot_id = data_plan->SnapshotId().value();
     const std::shared_ptr<SnapshotManager>& snapshot_manager =
         snapshot_reader_->GetSnapshotManager();
-    Result<Snapshot> snapshot_result = snapshot_manager->LoadSnapshot(snapshot_id);
+    // The data scan already loaded this snapshot. Reuse it for index planning.
+    const std::optional<Snapshot>& planned_snapshot = snapshot_reader_->GetSpecifiedSnapshot();
+    Result<Snapshot> snapshot_result = planned_snapshot && planned_snapshot->Id() == snapshot_id
+                                           ? Result<Snapshot>(planned_snapshot.value())
+                                           : snapshot_manager->LoadSnapshot(snapshot_id);
     if (!snapshot_result.ok()) {
         static auto logger = Logger::GetLogger("PrimaryKeyIndexBatchScan");
         PAIMON_LOG_WARN(logger,

--- a/src/paimon/core/table/source/snapshot/snapshot_reader.h
+++ b/src/paimon/core/table/source/snapshot/snapshot_reader.h
@@ -92,6 +92,10 @@ class SnapshotReader {
         return scan_->GetSnapshotManager();
     }
 
+    const std::optional<Snapshot>& GetSpecifiedSnapshot() const {
+        return scan_->GetSpecifiedSnapshot();
+    }
+
     const std::unique_ptr<IndexFileHandler>& GetIndexFileHandler() const {
         return index_file_handler_;
     }

--- a/test/inte/primary_key_sorted_index_inte_test.cpp
+++ b/test/inte/primary_key_sorted_index_inte_test.cpp
@@ -75,6 +75,11 @@ class TrackingLocalFileSystem : public LocalFileSystem {
         return index_paths;
     }
 
+    int64_t OpenCount(const std::string& path) const {
+        std::scoped_lock lock(mutex_);
+        return std::count(opened_paths_.begin(), opened_paths_.end(), path);
+    }
+
  private:
     mutable std::mutex mutex_;
     mutable std::vector<std::string> opened_paths_;
@@ -292,11 +297,15 @@ TEST_P(PrimaryKeySortedIndexInteTest, HistoricalSnapshotsMixedFilesAndDisabledIn
     std::shared_ptr<Predicate> predicate = ScoreEqual(/*partitioned=*/false, 0);
     const std::vector<int64_t> snapshot_ids = {2, 3, 5};
     for (int64_t snapshot_id : snapshot_ids) {
+        auto tracking_file_system = std::make_shared<TrackingLocalFileSystem>();
         ASSERT_OK_AND_ASSIGN(
             std::shared_ptr<Plan> plan,
             Scan(/*partitioned=*/false, predicate, snapshot_id, /*index_enabled=*/true,
-                 /*partition_filters=*/{}, /*branch=*/"", /*file_system=*/nullptr));
+                 /*partition_filters=*/{}, /*branch=*/"", tracking_file_system));
         ASSERT_EQ(snapshot_id, plan->SnapshotId());
+        ASSERT_EQ(1, tracking_file_system->OpenCount(
+                         PathUtil::JoinPath(TablePath(/*partitioned=*/false),
+                                            fmt::format("snapshot/snapshot-{}", snapshot_id))));
         const auto [indexed_count, data_count] = CountSplitKinds(plan);
         ASSERT_GT(indexed_count, 0);
         if (snapshot_id == 3) {


### PR DESCRIPTION
### Purpose

Closes #305.

Reduce two independent costs in PK read planning:

- **Snapshot reuse:** the data scan already loads the selected snapshot. Reuse it for index planning when its ID matches the data plan, instead of opening and parsing it again. Keep the existing load path otherwise. This is per-scan reuse; snapshot discovery and freshness do not change.
- **Option parsing:** absent optional settings currently construct a formatted `NotExist` status before discarding it. Return an empty optional directly and share this parsing path with required/default accessors. Required missing keys still return `NotExist`; invalid values, zero/false and explicitly empty strings retain their semantics.

No process-wide cache or resource-management layer is added.

#### Performance evidence

**Snapshot-only comparison.** With the same historical-snapshot integration fixture, selected-snapshot opens fall from **2 to 1** for both Parquet and ORC. An application-level C64 comparison, adding only snapshot reuse to an existing late-materialization baseline, measured:

| Metric | Before | After |
|---|---:|---:|
| Successful QPS | 1,047 | 1,244 |
| AVG | 61.2 ms | 51.5 ms |
| P99 | 109.7 ms | 90.0 ms |
| Worst Max | 3,457.0 ms | 1,132.5 ms |
| Successful reads / errors | 125,669 / 0 | 149,170 / 0 |

Two 60-second runs per version; QPS/AVG/P99 are the median of the two reported values, Max is the worst observed value. No throughput improvement was observed at C128. These older runs streamed full payload logs through the client connection, which later proved to constrain high-concurrency throughput; they do not establish a server capacity limit.

**Option-parsing-only comparison.** The baseline already contains snapshot reuse and late materialization. Hold the table snapshot, physical layout, routing/placement, workers and admission limit fixed; change only option parsing. At C128:

| Metric | Before | After |
|---|---:|---:|
| Successful QPS | 2,585 | 2,804 (+8.5%) |
| AVG | 49.5 ms | 45.7 ms (−7.7%) |
| P99 | 107.7 ms | 88.8 ms (−17.5%) |
| Worst Max | 1,160.2 ms | 1,141.8 ms |
| Successful reads / admission errors | 310,289 / 434 | 336,490 / 411 |

Environment: three Linux x86_64 serving nodes, 96 logical CPUs, approximately 1 TiB RAM and 25 Gbit/s networking per node; SSD-backed HDFS. Static PK table: 12M rows, 8 fixed buckets, two L2 Parquet files per bucket, uniform existing-key lookups returning a 1 KiB high-entropy payload. The parsing comparison uses approximately 16 KiB physical payload pages with dictionary encoding disabled; those layout changes are **not** part of this PR's measured increment. Each version has a 60-second warm-up and two 60-second windows at C64/C96/C128, in ascending then descending order. Full payloads are retained on the client and validated after measurement, not streamed during it. Across the parsing comparison, 1,478,786 successful returned values were validated.

Latency statistics cover successful requests, not rejections. There is between-run variation: the changed C128 throughput ranges from 2,698 to 2,911 QPS. Admission errors remain, and Max is not consistently improved at every concurrency (C96: 664 ms before, 1,553 ms after). These short tests are not a long-running SLA or an error-free capacity claim. The two comparisons use different physical layouts and are not combined into a cumulative speedup. Raising the admission limit is excluded from the PR benefit.

**Parsing microbenchmark.** `CoreOptions::FromMap({{"file.format", "parquet"}})`, C++17 `-O2 -Wall`, 2,000 calls per worker, shared start barrier, 1/8/32/64 workers; two repetitions with reversed baseline/fixed order. Aggregate calls/s:

| Workers | Before, range | After, range |
|---|---:|---:|
| 1 | 14,783–14,943 | 164,082–165,259 |
| 8 | 11,643–12,118 | 1,184,340–1,255,940 |
| 32 | 11,466–11,484 | 1,161,670–1,289,440 |
| 64 | 11,962–12,042 | 1,073,330–1,189,250 |

This isolates parsing, not end-to-end query speedup. Before the change, a high-concurrency diagnostic attributed about 62% of one server's on-CPU samples to `CoreOptions`, including error formatting/locale work. A subsequent diagnostic with the fix sampled approximately 0.38 CPU cores in `CoreOptions` and no missing-option error-formatting/locale hotspot. The diagnostic concurrency differs, so total CPU reduction is not directly compared.

A later same-host, local-filesystem before/after profile and its scope limitations are recorded in the [post-merge validation on #305](https://github.com/apache/paimon-cpp/issues/305#issuecomment-5615000909).

### Tests

- Extend `HistoricalSnapshotsMixedFilesAndDisabledIndex` to verify one snapshot open while preserving result checks for snapshots 2, 3 and 5. All 12 Parquet/ORC PK sorted-index integration cases pass. The same test with the old implementation fails in both formats because it opens the snapshot twice.
- All 41 `OptionsUtilsTest` and `CoreOptionsTest` cases pass, covering missing optional/required/default values, present values, invalid conversion and empty strings.
- Targeted executables were compiled from the changed sources against a matching main-based dependency bundle; **not a full CMake build**. The options executable builds with `-Wall` without warnings. The integration build has signed-comparison warnings from older bundled GoogleTest headers; no production-source warning observed. The full warning-free build requirement is therefore not yet verified.
- `pre-commit run --all-files` (pre-commit 3.8.0) rerun successfully; `git diff --check` passes.
- After maintainer approval, all community workflows passed on the merged PR, including GCC/Clang debug and release builds on x86_64/aarch64, GCC 8, ASAN/UBSAN, TSAN, pre-commit, license and script checks.

### API and Format

Only internal implementation/accessors under `src/`; no public API under `include/`, storage-format or protocol changes. No new dependencies, files or global ownership mechanism.

### Documentation

No new configuration or user-facing feature. Reproduction and expected behavior are recorded in #305; measurements and limitations are above.

### Generative AI tooling

Generated-by: OpenAI Codex (GPT-5)
