### PR TITLE
perf(manifest): selectively decode bucket entries with bounded block …

### DIFF
--- a/src/paimon/core/manifest/manifest_file.cpp
+++ b/src/paimon/core/manifest/manifest_file.cpp
@@ -22,10 +22,12 @@
 #include <limits>
 #include <utility>
 
+#include "arrow/array/array_primitive.h"
 #include "arrow/c/abi.h"
 #include "arrow/c/bridge.h"
 #include "paimon/common/data/columnar/columnar_row.h"
 #include "paimon/common/utils/arrow/status_utils.h"
+#include "paimon/common/utils/checked_cast.h"
 #include "paimon/core/io/rolling_file_writer.h"
 #include "paimon/core/manifest/manifest_entry.h"
 #include "paimon/core/manifest/manifest_entry_serializer.h"
@@ -106,7 +108,81 @@ Status ManifestFile::ReadBucketEntries(const std::string& file_name, int32_t buc
                 entries->push_back(std::move(entry));
             }
             return Status::OK();
-        });
+        },
+        [this, bucket](FileBatchReader* reader) { return PrepareBucketRead(reader, bucket); });
+}
+
+Status ManifestFile::PrepareBucketRead(FileBatchReader* reader, int32_t bucket) const {
+    if (!reader->SupportPreciseBitmapSelection()) {
+        return Status::OK();
+    }
+    PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<ArrowSchema> c_schema, reader->GetFileSchema());
+    PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Schema> file_schema,
+                                      arrow::ImportSchema(c_schema.get()));
+    const auto& target_type = serializer_->GetDataType();
+    const std::string& version_name = target_type->field(0)->name();
+    const std::string& bucket_name = target_type->field(3)->name();
+    auto version_field = file_schema->GetFieldByName(version_name);
+    auto bucket_field = file_schema->GetFieldByName(bucket_name);
+    if (!version_field || !bucket_field || version_field->type()->id() != arrow::Type::INT32 ||
+        bucket_field->type()->id() != arrow::Type::INT32) {
+        return Status::OK();
+    }
+    arrow::FieldVector probe_fields;
+    for (const auto& field : file_schema->fields()) {
+        if (field->name() == version_name || field->name() == bucket_name) {
+            probe_fields.push_back(field);
+        }
+    }
+    auto probe_schema = arrow::schema(probe_fields);
+    ArrowSchema probe_c_schema;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportSchema(*probe_schema, &probe_c_schema));
+    PAIMON_RETURN_NOT_OK(
+        reader->SetReadSchema(&probe_c_schema, /*predicate=*/nullptr, std::nullopt));
+    RoaringBitmap32 selected;
+    bool row_ids_fit = true;
+    while (true) {
+        PAIMON_ASSIGN_OR_RAISE(BatchReader::ReadBatch batch, reader->NextBatch());
+        if (BatchReader::IsEofBatch(batch)) {
+            break;
+        }
+        PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(
+            std::shared_ptr<arrow::Array> array,
+            arrow::ImportArray(batch.first.get(), batch.second.get()));
+        if (!array || array->type_id() != arrow::Type::STRUCT) {
+            return Status::Invalid("Manifest bucket probe must return a struct array");
+        }
+        auto rows = checked_pointer_cast<arrow::StructArray>(array);
+        auto version_array = rows->GetFieldByName(version_name);
+        auto bucket_array = rows->GetFieldByName(bucket_name);
+        if (!version_array || !bucket_array || version_array->type_id() != arrow::Type::INT32 ||
+            bucket_array->type_id() != arrow::Type::INT32) {
+            return Status::Invalid("Manifest bucket probe must return int32 version and bucket");
+        }
+        auto versions = checked_pointer_cast<arrow::Int32Array>(version_array);
+        auto buckets = checked_pointer_cast<arrow::Int32Array>(bucket_array);
+        for (int64_t i = 0; i < rows->length(); ++i) {
+            if (rows->IsNull(i) || versions->IsNull(i) || buckets->IsNull(i)) {
+                return Status::Invalid("Manifest version and bucket must not be null");
+            }
+            // Validate every entry, including buckets not selected by this scan.
+            PAIMON_RETURN_NOT_OK(ManifestEntrySerializer::ValidateVersion(versions->Value(i)));
+            if (buckets->Value(i) == bucket) {
+                PAIMON_ASSIGN_OR_RAISE(uint64_t file_row, reader->GetPreviousBatchFileRowId(i));
+                if (file_row > std::numeric_limits<uint32_t>::max()) {
+                    row_ids_fit = false;
+                } else {
+                    selected.Add(static_cast<uint32_t>(file_row));
+                }
+            }
+        }
+    }
+    // Keep the on-disk schema; ManifestMetaReader still performs schema evolution afterwards.
+    ArrowSchema full_c_schema;
+    PAIMON_RETURN_NOT_OK_FROM_ARROW(arrow::ExportSchema(*file_schema, &full_c_schema));
+    return reader->SetReadSchema(
+        &full_c_schema, /*predicate=*/nullptr,
+        row_ids_fit ? std::optional<RoaringBitmap32>(std::move(selected)) : std::nullopt);
 }
 
 Result<std::vector<ManifestFileMeta>> ManifestFile::Write(

--- a/src/paimon/core/manifest/manifest_file.h
+++ b/src/paimon/core/manifest/manifest_file.h
@@ -67,6 +67,8 @@ class ManifestFile : public ObjectsFile<ManifestEntry> {
                              std::vector<ManifestEntry>* entries) const;
 
  private:
+    Status PrepareBucketRead(FileBatchReader* reader, int32_t bucket) const;
+
     ManifestFile(const std::shared_ptr<FileSystem>& file_system,
                  const std::shared_ptr<ReaderBuilder>& reader_builder,
                  const std::shared_ptr<WriterBuilder>& writer_builder,

--- a/src/paimon/core/manifest/manifest_file_test.cpp
+++ b/src/paimon/core/manifest/manifest_file_test.cpp
@@ -25,6 +25,7 @@
 #include <utility>
 
 #include "arrow/api.h"
+#include "arrow/ipc/json_simple.h"
 #include "gtest/gtest.h"
 #include "paimon/common/data/binary_row.h"
 #include "paimon/common/data/data_define.h"
@@ -32,6 +33,7 @@
 #include "paimon/core/manifest/file_kind.h"
 #include "paimon/core/manifest/file_source.h"
 #include "paimon/core/manifest/manifest_entry.h"
+#include "paimon/core/manifest/manifest_entry_serializer.h"
 #include "paimon/core/manifest/manifest_file_meta.h"
 #include "paimon/core/stats/simple_stats.h"
 #include "paimon/core/utils/file_store_path_factory.h"
@@ -40,6 +42,8 @@
 #include "paimon/defs.h"
 #include "paimon/format/file_format.h"
 #include "paimon/format/file_format_factory.h"
+#include "paimon/format/format_writer.h"
+#include "paimon/format/writer_builder.h"
 #include "paimon/fs/local/local_file_system.h"
 #include "paimon/memory/memory_pool.h"
 #include "paimon/testing/utils/binary_row_generator.h"
@@ -100,36 +104,50 @@ class CountingFileSystem : public FileSystem {
 
 class ManifestFileTest : public testing::Test {
  public:
-    std::vector<ManifestEntry> ReadManifestEntry(
+    Result<std::vector<ManifestEntry>> TryReadManifestEntry(
         const std::string& file_format_str, const std::string& root_path,
         const std::string& file_name, const std::shared_ptr<MemoryPool>& pool,
-        const std::optional<int32_t>& bucket = std::nullopt) const {
+        const std::optional<int32_t>& bucket = std::nullopt, bool cache_enabled = false) const {
         std::shared_ptr<FileSystem> file_system = std::make_shared<LocalFileSystem>();
-        EXPECT_OK_AND_ASSIGN(std::shared_ptr<FileFormat> file_format,
-                             FileFormatFactory::Get(file_format_str, {}));
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileFormat> file_format,
+                               FileFormatFactory::Get(file_format_str, {}));
         auto unused_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
-        EXPECT_OK_AND_ASSIGN(std::shared_ptr<FileStorePathFactory> path_factory,
-                             FileStorePathFactory::Create(
-                                 root_path, unused_schema, /*partition_keys=*/{},
-                                 /*default_part_value=*/"", file_format->Identifier(),
-                                 /*data_file_prefix=*/"data-",
-                                 /*legacy_partition_name_enabled=*/true, /*external_paths=*/{},
-                                 /*global_index_external_path=*/std::nullopt,
-                                 /*index_file_in_data_file_dir=*/false, pool));
-        EXPECT_OK_AND_ASSIGN(CoreOptions options,
-                             CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
-        EXPECT_OK_AND_ASSIGN(
+        PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<FileStorePathFactory> path_factory,
+                               FileStorePathFactory::Create(
+                                   root_path, unused_schema, /*partition_keys=*/{},
+                                   /*default_part_value=*/"", file_format->Identifier(),
+                                   /*data_file_prefix=*/"data-",
+                                   /*legacy_partition_name_enabled=*/true, /*external_paths=*/{},
+                                   /*global_index_external_path=*/std::nullopt,
+                                   /*index_file_in_data_file_dir=*/false, pool));
+        PAIMON_ASSIGN_OR_RAISE(CoreOptions options,
+                               CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
+        if (cache_enabled) {
+            options.WithCache(
+                std::make_shared<CountingRoutingCache>(CacheKind::MANIFEST, 64 * 1024 * 1024));
+        }
+        PAIMON_ASSIGN_OR_RAISE(
             std::unique_ptr<ManifestFile> manifest_file,
             ManifestFile::Create(file_system, file_format, "zstd", path_factory,
                                  /*target_file_size=*/1024, pool, options, unused_schema));
         std::vector<ManifestEntry> manifest_entries;
         if (bucket) {
-            EXPECT_OK(
+            PAIMON_RETURN_NOT_OK(
                 manifest_file->ReadBucketEntries(file_name, bucket.value(), &manifest_entries));
         } else {
-            EXPECT_OK(manifest_file->Read(file_name, /*filter=*/nullptr, &manifest_entries));
+            PAIMON_RETURN_NOT_OK(
+                manifest_file->Read(file_name, /*filter=*/nullptr, &manifest_entries));
         }
 
+        return manifest_entries;
+    }
+
+    std::vector<ManifestEntry> ReadManifestEntry(
+        const std::string& file_format_str, const std::string& root_path,
+        const std::string& file_name, const std::shared_ptr<MemoryPool>& pool,
+        const std::optional<int32_t>& bucket = std::nullopt) const {
+        EXPECT_OK_AND_ASSIGN(auto manifest_entries, TryReadManifestEntry(file_format_str, root_path,
+                                                                         file_name, pool, bucket));
         return manifest_entries;
     }
 };
@@ -373,45 +391,97 @@ TEST_F(ManifestFileTest, TestReadBucketEntriesSkipsDeserializingOtherBuckets) {
                           "manifest-3a44a0da-1008-463c-914e-28d271375e24-0", pool);
     ASSERT_EQ(2, source_entries.size());
 
-    auto test_dir = UniqueTestDirectory::Create();
-    ASSERT_TRUE(test_dir);
-    std::shared_ptr<FileSystem> file_system = test_dir->GetFileSystem();
-    ASSERT_OK(file_system->Mkdirs(FileStorePathFactory::ManifestPath(test_dir->Str())));
-    ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileFormat> file_format,
-                         FileFormatFactory::Get("avro", {}));
-    auto unused_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
-    ASSERT_OK_AND_ASSIGN(
-        std::shared_ptr<FileStorePathFactory> path_factory,
-        FileStorePathFactory::Create(test_dir->Str(), unused_schema, /*partition_keys=*/{},
-                                     /*default_part_value=*/"", file_format->Identifier(),
-                                     /*data_file_prefix=*/"data-",
-                                     /*legacy_partition_name_enabled=*/true, /*external_paths=*/{},
-                                     /*global_index_external_path=*/std::nullopt,
-                                     /*index_file_in_data_file_dir=*/false, pool));
-    ASSERT_OK_AND_ASSIGN(CoreOptions options,
-                         CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
-    ASSERT_OK_AND_ASSIGN(
-        std::unique_ptr<ManifestFile> manifest_file,
-        ManifestFile::Create(file_system, file_format, "zstd", path_factory,
-                             /*target_file_size=*/1024, pool, options, unused_schema));
+    for (bool cache_enabled : {false, true}) {
+        SCOPED_TRACE(cache_enabled);
+        const std::string format = "avro";
+        auto test_dir = UniqueTestDirectory::Create();
+        ASSERT_TRUE(test_dir);
+        std::shared_ptr<FileSystem> file_system = test_dir->GetFileSystem();
+        ASSERT_OK(file_system->Mkdirs(FileStorePathFactory::ManifestPath(test_dir->Str())));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileFormat> file_format,
+                             FileFormatFactory::Get(format, {}));
+        auto unused_schema = arrow::schema(arrow::FieldVector({arrow::field("f0", arrow::utf8())}));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileStorePathFactory> path_factory,
+                             FileStorePathFactory::Create(
+                                 test_dir->Str(), unused_schema, /*partition_keys=*/{},
+                                 /*default_part_value=*/"", file_format->Identifier(),
+                                 /*data_file_prefix=*/"data-",
+                                 /*legacy_partition_name_enabled=*/true, /*external_paths=*/{},
+                                 /*global_index_external_path=*/std::nullopt,
+                                 /*index_file_in_data_file_dir=*/false, pool));
+        ASSERT_OK_AND_ASSIGN(CoreOptions options,
+                             CoreOptions::FromMap({{Options::FILE_FORMAT, "orc"}}));
+        if (cache_enabled) {
+            options.WithCache(
+                std::make_shared<CountingRoutingCache>(CacheKind::MANIFEST, 64 * 1024 * 1024));
+        }
+        ASSERT_OK_AND_ASSIGN(
+            std::unique_ptr<ManifestFile> manifest_file,
+            ManifestFile::Create(file_system, file_format, "null", path_factory,
+                                 /*target_file_size=*/1024, pool, options, unused_schema));
 
-    ManifestEntry invalid_other_bucket(FileKind(static_cast<int8_t>(2)),
-                                       source_entries[0].Partition(), /*bucket=*/1,
-                                       /*total_buckets=*/2, source_entries[0].File());
-    ManifestEntry valid_target_bucket(FileKind::Add(), source_entries[1].Partition(), /*bucket=*/0,
-                                      /*total_buckets=*/2, source_entries[1].File());
-    using WrittenFile = std::pair<std::string, int64_t>;
-    ASSERT_OK_AND_ASSIGN(
-        WrittenFile written_file,
-        manifest_file->WriteWithoutRolling({invalid_other_bucket, valid_target_bucket}));
+        ManifestEntry invalid_other_bucket(FileKind(static_cast<int8_t>(2)),
+                                           source_entries[0].Partition(), /*bucket=*/1,
+                                           /*total_buckets=*/2, source_entries[0].File());
+        ManifestEntry valid_target_bucket(FileKind::Add(), source_entries[1].Partition(),
+                                          /*bucket=*/0,
+                                          /*total_buckets=*/2, source_entries[1].File());
+        using WrittenFile = std::pair<std::string, int64_t>;
+        ASSERT_OK_AND_ASSIGN(
+            WrittenFile written_file,
+            manifest_file->WriteWithoutRolling({invalid_other_bucket, valid_target_bucket}));
 
-    std::vector<ManifestEntry> all_entries;
-    ASSERT_NOK_WITH_MSG(manifest_file->Read(written_file.first, /*filter=*/nullptr, &all_entries),
-                        "Unsupported byte value 2 for file kind.");
+        std::vector<ManifestEntry> all_entries;
+        ASSERT_NOK_WITH_MSG(
+            manifest_file->Read(written_file.first, /*filter=*/nullptr, &all_entries),
+            "Unsupported byte value 2 for file kind.");
 
-    std::vector<ManifestEntry> bucket_entries;
-    ASSERT_OK(manifest_file->ReadBucketEntries(written_file.first, /*bucket=*/0, &bucket_entries));
-    ASSERT_EQ(std::vector<ManifestEntry>({valid_target_bucket}), bucket_entries);
+        std::vector<ManifestEntry> bucket_entries;
+        ASSERT_OK(
+            manifest_file->ReadBucketEntries(written_file.first, /*bucket=*/0, &bucket_entries));
+        ASSERT_EQ(std::vector<ManifestEntry>({valid_target_bucket}), bucket_entries);
+    }
+}
+
+TEST_F(ManifestFileTest, TestBucketProbeValidatesVersionsOutsideSelectedBucket) {
+    auto pool = GetDefaultPool();
+    ManifestEntrySerializer serializer(pool);
+    auto type =
+        arrow::struct_({arrow::field(serializer.GetDataType()->field(0)->name(), arrow::int32()),
+                        arrow::field(serializer.GetDataType()->field(3)->name(), arrow::int32())});
+    const std::vector<std::pair<std::string, std::string>> cases = {
+        {R"([[999,1],[2,0]])", "Unsupported version: 999"},
+        {R"([[1,1],[2,0]])", "not compatible"},
+        {R"([[null,1],[2,0]])", "must not be null"},
+        {R"([[2,null],[2,0]])", "must not be null"}};
+    for (const auto& item : cases) {
+        SCOPED_TRACE(item.first);
+        auto dir = UniqueTestDirectory::Create();
+        ASSERT_TRUE(dir);
+        auto fs = dir->GetFileSystem();
+        const std::string manifest_dir = FileStorePathFactory::ManifestPath(dir->Str());
+        ASSERT_OK(fs->Mkdirs(manifest_dir));
+        const std::string file_name = "manifest-invalid-version";
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<FileFormat> format,
+                             FileFormatFactory::Get("avro", {}));
+        ArrowSchema c_schema;
+        ASSERT_TRUE(arrow::ExportSchema(*arrow::schema(type->fields()), &c_schema).ok());
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<WriterBuilder> builder,
+                             format->CreateWriterBuilder(&c_schema, 2));
+        ASSERT_OK_AND_ASSIGN(std::shared_ptr<OutputStream> output,
+                             fs->Create(manifest_dir + "/" + file_name, false));
+        ASSERT_OK_AND_ASSIGN(std::unique_ptr<FormatWriter> writer, builder->Build(output, "null"));
+        auto array = arrow::ipc::internal::json::ArrayFromJSON(type, item.first).ValueOrDie();
+        ArrowArray c_array;
+        ASSERT_TRUE(arrow::ExportArray(*array, &c_array).ok());
+        ASSERT_OK(writer->AddBatch(&c_array));
+        ASSERT_OK(writer->Flush());
+        ASSERT_OK(writer->Finish());
+        ASSERT_OK(output->Close());
+        ASSERT_NOK_WITH_MSG(TryReadManifestEntry("avro", dir->Str(), file_name, pool, /*bucket=*/0,
+                                                 /*cache_enabled=*/true),
+                            item.second);
+    }
 }
 
 TEST_F(ManifestFileTest, TestLegacyManifestFormatIsReadOnly) {

--- a/src/paimon/core/operation/file_store_scan.cpp
+++ b/src/paimon/core/operation/file_store_scan.cpp
@@ -415,8 +415,15 @@ Status FileStoreScan::ReadAndMergeBucketFileEntries(
         for (const auto& meta : manifest_metas) {
             auto read_meta_task = [this, meta, bucket]() -> Result<std::vector<ManifestEntry>> {
                 std::vector<ManifestEntry> bucket_entries;
-                PAIMON_RETURN_NOT_OK(
-                    manifest_file_->ReadBucketEntries(meta.FileName(), bucket, &bucket_entries));
+                if (meta.MinBucket() && meta.MaxBucket() && meta.MinBucket().value() == bucket &&
+                    meta.MaxBucket().value() == bucket) {
+                    // Every entry belongs to this bucket; a projection pass cannot prune rows.
+                    PAIMON_RETURN_NOT_OK(
+                        manifest_file_->Read(meta.FileName(), /*filter=*/nullptr, &bucket_entries));
+                } else {
+                    PAIMON_RETURN_NOT_OK(manifest_file_->ReadBucketEntries(meta.FileName(), bucket,
+                                                                           &bucket_entries));
+                }
                 return bucket_entries;
             };
             futures.push_back(Via(executor_.get(), read_meta_task));

--- a/src/paimon/core/utils/objects_file.h
+++ b/src/paimon/core/utils/objects_file.h
@@ -87,9 +87,11 @@ class ObjectsFile {
         return Status::OK();
     }
 
+    // Optional preparation may reread the file, so only run it for retained in-memory bytes.
     Status ReadArrowBatches(
         const std::string& file_name,
-        const std::function<Status(const std::shared_ptr<arrow::StructArray>&)>& consumer) const;
+        const std::function<Status(const std::shared_ptr<arrow::StructArray>&)>& consumer,
+        const std::function<Status(FileBatchReader*)>& prepare_reader = nullptr) const;
 
     std::shared_ptr<PathFactory> path_factory_;
     std::shared_ptr<MemoryPool> pool_;
@@ -170,7 +172,8 @@ Status ObjectsFile<T>::Read(const std::string& file_name,
 template <typename T>
 Status ObjectsFile<T>::ReadArrowBatches(
     const std::string& file_name,
-    const std::function<Status(const std::shared_ptr<arrow::StructArray>&)>& consumer) const {
+    const std::function<Status(const std::shared_ptr<arrow::StructArray>&)>& consumer,
+    const std::function<Status(FileBatchReader*)>& prepare_reader) const {
     std::string file_path = path_factory_->ToPath(file_name);
     std::shared_ptr<InputStream> file_input_stream;
     std::shared_ptr<Bytes> cached_bytes;
@@ -201,6 +204,9 @@ Status ObjectsFile<T>::ReadArrowBatches(
 
     PAIMON_ASSIGN_OR_RAISE(std::unique_ptr<FileBatchReader> batch_reader,
                            reader_builder_->Build(file_input_stream));
+    if (prepare_reader && cached_bytes) {
+        PAIMON_RETURN_NOT_OK(prepare_reader(batch_reader.get()));
+    }
     auto reader = std::make_unique<ManifestMetaReader>(std::move(batch_reader),
                                                        serializer_->GetDataType(), arrow_pool_);
     while (true) {

--- a/src/paimon/format/avro/avro_direct_decoder.cpp
+++ b/src/paimon/format/avro/avro_direct_decoder.cpp
@@ -458,6 +458,10 @@ Status DecodeFieldToBuilder(const ::avro::NodePtr& avro_node,
 
 }  // namespace
 
+Status AvroDirectDecoder::SkipValue(const ::avro::NodePtr& node, ::avro::Decoder* decoder) {
+    return SkipAvroValue(node, decoder);
+}
+
 Status AvroDirectDecoder::DecodeAvroToBuilder(const ::avro::NodePtr& avro_node,
                                               const std::optional<std::set<size_t>>& projection,
                                               ::avro::Decoder* decoder,

--- a/src/paimon/format/avro/avro_direct_decoder.h
+++ b/src/paimon/format/avro/avro_direct_decoder.h
@@ -87,6 +87,9 @@ class AvroDirectDecoder {
     /// @param array_builder Builder to reserve.
     /// @return Status::OK if all reservations succeed.
     static Status ReserveBuilderCapacity(int64_t capacity, arrow::ArrayBuilder* array_builder);
+
+    /// Consume a value without constructing an Arrow value.
+    static Status SkipValue(const ::avro::NodePtr& node, ::avro::Decoder* decoder);
 };
 
 }  // namespace paimon::avro

--- a/src/paimon/format/avro/avro_file_batch_reader.cpp
+++ b/src/paimon/format/avro/avro_file_batch_reader.cpp
@@ -18,6 +18,7 @@
 
 #include "paimon/format/avro/avro_file_batch_reader.h"
 
+#include <algorithm>
 #include <limits>
 #include <memory>
 #include <utility>
@@ -104,22 +105,75 @@ Result<BatchReader::ReadBatch> AvroFileBatchReader::NextBatch() {
     if (next_row_to_read_ == std::numeric_limits<uint64_t>::max()) {
         next_row_to_read_ = 0;
     }
+    previous_first_row_ = next_row_to_read_;
+    previous_row_ids_.clear();
+    previous_batch_row_count_ = 0;
+    if (selection_bitmap_ && selection_bitmap_->IsEmpty()) {
+        return BatchReader::MakeEofBatch();
+    }
     try {
         while (array_builder_->length() < batch_size_) {
+            if (selection_iterator_) {
+                if (*selection_iterator_ == *selection_end_) {
+                    break;
+                }
+                const uint64_t selected_row = static_cast<uint32_t>(**selection_iterator_);
+                if (selected_row >= total_rows_.value()) {
+                    break;
+                }
+                if (next_row_to_read_ < block_index_[selected_block_].first) {
+                    reader_->seek(block_index_[selected_block_].second);
+                    next_row_to_read_ = block_index_[selected_block_].first;
+                }
+            }
             if (!reader_->hasMore()) {
+                if (!selection_bitmap_ && !block_index_disabled_) {
+                    block_index_complete_ = true;
+                    total_rows_ = next_row_to_read_;
+                }
                 break;
+            }
+            if (!selection_bitmap_ && !block_index_complete_ && !block_index_disabled_) {
+                const int64_t block_position = reader_->previousSync();
+                if (block_index_.empty() || block_index_.back().second != block_position) {
+                    if (block_index_.size() == kMaxIndexedBlocks) {
+                        block_index_.clear();
+                        block_index_disabled_ = true;
+                    } else {
+                        block_index_.emplace_back(next_row_to_read_, block_position);
+                    }
+                }
+            }
+            reader_->decr();
+            const uint64_t file_row = next_row_to_read_++;
+            if (selection_bitmap_ &&
+                (file_row > std::numeric_limits<uint32_t>::max() ||
+                 !selection_bitmap_->Contains(static_cast<uint32_t>(file_row)))) {
+                PAIMON_RETURN_NOT_OK(AvroDirectDecoder::SkipValue(reader_->dataSchema().root(),
+                                                                  &reader_->decoder()));
+                continue;
             }
             if (array_builder_->length() == 0) {
                 PAIMON_RETURN_NOT_OK(
                     AvroDirectDecoder::ReserveBuilderCapacity(batch_size_, array_builder_.get()));
             }
-            reader_->decr();
             PAIMON_RETURN_NOT_OK(AvroDirectDecoder::DecodeAvroToBuilder(
                 reader_->dataSchema().root(), read_fields_projection_, &reader_->decoder(),
                 array_builder_.get(), &decode_context_));
+            if (selection_bitmap_) {
+                previous_row_ids_.push_back(file_row);
+            }
+            if (selection_iterator_) {
+                ++(*selection_iterator_);
+                if (*selection_iterator_ != *selection_end_) {
+                    const uint64_t selected_row = static_cast<uint32_t>(**selection_iterator_);
+                    auto block = std::upper_bound(
+                        block_index_.begin(), block_index_.end(), selected_row,
+                        [](uint64_t row, const auto& entry) { return row < entry.first; });
+                    selected_block_ = std::distance(block_index_.begin(), block) - 1;
+                }
+            }
         }
-        previous_first_row_ = next_row_to_read_;
-        next_row_to_read_ += array_builder_->length();
         if (array_builder_->length() == 0) {
             previous_batch_row_count_ = 0;
             return BatchReader::MakeEofBatch();
@@ -152,9 +206,6 @@ Status AvroFileBatchReader::SetReadSchema(::ArrowSchema* read_schema,
         return Status::Invalid("SetReadSchema failed: read schema cannot be nullptr");
     }
     // TODO(menglingda.mld): support predicate
-    if (selection_bitmap) {
-        // TODO(menglingda.mld): support bitmap
-    }
     PAIMON_ASSIGN_OR_RAISE_FROM_ARROW(std::shared_ptr<arrow::Schema> arrow_read_schema,
                                       arrow::ImportSchema(read_schema));
     PAIMON_ASSIGN_OR_RAISE(std::shared_ptr<arrow::Schema> file_schema,
@@ -180,6 +231,24 @@ Status AvroFileBatchReader::SetReadSchema(::ArrowSchema* read_schema,
     reader_ = std::move(reader);
     array_builder_ = std::move(array_builder);
     decode_context_.ClearBuilderMetadata();
+    selection_iterator_.reset();
+    selection_end_.reset();
+    selection_bitmap_ = selection_bitmap;
+    if (!block_index_complete_) {
+        block_index_.clear();
+        block_index_disabled_ = false;
+    }
+    if (selection_bitmap_ && !selection_bitmap_->IsEmpty() && block_index_complete_ &&
+        !block_index_.empty()) {
+        selection_iterator_ = selection_bitmap_->Begin();
+        selection_end_ = selection_bitmap_->End();
+        const uint64_t selected_row = static_cast<uint32_t>(**selection_iterator_);
+        auto block =
+            std::upper_bound(block_index_.begin(), block_index_.end(), selected_row,
+                             [](uint64_t row, const auto& entry) { return row < entry.first; });
+        selected_block_ = std::distance(block_index_.begin(), block) - 1;
+    }
+    previous_row_ids_.clear();
     previous_first_row_ = std::numeric_limits<uint64_t>::max();
     previous_batch_row_count_ = 0;
     next_row_to_read_ = std::numeric_limits<uint64_t>::max();

--- a/src/paimon/format/avro/avro_file_batch_reader.h
+++ b/src/paimon/format/avro/avro_file_batch_reader.h
@@ -63,7 +63,8 @@ class AvroFileBatchReader : public FileBatchReader {
                 fmt::format("batch_row_id {} is out of range, last batch row count is {}",
                             batch_row_id, previous_batch_row_count_));
         }
-        return previous_first_row_ + batch_row_id;
+        return selection_bitmap_ ? previous_row_ids_[batch_row_id]
+                                 : previous_first_row_ + batch_row_id;
     }
 
     Result<uint64_t> GetNumberOfRows() const override;
@@ -77,7 +78,7 @@ class AvroFileBatchReader : public FileBatchReader {
     }
 
     bool SupportPreciseBitmapSelection() const override {
-        return false;
+        return true;
     }
 
  private:
@@ -105,6 +106,17 @@ class AvroFileBatchReader : public FileBatchReader {
     std::unique_ptr<::avro::DataFileReaderBase> reader_;
     std::unique_ptr<arrow::ArrayBuilder> array_builder_;
     std::optional<std::set<size_t>> read_fields_projection_;
+    std::optional<RoaringBitmap32> selection_bitmap_;
+    // Reuse block boundaries discovered by a complete sequential pass over this reader's file.
+    // The index is local to the reader and bounded; oversized files retain sequential selection.
+    static constexpr size_t kMaxIndexedBlocks = 64 * 1024;
+    std::vector<std::pair<uint64_t, int64_t>> block_index_;
+    bool block_index_complete_ = false;
+    bool block_index_disabled_ = false;
+    std::optional<RoaringBitmap32::Iterator> selection_iterator_;
+    std::optional<RoaringBitmap32::Iterator> selection_end_;
+    size_t selected_block_ = 0;
+    std::vector<uint64_t> previous_row_ids_;
     uint64_t previous_first_row_ = std::numeric_limits<uint64_t>::max();
     uint64_t next_row_to_read_ = std::numeric_limits<uint64_t>::max();
     uint64_t previous_batch_row_count_ = 0;

--- a/src/paimon/format/avro/avro_file_batch_reader_test.cpp
+++ b/src/paimon/format/avro/avro_file_batch_reader_test.cpp
@@ -18,6 +18,7 @@
 
 #include "paimon/format/avro/avro_file_batch_reader.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
@@ -25,6 +26,8 @@
 #include "arrow/api.h"
 #include "arrow/c/bridge.h"
 #include "arrow/ipc/api.h"
+#include "avro/Compiler.hh"
+#include "avro/Generic.hh"
 #include "gtest/gtest.h"
 #include "paimon/common/utils/path_util.h"
 #include "paimon/core/manifest/manifest_file.h"
@@ -326,6 +329,216 @@ TEST_F(AvroFileBatchReaderTest, TestSetReadSchemaRejectNestedSubFieldProjection)
     ASSERT_NOK_WITH_MSG(batch_reader->SetReadSchema(c_schema.get(), /*predicate=*/nullptr,
                                                     /*selection_bitmap=*/std::nullopt),
                         "does not support nested sub-field projection");
+}
+
+TEST_F(AvroFileBatchReaderTest, TestPreciseBitmapSelectionAndReset) {
+    auto data_type = arrow::struct_(
+        {arrow::field("id", arrow::int32()),
+         arrow::field("payload",
+                      arrow::struct_({arrow::field("text", arrow::utf8()),
+                                      arrow::field("values", arrow::list(arrow::int32()))}))});
+    auto source =
+        arrow::ipc::internal::json::ArrayFromJSON(
+            data_type, R"([[0,["a",[1,2]]],[1,null],[2,["c",[]]],[3,["d",[4]]],[4,["e",null]]])")
+            .ValueOrDie();
+    const std::vector<std::vector<uint32_t>> selections = {
+        {}, {0}, {1, 3}, {0, 1, 2, 3, 4}, {2, 99}};
+    for (const std::string& compression : {std::string("null"), std::string("deflate")}) {
+        const std::string path = PathUtil::JoinPath(dir_->Str(), compression + ".avro");
+        WriteData(source, path, compression);
+        for (int32_t batch_size : {1, 2, 8}) {
+            ASSERT_OK_AND_ASSIGN(std::shared_ptr<ReaderBuilder> builder,
+                                 file_format_->CreateReaderBuilder(batch_size));
+            ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> input, fs_->Open(path));
+            ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileBatchReader> reader, builder->Build(input));
+            ASSERT_TRUE(reader->SupportPreciseBitmapSelection());
+            for (const auto& ids : selections) {
+                RoaringBitmap32 selection;
+                for (uint32_t id : ids) {
+                    selection.Add(id);
+                }
+                ArrowSchema c_schema;
+                ASSERT_TRUE(
+                    arrow::ExportSchema(*arrow::schema(data_type->fields()), &c_schema).ok());
+                ASSERT_OK(reader->SetReadSchema(&c_schema, nullptr, selection));
+                ASSERT_NOK(reader->GetPreviousBatchFileRowId(0));
+                size_t cursor = 0;
+                while (true) {
+                    ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatch batch, reader->NextBatch());
+                    if (BatchReader::IsEofBatch(batch)) {
+                        break;
+                    }
+                    auto array =
+                        arrow::ImportArray(batch.first.get(), batch.second.get()).ValueOrDie();
+                    ASSERT_GT(array->length(), 0);
+                    ASSERT_LE(array->length(), batch_size);
+                    for (int64_t i = 0; i < array->length(); ++i) {
+                        ASSERT_LT(cursor, ids.size());
+                        ASSERT_OK_AND_ASSIGN(uint64_t file_row,
+                                             reader->GetPreviousBatchFileRowId(i));
+                        ASSERT_EQ(file_row, ids[cursor++]);
+                        ASSERT_TRUE(array->Slice(i, 1)->Equals(source->Slice(file_row, 1)));
+                    }
+                    ASSERT_NOK(reader->GetPreviousBatchFileRowId(array->length()));
+                }
+                ASSERT_EQ(cursor, static_cast<size_t>(std::count_if(
+                                      ids.begin(), ids.end(), [](uint32_t id) { return id < 5; })));
+                ASSERT_NOK(reader->GetPreviousBatchFileRowId(0));
+            }
+            // Removing the bitmap must restore ordinary contiguous file row IDs.
+            ArrowSchema c_schema;
+            ASSERT_TRUE(arrow::ExportSchema(*arrow::schema(data_type->fields()), &c_schema).ok());
+            ASSERT_OK(reader->SetReadSchema(&c_schema, nullptr, std::nullopt));
+            ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatch batch, reader->NextBatch());
+            auto array = arrow::ImportArray(batch.first.get(), batch.second.get()).ValueOrDie();
+            ASSERT_TRUE(array->Equals(source->Slice(0, std::min(batch_size, 5))));
+            ASSERT_OK_AND_ASSIGN(uint64_t first_row, reader->GetPreviousBatchFileRowId(0));
+            ASSERT_EQ(first_row, 0);
+        }
+    }
+}
+
+TEST_F(AvroFileBatchReaderTest, TestBitmapSelectionAcrossBlocksAfterProjection) {
+    auto data_type = arrow::struct_(
+        {arrow::field("id", arrow::int32()), arrow::field("payload", arrow::utf8())});
+    std::string json = "[";
+    for (int32_t i = 0; i < 128; ++i) {
+        if (i != 0) {
+            json += ",";
+        }
+        json += fmt::format(R"([{},"{}"])", i, std::string(16384, 'a' + i % 26));
+    }
+    json += "]";
+    auto source = arrow::ipc::internal::json::ArrayFromJSON(data_type, json).ValueOrDie();
+    for (const std::string& compression : {std::string("null"), std::string("deflate")}) {
+        const std::string path = PathUtil::JoinPath(dir_->Str(), compression + ".avro");
+        WriteData(source, path, compression);
+        for (bool complete_projection : {false, true}) {
+            for (int32_t batch_size : {1, 7, 256}) {
+                ASSERT_OK_AND_ASSIGN(auto builder, file_format_->CreateReaderBuilder(batch_size));
+                ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> input, fs_->Open(path));
+                ASSERT_OK_AND_ASSIGN(auto reader, builder->Build(input));
+                ArrowSchema probe_schema;
+                ASSERT_TRUE(
+                    arrow::ExportSchema(*arrow::schema({data_type->field(0)}), &probe_schema).ok());
+                ASSERT_OK(reader->SetReadSchema(&probe_schema, nullptr, std::nullopt));
+                do {
+                    ASSERT_OK_AND_ASSIGN(auto batch, reader->NextBatch());
+                    if (BatchReader::IsEofBatch(batch)) {
+                        break;
+                    }
+                    ASSERT_TRUE(arrow::ImportArray(batch.first.get(), batch.second.get()).ok());
+                } while (complete_projection);
+                for (const std::vector<int32_t>& ids : std::vector<std::vector<int32_t>>{
+                         {}, {127}, {0, 1, 64, 65, 127}, {31, 32, 33}, {0, 128}, {999}}) {
+                    ArrowSchema full_schema;
+                    ASSERT_TRUE(
+                        arrow::ExportSchema(*arrow::schema(data_type->fields()), &full_schema)
+                            .ok());
+                    ASSERT_OK(
+                        reader->SetReadSchema(&full_schema, nullptr, RoaringBitmap32::From(ids)));
+                    size_t cursor = 0;
+                    while (true) {
+                        ASSERT_OK_AND_ASSIGN(auto batch, reader->NextBatch());
+                        if (BatchReader::IsEofBatch(batch)) {
+                            break;
+                        }
+                        auto array =
+                            arrow::ImportArray(batch.first.get(), batch.second.get()).ValueOrDie();
+                        for (int64_t i = 0; i < array->length(); ++i) {
+                            ASSERT_LT(cursor, ids.size());
+                            ASSERT_OK_AND_ASSIGN(uint64_t row,
+                                                 reader->GetPreviousBatchFileRowId(i));
+                            ASSERT_EQ(row, ids[cursor++]);
+                            ASSERT_TRUE(array->Slice(i, 1)->Equals(source->Slice(row, 1)));
+                        }
+                    }
+                    ASSERT_EQ(cursor, std::count_if(ids.begin(), ids.end(),
+                                                    [](int32_t id) { return id < 128; }));
+                }
+                ArrowSchema full_schema;
+                ASSERT_TRUE(
+                    arrow::ExportSchema(*arrow::schema(data_type->fields()), &full_schema).ok());
+                ASSERT_OK(reader->SetReadSchema(&full_schema, nullptr, std::nullopt));
+                ASSERT_OK_AND_ASSIGN(
+                    auto restored, paimon::test::ReadResultCollector::CollectResult(reader.get()));
+                ASSERT_TRUE(restored->Equals(std::make_shared<arrow::ChunkedArray>(source)));
+            }
+        }
+    }
+}
+
+TEST_F(AvroFileBatchReaderTest, TestBitmapSelectionAfterBlockIndexLimit) {
+    const std::string path = PathUtil::JoinPath(dir_->Str(), "many-blocks.avro");
+    const auto avro_schema = ::avro::compileJsonSchemaFromString(
+        R"({"type":"record","name":"row","fields":[{"name":"id","type":"int"}]})");
+    // Each flush produces one small block. Exercise sequential fallback beyond the index cap.
+    constexpr int32_t kRowCount = 64 * 1024 + 2;
+    {
+        ::avro::DataFileWriter<::avro::GenericDatum> writer(path.c_str(), avro_schema);
+        ::avro::GenericDatum datum(avro_schema);
+        for (int32_t i = 0; i < kRowCount; ++i) {
+            datum.value<::avro::GenericRecord>().fieldAt(0).value<int32_t>() = i;
+            writer.write(datum);
+            writer.flush();
+        }
+        writer.close();
+    }
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<ReaderBuilder> builder,
+                         file_format_->CreateReaderBuilder(1024));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> input, fs_->Open(path));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileBatchReader> reader, builder->Build(input));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::ChunkedArray> full_result,
+                         paimon::test::ReadResultCollector::CollectResult(reader.get()));
+    ASSERT_EQ(kRowCount, full_result->length());
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<ArrowSchema> c_schema, reader->GetFileSchema());
+    ASSERT_OK(
+        reader->SetReadSchema(c_schema.get(), nullptr, RoaringBitmap32::From({0, kRowCount - 1})));
+    ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatch batch, reader->NextBatch());
+    ASSERT_OK_AND_ASSIGN(uint64_t first, reader->GetPreviousBatchFileRowId(0));
+    ASSERT_OK_AND_ASSIGN(uint64_t last, reader->GetPreviousBatchFileRowId(1));
+    ASSERT_EQ(0, first);
+    ASSERT_EQ(kRowCount - 1, last);
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<arrow::Array> result,
+                         paimon::test::ReadResultCollector::GetArray(std::move(batch)));
+    ASSERT_EQ(2, result->length());
+    ASSERT_TRUE(result->Slice(0, 1)->Equals(*full_result->chunk(0)->Slice(0, 1)));
+    ASSERT_TRUE(result->Slice(1, 1)->Equals(
+        *full_result->chunk(full_result->num_chunks() - 1)->Slice(1, 1)));
+    ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatch eof, reader->NextBatch());
+    ASSERT_TRUE(BatchReader::IsEofBatch(eof));
+}
+
+TEST_F(AvroFileBatchReaderTest, TestBitmapSelectionOnEmptyFile) {
+    auto type = arrow::struct_({arrow::field("id", arrow::int32())});
+    auto source = arrow::ipc::internal::json::ArrayFromJSON(type, "[]").ValueOrDie();
+    const std::string path = PathUtil::JoinPath(dir_->Str(), "empty.avro");
+    WriteData(source, path, "null");
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<ReaderBuilder> builder,
+                         file_format_->CreateReaderBuilder(2));
+    ASSERT_OK_AND_ASSIGN(std::shared_ptr<InputStream> input, fs_->Open(path));
+    ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileBatchReader> reader, builder->Build(input));
+    for (bool scanned : {false, true}) {
+        SCOPED_TRACE(scanned);
+        for (const std::vector<int32_t>& ids :
+             std::vector<std::vector<int32_t>>{{}, {0}, {1, 100}}) {
+            ArrowSchema c_schema;
+            ASSERT_TRUE(arrow::ExportSchema(*arrow::schema(type->fields()), &c_schema).ok());
+            ASSERT_OK(reader->SetReadSchema(&c_schema, nullptr, RoaringBitmap32::From(ids)));
+            for (int32_t round = 0; round < 2; ++round) {
+                ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatch batch, reader->NextBatch());
+                ASSERT_TRUE(BatchReader::IsEofBatch(batch));
+                ASSERT_NOK(reader->GetPreviousBatchFileRowId(0));
+            }
+        }
+        ArrowSchema c_schema;
+        ASSERT_TRUE(arrow::ExportSchema(*arrow::schema(type->fields()), &c_schema).ok());
+        ASSERT_OK(reader->SetReadSchema(&c_schema, nullptr, std::nullopt));
+        ASSERT_OK_AND_ASSIGN(BatchReader::ReadBatch batch, reader->NextBatch());
+        ASSERT_TRUE(BatchReader::IsEofBatch(batch));
+        ASSERT_OK_AND_ASSIGN(uint64_t row_count, reader->GetNumberOfRows());
+        ASSERT_EQ(0, row_count);
+    }
 }
 
 TEST_F(AvroFileBatchReaderTest, TestGetPreviousBatchFileRowId) {


### PR DESCRIPTION
### Purpose

  Linked issue: #240 

  Reduce unnecessary decoding and Arrow materialization when reading a single bucket from a mixed-bucket manifest.

  - When manifest bytes are retained in memory, first read the version and bucket fields, validate every entry’s version, and collect matching row IDs. Then materialize only matching entries using precise bitmap selection.
  - Support precise bitmap selection in the Avro reader while preserving original file row IDs.
  - Reuse reader-local block indexes to skip blocks without matching rows. Limit indexes to 65,536 blocks and fall back to sequential selection when the limit is exceeded or the initial pass is incomplete.
  - Preserve single-pass reads when bytes are not retained, precise selection is unavailable, or manifest metadata identifies a single matching bucket.

  This change does not include the separate Avro skip-plan optimization. No isolated end-to-end latency improvement is claimed.

  ### Tests

  Added coverage for:

  - Empty, sparse, full, and out-of-range bitmap selections.
  - Nested nullable values, original row IDs, schema resets, and repeated EOF.
  - Cross-block selection after complete and incomplete projection passes.
  - Sequential fallback after exceeding the block-index limit.
  - Cached and uncached bucket reads.
  - Invalid versions and null version/bucket fields outside the selected bucket.

  Local validation:

  - Avro tests: 73/73 passed.
  - Manifest and scan tests: 43/43 passed.
  - Read integration tests: 294/294 passed.
  - Core tests: 1,899/1,901 passed. Two commit-path tests failed because their fixtures select ORC manifests, which the writer rejects as read-only. A separate clean-main reproduction was not run.
  - Changed-file pre-commit checks and git diff --check passed.

  For local GCC 13 validation, -Wmaybe-uninitialized was downgraded from an error only for the unchanged arrow_realtime_store_test.cpp generated build rule. No warning-policy changes are included.

  ### API and Format

  No public API signatures, storage formats, or protocols are changed.

  The Avro reader now honors the existing selection bitmap API and reports precise bitmap-selection support. Block indexes are transient, bounded, reader-local state.

  ### Documentation

  No new user-facing configuration is introduced. Implementation comments describe the retained-bytes requirement, bounded indexes, and fallback behavior.

  ### Generative AI tooling

  Generated-by: OpenAI Codex (GPT-5).