### PR TITLE
perf(parquet): avoid duplicate pre-buffering for mixed row groups

### DIFF
--- a/src/paimon/format/parquet/file_reader_wrapper.cpp
+++ b/src/paimon/format/parquet/file_reader_wrapper.cpp
@@ -87,7 +87,7 @@ std::vector<::arrow::io::ReadRange> MergeOverlappingRanges(
 
 Result<std::unique_ptr<FileReaderWrapper>> FileReaderWrapper::Create(
     std::unique_ptr<::parquet::arrow::FileReader>&& file_reader, int64_t batch_size,
-    std::shared_ptr<::arrow::MemoryPool> pool) {
+    std::shared_ptr<::arrow::MemoryPool> pool, bool pre_buffer_enabled) {
     try {
         if (file_reader == nullptr) {
             return Status::Invalid("file reader wrapper create failed. file reader is nullptr");
@@ -109,8 +109,9 @@ Result<std::unique_ptr<FileReaderWrapper>> FileReaderWrapper::Create(
         }
         std::vector<int32_t> columns_indices =
             arrow::internal::Iota(file_reader->parquet_reader()->metadata()->num_columns());
-        auto file_reader_wrapper = std::unique_ptr<FileReaderWrapper>(new FileReaderWrapper(
-            std::move(file_reader), all_row_group_ranges, num_rows, batch_size, pool));
+        auto file_reader_wrapper = std::unique_ptr<FileReaderWrapper>(
+            new FileReaderWrapper(std::move(file_reader), all_row_group_ranges, num_rows,
+                                  batch_size, pool, pre_buffer_enabled));
         std::vector<TargetRowGroup> all_target_row_groups;
         for (int32_t i = 0; i < file_reader_wrapper->GetNumberOfRowGroups(); i++) {
             all_target_row_groups.emplace_back(/*rg_index=*/i, /*is_partially_matched=*/false,
@@ -149,11 +150,12 @@ Status FileReaderWrapper::Close() {
 FileReaderWrapper::FileReaderWrapper(
     std::unique_ptr<::parquet::arrow::FileReader>&& file_reader,
     const std::vector<std::pair<uint64_t, uint64_t>>& all_row_group_ranges, uint64_t num_rows,
-    int64_t batch_size, std::shared_ptr<::arrow::MemoryPool> pool)
+    int64_t batch_size, std::shared_ptr<::arrow::MemoryPool> pool, bool pre_buffer_enabled)
     : file_reader_(std::move(file_reader)),
       all_row_group_ranges_(all_row_group_ranges),
       pool_(std::move(pool)),
       batch_size_(batch_size),
+      pre_buffer_enabled_(pre_buffer_enabled),
       num_rows_(num_rows) {}
 
 void FileReaderWrapper::WaitForPendingPreBuffer() {
@@ -219,10 +221,36 @@ Status FileReaderWrapper::SeekToRow(uint64_t row_number) {
 
                 // Rebuild batch_reader_ for non-page-filtered RGs at/after seek position.
                 std::vector<int32_t> fully_matched_indices;
+                bool has_partially_matched = false;
                 for (uint64_t j = i; j < target_row_groups_.size(); j++) {
+                    if (!target_row_groups_[j].IsExcludedByReadRange() &&
+                        target_row_groups_[j].IsPartiallyMatched()) {
+                        has_partially_matched = true;
+                    }
                     if (!target_row_groups_[j].IsExcludedByReadRange() &&
                         !target_row_groups_[j].IsPartiallyMatched()) {
                         fully_matched_indices.push_back(target_row_groups_[j].GetRowGroupIndex());
+                    }
+                }
+                if (pre_buffer_enabled_) {
+                    WaitForPendingPreBuffer();
+                    if (!has_partially_matched) {
+                        // Keep Arrow's standard column-chunk range handling for full-only plans.
+                        file_reader_->parquet_reader()->PreBuffer(
+                            fully_matched_indices, target_column_indices_,
+                            file_reader_->properties().io_context(),
+                            file_reader_->properties().cache_options());
+                    } else {
+                        PAIMON_ASSIGN_OR_RAISE(
+                            std::vector<::arrow::io::ReadRange> ranges,
+                            CollectPreBufferRanges(target_column_indices_, /*start_idx=*/i));
+                        Status pre_buffer_status = DispatchPreBuffer(std::move(ranges));
+                        if (!pre_buffer_status.ok() && !fully_matched_indices.empty()) {
+                            ::arrow::io::IOContext io_ctx(pool_.get());
+                            file_reader_->parquet_reader()->PreBuffer(
+                                fully_matched_indices, target_column_indices_, io_ctx,
+                                file_reader_->properties().cache_options());
+                        }
                     }
                 }
                 if (!fully_matched_indices.empty()) {
@@ -470,15 +498,17 @@ Result<std::vector<std::pair<uint64_t, uint64_t>>> FileReaderWrapper::GetPreBuff
     return pre_buffer_ranges;
 }
 
-void FileReaderWrapper::DispatchPreBuffer(std::vector<::arrow::io::ReadRange> ranges) {
+Status FileReaderWrapper::DispatchPreBuffer(std::vector<::arrow::io::ReadRange> ranges) {
     const auto& cache_opts = file_reader_->properties().cache_options();
     ::arrow::io::IOContext io_ctx(pool_.get());
     auto merged_ranges = MergeOverlappingRanges(std::move(ranges));
     try {
         file_reader_->parquet_reader()->PreBufferRanges(merged_ranges, io_ctx, cache_opts);
         prebuffered_ranges_ = std::move(merged_ranges);
-    } catch (const std::exception&) {
+        return Status::OK();
+    } catch (const std::exception& e) {
         prebuffered_ranges_.clear();
+        return Status::IOError("Parquet pre-buffer failed: ", e.what());
     }
 }
 
@@ -514,15 +544,40 @@ Status FileReaderWrapper::PrepareForReading(const std::vector<TargetRowGroup>& t
                 fully_matched_row_groups.push_back(trg.GetRowGroupIndex());
             }
         }
-
-        bool has_partially_matched = fully_matched_row_groups.size() != active_count;
+        const bool has_partially_matched = fully_matched_row_groups.size() != active_count;
 
         WaitForPendingPreBuffer();
 
-        // TODO(Yonghao Fang): Neither Paimon nor Arrow manage the size and lifecycle of prebuffered
-        // caches. So when a lot of row is needed, there is possibility of OOM due to too much
-        // prebuffering. Also, DispatchPreBuffer will drop previous prebuffered ranges by
-        // GetRecordBatchReader, which cause IO wastes.
+        // TODO(Yonghao Fang): Neither Paimon nor Arrow manage the size and lifecycle of
+        // pre-buffered caches, so reading many rows may consume too much memory.
+        // Dispatch one cache for both full and page-filtered row groups before constructing the
+        // standard reader. Arrow's automatic pre-buffer is disabled when this flag is set, so
+        // GetRecordBatchReader cannot replace this cache with a full-row-group-only cache.
+        bool managed_pre_buffer_succeeded = false;
+        if (pre_buffer_enabled_) {
+            if (!has_partially_matched) {
+                // Preserve Arrow's range validation and legacy file handling for full-only plans.
+                file_reader_->parquet_reader()->PreBuffer(
+                    fully_matched_row_groups, column_indices,
+                    file_reader_->properties().io_context(),
+                    file_reader_->properties().cache_options());
+                managed_pre_buffer_succeeded = true;
+            } else {
+                PAIMON_ASSIGN_OR_RAISE(std::vector<::arrow::io::ReadRange> all_ranges,
+                                       CollectPreBufferRanges(column_indices, first_active_idx));
+                Status pre_buffer_status = DispatchPreBuffer(std::move(all_ranges));
+                managed_pre_buffer_succeeded = pre_buffer_status.ok();
+                if (!managed_pre_buffer_succeeded && !fully_matched_row_groups.empty()) {
+                    // Preserve Arrow's original error and fallback behavior if range pre-buffering
+                    // cannot be initialized: full row groups still use the standard cache, while
+                    // page-filtered row groups retain their existing best-effort path below.
+                    ::arrow::io::IOContext io_ctx(pool_.get());
+                    file_reader_->parquet_reader()->PreBuffer(
+                        fully_matched_row_groups, column_indices, io_ctx,
+                        file_reader_->properties().cache_options());
+                }
+            }
+        }
 
         // Create standard reader for fully-matched row groups.
         if (!fully_matched_row_groups.empty()) {
@@ -532,12 +587,14 @@ Status FileReaderWrapper::PrepareForReading(const std::vector<TargetRowGroup>& t
             batch_reader_.reset();
         }
 
-        // When page-filtered RGs exist, issue a single PreBuffer covering both kinds.
-        // Otherwise GetRecordBatchReader already issued PreBuffer internally.
-        if (has_partially_matched) {
+        // Preserve the legacy page-filtered path for callers that leave Arrow in charge of
+        // pre-buffering. This includes page-range caching when automatic pre-buffering is off;
+        // PageFilteredRowGroupReader retains its full-chunk fallback if this best-effort call
+        // fails.
+        if ((!pre_buffer_enabled_ || !managed_pre_buffer_succeeded) && has_partially_matched) {
             PAIMON_ASSIGN_OR_RAISE(std::vector<::arrow::io::ReadRange> all_ranges,
                                    CollectPreBufferRanges(column_indices, first_active_idx));
-            DispatchPreBuffer(std::move(all_ranges));
+            (void)DispatchPreBuffer(std::move(all_ranges));
         }
 
         // Reset read state to the first row group that will be read.

--- a/src/paimon/format/parquet/file_reader_wrapper.cpp
+++ b/src/paimon/format/parquet/file_reader_wrapper.cpp
@@ -45,6 +45,19 @@ namespace paimon::parquet {
 
 namespace {
 
+Status ValidatePreBufferRange(const ::arrow::io::ReadRange& range, int64_t file_size) {
+    PAIMON_RETURN_NOT_OK(ValidateValueNonNegative(range.offset, "pre-buffer range offset"));
+    PAIMON_RETURN_NOT_OK(ValidateValueNonNegative(range.length, "pre-buffer range length"));
+    if (range.offset > std::numeric_limits<int64_t>::max() - range.length) {
+        return Status::Invalid(fmt::format("pre-buffer range overflows: offset={}, length={}",
+                                           range.offset, range.length));
+    }
+    if (file_size >= 0 && (range.offset > file_size || range.length > file_size - range.offset)) {
+        return Status::Invalid("pre-buffer range exceeds file size");
+    }
+    return Status::OK();
+}
+
 // Merge overlapping or adjacent ReadRanges into a minimal set of non-overlapping ranges.
 // PreBufferRanges requires non-overlapping ranges, so this is necessary when combining
 // ranges from multiple sources (page-level ranges, column chunk ranges, etc.).
@@ -87,10 +100,13 @@ std::vector<::arrow::io::ReadRange> MergeOverlappingRanges(
 
 Result<std::unique_ptr<FileReaderWrapper>> FileReaderWrapper::Create(
     std::unique_ptr<::parquet::arrow::FileReader>&& file_reader, int64_t batch_size,
-    std::shared_ptr<::arrow::MemoryPool> pool, bool pre_buffer_enabled) {
+    std::shared_ptr<::arrow::MemoryPool> pool, bool pre_buffer_enabled, int64_t file_size) {
     try {
         if (file_reader == nullptr) {
             return Status::Invalid("file reader wrapper create failed. file reader is nullptr");
+        }
+        if (pre_buffer_enabled && file_size < 0) {
+            return Status::Invalid("managed pre-buffering requires a non-negative file size");
         }
         std::vector<std::pair<uint64_t, uint64_t>> all_row_group_ranges;
         auto meta_data = file_reader->parquet_reader()->metadata();
@@ -111,7 +127,7 @@ Result<std::unique_ptr<FileReaderWrapper>> FileReaderWrapper::Create(
             arrow::internal::Iota(file_reader->parquet_reader()->metadata()->num_columns());
         auto file_reader_wrapper = std::unique_ptr<FileReaderWrapper>(
             new FileReaderWrapper(std::move(file_reader), all_row_group_ranges, num_rows,
-                                  batch_size, pool, pre_buffer_enabled));
+                                  batch_size, pool, pre_buffer_enabled, file_size));
         std::vector<TargetRowGroup> all_target_row_groups;
         for (int32_t i = 0; i < file_reader_wrapper->GetNumberOfRowGroups(); i++) {
             all_target_row_groups.emplace_back(/*rg_index=*/i, /*is_partially_matched=*/false,
@@ -150,12 +166,14 @@ Status FileReaderWrapper::Close() {
 FileReaderWrapper::FileReaderWrapper(
     std::unique_ptr<::parquet::arrow::FileReader>&& file_reader,
     const std::vector<std::pair<uint64_t, uint64_t>>& all_row_group_ranges, uint64_t num_rows,
-    int64_t batch_size, std::shared_ptr<::arrow::MemoryPool> pool, bool pre_buffer_enabled)
+    int64_t batch_size, std::shared_ptr<::arrow::MemoryPool> pool, bool pre_buffer_enabled,
+    int64_t file_size)
     : file_reader_(std::move(file_reader)),
       all_row_group_ranges_(all_row_group_ranges),
       pool_(std::move(pool)),
       batch_size_(batch_size),
       pre_buffer_enabled_(pre_buffer_enabled),
+      file_size_(file_size),
       num_rows_(num_rows) {}
 
 void FileReaderWrapper::WaitForPendingPreBuffer() {
@@ -219,47 +237,12 @@ Status FileReaderWrapper::SeekToRow(uint64_t row_number) {
                     return Status::OK();
                 }
 
-                // Rebuild batch_reader_ for non-page-filtered RGs at/after seek position.
-                std::vector<int32_t> fully_matched_indices;
-                bool has_partially_matched = false;
-                for (uint64_t j = i; j < target_row_groups_.size(); j++) {
-                    if (!target_row_groups_[j].IsExcludedByReadRange() &&
-                        target_row_groups_[j].IsPartiallyMatched()) {
-                        has_partially_matched = true;
-                    }
-                    if (!target_row_groups_[j].IsExcludedByReadRange() &&
-                        !target_row_groups_[j].IsPartiallyMatched()) {
-                        fully_matched_indices.push_back(target_row_groups_[j].GetRowGroupIndex());
-                    }
-                }
-                if (pre_buffer_enabled_) {
-                    WaitForPendingPreBuffer();
-                    if (!has_partially_matched) {
-                        // Keep Arrow's standard column-chunk range handling for full-only plans.
-                        file_reader_->parquet_reader()->PreBuffer(
-                            fully_matched_indices, target_column_indices_,
-                            file_reader_->properties().io_context(),
-                            file_reader_->properties().cache_options());
-                    } else {
-                        PAIMON_ASSIGN_OR_RAISE(
-                            std::vector<::arrow::io::ReadRange> ranges,
-                            CollectPreBufferRanges(target_column_indices_, /*start_idx=*/i));
-                        Status pre_buffer_status = DispatchPreBuffer(std::move(ranges));
-                        if (!pre_buffer_status.ok() && !fully_matched_indices.empty()) {
-                            ::arrow::io::IOContext io_ctx(pool_.get());
-                            file_reader_->parquet_reader()->PreBuffer(
-                                fully_matched_indices, target_column_indices_, io_ctx,
-                                file_reader_->properties().cache_options());
-                        }
-                    }
-                }
-                if (!fully_matched_indices.empty()) {
-                    PAIMON_RETURN_NOT_OK_FROM_ARROW(file_reader_->GetRecordBatchReader(
-                        fully_matched_indices, target_column_indices_, &batch_reader_));
-                } else {
-                    batch_reader_.reset();
-                }
-                return Status::OK();
+                // Reuse initialization so seeks refresh the same cache and fallback paths.
+                pending_start_idx_ = i;
+                const uint64_t previous_first_row = previous_first_row_;
+                Status status = PrepareForReading(target_row_groups_, target_column_indices_);
+                previous_first_row_ = previous_first_row;
+                return status;
             }
         }
         next_row_to_read_ = num_rows_;
@@ -422,6 +405,20 @@ Result<std::vector<std::pair<uint64_t, uint64_t>>> FileReaderWrapper::GetRowGrou
 Status FileReaderWrapper::PrepareForReadingLazy(
     const std::vector<TargetRowGroup>& target_row_groups,
     const std::vector<int32_t>& column_indices) {
+    const auto& metadata = file_reader_->parquet_reader()->metadata();
+    for (int32_t column_index : column_indices) {
+        if (column_index < 0 || column_index >= metadata->num_columns()) {
+            return Status::Invalid(fmt::format("column index {} is out of bound {}", column_index,
+                                               metadata->num_columns()));
+        }
+    }
+    for (const auto& row_group : target_row_groups) {
+        int32_t index = row_group.GetRowGroupIndex();
+        if (index < 0 || index >= metadata->num_row_groups()) {
+            return Status::Invalid(fmt::format("row group index {} is out of bound {}", index,
+                                               metadata->num_row_groups()));
+        }
+    }
     target_row_groups_ = target_row_groups;
     target_column_indices_ = column_indices;
     reader_initialized_ = false;
@@ -470,6 +467,10 @@ Result<std::vector<::arrow::io::ReadRange>> FileReaderWrapper::DoCollectPreBuffe
                 }
             }
         }
+        // Validate metadata before either signed range merging or unsigned conversion.
+        for (const auto& range : ranges) {
+            PAIMON_RETURN_NOT_OK(ValidatePreBufferRange(range, file_size_));
+        }
         return ranges;
     }
     PAIMON_PARQUET_CATCH_AND_RETURN_STATUS("FileReaderWrapper::DoCollectPreBufferRanges")
@@ -483,15 +484,6 @@ Result<std::vector<std::pair<uint64_t, uint64_t>>> FileReaderWrapper::GetPreBuff
     std::vector<std::pair<uint64_t, uint64_t>> pre_buffer_ranges;
     pre_buffer_ranges.reserve(ranges.size());
     for (const auto& range : ranges) {
-        // Ranges come from signed parquet metadata; a corrupt footer may hold negative or
-        // overflowing values. Validate before converting to uint64_t, since downstream
-        // range coalescing does unchecked offset + length arithmetic on them.
-        PAIMON_RETURN_NOT_OK(ValidateValueNonNegative(range.offset, "pre-buffer range offset"));
-        PAIMON_RETURN_NOT_OK(ValidateValueNonNegative(range.length, "pre-buffer range length"));
-        if (range.offset > std::numeric_limits<int64_t>::max() - range.length) {
-            return Status::Invalid(fmt::format("pre-buffer range overflows: offset={}, length={}",
-                                               range.offset, range.length));
-        }
         pre_buffer_ranges.emplace_back(static_cast<uint64_t>(range.offset),
                                        static_cast<uint64_t>(range.length));
     }
@@ -499,6 +491,9 @@ Result<std::vector<std::pair<uint64_t, uint64_t>>> FileReaderWrapper::GetPreBuff
 }
 
 Status FileReaderWrapper::DispatchPreBuffer(std::vector<::arrow::io::ReadRange> ranges) {
+    for (const auto& range : ranges) {
+        PAIMON_RETURN_NOT_OK(ValidatePreBufferRange(range, file_size_));
+    }
     const auto& cache_opts = file_reader_->properties().cache_options();
     ::arrow::io::IOContext io_ctx(pool_.get());
     auto merged_ranges = MergeOverlappingRanges(std::move(ranges));
@@ -507,7 +502,10 @@ Status FileReaderWrapper::DispatchPreBuffer(std::vector<::arrow::io::ReadRange> 
         prebuffered_ranges_ = std::move(merged_ranges);
         return Status::OK();
     } catch (const std::exception& e) {
-        prebuffered_ranges_.clear();
+        // Cache initialization can fail after asynchronous reads have been submitted.
+        // Drain them before a fallback replaces the cache.
+        prebuffered_ranges_ = std::move(merged_ranges);
+        WaitForPendingPreBuffer();
         return Status::IOError("Parquet pre-buffer failed: ", e.what());
     }
 }
@@ -515,8 +513,9 @@ Status FileReaderWrapper::DispatchPreBuffer(std::vector<::arrow::io::ReadRange> 
 Status FileReaderWrapper::PrepareForReading(const std::vector<TargetRowGroup>& target_row_groups,
                                             const std::vector<int32_t>& column_indices) {
     try {
-        target_row_groups_ = target_row_groups;
-        target_column_indices_ = column_indices;
+        const auto pending_start_idx = pending_start_idx_;
+        PAIMON_RETURN_NOT_OK(PrepareForReadingLazy(target_row_groups, column_indices));
+        pending_start_idx_ = pending_start_idx;
 
         // Find the first row group to read: skip read-range-excluded ones, and honor a
         // seek issued while the reader was still uninitialized (SeekToRow defers reader

--- a/src/paimon/format/parquet/file_reader_wrapper.h
+++ b/src/paimon/format/parquet/file_reader_wrapper.h
@@ -58,9 +58,11 @@ class FileReaderWrapper {
  public:
     ~FileReaderWrapper();
 
+    // When pre_buffer_enabled is true, the wrapper manages the cache for full and partial
+    // row groups together; the supplied Arrow reader must have automatic pre-buffering disabled.
     static Result<std::unique_ptr<FileReaderWrapper>> Create(
         std::unique_ptr<::parquet::arrow::FileReader>&& reader, int64_t batch_size,
-        std::shared_ptr<arrow::MemoryPool> pool);
+        std::shared_ptr<arrow::MemoryPool> pool, bool pre_buffer_enabled = false);
 
     /// Seek to the specified row number.
     /// @param row_number The row to seek to (must be at a row group boundary).
@@ -162,7 +164,7 @@ class FileReaderWrapper {
     FileReaderWrapper(std::unique_ptr<::parquet::arrow::FileReader>&& file_reader,
                       const std::vector<std::pair<uint64_t, uint64_t>>& all_row_group_ranges,
                       uint64_t num_rows, int64_t batch_size,
-                      std::shared_ptr<::arrow::MemoryPool> pool);
+                      std::shared_ptr<::arrow::MemoryPool> pool, bool pre_buffer_enabled);
 
     /// Wait for all pending PreBuffer operations to complete.
     void WaitForPendingPreBuffer();
@@ -193,7 +195,7 @@ class FileReaderWrapper {
         uint64_t start_idx);
 
     /// Dispatch a single PreBufferRanges call with merged ranges.
-    void DispatchPreBuffer(std::vector<::arrow::io::ReadRange> ranges);
+    Status DispatchPreBuffer(std::vector<::arrow::io::ReadRange> ranges);
 
     std::unique_ptr<::parquet::arrow::FileReader> file_reader_;
     std::unique_ptr<arrow::RecordBatchReader> batch_reader_;
@@ -203,6 +205,7 @@ class FileReaderWrapper {
 
     std::shared_ptr<::arrow::MemoryPool> pool_;
     int64_t batch_size_;  // 0 means no limit
+    bool pre_buffer_enabled_;
 
     const uint64_t num_rows_;
     uint64_t next_row_to_read_ = std::numeric_limits<uint64_t>::max();

--- a/src/paimon/format/parquet/file_reader_wrapper.h
+++ b/src/paimon/format/parquet/file_reader_wrapper.h
@@ -60,9 +60,11 @@ class FileReaderWrapper {
 
     // When pre_buffer_enabled is true, the wrapper manages the cache for full and partial
     // row groups together; the supplied Arrow reader must have automatic pre-buffering disabled.
+    // Managed pre-buffering requires file_size to validate ranges before allocating buffers.
     static Result<std::unique_ptr<FileReaderWrapper>> Create(
         std::unique_ptr<::parquet::arrow::FileReader>&& reader, int64_t batch_size,
-        std::shared_ptr<arrow::MemoryPool> pool, bool pre_buffer_enabled = false);
+        std::shared_ptr<arrow::MemoryPool> pool, bool pre_buffer_enabled = false,
+        int64_t file_size = -1);
 
     /// Seek to the specified row number.
     /// @param row_number The row to seek to (must be at a row group boundary).
@@ -164,7 +166,8 @@ class FileReaderWrapper {
     FileReaderWrapper(std::unique_ptr<::parquet::arrow::FileReader>&& file_reader,
                       const std::vector<std::pair<uint64_t, uint64_t>>& all_row_group_ranges,
                       uint64_t num_rows, int64_t batch_size,
-                      std::shared_ptr<::arrow::MemoryPool> pool, bool pre_buffer_enabled);
+                      std::shared_ptr<::arrow::MemoryPool> pool, bool pre_buffer_enabled,
+                      int64_t file_size);
 
     /// Wait for all pending PreBuffer operations to complete.
     void WaitForPendingPreBuffer();
@@ -206,6 +209,7 @@ class FileReaderWrapper {
     std::shared_ptr<::arrow::MemoryPool> pool_;
     int64_t batch_size_;  // 0 means no limit
     bool pre_buffer_enabled_;
+    int64_t file_size_;
 
     const uint64_t num_rows_;
     uint64_t next_row_to_read_ = std::numeric_limits<uint64_t>::max();

--- a/src/paimon/format/parquet/file_reader_wrapper_test.cpp
+++ b/src/paimon/format/parquet/file_reader_wrapper_test.cpp
@@ -140,6 +140,25 @@ class ReadTrackingInputStream : public InputStream {
     std::atomic<bool> fail_reads_{false};
 };
 
+class FailingPreBufferInputStream : public ArrowInputStreamAdapter {
+ public:
+    FailingPreBufferInputStream(const std::shared_ptr<paimon::InputStream>& input,
+                                int64_t file_length, const std::shared_ptr<arrow::MemoryPool>& pool,
+                                std::shared_ptr<std::atomic<bool>> fail_will_need)
+        : ArrowInputStreamAdapter(input, file_length, pool),
+          fail_will_need_(std::move(fail_will_need)) {}
+
+    arrow::Status WillNeed(const std::vector<arrow::io::ReadRange>& ranges) override {
+        if (fail_will_need_ && fail_will_need_->exchange(false)) {
+            return arrow::Status::IOError("injected pre-buffer initialization failure");
+        }
+        return ArrowInputStreamAdapter::WillNeed(ranges);
+    }
+
+ private:
+    std::shared_ptr<std::atomic<bool>> fail_will_need_;
+};
+
 class FileReaderWrapperTest : public ::testing::Test {
  public:
     void SetUp() override {
@@ -214,10 +233,11 @@ class FileReaderWrapperTest : public ::testing::Test {
 
     Result<std::unique_ptr<FileReaderWrapper>> PrepareReaderWrapperOnStream(
         std::shared_ptr<InputStream> in, int64_t wrapper_batch_size = 0,
-        bool paimon_managed_pre_buffer = false, bool enable_pre_buffer = true) {
+        bool paimon_managed_pre_buffer = false, bool enable_pre_buffer = true,
+        std::shared_ptr<std::atomic<bool>> fail_will_need = nullptr) {
         PAIMON_ASSIGN_OR_RAISE(int64_t file_length, in->Length());
-        auto input_stream =
-            std::make_unique<ArrowInputStreamAdapter>(std::move(in), file_length, arrow_pool_);
+        auto input_stream = std::make_unique<FailingPreBufferInputStream>(
+            in, file_length, arrow_pool_, std::move(fail_will_need));
         ::parquet::arrow::FileReaderBuilder file_reader_builder;
         ::parquet::ReaderProperties reader_properties;
         reader_properties.enable_buffered_stream();
@@ -234,7 +254,8 @@ class FileReaderWrapperTest : public ::testing::Test {
                                             ->properties(arrow_reader_props)
                                             ->Build(&file_reader));
         return FileReaderWrapper::Create(std::move(file_reader), wrapper_batch_size, arrow_pool_,
-                                         enable_pre_buffer && paimon_managed_pre_buffer);
+                                         enable_pre_buffer && paimon_managed_pre_buffer,
+                                         file_length);
     }
 
     void PrepareParquetFile(const std::string& file_path, int32_t row_count,
@@ -441,15 +462,48 @@ TEST_F(FileReaderWrapperTest, ManagedPreBufferBackwardSeekRefreshesCacheCoverage
     ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::RecordBatch> batch, reader->Next());
     ASSERT_TRUE(batch);
     ASSERT_EQ(2000, reader->GetPreviousBatchFirstRowNumber().value());
-    ASSERT_FALSE(reader->prebuffered_ranges_.empty());
-    const int64_t initial_min_offset = reader->prebuffered_ranges_.front().offset;
 
     ASSERT_OK(reader->SeekToRow(0));
-    ASSERT_FALSE(reader->prebuffered_ranges_.empty());
-    ASSERT_LT(reader->prebuffered_ranges_.front().offset, initial_min_offset);
-    ASSERT_OK_AND_ASSIGN(batch, reader->Next());
-    ASSERT_TRUE(batch);
-    ASSERT_EQ(0, reader->GetPreviousBatchFirstRowNumber().value());
+    ASSERT_EQ(2000, reader->GetPreviousBatchFirstRowNumber().value());
+    const auto [schema, struct_type] = PrepareArrowSchema();
+    int64_t rows = 0;
+    while (true) {
+        ASSERT_OK_AND_ASSIGN(batch, reader->Next());
+        if (!batch) {
+            break;
+        }
+        ASSERT_OK_AND_ASSIGN(uint64_t first_row, reader->GetPreviousBatchFirstRowNumber());
+        const uint64_t expected_first_row = rows < 1000 ? rows : rows + 1000;
+        ASSERT_EQ(expected_first_row, first_row);
+        auto expected_array = PrepareArray(struct_type, batch->num_rows(), first_row);
+        auto expected_batch = arrow::RecordBatch::FromStructArray(expected_array);
+        ASSERT_TRUE(expected_batch.ok());
+        ASSERT_TRUE(batch->Equals(*expected_batch.ValueOrDie()));
+        rows += batch->num_rows();
+    }
+    ASSERT_EQ(2100, rows);
+}
+
+TEST_F(FileReaderWrapperTest, ManagedPreBufferRejectsInvalidIndicesBeforeReading) {
+    std::string file_path = PathUtil::JoinPath(dir_->Str(), "invalid_indices.parquet");
+    PrepareParquetFile(file_path, /*row_count=*/1000);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs_->Open(file_path));
+    auto tracking = std::make_shared<ReadTrackingInputStream>(std::move(in));
+    ASSERT_OK_AND_ASSIGN(auto reader,
+                         PrepareReaderWrapperOnStream(tracking, /*wrapper_batch_size=*/512,
+                                                      /*paimon_managed_pre_buffer=*/true));
+    const int64_t baseline = tracking->GetPositionalReadCount();
+    for (int32_t column : {-1, 3}) {
+        ASSERT_NOK_WITH_MSG(
+            reader->PrepareForReading({TargetRowGroup(0, false, RowRanges())}, {column}),
+            "column index");
+    }
+    for (int32_t row_group : {-1, 1}) {
+        ASSERT_NOK_WITH_MSG(
+            reader->PrepareForReading({TargetRowGroup(row_group, false, RowRanges())}, {0}),
+            "row group index");
+    }
+    ASSERT_EQ(baseline, tracking->GetPositionalReadCount());
 }
 
 TEST_F(FileReaderWrapperTest, ManagedPreBufferUsesSingleCacheForMixedRowGroups) {
@@ -533,6 +587,43 @@ TEST_F(FileReaderWrapperTest, ManagedPreBufferUsesSingleCacheForMixedRowGroups) 
     assert_equal_batches(arrow_all_partial, paimon_all_partial);
     ASSERT_EQ(arrow_all_partial.bytes, paimon_all_partial.bytes);
     ASSERT_EQ(arrow_all_partial.calls, paimon_all_partial.calls);
+}
+
+TEST_F(FileReaderWrapperTest, ManagedPreBufferRecoversFromInitializationFailure) {
+    std::string file_path = PathUtil::JoinPath(dir_->Str(), "prebuffer_fallback.parquet");
+    PrepareParquetFile(file_path, /*row_count=*/2000, /*enable_page_index=*/true);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs_->Open(file_path));
+    auto fail_will_need = std::make_shared<std::atomic<bool>>(false);
+    ASSERT_OK_AND_ASSIGN(auto reader,
+                         PrepareReaderWrapperOnStream(in, /*wrapper_batch_size=*/512,
+                                                      /*paimon_managed_pre_buffer=*/true,
+                                                      /*enable_pre_buffer=*/true, fail_will_need));
+    ASSERT_OK(reader->PrepareForReadingLazy(
+        {TargetRowGroup(0, false, RowRanges()),
+         TargetRowGroup(1, true, RowRanges({RowRanges::Range(0, 99)}))},
+        {0, 1, 2}));
+    for (bool seek : {false, true}) {
+        SCOPED_TRACE(seek);
+        fail_will_need->store(true);
+        if (seek) {
+            ASSERT_OK(reader->SeekToRow(0));
+        }
+        const auto schema_pair = PrepareArrowSchema();
+        int64_t rows = 0;
+        while (true) {
+            ASSERT_OK_AND_ASSIGN(auto batch, reader->Next());
+            if (!batch) {
+                break;
+            }
+            auto expected = arrow::RecordBatch::FromStructArray(
+                PrepareArray(schema_pair.second, batch->num_rows(), rows));
+            ASSERT_TRUE(expected.ok());
+            ASSERT_TRUE(batch->Equals(*expected.ValueOrDie()));
+            rows += batch->num_rows();
+        }
+        ASSERT_FALSE(fail_will_need->load());
+        ASSERT_EQ(1100, rows);
+    }
 }
 
 TEST_F(FileReaderWrapperTest, ManagedPreBufferPropagatesReadErrors) {
@@ -1110,6 +1201,74 @@ TEST_F(FileReaderWrapperTest, GetPreBufferRangesRejectsNegativeMetadataOffset) {
                         /*ranges=*/RowRanges())},
         /*column_indices=*/{0, 1, 2}));
     ASSERT_NOK_WITH_MSG(reader_wrapper->GetPreBufferRanges(), "pre-buffer range offset");
+}
+
+TEST_F(FileReaderWrapperTest, ManagedMixedPreBufferRejectsCorruptMetadataBeforeReading) {
+    std::string file_path = PathUtil::JoinPath(dir_->Str(), "valid.parquet");
+    PrepareParquetFile(file_path, /*row_count=*/2000, /*enable_page_index=*/true);
+    std::ifstream file(file_path, std::ios::binary);
+    const std::string original((std::istreambuf_iterator<char>(file)),
+                               std::istreambuf_iterator<char>());
+    struct Corruption {
+        int16_t field;
+        int64_t value;
+        const char* error;
+    };
+    for (const auto& corruption :
+         {Corruption{9, -1, "pre-buffer range offset"},
+          Corruption{7, -1, "pre-buffer range length"},
+          Corruption{7, std::numeric_limits<int64_t>::max(), "pre-buffer range overflows"},
+          Corruption{7, static_cast<int64_t>(original.size()), "exceeds file size"}}) {
+        SCOPED_TRACE(corruption.error);
+        std::string content = original;
+        const size_t tail = content.size();
+        uint32_t footer_length = static_cast<uint8_t>(content[tail - 8]) |
+                                 (static_cast<uint8_t>(content[tail - 7]) << 8) |
+                                 (static_cast<uint8_t>(content[tail - 6]) << 16) |
+                                 (static_cast<uint8_t>(content[tail - 5]) << 24);
+        CompactThriftFooter footer(&content, tail - 8 - footer_length);
+        ASSERT_TRUE(footer.SeekField(4, CompactThriftFooter::kList));
+        ASSERT_TRUE(footer.EnterFirstListElement());
+        ASSERT_TRUE(footer.SeekField(1, CompactThriftFooter::kList));
+        ASSERT_TRUE(footer.EnterFirstListElement());
+        ASSERT_TRUE(footer.SeekField(3, CompactThriftFooter::kStruct));
+        ASSERT_TRUE(footer.SeekField(corruption.field, CompactThriftFooter::kI64));
+        const size_t start = footer.pos();
+        size_t end = start;
+        while (static_cast<uint8_t>(content[end++]) & 0x80) {
+        }
+        uint64_t encoded = (static_cast<uint64_t>(corruption.value) << 1) ^
+                           (corruption.value < 0 ? std::numeric_limits<uint64_t>::max() : 0);
+        std::string replacement;
+        do {
+            uint8_t byte = encoded & 0x7f;
+            encoded >>= 7;
+            replacement.push_back(static_cast<char>(byte | (encoded ? 0x80 : 0)));
+        } while (encoded);
+        content.replace(start, end - start, replacement);
+        footer_length = footer_length - (end - start) + replacement.size();
+        for (uint32_t i = 0; i < 4; ++i) {
+            content[content.size() - 8 + i] = static_cast<char>((footer_length >> (8 * i)) & 0xff);
+        }
+        const std::string corrupt_path = PathUtil::JoinPath(dir_->Str(), "corrupt_mixed.parquet");
+        std::ofstream out(corrupt_path, std::ios::binary);
+        out.write(content.data(), static_cast<std::streamsize>(content.size()));
+        out.close();
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs_->Open(corrupt_path));
+        auto tracking = std::make_shared<ReadTrackingInputStream>(std::move(in));
+        ASSERT_OK_AND_ASSIGN(auto reader,
+                             PrepareReaderWrapperOnStream(tracking, /*wrapper_batch_size=*/512,
+                                                          /*paimon_managed_pre_buffer=*/true));
+        const std::vector<TargetRowGroup> mixed = {
+            TargetRowGroup(0, false, RowRanges()),
+            TargetRowGroup(1, true, RowRanges({RowRanges::Range(0, 99)}))};
+        ASSERT_OK(reader->PrepareForReadingLazy(mixed, {0, 1, 2}));
+        // The failed range query still loads the page indexes, separating metadata I/O from data.
+        ASSERT_NOK_WITH_MSG(reader->GetPreBufferRanges(), corruption.error);
+        const int64_t baseline = tracking->GetPositionalReadCount();
+        ASSERT_NOK_WITH_MSG(reader->PrepareForReading(mixed, {0, 1, 2}), corruption.error);
+        ASSERT_EQ(baseline, tracking->GetPositionalReadCount());
+    }
 }
 
 }  // namespace paimon::parquet::test

--- a/src/paimon/format/parquet/file_reader_wrapper_test.cpp
+++ b/src/paimon/format/parquet/file_reader_wrapper_test.cpp
@@ -18,6 +18,7 @@
 
 #include "paimon/format/parquet/file_reader_wrapper.h"
 
+#include <atomic>
 #include <fstream>
 #include <functional>
 #include <iterator>
@@ -82,12 +83,19 @@ class ReadTrackingInputStream : public InputStream {
 
     Result<int64_t> Read(char* buffer, int64_t size, int64_t offset) override {
         RecordPositionalRead(offset, size);
+        if (fail_reads_.load()) {
+            return Status::IOError("injected pre-buffer read failure");
+        }
         return input_->Read(buffer, size, offset);
     }
 
     void ReadAsync(char* buffer, int64_t size, int64_t offset,
                    std::function<void(Status)>&& callback) override {
         RecordPositionalRead(offset, size);
+        if (fail_reads_.load()) {
+            callback(Status::IOError("injected pre-buffer read failure"));
+            return;
+        }
         input_->ReadAsync(buffer, size, offset, std::move(callback));
     }
 
@@ -108,16 +116,28 @@ class ReadTrackingInputStream : public InputStream {
         return positional_read_bytes_;
     }
 
+    int64_t GetPositionalReadCount() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return positional_read_count_;
+    }
+
+    void FailReads() {
+        fail_reads_.store(true);
+    }
+
  private:
     void RecordPositionalRead(int64_t offset, int64_t size) {
         (void)offset;
         std::lock_guard<std::mutex> lock(mutex_);
         positional_read_bytes_ += size;
+        positional_read_count_++;
     }
 
     std::shared_ptr<InputStream> input_;
     mutable std::mutex mutex_;
     int64_t positional_read_bytes_ = 0;
+    int64_t positional_read_count_ = 0;
+    std::atomic<bool> fail_reads_{false};
 };
 
 class FileReaderWrapperTest : public ::testing::Test {
@@ -193,7 +213,8 @@ class FileReaderWrapperTest : public ::testing::Test {
     }
 
     Result<std::unique_ptr<FileReaderWrapper>> PrepareReaderWrapperOnStream(
-        std::shared_ptr<InputStream> in, int64_t wrapper_batch_size = 0) {
+        std::shared_ptr<InputStream> in, int64_t wrapper_batch_size = 0,
+        bool paimon_managed_pre_buffer = false, bool enable_pre_buffer = true) {
         PAIMON_ASSIGN_OR_RAISE(int64_t file_length, in->Length());
         auto input_stream =
             std::make_unique<ArrowInputStreamAdapter>(std::move(in), file_length, arrow_pool_);
@@ -204,7 +225,7 @@ class FileReaderWrapperTest : public ::testing::Test {
             file_reader_builder.Open(std::move(input_stream), reader_properties));
 
         ::parquet::ArrowReaderProperties arrow_reader_props;
-        arrow_reader_props.set_pre_buffer(true);
+        arrow_reader_props.set_pre_buffer(enable_pre_buffer && !paimon_managed_pre_buffer);
         arrow_reader_props.set_batch_size(static_cast<int64_t>(batch_size_));
         arrow_reader_props.set_use_threads(true);
         arrow_reader_props.set_cache_options(arrow::io::CacheOptions::Defaults());
@@ -212,7 +233,8 @@ class FileReaderWrapperTest : public ::testing::Test {
         PAIMON_RETURN_NOT_OK_FROM_ARROW(file_reader_builder.memory_pool(arrow_pool_.get())
                                             ->properties(arrow_reader_props)
                                             ->Build(&file_reader));
-        return FileReaderWrapper::Create(std::move(file_reader), wrapper_batch_size, arrow_pool_);
+        return FileReaderWrapper::Create(std::move(file_reader), wrapper_batch_size, arrow_pool_,
+                                         enable_pre_buffer && paimon_managed_pre_buffer);
     }
 
     void PrepareParquetFile(const std::string& file_path, int32_t row_count,
@@ -401,6 +423,160 @@ TEST_F(FileReaderWrapperTest, SeekBeforeInitIssuesNoReadsAndStartsAtSeekPosition
     // RG2..RG5 cover rows [2000, 5500).
     ASSERT_EQ(3500, total_rows);
     ASSERT_EQ(5500, reader_wrapper->GetNextRowToRead());
+}
+
+TEST_F(FileReaderWrapperTest, ManagedPreBufferBackwardSeekRefreshesCacheCoverage) {
+    std::string file_path = PathUtil::JoinPath(dir_->Str(), "managed_seek.parquet");
+    PrepareParquetFile(file_path, /*row_count=*/5500, /*enable_page_index=*/true);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs_->Open(file_path));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileReaderWrapper> reader,
+                         PrepareReaderWrapperOnStream(std::move(in), /*wrapper_batch_size=*/512,
+                                                      /*paimon_managed_pre_buffer=*/true));
+
+    ASSERT_OK(reader->PrepareForReadingLazy(
+        {TargetRowGroup(0, false, RowRanges()), TargetRowGroup(2, false, RowRanges()),
+         TargetRowGroup(3, true, RowRanges({RowRanges::Range(0, 99)}))},
+        /*column_indices=*/{0, 1, 2}));
+    ASSERT_OK(reader->SeekToRow(2000));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::RecordBatch> batch, reader->Next());
+    ASSERT_TRUE(batch);
+    ASSERT_EQ(2000, reader->GetPreviousBatchFirstRowNumber().value());
+    ASSERT_FALSE(reader->prebuffered_ranges_.empty());
+    const int64_t initial_min_offset = reader->prebuffered_ranges_.front().offset;
+
+    ASSERT_OK(reader->SeekToRow(0));
+    ASSERT_FALSE(reader->prebuffered_ranges_.empty());
+    ASSERT_LT(reader->prebuffered_ranges_.front().offset, initial_min_offset);
+    ASSERT_OK_AND_ASSIGN(batch, reader->Next());
+    ASSERT_TRUE(batch);
+    ASSERT_EQ(0, reader->GetPreviousBatchFirstRowNumber().value());
+}
+
+TEST_F(FileReaderWrapperTest, ManagedPreBufferUsesSingleCacheForMixedRowGroups) {
+    std::string file_path = PathUtil::JoinPath(dir_->Str(), "managed_prebuffer.parquet");
+    PrepareParquetFile(file_path, /*row_count=*/3000, /*enable_page_index=*/true);
+    const std::vector<int32_t> all_columns = {0, 1, 2};
+    const RowRanges partial_ranges({RowRanges::Range(0, 99)});
+
+    struct ReadStats {
+        int64_t bytes;
+        int64_t calls;
+        int64_t rows;
+        std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+    };
+    auto read = [&](const std::vector<TargetRowGroup>& row_groups,
+                    bool paimon_managed_pre_buffer) -> ReadStats {
+        EXPECT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs_->Open(file_path));
+        auto tracking_stream = std::make_shared<ReadTrackingInputStream>(std::move(in));
+        EXPECT_OK_AND_ASSIGN(
+            std::unique_ptr<FileReaderWrapper> reader,
+            PrepareReaderWrapperOnStream(tracking_stream, /*wrapper_batch_size=*/512,
+                                         paimon_managed_pre_buffer));
+        const int64_t baseline_bytes = tracking_stream->GetPositionalReadBytes();
+        const int64_t baseline_calls = tracking_stream->GetPositionalReadCount();
+        EXPECT_OK(reader->PrepareForReading(row_groups, all_columns));
+        int64_t rows = 0;
+        std::vector<std::shared_ptr<arrow::RecordBatch>> batches;
+        while (true) {
+            EXPECT_OK_AND_ASSIGN(std::shared_ptr<arrow::RecordBatch> batch, reader->Next());
+            if (!batch) {
+                break;
+            }
+            rows += batch->num_rows();
+            batches.push_back(std::move(batch));
+        }
+        reader.reset();
+        return {tracking_stream->GetPositionalReadBytes() - baseline_bytes,
+                tracking_stream->GetPositionalReadCount() - baseline_calls, rows,
+                std::move(batches)};
+    };
+    auto assert_equal_batches = [](const ReadStats& expected, const ReadStats& actual) {
+        ASSERT_EQ(expected.batches.size(), actual.batches.size());
+        for (size_t i = 0; i < expected.batches.size(); ++i) {
+            ASSERT_TRUE(expected.batches[i]->Equals(*actual.batches[i]));
+        }
+    };
+
+    const std::vector<TargetRowGroup> mixed = {
+        TargetRowGroup(/*rg_index=*/0, /*is_partially_matched=*/false, RowRanges()),
+        TargetRowGroup(/*rg_index=*/1, /*is_partially_matched=*/true, partial_ranges)};
+    ReadStats arrow_managed = read(mixed, /*paimon_managed_pre_buffer=*/false);
+    ReadStats paimon_managed = read(mixed, /*paimon_managed_pre_buffer=*/true);
+    ASSERT_EQ(1100, arrow_managed.rows);
+    ASSERT_EQ(arrow_managed.rows, paimon_managed.rows);
+    assert_equal_batches(arrow_managed, paimon_managed);
+    ASSERT_LT(paimon_managed.bytes, arrow_managed.bytes)
+        << "managed=" << paimon_managed.bytes << ", arrow=" << arrow_managed.bytes;
+    ASSERT_LE(paimon_managed.calls, arrow_managed.calls)
+        << "managed=" << paimon_managed.calls << ", arrow=" << arrow_managed.calls;
+    RecordProperty("mixed_arrow_bytes", arrow_managed.bytes);
+    RecordProperty("mixed_paimon_bytes", paimon_managed.bytes);
+    RecordProperty("mixed_arrow_calls", arrow_managed.calls);
+    RecordProperty("mixed_paimon_calls", paimon_managed.calls);
+
+    const std::vector<TargetRowGroup> all_full = {
+        TargetRowGroup(/*rg_index=*/0, /*is_partially_matched=*/false, RowRanges()),
+        TargetRowGroup(/*rg_index=*/1, /*is_partially_matched=*/false, RowRanges())};
+    ReadStats arrow_all_full = read(all_full, /*paimon_managed_pre_buffer=*/false);
+    ReadStats paimon_all_full = read(all_full, /*paimon_managed_pre_buffer=*/true);
+    ASSERT_EQ(2000, paimon_all_full.rows);
+    assert_equal_batches(arrow_all_full, paimon_all_full);
+    ASSERT_EQ(arrow_all_full.bytes, paimon_all_full.bytes);
+    ASSERT_EQ(arrow_all_full.calls, paimon_all_full.calls);
+
+    const std::vector<TargetRowGroup> all_partial = {
+        TargetRowGroup(/*rg_index=*/0, /*is_partially_matched=*/true, partial_ranges),
+        TargetRowGroup(/*rg_index=*/1, /*is_partially_matched=*/true, partial_ranges)};
+    ReadStats arrow_all_partial = read(all_partial, /*paimon_managed_pre_buffer=*/false);
+    ReadStats paimon_all_partial = read(all_partial, /*paimon_managed_pre_buffer=*/true);
+    ASSERT_EQ(200, paimon_all_partial.rows);
+    assert_equal_batches(arrow_all_partial, paimon_all_partial);
+    ASSERT_EQ(arrow_all_partial.bytes, paimon_all_partial.bytes);
+    ASSERT_EQ(arrow_all_partial.calls, paimon_all_partial.calls);
+}
+
+TEST_F(FileReaderWrapperTest, ManagedPreBufferPropagatesReadErrors) {
+    std::string file_path = PathUtil::JoinPath(dir_->Str(), "managed_read_error.parquet");
+    PrepareParquetFile(file_path, /*row_count=*/2000, /*enable_page_index=*/true);
+    for (bool managed : {false, true}) {
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs_->Open(file_path));
+        auto tracking = std::make_shared<ReadTrackingInputStream>(std::move(in));
+        ASSERT_OK_AND_ASSIGN(
+            std::unique_ptr<FileReaderWrapper> reader,
+            PrepareReaderWrapperOnStream(tracking, /*wrapper_batch_size=*/512, managed));
+        const std::vector<TargetRowGroup> mixed = {
+            TargetRowGroup(0, false, RowRanges()),
+            TargetRowGroup(1, true, RowRanges({RowRanges::Range(0, 99)}))};
+        ASSERT_OK(reader->PrepareForReadingLazy(mixed, /*column_indices=*/{0, 1, 2}));
+        // Load page indexes before injecting failures into the actual data reads.
+        ASSERT_OK_AND_ASSIGN(auto ranges, reader->GetPreBufferRanges());
+        ASSERT_FALSE(ranges.empty());
+        tracking->FailReads();
+        Status status = reader->PrepareForReading(mixed, /*column_indices=*/{0, 1, 2});
+        if (status.ok()) {
+            auto batch = reader->Next();
+            ASSERT_FALSE(batch.ok());
+            status = batch.status();
+        }
+        ASSERT_NOK_WITH_MSG(status, "injected pre-buffer read failure");
+    }
+}
+
+TEST_F(FileReaderWrapperTest, DisabledPreBufferPreservesPageFilteredCache) {
+    std::string file_path = PathUtil::JoinPath(dir_->Str(), "disabled_prebuffer.parquet");
+    PrepareParquetFile(file_path, /*row_count=*/1000, /*enable_page_index=*/true);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs_->Open(file_path));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileReaderWrapper> reader,
+                         PrepareReaderWrapperOnStream(std::move(in), /*wrapper_batch_size=*/512,
+                                                      /*paimon_managed_pre_buffer=*/true,
+                                                      /*enable_pre_buffer=*/false));
+    RowRanges ranges({RowRanges::Range(0, 99)});
+    ASSERT_OK(reader->PrepareForReading(
+        {TargetRowGroup(/*rg_index=*/0, /*is_partially_matched=*/true, std::move(ranges))},
+        /*column_indices=*/{0, 1, 2}));
+    ASSERT_FALSE(reader->prebuffered_ranges_.empty());
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::RecordBatch> batch, reader->Next());
+    ASSERT_TRUE(batch);
 }
 
 /// Regression: when batch_size_ is 0 (the default) and a row group is consumed via

--- a/src/paimon/format/parquet/parquet_file_batch_reader.cpp
+++ b/src/paimon/format/parquet/parquet_file_batch_reader.cpp
@@ -325,10 +325,11 @@ Result<std::unique_ptr<ParquetFileBatchReader>> ParquetFileBatchReader::Create(
         PAIMON_RETURN_NOT_OK_FROM_ARROW(file_reader_builder.memory_pool(pool.get())
                                             ->properties(arrow_reader_properties)
                                             ->Build(&file_reader));
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(int64_t file_size, input_stream->GetSize());
         PAIMON_ASSIGN_OR_RAISE(
             std::unique_ptr<FileReaderWrapper> reader,
             FileReaderWrapper::Create(std::move(file_reader), static_cast<int64_t>(batch_size),
-                                      pool, pre_buffer_enabled));
+                                      pool, pre_buffer_enabled, file_size));
         // Arrow silently ignores set_read_dictionary for leaves it cannot read as dictionaries,
         // so take the columns it really emits that way from the schema it just derived.
         std::set<std::string> dictionary_fields;

--- a/src/paimon/format/parquet/parquet_file_batch_reader.cpp
+++ b/src/paimon/format/parquet/parquet_file_batch_reader.cpp
@@ -302,6 +302,9 @@ Result<std::unique_ptr<ParquetFileBatchReader>> ParquetFileBatchReader::Create(
 
         PAIMON_ASSIGN_OR_RAISE(::parquet::ArrowReaderProperties arrow_reader_properties,
                                CreateArrowReaderProperties(pool, options, batch_size, hints));
+        const bool pre_buffer_enabled = arrow_reader_properties.pre_buffer();
+        // FileReaderWrapper dispatches a single cache after row-group/page-index filtering.
+        arrow_reader_properties.set_pre_buffer(false);
 
         ::parquet::arrow::FileReaderBuilder file_reader_builder;
         PAIMON_RETURN_NOT_OK_FROM_ARROW(
@@ -322,9 +325,10 @@ Result<std::unique_ptr<ParquetFileBatchReader>> ParquetFileBatchReader::Create(
         PAIMON_RETURN_NOT_OK_FROM_ARROW(file_reader_builder.memory_pool(pool.get())
                                             ->properties(arrow_reader_properties)
                                             ->Build(&file_reader));
-        PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileReaderWrapper> reader,
-                               FileReaderWrapper::Create(std::move(file_reader),
-                                                         static_cast<int64_t>(batch_size), pool));
+        PAIMON_ASSIGN_OR_RAISE(
+            std::unique_ptr<FileReaderWrapper> reader,
+            FileReaderWrapper::Create(std::move(file_reader), static_cast<int64_t>(batch_size),
+                                      pool, pre_buffer_enabled));
         // Arrow silently ignores set_read_dictionary for leaves it cannot read as dictionaries,
         // so take the columns it really emits that way from the schema it just derived.
         std::set<std::string> dictionary_fields;

--- a/src/paimon/format/parquet/parquet_file_batch_reader_test.cpp
+++ b/src/paimon/format/parquet/parquet_file_batch_reader_test.cpp
@@ -1785,6 +1785,70 @@ TEST_F(ParquetFileBatchReaderTest, TestPreBufferRangeWithPageFilteredRowGroup) {
     ASSERT_LT(filtered_total, chunk_end - chunk_offset);
 }
 
+TEST_F(ParquetFileBatchReaderTest, TestMixedRowGroupPreBufferThroughBuilder) {
+    auto src_array = MakeSequentialIntData(12);
+    auto schema = arrow::schema({arrow::field("f0", arrow::int32())});
+    WriteArray(file_path_, src_array, schema, /*write_batch_size=*/1,
+               /*enable_dictionary=*/false, /*max_row_group_length=*/4, /*max_page_size=*/1);
+    // RG0 is fully matched, RG1 keeps two pages, and RG2 is pruned entirely.
+    auto predicate = PredicateBuilder::LessThan(/*field_index=*/0, /*field_name=*/"f0",
+                                                FieldType::INT, Literal(6));
+    auto expected = std::make_shared<arrow::ChunkedArray>(src_array->Slice(0, 6));
+    enum class PreBufferMode { DEFAULT, DISABLED, FRAMEWORK_PREFETCH };
+    uint64_t disabled_bytes = 0;
+    for (PreBufferMode mode :
+         {PreBufferMode::DEFAULT, PreBufferMode::DISABLED, PreBufferMode::FRAMEWORK_PREFETCH}) {
+        SCOPED_TRACE(static_cast<int32_t>(mode));
+        std::map<std::string, std::string> options = {
+            {PARQUET_READ_ENABLE_PAGE_INDEX_FILTER, "true"},
+            {PARQUET_READ_CACHE_OPTION_HOLE_SIZE_LIMIT, "0"}};
+        if (mode != PreBufferMode::DEFAULT) {
+            options[PARQUET_READ_ENABLE_PRE_BUFFER] =
+                mode == PreBufferMode::DISABLED ? "false" : "true";
+        }
+        ParquetReaderBuilder builder(options, /*batch_size=*/2);
+        if (mode == PreBufferMode::FRAMEWORK_PREFETCH) {
+            ReadHints hints;
+            hints.prefetch_enabled = true;
+            hints.read_ahead_cache_enabled = true;
+            builder.WithReadHints(hints);
+        }
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> in, fs_->Open(file_path_));
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileBatchReader> reader, builder.Build(in));
+        auto parquet_reader = dynamic_cast<ParquetFileBatchReader*>(reader.get());
+        ASSERT_TRUE(parquet_reader);
+        ArrowSchema c_schema;
+        ASSERT_TRUE(arrow::ExportSchema(*schema, &c_schema).ok());
+        ASSERT_OK(reader->SetReadSchema(&c_schema, predicate, std::nullopt));
+        // Load page indexes before measuring data I/O. With zero coalescing gap, the
+        // exported ranges are the exact data bytes needed by the mixed scan.
+        ASSERT_OK_AND_ASSIGN(auto ranges, parquet_reader->PreBufferRange());
+        uint64_t expected_bytes = 0;
+        for (const auto& range : ranges) {
+            expected_bytes += range.second;
+        }
+        ASSERT_GT(expected_bytes, 0u);
+        ASSERT_OK_AND_ASSIGN(uint64_t baseline, reader->GetReaderMetrics()->GetCounter(
+                                                    ParquetMetrics::READ_STORAGE_BYTES));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::ChunkedArray> result,
+                             paimon::test::ReadResultCollector::CollectResult(reader.get()));
+        reader->Close();
+        ASSERT_TRUE(expected->Equals(result)) << result->ToString();
+        ASSERT_OK_AND_ASSIGN(uint64_t total_bytes, reader->GetReaderMetrics()->GetCounter(
+                                                       ParquetMetrics::READ_STORAGE_BYTES));
+        const uint64_t data_bytes = total_bytes - baseline;
+        if (mode == PreBufferMode::DEFAULT) {
+            ASSERT_EQ(expected_bytes, data_bytes);
+        } else if (mode == PreBufferMode::DISABLED) {
+            disabled_bytes = data_bytes;
+            ASSERT_GT(disabled_bytes, expected_bytes);
+        } else {
+            // Framework prefetch hints override an explicitly enabled option.
+            ASSERT_EQ(disabled_bytes, data_bytes);
+        }
+    }
+}
+
 // End-to-end: PreBufferRange() feeds the shared ReadAheadCache through CacheInputStream,
 // and data reads are served from the cache.
 TEST_F(ParquetFileBatchReaderTest, TestPreBufferRangeFeedsReadAheadCache) {

--- a/test/inte/write_and_read_inte_test.cpp
+++ b/test/inte/write_and_read_inte_test.cpp
@@ -2939,9 +2939,9 @@ TEST_P(WriteAndReadInteTest, TestAppendWithParquetPageIndexFilter) {
     ASSERT_TRUE(expected->Equals(read_result)) << read_result->ToString();
 }
 
-/// Reproduces the prefetch + parquet page-index filter failure: the predicate keeps only the last
-/// page of RG1, RG2 and RG3, so the prefetch reader ends up seeking to a row in the middle of a row
-/// group, which FileReaderWrapper::SeekToRow rejects.
+/// Exercise both partial-only and mixed row groups with and without prefetch. The partial
+/// groups start reading inside the row group, reproducing the need for row-group-aligned seeks
+/// when parallel prefetch dispatches them to different sub-readers.
 TEST_P(WriteAndReadInteTest, TestAppendWithParquetPageIndexFilterAndPrefetch) {
     auto [file_format, file_system] = GetParam();
     if (file_format != "parquet" || file_system != "local") {
@@ -2984,49 +2984,63 @@ TEST_P(WriteAndReadInteTest, TestAppendWithParquetPageIndexFilterAndPrefetch) {
     ASSERT_OK(helper->WriteAndCommit(std::move(batch), /*commit_identifier=*/0,
                                      /*expected_commit_messages=*/std::nullopt));
 
-    // Keep only the last row of RG1, RG2 and RG3, so each row group is partially matched and its
-    // first selected row is 3 rows behind the row group start.
-    auto predicate = PredicateBuilder::In(/*field_index=*/0, /*field_name=*/"f0", FieldType::INT,
-                                          {Literal(7), Literal(11), Literal(15)});
-    ASSERT_TRUE(predicate);
+    for (bool mixed : {false, true}) {
+        SCOPED_TRACE(mixed);
+        // Preserve the partial-only regression and also cover a full RG1 followed by
+        // partial RG2 and RG3. Both plans exclude RG0.
+        std::vector<Literal> selected_values =
+            mixed ? std::vector<Literal>{Literal(4), Literal(5),  Literal(6),
+                                         Literal(7), Literal(11), Literal(15)}
+                  : std::vector<Literal>{Literal(7), Literal(11), Literal(15)};
+        auto predicate = PredicateBuilder::In(
+            /*field_index=*/0, /*field_name=*/"f0", FieldType::INT, selected_values);
+        ASSERT_TRUE(predicate);
 
-    ScanContextBuilder scan_context_builder(table_path);
-    scan_context_builder.SetOptions(options)
-        .AddOption(Options::SCAN_MODE, StartupMode::LatestFull().ToString())
-        .SetPredicate(predicate);
-    ASSERT_OK_AND_ASSIGN(auto scan_context, scan_context_builder.Finish());
-    ASSERT_OK_AND_ASSIGN(auto table_scan, TableScan::Create(std::move(scan_context)));
-    ASSERT_OK_AND_ASSIGN(auto result_plan, table_scan->CreatePlan());
-    ASSERT_FALSE(result_plan->Splits().empty());
+        ScanContextBuilder scan_context_builder(table_path);
+        scan_context_builder.SetOptions(options)
+            .AddOption(Options::SCAN_MODE, StartupMode::LatestFull().ToString())
+            .SetPredicate(predicate);
+        ASSERT_OK_AND_ASSIGN(auto scan_context, scan_context_builder.Finish());
+        ASSERT_OK_AND_ASSIGN(auto table_scan, TableScan::Create(std::move(scan_context)));
+        ASSERT_OK_AND_ASSIGN(auto result_plan, table_scan->CreatePlan());
+        ASSERT_FALSE(result_plan->Splits().empty());
 
-    // The row group aligned read ranges still cover RG0 although the predicate pruned that row
-    // group, and 2 sub readers take the ranges round robin. The reader0 owning RG0's range
-    // therefore finds no data for it and skips ahead into the next row group it owns, whose first
-    // selected row sits in the middle of that row group. Row level filtering stays off: the
-    // expected rows below are exactly what page-index filtering selects.
-    ReadContextBuilder read_context_builder(table_path);
-    read_context_builder.SetOptions(options)
-        .SetPredicate(predicate)
-        .EnablePrefetch(true)
-        .SetPrefetchMaxParallelNum(2)
-        .SetPrefetchBatchCount(3)
-        .AddOption("test.enable-adaptive-prefetch-strategy", "false");
-    ASSERT_OK_AND_ASSIGN(auto read_context, read_context_builder.Finish());
-    ASSERT_OK_AND_ASSIGN(auto table_read, TableRead::Create(std::move(read_context)));
-    ASSERT_OK_AND_ASSIGN(auto batch_reader, table_read->CreateReader(result_plan->Splits()));
-    ASSERT_OK_AND_ASSIGN(auto read_result,
-                         ReadResultCollector::CollectResult(std::move(batch_reader)));
+        // The row group aligned read ranges still cover RG0 although the predicate pruned that row
+        // group, and 2 sub readers take the ranges round robin. The reader0 owning RG0's range
+        // therefore finds no data for it and skips ahead into the next row group it owns, whose
+        // first selected row sits in the middle of that row group. Row level filtering stays off:
+        // the expected rows below are exactly what page-index filtering selects.
+        for (bool prefetch : {false, true}) {
+            SCOPED_TRACE(prefetch);
+            ReadContextBuilder read_context_builder(table_path);
+            read_context_builder.SetOptions(options)
+                .SetPredicate(predicate)
+                .EnablePrefetch(prefetch)
+                .SetPrefetchMaxParallelNum(2)
+                .SetPrefetchBatchCount(3)
+                .AddOption("test.enable-adaptive-prefetch-strategy", "false");
+            ASSERT_OK_AND_ASSIGN(auto read_context, read_context_builder.Finish());
+            ASSERT_OK_AND_ASSIGN(auto table_read, TableRead::Create(std::move(read_context)));
+            ASSERT_OK_AND_ASSIGN(auto batch_reader,
+                                 table_read->CreateReader(result_plan->Splits()));
+            ASSERT_OK_AND_ASSIGN(auto read_result,
+                                 ReadResultCollector::CollectResult(std::move(batch_reader)));
 
-    arrow::FieldVector fields_with_row_kind = fields;
-    fields_with_row_kind.insert(fields_with_row_kind.begin(),
-                                arrow::field("_VALUE_KIND", arrow::int8()));
-    auto expected_data_type = arrow::struct_(fields_with_row_kind);
-    auto expected = std::make_shared<arrow::ChunkedArray>(
-        arrow::ipc::internal::json::ArrayFromJSON(expected_data_type, R"([
-[0, 7, "v7"], [0, 11, "v11"], [0, 15, "v15"]
-])")
-            .ValueOrDie());
-    ASSERT_TRUE(expected->Equals(read_result)) << read_result->ToString();
+            arrow::FieldVector fields_with_row_kind = fields;
+            fields_with_row_kind.insert(fields_with_row_kind.begin(),
+                                        arrow::field("_VALUE_KIND", arrow::int8()));
+            auto expected_data_type = arrow::struct_(fields_with_row_kind);
+            std::string expected_json = mixed ? R"([
+[0, 4, "v4"], [0, 5, "v5"], [0, 6, "v6"], [0, 7, "v7"],
+[0, 11, "v11"], [0, 15, "v15"]
+])"
+                                              : R"([[0, 7, "v7"], [0, 11, "v11"], [0, 15, "v15"]])";
+            auto expected = std::make_shared<arrow::ChunkedArray>(
+                arrow::ipc::internal::json::ArrayFromJSON(expected_data_type, expected_json)
+                    .ValueOrDie());
+            ASSERT_TRUE(expected->Equals(read_result)) << read_result->ToString();
+        }
+    }
 }
 
 TEST_P(WriteAndReadInteTest, TestAppendWithParquetMetadataCache) {


### PR DESCRIPTION
### Purpose

  Linked issue: close #240 

  When a scan includes both fully matched and page-filtered row groups, Arrow’s automatic pre-buffering and Paimon’s range pre-buffering can read the same data twice.

  Let FileReaderWrapper manage a shared pre-buffer cache for both kinds of row groups. Refresh cache coverage when seeking, preserve Arrow’s standard handling for full-only scans, and retain existing fallback behavior.

  ### Tests

  Added regression tests in FileReaderWrapperTest:

  - ManagedPreBufferUsesSingleCacheForMixedRowGroups: checks equivalent results with fewer bytes read for mixed scans and unchanged I/O for full-only and partial-only scans.
  - ManagedPreBufferBackwardSeekRefreshesCacheCoverage: checks cache coverage after backward seeks.
  - ManagedPreBufferPropagatesReadErrors: checks propagation of injected read failures.
  - DisabledPreBufferPreservesPageFilteredCache: checks page-filtered caching when automatic pre-buffering is disabled.

  Tests were not run while preparing this description. No integration tests were added.

  ### API and Format

  No changes to public APIs under include/, storage formats, or protocols.

  ### Documentation

  No new user-facing features or configuration options. No documentation changes required.

  ### Generative AI tooling

  Generated-by: OpenAI Codex (GPT-6)